### PR TITLE
Print "No changes" when plan/apply detects no diff

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -17,31 +17,31 @@ type ApplyOptions struct {
 	WithTx     bool   `help:"Execute the pre-SQL and schema changes in a transaction."`
 }
 
-func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (bool, error) {
+func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) error {
 	conn, err := client.connect()
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer conn.Close(ctx) //nolint:errcheck
 
 	cat, err := catalog.NewCatalog(conn, client.Schemas)
 	if err != nil {
-		return false, fmt.Errorf("failed to create catalog: %w", err)
+		return fmt.Errorf("failed to create catalog: %w", err)
 	}
 
 	currentTables, err := cat.Tables(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to fetch tables: %w", err)
+		return fmt.Errorf("failed to fetch tables: %w", err)
 	}
 
 	currentViews, err := cat.Views(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to fetch views: %w", err)
+		return fmt.Errorf("failed to fetch views: %w", err)
 	}
 
 	desired, err := parser.ParseSQLFile(options.File)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse SQL file: %w", err)
+		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
 	stmts := diff.DiffTables(currentTables, desired.Tables)
@@ -51,13 +51,13 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if options.PreSQLFile != "" {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)
 		if err != nil {
-			return false, fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
+			return fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
 		}
 		preSQL = string(rawPreSQL)
 	}
 
 	if len(stmts) == 0 {
-		return false, nil
+		return nil
 	}
 
 	exec := conn.Exec
@@ -66,7 +66,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if options.WithTx {
 		tx, err := conn.Begin(ctx)
 		if err != nil {
-			return false, fmt.Errorf("failed to begin transaction: %w", err)
+			return fmt.Errorf("failed to begin transaction: %w", err)
 		}
 		defer tx.Rollback(ctx) //nolint:errcheck
 		exec = tx.Exec
@@ -75,20 +75,20 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 
 	if preSQL != "" {
 		if _, err := exec(ctx, preSQL); err != nil {
-			return false, fmt.Errorf("failed to execute pre-SQL: %w", err)
+			return fmt.Errorf("failed to execute pre-SQL: %w", err)
 		}
 	}
 
 	for _, stmt := range stmts {
 		fmt.Fprintln(w, stmt) //nolint:errcheck
 		if _, err := exec(ctx, stmt); err != nil {
-			return false, fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)
+			return fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)
 		}
 	}
 
 	if err := commit(ctx); err != nil {
-		return false, fmt.Errorf("failed to commit transaction: %w", err)
+		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	return true, nil
+	return nil
 }

--- a/apply.go
+++ b/apply.go
@@ -17,31 +17,31 @@ type ApplyOptions struct {
 	WithTx     bool   `help:"Execute the pre-SQL and schema changes in a transaction."`
 }
 
-func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) error {
+func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (bool, error) {
 	conn, err := client.connect()
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer conn.Close(ctx) //nolint:errcheck
 
 	cat, err := catalog.NewCatalog(conn, client.Schemas)
 	if err != nil {
-		return fmt.Errorf("failed to create catalog: %w", err)
+		return false, fmt.Errorf("failed to create catalog: %w", err)
 	}
 
 	currentTables, err := cat.Tables(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to fetch tables: %w", err)
+		return false, fmt.Errorf("failed to fetch tables: %w", err)
 	}
 
 	currentViews, err := cat.Views(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to fetch views: %w", err)
+		return false, fmt.Errorf("failed to fetch views: %w", err)
 	}
 
 	desired, err := parser.ParseSQLFile(options.File)
 	if err != nil {
-		return fmt.Errorf("failed to parse SQL file: %w", err)
+		return false, fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
 	stmts := diff.DiffTables(currentTables, desired.Tables)
@@ -51,13 +51,13 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if options.PreSQLFile != "" {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)
 		if err != nil {
-			return fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
+			return false, fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
 		}
 		preSQL = string(rawPreSQL)
 	}
 
 	if len(stmts) == 0 {
-		return nil
+		return false, nil
 	}
 
 	exec := conn.Exec
@@ -66,7 +66,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if options.WithTx {
 		tx, err := conn.Begin(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to begin transaction: %w", err)
+			return false, fmt.Errorf("failed to begin transaction: %w", err)
 		}
 		defer tx.Rollback(ctx) //nolint:errcheck
 		exec = tx.Exec
@@ -75,20 +75,20 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 
 	if preSQL != "" {
 		if _, err := exec(ctx, preSQL); err != nil {
-			return fmt.Errorf("failed to execute pre-SQL: %w", err)
+			return false, fmt.Errorf("failed to execute pre-SQL: %w", err)
 		}
 	}
 
 	for _, stmt := range stmts {
 		fmt.Fprintln(w, stmt) //nolint:errcheck
 		if _, err := exec(ctx, stmt); err != nil {
-			return fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)
+			return false, fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)
 		}
 	}
 
 	if err := commit(ctx); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
+		return false, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	return nil
+	return true, nil
 }

--- a/apply_test.go
+++ b/apply_test.go
@@ -42,7 +42,8 @@ func TestApply(t *testing.T) {
 				ConnString: conn.Config().ConnString(),
 				Schemas:    []string{"public"},
 			})
-			require.NoError(t, client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard))
+			_, err = client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+			require.NoError(t, err)
 
 			// Verify
 			got, err := client.Dump(ctx, &pistachio.DumpOptions{})
@@ -77,10 +78,11 @@ func TestApply_WithPreSQLFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	require.NoError(t, client.Apply(ctx, &pistachio.ApplyOptions{
+	_, applyErr := client.Apply(ctx, &pistachio.ApplyOptions{
 		File:       desiredFile,
 		PreSQLFile: preSQLFile,
-	}, io.Discard))
+	}, io.Discard)
+	require.NoError(t, applyErr)
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
 	require.NoError(t, err)
@@ -113,7 +115,7 @@ SELECT * FROM public.missing_table;`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		File:       desiredFile,
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
@@ -148,7 +150,7 @@ func TestApply_WithTx_Success(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		File:       desiredFile,
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
@@ -179,7 +181,7 @@ func TestApply_NoDiff(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 	require.NoError(t, err)
 }
 
@@ -206,7 +208,7 @@ func TestApply_ExecError(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -223,7 +225,7 @@ func TestApply_EmptySchemas(t *testing.T) {
 		Schemas:    []string{},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -237,7 +239,7 @@ func TestApply_InvalidConnString(t *testing.T) {
 	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -253,7 +255,7 @@ func TestApply_InvalidDesiredFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: "/nonexistent/file.sql"}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: "/nonexistent/file.sql"}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -275,7 +277,7 @@ func TestApply_InvalidPreSQLFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		File:       desiredFile,
 		PreSQLFile: "/nonexistent/pre.sql",
 	}, io.Discard)

--- a/apply_test.go
+++ b/apply_test.go
@@ -42,7 +42,7 @@ func TestApply(t *testing.T) {
 				ConnString: conn.Config().ConnString(),
 				Schemas:    []string{"public"},
 			})
-			_, err = client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+			err = client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 			require.NoError(t, err)
 
 			// Verify
@@ -78,7 +78,7 @@ func TestApply_WithPreSQLFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	_, applyErr := client.Apply(ctx, &pistachio.ApplyOptions{
+	applyErr := client.Apply(ctx, &pistachio.ApplyOptions{
 		File:       desiredFile,
 		PreSQLFile: preSQLFile,
 	}, io.Discard)
@@ -115,7 +115,7 @@ SELECT * FROM public.missing_table;`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+	err := client.Apply(ctx, &pistachio.ApplyOptions{
 		File:       desiredFile,
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
@@ -150,7 +150,7 @@ func TestApply_WithTx_Success(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+	err := client.Apply(ctx, &pistachio.ApplyOptions{
 		File:       desiredFile,
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
@@ -181,7 +181,7 @@ func TestApply_NoDiff(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 	require.NoError(t, err)
 }
 
@@ -208,7 +208,7 @@ func TestApply_ExecError(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -225,7 +225,7 @@ func TestApply_EmptySchemas(t *testing.T) {
 		Schemas:    []string{},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -239,7 +239,7 @@ func TestApply_InvalidConnString(t *testing.T) {
 	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -255,7 +255,7 @@ func TestApply_InvalidDesiredFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{File: "/nonexistent/file.sql"}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{File: "/nonexistent/file.sql"}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -277,7 +277,7 @@ func TestApply_InvalidPreSQLFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+	err := client.Apply(ctx, &pistachio.ApplyOptions{
 		File:       desiredFile,
 		PreSQLFile: "/nonexistent/pre.sql",
 	}, io.Discard)

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/winebarrel/pistachio"
@@ -12,5 +13,14 @@ type Apply struct {
 }
 
 func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer) error {
-	return client.Apply(ctx, &cmd.ApplyOptions, w)
+	applied, err := client.Apply(ctx, &cmd.ApplyOptions, w)
+	if err != nil {
+		return err
+	}
+
+	if !applied {
+		fmt.Fprintln(w, "No changes") //nolint:errcheck
+	}
+
+	return nil
 }

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -13,13 +14,16 @@ type Apply struct {
 }
 
 func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer) error {
-	applied, err := client.Apply(ctx, &cmd.ApplyOptions, w)
+	var buf bytes.Buffer
+	err := client.Apply(ctx, &cmd.ApplyOptions, &buf)
 	if err != nil {
 		return err
 	}
 
-	if !applied {
+	if buf.Len() == 0 {
 		fmt.Fprintln(w, "No changes") //nolint:errcheck
+	} else {
+		w.Write(buf.Bytes()) //nolint:errcheck
 	}
 
 	return nil

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -142,6 +142,22 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	assert.Equal(t, "No changes\n", buf.String())
 }
 
+func TestApply_Run_Error(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "invalid://connection",
+		Schemas:    []string{"public"},
+	})
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{File: desiredFile}}
+	err := cmd.Run(ctx, client, &buf)
+	require.Error(t, err)
+}
+
 func TestApply_Run(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -90,6 +90,58 @@ func TestDump_Run_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPlan_Run_NoChanges(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{File: desiredFile}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "No changes\n", buf.String())
+}
+
+func TestApply_Run_NoChanges(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{File: desiredFile}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "No changes\n", buf.String())
+}
+
 func TestApply_Run(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -18,7 +18,11 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return err
 	}
 
-	fmt.Fprintln(w, plan) //nolint:errcheck
+	if plan == "" {
+		fmt.Fprintln(w, "No changes") //nolint:errcheck
+	} else {
+		fmt.Fprintln(w, plan) //nolint:errcheck
+	}
 
 	return nil
 }


### PR DESCRIPTION
Previously, plan printed an empty line and apply printed nothing when there were no schema changes. Now both commands print "No changes" for clearer feedback.