### PR TITLE
Introduce codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Start PostgreSQL
         run: |
           for i in {1..60}; do docker compose up -d --quiet-pull && break; sleep 1; done
-          for i in {1..60}; do pg_isready -U postgres -h 127.0.0.1 -p 15432 && break; sleep 1; done
+          for i in {1..60}; do pg_isready -U postgres -h 127.0.0.1 -p 5432 && break; sleep 1; done
       - run: make TEST_OPTS='-coverprofile=coverage.txt'
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Start PostgreSQL
         run: |
           for i in {1..60}; do docker compose up -d --quiet-pull && break; sleep 1; done
-          for i in {1..60}; do pg_isready -U postgres -h 127.0.0.1 -p 5432 && break; sleep 1; done
-      - run: make
+          for i in {1..60}; do pg_isready -U postgres -h 127.0.0.1 -p 15432 && break; sleep 1; done
+      - run: make TEST_OPTS='-coverprofile=coverage.txt'
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ vet:
 
 .PHONY: test
 test:
-	go test -p 1 -v ./...
+	go test -p 1 -v ./... $(TEST_OPTS)
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
This pull request updates the CI workflow and test configuration to improve code coverage reporting and allow for more flexible test options. The main changes involve updating the PostgreSQL port in the workflow, adding code coverage reporting with Codecov, and making the test command accept additional options.

**CI workflow and code coverage improvements:**

* Changed the PostgreSQL health check port from `5432` to `15432` in the GitHub Actions workflow to match the expected configuration.
* Updated the test command in the workflow to run with code coverage enabled by passing `TEST_OPTS='-coverprofile=coverage.txt'` to `make`.
* Added a step to upload coverage reports to Codecov using the `codecov/codecov-action` in the CI workflow.

**Test command flexibility:**

* Modified the `test` target in the `Makefile` to accept additional options through the `TEST_OPTS` variable, enabling custom test flags such as coverage reporting.