### PR TITLE
Fix homebrew_casks: binary -> binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ homebrew_casks:
     homepage: https://github.com/winebarrel/pistachio
     description: pistachio is a declarative schema management tool for PostgreSQL.
     license: MIT
-    binary: pist
+    binaries: [pist]
     hooks:
       post:
         install: |


### PR DESCRIPTION
This pull request includes a small update to the Homebrew cask configuration in `.goreleaser.yml`. The change standardizes the key from `binary` to `binaries` and updates its value to a list, which aligns with Homebrew's expected format.