### PR TITLE
Further improve test coverage to 88%

### DIFF
--- a/apply_test.go
+++ b/apply_test.go
@@ -183,6 +183,50 @@ func TestApply_NoDiff(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestApply_ExecError(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	// Desired has a column with a type that references a nonexistent type → exec error on ALTER TABLE
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    data nonexistent_type,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	require.Error(t, err)
+}
+
+func TestApply_EmptySchemas(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	require.Error(t, err)
+}
+
 func TestApply_InvalidConnString(t *testing.T) {
 	ctx := context.Background()
 	client := pistachio.NewClient(&pistachio.Options{

--- a/dump_test.go
+++ b/dump_test.go
@@ -28,6 +28,32 @@ func TestDump_InvalidConnString(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDump_UnreachableHost(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "postgres://postgres@192.0.2.1:5432/postgres?connect_timeout=1",
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect")
+}
+
+func TestDump_EmptySchemas(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{},
+	})
+
+	_, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.Error(t, err)
+}
+
 func TestDump(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -293,6 +293,81 @@ CREATE VIEW public.v2 AS SELECT name FROM users;`
 	assert.Equal(t, 2, result.Views.Len())
 }
 
+func TestParseSQL_UnnamedConstraintSkipped(t *testing.T) {
+	// Unnamed inline NOT NULL constraints are skipped by parseTableConstraint
+	sql := `CREATE TABLE public.items (
+    id integer NOT NULL,
+    name text
+);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl := result.Tables.Get("public.items")
+	require.NotNil(t, tbl)
+	assert.Equal(t, 0, tbl.Constraints.Len())
+}
+
+func TestParseSQL_CommentRemove(t *testing.T) {
+	// When COMMENT ON ... IS '' (empty string), the comment is set to nil
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+COMMENT ON TABLE public.users IS 'Users';
+COMMENT ON TABLE public.users IS '';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl := result.Tables.Get("public.users")
+	require.NotNil(t, tbl)
+	assert.Nil(t, tbl.Comment)
+}
+
+func TestParseSQL_ViewCommentRemove(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.v1 AS SELECT id FROM users;
+COMMENT ON VIEW public.v1 IS 'my view';
+COMMENT ON VIEW public.v1 IS '';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	v := result.Views.Get("public.v1")
+	require.NotNil(t, v)
+	assert.Nil(t, v.Comment)
+}
+
+func TestParseSQL_ColumnCommentRemove(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+COMMENT ON COLUMN public.users.name IS 'Name';
+COMMENT ON COLUMN public.users.name IS '';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl := result.Tables.Get("public.users")
+	require.NotNil(t, tbl)
+	col, ok := tbl.Columns.GetOk("name")
+	require.True(t, ok)
+	assert.Nil(t, col.Comment)
+}
+
+func TestParseSQL_IndexOnUnknownTableSkipped(t *testing.T) {
+	sql := `CREATE INDEX idx_name ON public.nonexistent USING btree (name);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Tables.Len())
+}
+
 func TestParseSQL_ForeignKeyWithSchema(t *testing.T) {
 	sql := `CREATE TABLE myschema.users (
     id integer NOT NULL,

--- a/plan_test.go
+++ b/plan_test.go
@@ -33,6 +33,30 @@ func TestPlan_InvalidConnString(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPlan_WithPassword(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Password:   "dummy",
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{File: desiredFile})
+	require.NoError(t, err)
+	assert.Contains(t, got, "CREATE TABLE public.users")
+}
+
 func TestPlan_InvalidDesiredFile(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
@@ -44,6 +68,23 @@ func TestPlan_InvalidDesiredFile(t *testing.T) {
 	})
 
 	_, err := client.Plan(ctx, &pistachio.PlanOptions{File: "/nonexistent/file.sql"})
+	require.Error(t, err)
+}
+
+func TestPlan_EmptySchemas(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{},
+	})
+
+	_, err := client.Plan(ctx, &pistachio.PlanOptions{File: desiredFile})
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
- parser: add tests for comment removal, unnamed constraint skip, index on unknown table
- apply: add exec error, empty schemas error tests
- plan: add password path, empty schemas error tests
- dump: add unreachable host (connect error), empty schemas error tests