### PR TITLE
Add --omit-schema option to dump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ pist dump --split ./schema/
 # => ./schema/public.users.sql, ./schema/public.orders.sql, ...
 ```
 
+Use `--omit-schema` to omit schema names from the dump output.
+
+```bash
+pist dump --omit-schema
+# => CREATE TABLE users (...) instead of CREATE TABLE public.users (...)
+
+pist dump --omit-schema --split ./schema/
+# => ./schema/users.sql, ./schema/orders.sql, ...
+```
+
 ## Example
 
 Create a schema file:

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -190,7 +190,7 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) []strin
 	// Drop removed or changed indexes
 	for name, currentIdx := range current.All() {
 		desiredIdx, ok := desired.GetOk(name)
-		if !ok || currentIdx.Definition != desiredIdx.Definition {
+		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			stmts = append(stmts, "DROP INDEX "+model.Ident(currentIdx.Schema, name)+";")
 		}
 	}
@@ -198,7 +198,7 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) []strin
 	// Add new or changed indexes
 	for name, desiredIdx := range desired.All() {
 		currentIdx, ok := current.GetOk(name)
-		if !ok || currentIdx.Definition != desiredIdx.Definition {
+		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			stmts = append(stmts, desiredIdx.Definition+";")
 		}
 	}
@@ -269,6 +269,40 @@ func equalPtr[T comparable](a, b *T) bool {
 		return false
 	}
 	return *a == *b
+}
+
+// parseIndexDef parses an index definition string into a pg_query IndexStmt node.
+func parseIndexDef(def string) (*pg_query.IndexStmt, error) {
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return nil, err
+	}
+	is := result.Stmts[0].Stmt.GetIndexStmt()
+	if is == nil {
+		return nil, fmt.Errorf("unexpected parse result for index definition: %s", def)
+	}
+	return is, nil
+}
+
+// normalizeIndexSchema normalizes the table's schema name in an IndexStmt
+// so that an empty schema (implicit public) is treated the same as an explicit "public" schema.
+func normalizeIndexSchema(is *pg_query.IndexStmt) {
+	if is.Relation != nil && is.Relation.Schemaname == "" {
+		is.Relation.Schemaname = "public"
+	}
+}
+
+// equalIndexDef compares two index definitions by their parse trees,
+// so that schema qualification differences do not cause false diffs.
+func equalIndexDef(a, b string) bool {
+	nodeA, errA := parseIndexDef(a)
+	nodeB, errB := parseIndexDef(b)
+	if errA != nil || errB != nil {
+		return a == b
+	}
+	normalizeIndexSchema(nodeA)
+	normalizeIndexSchema(nodeB)
+	return proto.Equal(nodeA, nodeB)
 }
 
 // parseFKDef parses a FK constraint definition string into a pg_query Constraint node.

--- a/dump.go
+++ b/dump.go
@@ -28,6 +28,8 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 	tables := orderedmap.New[string, *model.Table]()
 	for _, t := range r.Tables.CollectValues() {
 		copied := *t
+		fqtn := t.FQTN()
+		tableName := model.Ident(t.Name)
 		copied.Schema = ""
 		if copied.ForeignKeys.Len() > 0 {
 			fks := orderedmap.New[string, *model.ForeignKey]()
@@ -38,7 +40,17 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 			}
 			copied.ForeignKeys = fks
 		}
-		tables.Set(t.FQTN(), &copied)
+		if copied.Indexes.Len() > 0 {
+			idxs := orderedmap.New[string, *model.Index]()
+			for _, idx := range copied.Indexes.CollectValues() {
+				idxCopied := *idx
+				idxCopied.Schema = ""
+				idxCopied.Definition = strings.ReplaceAll(idx.Definition, " ON "+fqtn+" ", " ON "+tableName+" ")
+				idxs.Set(idx.Name, &idxCopied)
+			}
+			copied.Indexes = idxs
+		}
+		tables.Set(fqtn, &copied)
 	}
 	return tables
 }

--- a/dump.go
+++ b/dump.go
@@ -11,40 +11,86 @@ import (
 )
 
 type DumpOptions struct {
-	Split string `help:"Output each table/view as a separate file in the specified directory."`
+	Split      string `help:"Output each table/view as a separate file in the specified directory."`
+	OmitSchema bool   `help:"Omit schema name from the dump output."`
 }
 
 type DumpResult struct {
-	Tables *orderedmap.Map[string, *model.Table]
-	Views  *orderedmap.Map[string, *model.View]
+	Tables     *orderedmap.Map[string, *model.Table]
+	Views      *orderedmap.Map[string, *model.View]
+	OmitSchema bool
+}
+
+func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
+	if !r.OmitSchema {
+		return r.Tables
+	}
+	tables := orderedmap.New[string, *model.Table]()
+	for _, t := range r.Tables.CollectValues() {
+		copied := *t
+		copied.Schema = ""
+		if copied.ForeignKeys.Len() > 0 {
+			fks := orderedmap.New[string, *model.ForeignKey]()
+			for _, fk := range copied.ForeignKeys.CollectValues() {
+				fkCopied := *fk
+				fkCopied.Schema = ""
+				fks.Set(fk.Name, &fkCopied)
+			}
+			copied.ForeignKeys = fks
+		}
+		tables.Set(t.FQTN(), &copied)
+	}
+	return tables
+}
+
+func (r *DumpResult) views() *orderedmap.Map[string, *model.View] {
+	if !r.OmitSchema {
+		return r.Views
+	}
+	views := orderedmap.New[string, *model.View]()
+	for _, v := range r.Views.CollectValues() {
+		copied := *v
+		copied.Schema = ""
+		views.Set(v.FQVN(), &copied)
+	}
+	return views
 }
 
 func (r *DumpResult) String() string {
 	var parts []string
-	if r.Tables.Len() > 0 {
-		parts = append(parts, model.TablesToSQL(r.Tables))
+	tables := r.tables()
+	views := r.views()
+	if tables.Len() > 0 {
+		parts = append(parts, model.TablesToSQL(tables))
 	}
-	if r.Views.Len() > 0 {
-		parts = append(parts, model.ViewsToSQL(r.Views))
+	if views.Len() > 0 {
+		parts = append(parts, model.ViewsToSQL(views))
 	}
 	return strings.Join(parts, "\n\n")
 }
 
 func (r *DumpResult) Files() map[string]string {
 	files := make(map[string]string)
-	for _, t := range r.Tables.CollectValues() {
+	for _, t := range r.tables().CollectValues() {
 		files[toFileName(t.Schema, t.Name)] = model.TableToSQL(t) + "\n"
 	}
-	for _, v := range r.Views.CollectValues() {
+	for _, v := range r.views().CollectValues() {
 		files[toFileName(v.Schema, v.Name)] = model.ViewToSQL(v) + "\n"
 	}
 	return files
 }
 
-var fileNameReplacer = strings.NewReplacer(`"`, "", " ", "_")
+var fileNameReplacer = strings.NewReplacer(
+	`"`, "",
+	" ", "_",
+)
 
 func toFileName(schema, name string) string {
-	return fileNameReplacer.Replace(schema+"."+name) + ".sql"
+	base := name
+	if schema != "" {
+		base = schema + "." + name
+	}
+	return fileNameReplacer.Replace(base) + ".sql"
 }
 
 func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResult, error) {
@@ -70,7 +116,8 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 	}
 
 	return &DumpResult{
-		Tables: tables,
-		Views:  views,
+		Tables:     tables,
+		Views:      views,
+		OmitSchema: options.OmitSchema,
 	}, nil
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -186,6 +186,109 @@ CREATE TABLE public."My Table" (
 	assert.Contains(t, files, "public.My_Table.sql")
 }
 
+func TestDumpResult_OmitSchema_String(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "CREATE TABLE users")
+	assert.NotContains(t, s, "public.users")
+	assert.Contains(t, s, "CREATE OR REPLACE VIEW active_users")
+	assert.NotContains(t, s, "public.active_users")
+}
+
+func TestDumpResult_OmitSchema_Files(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Contains(t, files, "users.sql")
+	assert.NotContains(t, files, "public.users.sql")
+	assert.Contains(t, files["users.sql"], "CREATE TABLE users")
+}
+
+func TestDumpResult_OmitSchema_ForeignKey(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "ALTER TABLE ONLY orders")
+	assert.NotContains(t, s, "public.orders")
+}
+
+func TestDumpResult_OmitSchema_Comment(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+COMMENT ON TABLE public.users IS 'User accounts';`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "COMMENT ON TABLE users")
+	assert.NotContains(t, s, "public.users")
+}
+
 func TestDump(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/dump_test.go
+++ b/dump_test.go
@@ -289,6 +289,30 @@ COMMENT ON TABLE public.users IS 'User accounts';`)
 	assert.NotContains(t, s, "public.users")
 }
 
+func TestDumpResult_OmitSchema_Index(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_id ON public.users (id);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "CREATE INDEX idx_users_id ON users")
+	assert.NotContains(t, s, "ON public.users")
+}
+
 func TestDump(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/model/util.go
+++ b/model/util.go
@@ -10,10 +10,13 @@ import (
 var safeIdentifierPattern = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
 
 func Ident(names ...string) string {
-	idents := make([]string, len(names))
+	var idents []string
 
-	for i, n := range names {
-		idents[i] = quoteIdent(n)
+	for _, n := range names {
+		if n == "" {
+			continue
+		}
+		idents = append(idents, quoteIdent(n))
 	}
 
 	return strings.Join(idents, ".")

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -23,7 +23,7 @@ func TestIdent_uppercase(t *testing.T) {
 }
 
 func TestIdent_empty(t *testing.T) {
-	assert.Equal(t, `""`, Ident(""))
+	assert.Equal(t, "", Ident(""))
 }
 
 func TestIdent_withSpecialChars(t *testing.T) {


### PR DESCRIPTION
Allow omitting schema names from dump output SQL and split filenames.