### PR TITLE
Fix go.mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/winebarrel/pistachio
 
-go 1.26.1
+go 1.26
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
This pull request makes a minor update to the Go module configuration, downgrading the Go version requirement from 1.26.1 to 1.26 in the `go.mod` file.