### PR TITLE
Add --split option to dump command for per-table/view file output

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -12,9 +12,9 @@ import (
 )
 
 type ApplyOptions struct {
-	File       string `arg:"" help:"Path to the desired schema SQL file."`
-	PreSQLFile string `type:"path" help:"Path to a SQL file to execute before applying changes."`
-	WithTx     bool   `help:"Execute the pre-SQL and schema changes in a transaction."`
+	Files      []string `arg:"" help:"Path to the desired schema SQL file(s)."`
+	PreSQLFile string   `type:"path" help:"Path to a SQL file to execute before applying changes."`
+	WithTx     bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
 }
 
 func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) error {
@@ -39,7 +39,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to fetch views: %w", err)
 	}
 
-	desired, err := parser.ParseSQLFile(options.File)
+	desired, err := parser.ParseSQLFiles(options.Files)
 	if err != nil {
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}

--- a/apply_test.go
+++ b/apply_test.go
@@ -48,7 +48,7 @@ func TestApply(t *testing.T) {
 			// Verify
 			got, err := client.Dump(ctx, &pistachio.DumpOptions{})
 			require.NoError(t, err)
-			assert.Equal(t, strings.TrimSpace(tc.Applied), strings.TrimSpace(got))
+			assert.Equal(t, strings.TrimSpace(tc.Applied), strings.TrimSpace(got.String()))
 		})
 	}
 }
@@ -86,8 +86,8 @@ func TestApply_WithPreSQLFile(t *testing.T) {
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
 	require.NoError(t, err)
-	assert.Contains(t, got, "CREATE TABLE public.pre_hook")
-	assert.Contains(t, got, "CREATE TABLE public.users")
+	assert.Contains(t, got.String(), "CREATE TABLE public.pre_hook")
+	assert.Contains(t, got.String(), "CREATE TABLE public.users")
 }
 
 func TestApply_WithTx(t *testing.T) {
@@ -124,8 +124,8 @@ SELECT * FROM public.missing_table;`), 0o644))
 
 	got, dumpErr := client.Dump(ctx, &pistachio.DumpOptions{})
 	require.NoError(t, dumpErr)
-	assert.NotContains(t, got, "CREATE TABLE public.pre_hook")
-	assert.NotContains(t, got, "CREATE TABLE public.users")
+	assert.NotContains(t, got.String(), "CREATE TABLE public.pre_hook")
+	assert.NotContains(t, got.String(), "CREATE TABLE public.users")
 }
 
 func TestApply_WithTx_Success(t *testing.T) {
@@ -159,7 +159,7 @@ func TestApply_WithTx_Success(t *testing.T) {
 
 	got, dumpErr := client.Dump(ctx, &pistachio.DumpOptions{})
 	require.NoError(t, dumpErr)
-	assert.Contains(t, got, "CREATE TABLE public.users")
+	assert.Contains(t, got.String(), "CREATE TABLE public.users")
 }
 
 func TestApply_NoDiff(t *testing.T) {

--- a/apply_test.go
+++ b/apply_test.go
@@ -42,7 +42,7 @@ func TestApply(t *testing.T) {
 				ConnString: conn.Config().ConnString(),
 				Schemas:    []string{"public"},
 			})
-			err = client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+			err = client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 			require.NoError(t, err)
 
 			// Verify
@@ -79,7 +79,7 @@ func TestApply_WithPreSQLFile(t *testing.T) {
 	})
 
 	applyErr := client.Apply(ctx, &pistachio.ApplyOptions{
-		File:       desiredFile,
+		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 	}, io.Discard)
 	require.NoError(t, applyErr)
@@ -116,7 +116,7 @@ SELECT * FROM public.missing_table;`), 0o644))
 	})
 
 	err := client.Apply(ctx, &pistachio.ApplyOptions{
-		File:       desiredFile,
+		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
 	}, io.Discard)
@@ -151,7 +151,7 @@ func TestApply_WithTx_Success(t *testing.T) {
 	})
 
 	err := client.Apply(ctx, &pistachio.ApplyOptions{
-		File:       desiredFile,
+		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
 	}, io.Discard)
@@ -181,7 +181,7 @@ func TestApply_NoDiff(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 }
 
@@ -208,7 +208,7 @@ func TestApply_ExecError(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -225,7 +225,7 @@ func TestApply_EmptySchemas(t *testing.T) {
 		Schemas:    []string{},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -239,7 +239,7 @@ func TestApply_InvalidConnString(t *testing.T) {
 	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: desiredFile}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -255,7 +255,7 @@ func TestApply_InvalidDesiredFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{File: "/nonexistent/file.sql"}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{"/nonexistent/file.sql"}}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -278,7 +278,7 @@ func TestApply_InvalidPreSQLFile(t *testing.T) {
 	})
 
 	err := client.Apply(ctx, &pistachio.ApplyOptions{
-		File:       desiredFile,
+		Files:      []string{desiredFile},
 		PreSQLFile: "/nonexistent/pre.sql",
 	}, io.Discard)
 	require.Error(t, err)

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -61,6 +61,126 @@ func TestDump_Run(t *testing.T) {
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
 }
 
+func TestDump_Run_Split(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	splitDir := filepath.Join(t.TempDir(), "split_output")
+	var buf bytes.Buffer
+	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+
+	usersData, err := os.ReadFile(filepath.Join(splitDir, "public.users.sql"))
+	require.NoError(t, err)
+	assert.Contains(t, string(usersData), "CREATE TABLE public.users")
+
+	postsData, err := os.ReadFile(filepath.Join(splitDir, "public.posts.sql"))
+	require.NoError(t, err)
+	assert.Contains(t, string(postsData), "CREATE TABLE public.posts")
+
+	assert.Contains(t, buf.String(), "public.users.sql")
+	assert.Contains(t, buf.String(), "public.posts.sql")
+}
+
+func TestDump_Run_Split_WithView(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	splitDir := filepath.Join(t.TempDir(), "split_output")
+	var buf bytes.Buffer
+	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+
+	usersData, err := os.ReadFile(filepath.Join(splitDir, "public.users.sql"))
+	require.NoError(t, err)
+	assert.Contains(t, string(usersData), "CREATE TABLE public.users")
+
+	viewData, err := os.ReadFile(filepath.Join(splitDir, "public.active_users.sql"))
+	require.NoError(t, err)
+	assert.Contains(t, string(viewData), "CREATE OR REPLACE VIEW")
+}
+
+func TestDump_Run_Split_Empty(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	splitDir := filepath.Join(t.TempDir(), "split_output")
+	var buf bytes.Buffer
+	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(splitDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	assert.Empty(t, buf.String())
+}
+
+func TestDump_Run_Split_SpecialCharacters(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public."My Table" (
+    id integer NOT NULL
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	splitDir := filepath.Join(t.TempDir(), "split_output")
+	var buf bytes.Buffer
+	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(splitDir, "public.My_Table.sql"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `CREATE TABLE public."My Table"`)
+}
+
 func TestPlan_Run_Error(t *testing.T) {
 	ctx := context.Background()
 	client := pistachio.NewClient(&pistachio.Options{

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -33,7 +33,7 @@ func TestPlan_Run(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{File: desiredFile}}
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
@@ -181,6 +181,55 @@ CREATE TABLE public."My Table" (
 	assert.Contains(t, string(data), `CREATE TABLE public."My Table"`)
 }
 
+func TestDump_Run_Split_MkdirError(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: "/dev/null/invalid"}}
+	err := cmd.Run(ctx, client, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create directory")
+}
+
+func TestDump_Run_Split_WriteError(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	splitDir := filepath.Join(t.TempDir(), "split_output")
+	require.NoError(t, os.MkdirAll(splitDir, 0o555))
+
+	var buf bytes.Buffer
+	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	err := cmd.Run(ctx, client, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write")
+}
+
 func TestPlan_Run_Error(t *testing.T) {
 	ctx := context.Background()
 	client := pistachio.NewClient(&pistachio.Options{
@@ -192,7 +241,7 @@ func TestPlan_Run_Error(t *testing.T) {
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{File: desiredFile}}
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 }
@@ -230,7 +279,7 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{File: desiredFile}}
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "No changes\n", buf.String())
@@ -256,7 +305,7 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{File: desiredFile}}
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "No changes\n", buf.String())
@@ -273,7 +322,7 @@ func TestApply_Run_Error(t *testing.T) {
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{File: desiredFile}}
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 }
@@ -297,7 +346,7 @@ func TestApply_Run(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{File: desiredFile}}
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")

--- a/cmd/command/dump.go
+++ b/cmd/command/dump.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/winebarrel/pistachio"
 )
@@ -13,12 +15,27 @@ type Dump struct {
 }
 
 func (cmd *Dump) Run(ctx context.Context, client *pistachio.Client, w io.Writer) error {
-	dump, err := client.Dump(ctx, &cmd.DumpOptions)
+	result, err := client.Dump(ctx, &cmd.DumpOptions)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(w, dump) //nolint:errcheck
+	if cmd.Split == "" {
+		fmt.Fprintln(w, result) //nolint:errcheck
+		return nil
+	}
+
+	if err := os.MkdirAll(cmd.Split, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	for name, content := range result.Files() {
+		path := filepath.Join(cmd.Split, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", path, err)
+		}
+		fmt.Fprintln(w, path) //nolint:errcheck
+	}
 
 	return nil
 }

--- a/dump.go
+++ b/dump.go
@@ -5,41 +5,72 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/catalog"
 	"github.com/winebarrel/pistachio/model"
 )
 
-type DumpOptions struct{}
+type DumpOptions struct {
+	Split string `help:"Output each table/view as a separate file in the specified directory."`
+}
 
-func (client *Client) Dump(ctx context.Context, options *DumpOptions) (string, error) {
+type DumpResult struct {
+	Tables *orderedmap.Map[string, *model.Table]
+	Views  *orderedmap.Map[string, *model.View]
+}
+
+func (r *DumpResult) String() string {
+	var parts []string
+	if r.Tables.Len() > 0 {
+		parts = append(parts, model.TablesToSQL(r.Tables))
+	}
+	if r.Views.Len() > 0 {
+		parts = append(parts, model.ViewsToSQL(r.Views))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func (r *DumpResult) Files() map[string]string {
+	files := make(map[string]string)
+	for _, t := range r.Tables.CollectValues() {
+		files[toFileName(t.Schema, t.Name)] = model.TableToSQL(t) + "\n"
+	}
+	for _, v := range r.Views.CollectValues() {
+		files[toFileName(v.Schema, v.Name)] = model.ViewToSQL(v) + "\n"
+	}
+	return files
+}
+
+var fileNameReplacer = strings.NewReplacer(`"`, "", " ", "_")
+
+func toFileName(schema, name string) string {
+	return fileNameReplacer.Replace(schema+"."+name) + ".sql"
+}
+
+func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResult, error) {
 	conn, err := client.connect()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer conn.Close(ctx) //nolint:errcheck
 
 	catalog, err := catalog.NewCatalog(conn, client.Schemas)
 	if err != nil {
-		return "", fmt.Errorf("failed to create catalog: %w", err)
+		return nil, fmt.Errorf("failed to create catalog: %w", err)
 	}
 
 	tables, err := catalog.Tables(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch tables: %w", err)
+		return nil, fmt.Errorf("failed to fetch tables: %w", err)
 	}
 
 	views, err := catalog.Views(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch views: %w", err)
+		return nil, fmt.Errorf("failed to fetch views: %w", err)
 	}
 
-	var parts []string
-	if tables.Len() > 0 {
-		parts = append(parts, model.TablesToSQL(tables))
-	}
-	if views.Len() > 0 {
-		parts = append(parts, model.ViewsToSQL(views))
-	}
-
-	return strings.Join(parts, "\n\n"), nil
+	return &DumpResult{
+		Tables: tables,
+		Views:  views,
+	}, nil
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -54,6 +54,26 @@ func TestDump_EmptySchemas(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDump_CanceledContext(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	_, err := client.Dump(canceledCtx, &pistachio.DumpOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch tables")
+}
+
 func TestDumpResult_String_Empty(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/dump_test.go
+++ b/dump_test.go
@@ -54,6 +54,118 @@ func TestDump_EmptySchemas(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDumpResult_String_Empty(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "", got.String())
+}
+
+func TestDumpResult_Files_Tables(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Len(t, files, 2)
+	assert.Contains(t, files, "public.users.sql")
+	assert.Contains(t, files, "public.posts.sql")
+	assert.Contains(t, files["public.users.sql"], "CREATE TABLE public.users")
+	assert.Contains(t, files["public.posts.sql"], "CREATE TABLE public.posts")
+}
+
+func TestDumpResult_Files_Views(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Len(t, files, 2)
+	assert.Contains(t, files, "public.users.sql")
+	assert.Contains(t, files, "public.active_users.sql")
+	assert.Contains(t, files["public.active_users.sql"], "CREATE OR REPLACE VIEW")
+}
+
+func TestDumpResult_Files_Empty(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Empty(t, files)
+}
+
+func TestDumpResult_Files_SpecialCharacters(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public."My Table" (
+    id integer NOT NULL
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Contains(t, files, "public.My_Table.sql")
+}
+
 func TestDump(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
@@ -74,7 +186,7 @@ func TestDump(t *testing.T) {
 			})
 			got, err := client.Dump(ctx, &pistachio.DumpOptions{})
 			require.NoError(t, err)
-			assert.Equal(t, strings.TrimSpace(tc.Dump), strings.TrimSpace(got))
+			assert.Equal(t, strings.TrimSpace(tc.Dump), strings.TrimSpace(got.String()))
 		})
 	}
 }

--- a/model/table.go
+++ b/model/table.go
@@ -126,20 +126,24 @@ func (t Table) CommentSQL() string {
 	return strings.Join(stmts, "\n")
 }
 
+func TableToSQL(t *Table) string {
+	parts := []string{"-- " + t.FQTN(), t.SQL()}
+	if s := t.IdxSQL(); s != "" {
+		parts = append(parts, s)
+	}
+	if s := t.FkSQL(); s != "" {
+		parts = append(parts, "\n"+s)
+	}
+	if s := t.CommentSQL(); s != "" {
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, "\n")
+}
+
 func TablesToSQL(tables *orderedmap.Map[string, *Table]) string {
 	return strings.Join(
 		orderedmap.TransformSlice(tables, func(_ string, t *Table) string {
-			parts := []string{"-- " + t.FQTN(), t.SQL()}
-			if s := t.IdxSQL(); s != "" {
-				parts = append(parts, s)
-			}
-			if s := t.FkSQL(); s != "" {
-				parts = append(parts, "\n"+s)
-			}
-			if s := t.CommentSQL(); s != "" {
-				parts = append(parts, s)
-			}
-			return strings.Join(parts, "\n")
+			return TableToSQL(t)
 		}),
 		"\n\n",
 	)

--- a/model/view.go
+++ b/model/view.go
@@ -31,14 +31,18 @@ func (v View) CommentSQL() string {
 	return ""
 }
 
+func ViewToSQL(v *View) string {
+	parts := []string{"-- " + v.FQVN(), v.SQL()}
+	if s := v.CommentSQL(); s != "" {
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, "\n")
+}
+
 func ViewsToSQL(views *orderedmap.Map[string, *View]) string {
 	return strings.Join(
 		orderedmap.TransformSlice(views, func(_ string, v *View) string {
-			parts := []string{"-- " + v.FQVN(), v.SQL()}
-			if s := v.CommentSQL(); s != "" {
-				parts = append(parts, s)
-			}
-			return strings.Join(parts, "\n")
+			return ViewToSQL(v)
 		}),
 		"\n\n",
 	)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -33,6 +33,19 @@ func ParseSQLFile(path string) (*ParseResult, error) {
 	return ParseSQL(sql)
 }
 
+func ParseSQLFiles(paths []string) (*ParseResult, error) {
+	var sqls []string
+	for _, path := range paths {
+		sql, err := ReadSQLFile(path)
+		if err != nil {
+			return nil, err
+		}
+		sqls = append(sqls, sql)
+	}
+
+	return ParseSQL(strings.Join(sqls, "\n"))
+}
+
 func ParseSQL(sql string) (*ParseResult, error) {
 	result, err := pg_query.Parse(sql)
 	if err != nil {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -57,6 +57,38 @@ func TestParseSQLFile(t *testing.T) {
 	assert.Equal(t, "public", tbl.Schema)
 }
 
+func TestParseSQLFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := filepath.Join(tmpDir, "tables.sql")
+	file2 := filepath.Join(tmpDir, "views.sql")
+
+	require.NoError(t, os.WriteFile(file1, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+	require.NoError(t, os.WriteFile(file2, []byte(`CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	result, err := parser.ParseSQLFiles([]string{file1, file2})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Tables.Len())
+
+	_, ok := result.Tables.GetOk("public.users")
+	assert.True(t, ok)
+	_, ok = result.Tables.GetOk("public.posts")
+	assert.True(t, ok)
+}
+
+func TestParseSQLFiles_FileNotFound(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "exists.sql")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	_, err := parser.ParseSQLFiles([]string{tmpFile, "/nonexistent/file.sql"})
+	require.Error(t, err)
+}
+
 func TestReadSQLFile(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "test.sql")
 	sql := "SELECT 1;"

--- a/plan.go
+++ b/plan.go
@@ -11,7 +11,7 @@ import (
 )
 
 type PlanOptions struct {
-	File string `arg:"" help:"Path to the desired schema SQL file."`
+	Files []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 }
 
 func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, error) {
@@ -36,7 +36,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to fetch views: %w", err)
 	}
 
-	desired, err := parser.ParseSQLFile(options.File)
+	desired, err := parser.ParseSQLFiles(options.Files)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -29,7 +29,7 @@ func TestPlan_InvalidConnString(t *testing.T) {
 	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
-	_, err := client.Plan(ctx, &pistachio.PlanOptions{File: desiredFile})
+	_, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 	require.Error(t, err)
 }
 
@@ -52,7 +52,7 @@ func TestPlan_WithPassword(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{File: desiredFile})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Contains(t, got, "CREATE TABLE public.users")
 }
@@ -67,7 +67,7 @@ func TestPlan_InvalidDesiredFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	_, err := client.Plan(ctx, &pistachio.PlanOptions{File: "/nonexistent/file.sql"})
+	_, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{"/nonexistent/file.sql"}})
 	require.Error(t, err)
 }
 
@@ -84,7 +84,7 @@ func TestPlan_EmptySchemas(t *testing.T) {
 		Schemas:    []string{},
 	})
 
-	_, err := client.Plan(ctx, &pistachio.PlanOptions{File: desiredFile})
+	_, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 	require.Error(t, err)
 }
 
@@ -111,7 +111,7 @@ func TestPlan(t *testing.T) {
 				Schemas:    []string{"public"},
 			})
 
-			got, err := client.Plan(ctx, &pistachio.PlanOptions{File: desiredFile})
+			got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.Plan), strings.TrimSpace(got))
 		})


### PR DESCRIPTION
This pull request introduces support for splitting schema dumps into separate files for each table and view, and updates the handling of schema file inputs to accept multiple files. It also refactors the dump logic to return structured results and improves test coverage for the new features.

**Schema file handling and CLI changes:**

* Updated the `ApplyOptions` and `PlanOptions` structs to accept a slice of file paths (`Files []string`) instead of a single file, allowing users to specify multiple schema SQL files. All relevant usages, including tests, have been updated accordingly. [[1]](diffhunk://#diff-86ae12b12a6a3e85fd29fb29e6745818c470d89b611f10125ad5761a707e5a76L15-R15) [[2]](diffhunk://#diff-86ae12b12a6a3e85fd29fb29e6745818c470d89b611f10125ad5761a707e5a76L42-R42) [[3]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L45-R51) [[4]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L82-R90) [[5]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L119-R128) [[6]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L154-R162) [[7]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L184-R184) [[8]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L211-R211) [[9]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L228-R228) [[10]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L242-R242) [[11]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L258-R258) [[12]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L281-R281) [[13]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L36-R36) [[14]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L75-R244) [[15]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L113-R282) [[16]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L139-R308) [[17]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L156-R325) [[18]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L180-R349)

**Schema dump improvements:**

* Added a `Split` option to `DumpOptions` that, when set, outputs each table/view as a separate `.sql` file in the specified directory. The dump command now creates the directory if it doesn't exist and writes each object to its own file. [[1]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR8-R75) [[2]](diffhunk://#diff-f576aac4d4b99e2301c6080111d85f2f0a74acddd48ea3d158482527e6dd13c6R7-R8) [[3]](diffhunk://#diff-f576aac4d4b99e2301c6080111d85f2f0a74acddd48ea3d158482527e6dd13c6L16-R38)
* Refactored the dump logic to return a `DumpResult` struct, encapsulating tables and views, with methods to output the combined SQL as a string or as a map of individual files.

**Testing enhancements:**

* Added comprehensive tests for the new dump splitting functionality, including cases for tables, views, empty schemas, special characters in names, and error scenarios (e.g., directory creation and file write errors).

These changes improve flexibility for users working with multiple schema files and make schema dumps more manageable, especially for large databases or for version control workflows.