### PR TITLE
Add error path tests and cmd/command tests to improve coverage to 87%

### DIFF
--- a/apply_test.go
+++ b/apply_test.go
@@ -125,3 +125,115 @@ SELECT * FROM public.missing_table;`), 0o644))
 	assert.NotContains(t, got, "CREATE TABLE public.pre_hook")
 	assert.NotContains(t, got, "CREATE TABLE public.users")
 }
+
+func TestApply_WithTx_Success(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	tmpDir := t.TempDir()
+	desiredFile := filepath.Join(tmpDir, "desired.sql")
+	preSQLFile := filepath.Join(tmpDir, "pre.sql")
+
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+	require.NoError(t, os.WriteFile(preSQLFile, []byte(`SELECT 1;`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{
+		File:       desiredFile,
+		PreSQLFile: preSQLFile,
+		WithTx:     true,
+	}, io.Discard)
+	require.NoError(t, err)
+
+	got, dumpErr := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, dumpErr)
+	assert.Contains(t, got, "CREATE TABLE public.users")
+}
+
+func TestApply_NoDiff(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	require.NoError(t, err)
+}
+
+func TestApply_InvalidConnString(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "invalid://connection",
+		Schemas:    []string{"public"},
+	})
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	require.Error(t, err)
+}
+
+func TestApply_InvalidDesiredFile(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: "/nonexistent/file.sql"}, io.Discard)
+	require.Error(t, err)
+}
+
+func TestApply_InvalidPreSQLFile(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{
+		File:       desiredFile,
+		PreSQLFile: "/nonexistent/pre.sql",
+	}, io.Discard)
+	require.Error(t, err)
+}

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -1,0 +1,116 @@
+package command_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio"
+	"github.com/winebarrel/pistachio/cmd/command"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+func TestPlan_Run(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{File: desiredFile}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+}
+
+func TestDump_Run(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Dump{}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+}
+
+func TestPlan_Run_Error(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "invalid://connection",
+		Schemas:    []string{"public"},
+	})
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{File: desiredFile}}
+	err := cmd.Run(ctx, client, &buf)
+	require.Error(t, err)
+}
+
+func TestDump_Run_Error(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "invalid://connection",
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Dump{}
+	err := cmd.Run(ctx, client, &buf)
+	require.Error(t, err)
+}
+
+func TestApply_Run(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{File: desiredFile}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+}

--- a/dump_test.go
+++ b/dump_test.go
@@ -17,6 +17,17 @@ type dumpTestCase struct {
 	Dump string `yaml:"dump"`
 }
 
+func TestDump_InvalidConnString(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "invalid://connection",
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.Error(t, err)
+}
+
 func TestDump(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/plan_test.go
+++ b/plan_test.go
@@ -19,6 +19,34 @@ type planTestCase struct {
 	Plan    string `yaml:"plan"`
 }
 
+func TestPlan_InvalidConnString(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "invalid://connection",
+		Schemas:    []string{"public"},
+	})
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	_, err := client.Plan(ctx, &pistachio.PlanOptions{File: desiredFile})
+	require.Error(t, err)
+}
+
+func TestPlan_InvalidDesiredFile(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Plan(ctx, &pistachio.PlanOptions{File: "/nonexistent/file.sql"})
+	require.Error(t, err)
+}
+
 func TestPlan(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/testdata/plan/empty.yml
+++ b/testdata/plan/empty.yml
@@ -1,0 +1,3 @@
+init: ""
+desired: ""
+plan: ""


### PR DESCRIPTION
- apply: add WithTx success, NoDiff, invalid conn/file/pre-SQL error tests
- plan: add invalid conn/file error tests
- dump: add invalid conn error test
- cmd/command: add full test coverage for Plan/Dump/Apply Run methods