### PR TITLE
Fix false FK diff when implicit public schema differs from explicit one

### DIFF
--- a/diff/tables.go
+++ b/diff/tables.go
@@ -293,6 +293,15 @@ func parseFKDef(def string) (*pg_query.Constraint, error) {
 	return con, nil
 }
 
+// normalizeFKSchema normalizes the referenced table's schema name in a FK
+// constraint node so that an empty schema (implicit public) is treated
+// the same as an explicit "public" schema.
+func normalizeFKSchema(con *pg_query.Constraint) {
+	if con.Pktable != nil && con.Pktable.Schemaname == "" {
+		con.Pktable.Schemaname = "public"
+	}
+}
+
 // equalFKDef compares two FK constraint definitions by their parse trees,
 // so that formatting differences do not cause false diffs.
 func equalFKDef(a, b string) bool {
@@ -301,6 +310,8 @@ func equalFKDef(a, b string) bool {
 	if errA != nil || errB != nil {
 		return a == b
 	}
+	normalizeFKSchema(nodeA)
+	normalizeFKSchema(nodeB)
 	return proto.Equal(nodeA, nodeB)
 }
 

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -417,6 +417,12 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 	assert.Contains(t, stmts[1], "ADD CONSTRAINT fk_user")
 }
 
+func TestEqualFKDef_implicitPublicSchema(t *testing.T) {
+	a := "FOREIGN KEY (user_id) REFERENCES users(id)"
+	b := "FOREIGN KEY (user_id) REFERENCES public.users(id)"
+	assert.True(t, equalFKDef(a, b))
+}
+
 func TestEqualFKDef_parseError(t *testing.T) {
 	// When both fail to parse, falls back to string comparison
 	assert.True(t, equalFKDef("not sql", "not sql"))


### PR DESCRIPTION
pg_get_constraintdef() returns FK definitions without the schema name (e.g. REFERENCES users(id)) when the referenced table is in the public schema, while the SQL parser preserves the explicit schema prefix (e.g. REFERENCES public.users(id)). This caused equalFKDef to report a diff on every plan/apply even when no real change existed.

Normalize empty schema to "public" before comparing FK parse trees.