### PR TITLE
Fix Homebrew cask binary name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,7 @@ homebrew_casks:
     homepage: https://github.com/winebarrel/pistachio
     description: pistachio is a declarative schema management tool for PostgreSQL.
     license: MIT
+    binary: pist
     hooks:
       post:
         install: |


### PR DESCRIPTION
Add explicit binary field to homebrew_casks config to use "pist" instead of defaulting to the project name "pistachio".