### PR TITLE
Improve test coverage for diff, model, and parser packages

### DIFF
--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -398,6 +398,63 @@ func TestEqualFKDef_different(t *testing.T) {
 	assert.False(t, equalFKDef(a, b))
 }
 
+func TestDiffTables_newTable_withForeignKey(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	tbl := newTable("public", "orders")
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.ForeignKeys.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	desired.Set("public.orders", tbl)
+
+	stmts := DiffTables(current, desired)
+	assert.Len(t, stmts, 2)
+	assert.Contains(t, stmts[0], "CREATE TABLE")
+	assert.Contains(t, stmts[1], "ADD CONSTRAINT fk_user")
+}
+
+func TestEqualFKDef_parseError(t *testing.T) {
+	// When both fail to parse, falls back to string comparison
+	assert.True(t, equalFKDef("not sql", "not sql"))
+	assert.False(t, equalFKDef("not sql", "other"))
+}
+
+func TestEqualDefault_parseError(t *testing.T) {
+	// When both fail to parse, falls back to string comparison
+	assert.True(t, equalDefault(ptr(")))invalid"), ptr(")))invalid")))
+	assert.False(t, equalDefault(ptr(")))invalid"), ptr(")))other")))
+}
+
+func TestEqualViewDef_parseError(t *testing.T) {
+	// When normalization fails, falls back to string comparison
+	assert.True(t, equalViewDef(")))invalid", ")))invalid"))
+	assert.False(t, equalViewDef(")))invalid", ")))other"))
+}
+
+func TestDiffForeignKeys_change(t *testing.T) {
+	current := orderedmap.New[string, *model.ForeignKey]()
+	current.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	desired := orderedmap.New[string, *model.ForeignKey]()
+	desired.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	stmts := diffForeignKeys("public.orders", current, desired)
+	assert.Len(t, stmts, 2)
+	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", stmts[0])
+	assert.Contains(t, stmts[1], "ADD CONSTRAINT fk_user")
+}
+
 func TestDiffTable_partitionChild(t *testing.T) {
 	parent := "public.events"
 	bound := "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')"

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -200,3 +200,39 @@ func TestTablesToSQL(t *testing.T) {
 	assert.Contains(t, got, "-- public.users")
 	assert.Contains(t, got, "CREATE TABLE public.users")
 }
+
+func TestTablesToSQL_withIndexAndFK(t *testing.T) {
+	tables := orderedmap.New[string, *Table]()
+	tbl := newTable("public", "orders")
+	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.Indexes.Set("idx_user", &Index{Definition: "CREATE INDEX idx_user ON public.orders USING btree (user_id)"})
+	tbl.ForeignKeys.Set("fk_user", &ForeignKey{
+		Constraint: Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	comment := "Orders table"
+	tbl.Comment = &comment
+	tables.Set("public.orders", tbl)
+
+	got := TablesToSQL(tables)
+	assert.Contains(t, got, "-- public.orders")
+	assert.Contains(t, got, "CREATE TABLE public.orders")
+	assert.Contains(t, got, "CREATE INDEX idx_user")
+	assert.Contains(t, got, "ADD CONSTRAINT fk_user")
+	assert.Contains(t, got, "COMMENT ON TABLE public.orders")
+}
+
+func TestTablesToSQL_multipleTables(t *testing.T) {
+	tables := orderedmap.New[string, *Table]()
+	t1 := newTable("public", "a")
+	t1.Columns.Set("id", &Column{Name: "id", TypeName: "integer"})
+	tables.Set("public.a", t1)
+	t2 := newTable("public", "b")
+	t2.Columns.Set("id", &Column{Name: "id", TypeName: "integer"})
+	tables.Set("public.b", t2)
+
+	got := TablesToSQL(tables)
+	assert.Contains(t, got, "-- public.a")
+	assert.Contains(t, got, "-- public.b")
+}

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -34,6 +34,16 @@ func TestIdent_withDoubleQuote(t *testing.T) {
 	assert.Equal(t, `"my""table"`, Ident(`my"table`))
 }
 
+func TestIdent_unreservedKeyword(t *testing.T) {
+	// "name" is unreserved in PostgreSQL, should not be quoted
+	assert.Equal(t, "name", Ident("name"))
+}
+
+func TestIdent_multipleTokens(t *testing.T) {
+	// A string that scans to multiple tokens should be quoted
+	assert.Equal(t, `"a b"`, Ident("a b"))
+}
+
 func TestQuoteLiteral(t *testing.T) {
 	assert.Equal(t, "'hello'", QuoteLiteral("hello"))
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -125,6 +125,80 @@ COMMENT ON COLUMN public.users.name IS 'User name';`
 	assert.Equal(t, "User name", *col.Comment)
 }
 
+func TestParseSQL_SchemaQualifiedView(t *testing.T) {
+	sql := `CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW myschema.active_users AS SELECT id, name FROM myschema.users;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Views.Len())
+
+	v, ok := result.Views.GetOk("myschema.active_users")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", v.Schema)
+	assert.Equal(t, "active_users", v.Name)
+}
+
+func TestParseSQL_CommentOnTable(t *testing.T) {
+	sql := `CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+COMMENT ON TABLE myschema.users IS 'Users table';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("myschema.users")
+	require.True(t, ok)
+	require.NotNil(t, tbl.Comment)
+	assert.Equal(t, "Users table", *tbl.Comment)
+}
+
+func TestParseSQL_ForeignKeyNotValid(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.orders")
+	require.True(t, ok)
+	fk, ok := tbl.ForeignKeys.GetOk("fk_user")
+	require.True(t, ok)
+	assert.False(t, fk.Validated)
+	assert.Equal(t, "public", *fk.RefSchema)
+	assert.Equal(t, "users", *fk.RefTable)
+	assert.Equal(t, []string{"user_id"}, fk.Columns)
+}
+
+func TestParseSQL_TablespaceOnCreate(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+) TABLESPACE my_ts;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	require.NotNil(t, tbl.TableSpace)
+	assert.Equal(t, "my_ts", *tbl.TableSpace)
+}
+
 func TestParseSQL_AlterTableNonFK(t *testing.T) {
 	sql := `CREATE TABLE public.items (
     id integer NOT NULL,
@@ -139,4 +213,105 @@ ALTER TABLE public.items ADD CONSTRAINT items_code_unique UNIQUE (code);`
 	require.NotNil(t, tbl)
 	_, ok := tbl.Constraints.GetOk("items_code_unique")
 	assert.True(t, ok)
+}
+
+func TestParseSQL_AlterTableUnknownTable(t *testing.T) {
+	// ALTER TABLE referencing a table not in parsed result is silently skipped
+	sql := `ALTER TABLE public.nonexistent ADD CONSTRAINT fk FOREIGN KEY (id) REFERENCES public.other(id);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Tables.Len())
+}
+
+func TestParseSQL_CommentOnUnknownTable(t *testing.T) {
+	// COMMENT on unknown table is silently skipped
+	sql := `COMMENT ON TABLE public.nonexistent IS 'test';`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Tables.Len())
+}
+
+func TestParseSQL_PartitionListType(t *testing.T) {
+	sql := `CREATE TABLE public.sales (
+    id integer NOT NULL,
+    region text NOT NULL,
+    CONSTRAINT sales_pkey PRIMARY KEY (id, region)
+)
+PARTITION BY LIST (region);
+CREATE TABLE public.sales_east PARTITION OF public.sales FOR VALUES IN ('east');`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Tables.Len())
+
+	parent, ok := result.Tables.GetOk("public.sales")
+	require.True(t, ok)
+	assert.True(t, parent.Partitioned)
+	require.NotNil(t, parent.PartitionDef)
+	assert.Contains(t, *parent.PartitionDef, "LIST")
+
+	child, ok := result.Tables.GetOk("public.sales_east")
+	require.True(t, ok)
+	require.NotNil(t, child.PartitionOf)
+	require.NotNil(t, child.PartitionBound)
+}
+
+func TestParseSQL_InlineUniqueConstraint(t *testing.T) {
+	sql := `CREATE TABLE public.items (
+    id integer NOT NULL,
+    code text NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id),
+    CONSTRAINT items_code_key UNIQUE (code),
+    CONSTRAINT items_code_check CHECK (code <> '')
+);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl := result.Tables.Get("public.items")
+	require.NotNil(t, tbl)
+	assert.Equal(t, 3, tbl.Constraints.Len())
+
+	_, ok := tbl.Constraints.GetOk("items_pkey")
+	assert.True(t, ok)
+	_, ok = tbl.Constraints.GetOk("items_code_key")
+	assert.True(t, ok)
+	_, ok = tbl.Constraints.GetOk("items_code_check")
+	assert.True(t, ok)
+}
+
+func TestParseSQL_MultipleViews(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.v1 AS SELECT id FROM users;
+CREATE VIEW public.v2 AS SELECT name FROM users;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Views.Len())
+}
+
+func TestParseSQL_ForeignKeyWithSchema(t *testing.T) {
+	sql := `CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE myschema.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id)
+);
+ALTER TABLE myschema.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES myschema.users(id);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("myschema.orders")
+	require.True(t, ok)
+	fk, ok := tbl.ForeignKeys.GetOk("fk_user")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", fk.Schema)
+	assert.Equal(t, "myschema", *fk.RefSchema)
 }

--- a/testdata/parser/schema_qualified_comment.yml
+++ b/testdata/parser/schema_qualified_comment.yml
@@ -1,0 +1,17 @@
+input: |
+  CREATE TABLE myschema.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  COMMENT ON TABLE myschema.users IS 'Users in myschema';
+  COMMENT ON COLUMN myschema.users.name IS 'User name';
+expected: |
+  -- myschema.users
+  CREATE TABLE myschema.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  COMMENT ON TABLE myschema.users IS 'Users in myschema';
+  COMMENT ON COLUMN myschema.users.name IS 'User name';

--- a/testdata/parser/schema_qualified_index.yml
+++ b/testdata/parser/schema_qualified_index.yml
@@ -1,0 +1,15 @@
+input: |
+  CREATE TABLE myschema.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_name ON myschema.users USING btree (name);
+expected: |
+  -- myschema.users
+  CREATE TABLE myschema.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_name ON myschema.users USING btree (name);

--- a/testdata/parser/schema_qualified_view.yml
+++ b/testdata/parser/schema_qualified_view.yml
@@ -1,0 +1,14 @@
+input: |
+  CREATE TABLE myschema.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW myschema.active_users AS SELECT id, name FROM myschema.users;
+expected: |
+  -- myschema.users
+  CREATE TABLE myschema.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/parser/type_aliases.yml
+++ b/testdata/parser/type_aliases.yml
@@ -1,0 +1,19 @@
+input: |
+  CREATE TABLE public.items (
+      id int NOT NULL,
+      name varchar(255) NOT NULL,
+      price numeric(10,2),
+      active bool DEFAULT true,
+      tags text[],
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+expected: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      name character varying(255) NOT NULL,
+      price numeric(10,2),
+      active boolean DEFAULT true,
+      tags text[],
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );

--- a/testdata/parser/unique_constraint.yml
+++ b/testdata/parser/unique_constraint.yml
@@ -1,0 +1,15 @@
+input: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );

--- a/testdata/parser/with_collation.yml
+++ b/testdata/parser/with_collation.yml
@@ -1,0 +1,13 @@
+input: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "en_US" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "en_US" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/parser/with_tablespace_index.yml
+++ b/testdata/parser/with_tablespace_index.yml
@@ -1,0 +1,15 @@
+input: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_name ON public.users USING btree (name) TABLESPACE fast_ssd;
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_name ON public.users USING btree (name) TABLESPACE fast_ssd;


### PR DESCRIPTION
- diff: add tests for FK in newTableExtras, equalFKDef/equalDefault/equalViewDef error fallback, FK change detection
- model: add TablesToSQL tests with indexes, FKs, comments, and multiple tables; add quoteIdent edge cases
- parser: add fixtures for collation, type aliases, unique constraint, tablespace index, schema-qualified index/comment/view, list partition; add inline tests for unknown table/comment, NOT VALID FK, multi-view, schema FK