### PR TITLE
Fix bin-name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Run GoReleaser
         run: |
-          docker run \
+          docker run -q \
             --rm \
             -e CGO_ENABLED=1 \
             -e GITHUB_TOKEN \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ builds:
   - &build
     id: darwin-amd64
     main: ./cmd/pist
+    binary: pist
     env:
       - CGO_ENABLED=1
       - CC=o64-clang
@@ -51,7 +52,7 @@ homebrew_casks:
       post:
         install: |
           if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/pistachio"]
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/pist"]
           end
 nfpms:
   - file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}"


### PR DESCRIPTION
This pull request makes minor adjustments to the `.goreleaser.yml` configuration to ensure consistency in the naming of the output binary and its installation path for macOS builds.

- Build configuration updates:
  * Sets the `binary` name to `pist` in the `darwin-amd64` build configuration to match the intended output binary name.

- Homebrew cask installation fix:
  * Updates the Homebrew cask post-install script to reference the correct binary name (`pist` instead of `pistachio`) when clearing the quarantine attribute.