### PR TITLE
Add codecov yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "internal/testutil"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 88%
+    patch:
+      default:
+        target: 80%
+
 ignore:
   - "internal/testutil"
+  - "cmd/pist"


### PR DESCRIPTION
This pull request adds a `codecov.yml` configuration file to set up code coverage requirements and specify files to ignore in coverage reports.

Codecov configuration:

* Added a `codecov.yml` file to enforce minimum coverage thresholds (88% for the overall project, 80% for patches) and to ignore the `internal/testutil` and `cmd/pist` directories from coverage calculations.