### PR TITLE
Add --schema-map option to remap schema names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Flags:
                               ($DATABASE_URL)
       --password=STRING       PostgreSQL password ($PGPASSWORD).
   -n, --schemas=public,...    Schemas to inspect and modify ($PGSCHEMAS).
+  -m, --schema-map=KEY=VALUE;...
+                              Schema name mapping (e.g. -m old=new).
       --version
 
 Commands:
@@ -82,6 +84,26 @@ Dump the current database schema as SQL. Output can be used directly as a schema
 ```bash
 pist dump
 ```
+
+### Schema name mapping
+
+Use `-m` / `--schema-map` to remap schema names. This is useful when you want to manage a database whose schema name differs from the one used in your SQL files.
+
+For example, to dump a `staging` schema as if it were `public`:
+
+```bash
+pist -n staging -m staging=public dump
+```
+
+You can also use it with `plan` and `apply`. The desired SQL files use the mapped name (`public`), while the generated SQL targets the real database schema (`staging`):
+
+```bash
+# schema.sql uses "public" as the schema name
+pist -n staging -m staging=public plan schema.sql
+pist -n staging -m staging=public apply schema.sql
+```
+
+### Split dump
 
 Use `--split` to output each table/view as a separate file in the specified directory.
 

--- a/apply.go
+++ b/apply.go
@@ -44,8 +44,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	stmts := diff.DiffTables(currentTables, desired.Tables)
-	stmts = append(stmts, diff.DiffViews(currentViews, desired.Views)...)
+	stmts := diff.DiffTables(currentTables, client.reverseRemapTableSchemas(desired.Tables))
+	stmts = append(stmts, diff.DiffViews(currentViews, client.reverseRemapViewSchemas(desired.Views))...)
 
 	var preSQL string
 	if options.PreSQLFile != "" {

--- a/dump.go
+++ b/dump.go
@@ -70,7 +70,7 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 	}
 
 	return &DumpResult{
-		Tables: tables,
-		Views:  views,
+		Tables: client.remapTableSchemas(tables),
+		Views:  client.remapViewSchemas(views),
 	}, nil
 }

--- a/options.go
+++ b/options.go
@@ -1,10 +1,30 @@
 package pistachio
 
+import "fmt"
+
 type Options struct {
 	ConnString string            `short:"c" env:"DATABASE_URL" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
 	Password   string            `env:"PGPASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PGSCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
+}
+
+func (o *Options) AfterApply() error {
+	return o.ValidateSchemaMap()
+}
+
+func (o *Options) ValidateSchemaMap() error {
+	if len(o.SchemaMap) <= 1 {
+		return nil
+	}
+	seen := make(map[string]string, len(o.SchemaMap))
+	for from, to := range o.SchemaMap {
+		if prev, ok := seen[to]; ok {
+			return fmt.Errorf("duplicate schema-map destination %q: both %q and %q map to it", to, prev, from)
+		}
+		seen[to] = from
+	}
+	return nil
 }
 
 func (o *Options) RemapSchema(schema string) string {

--- a/options.go
+++ b/options.go
@@ -1,7 +1,30 @@
 package pistachio
 
 type Options struct {
-	ConnString string   `short:"c" env:"DATABASE_URL" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
-	Password   string   `env:"PGPASSWORD" help:"PostgreSQL password."`
-	Schemas    []string `short:"n" env:"PGSCHEMAS" default:"public" help:"Schemas to inspect and modify."`
+	ConnString string            `short:"c" env:"DATABASE_URL" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
+	Password   string            `env:"PGPASSWORD" help:"PostgreSQL password."`
+	Schemas    []string          `short:"n" env:"PGSCHEMAS" default:"public" help:"Schemas to inspect and modify."`
+	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
+}
+
+func (o *Options) RemapSchema(schema string) string {
+	if o.SchemaMap == nil {
+		return schema
+	}
+	if mapped, ok := o.SchemaMap[schema]; ok {
+		return mapped
+	}
+	return schema
+}
+
+func (o *Options) ReverseRemapSchema(schema string) string {
+	if o.SchemaMap == nil {
+		return schema
+	}
+	for k, v := range o.SchemaMap {
+		if v == schema {
+			return k
+		}
+	}
+	return schema
 }

--- a/plan.go
+++ b/plan.go
@@ -41,8 +41,8 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	stmts := diff.DiffTables(currentTables, desired.Tables)
-	stmts = append(stmts, diff.DiffViews(currentViews, desired.Views)...)
+	stmts := diff.DiffTables(currentTables, client.reverseRemapTableSchemas(desired.Tables))
+	stmts = append(stmts, diff.DiffViews(currentViews, client.reverseRemapViewSchemas(desired.Views))...)
 
 	return strings.Join(stmts, "\n"), nil
 }

--- a/remap.go
+++ b/remap.go
@@ -1,0 +1,130 @@
+package pistachio
+
+import (
+	"strings"
+
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// buildDefReplacer builds a strings.Replacer that replaces schema-qualified
+// prefixes in raw SQL definitions (e.g. "staging." → "public.").
+// It handles both unquoted and quoted schema identifiers.
+func buildDefReplacer(schemaMap map[string]string) *strings.Replacer {
+	var pairs []string
+	for from, to := range schemaMap {
+		fromIdent := model.Ident(from)
+		toIdent := model.Ident(to)
+		// Always add the Ident form (handles quoting)
+		pairs = append(pairs, fromIdent+".", toIdent+".")
+		// If Ident differs from raw name, also add the raw form
+		if fromIdent != from {
+			pairs = append(pairs, from+".", to+".")
+		}
+	}
+	return strings.NewReplacer(pairs...)
+}
+
+func buildReverseDefReplacer(schemaMap map[string]string) *strings.Replacer {
+	reversed := make(map[string]string, len(schemaMap))
+	for k, v := range schemaMap {
+		reversed[v] = k
+	}
+	return buildDefReplacer(reversed)
+}
+
+func (client *Client) remapTableSchemas(tables *orderedmap.Map[string, *model.Table]) *orderedmap.Map[string, *model.Table] {
+	if len(client.SchemaMap) == 0 {
+		return tables
+	}
+
+	replacer := buildDefReplacer(client.SchemaMap)
+	remapped := orderedmap.New[string, *model.Table]()
+
+	for _, t := range tables.CollectValues() {
+		t.Schema = client.RemapSchema(t.Schema)
+
+		for _, idx := range t.Indexes.CollectValues() {
+			idx.Schema = client.RemapSchema(idx.Schema)
+			idx.Definition = replacer.Replace(idx.Definition)
+		}
+
+		for _, fk := range t.ForeignKeys.CollectValues() {
+			fk.Schema = client.RemapSchema(fk.Schema)
+			fk.Definition = replacer.Replace(fk.Definition)
+			if fk.RefSchema != nil {
+				mapped := client.RemapSchema(*fk.RefSchema)
+				fk.RefSchema = &mapped
+			}
+		}
+
+		remapped.Set(t.FQTN(), t)
+	}
+
+	return remapped
+}
+
+func (client *Client) remapViewSchemas(views *orderedmap.Map[string, *model.View]) *orderedmap.Map[string, *model.View] {
+	if len(client.SchemaMap) == 0 {
+		return views
+	}
+
+	replacer := buildDefReplacer(client.SchemaMap)
+	remapped := orderedmap.New[string, *model.View]()
+
+	for _, v := range views.CollectValues() {
+		v.Schema = client.RemapSchema(v.Schema)
+		v.Definition = replacer.Replace(v.Definition)
+		remapped.Set(v.FQVN(), v)
+	}
+
+	return remapped
+}
+
+func (client *Client) reverseRemapTableSchemas(tables *orderedmap.Map[string, *model.Table]) *orderedmap.Map[string, *model.Table] {
+	if len(client.SchemaMap) == 0 {
+		return tables
+	}
+
+	replacer := buildReverseDefReplacer(client.SchemaMap)
+	remapped := orderedmap.New[string, *model.Table]()
+
+	for _, t := range tables.CollectValues() {
+		t.Schema = client.ReverseRemapSchema(t.Schema)
+
+		for _, idx := range t.Indexes.CollectValues() {
+			idx.Schema = client.ReverseRemapSchema(idx.Schema)
+			idx.Definition = replacer.Replace(idx.Definition)
+		}
+
+		for _, fk := range t.ForeignKeys.CollectValues() {
+			fk.Schema = client.ReverseRemapSchema(fk.Schema)
+			fk.Definition = replacer.Replace(fk.Definition)
+			if fk.RefSchema != nil {
+				mapped := client.ReverseRemapSchema(*fk.RefSchema)
+				fk.RefSchema = &mapped
+			}
+		}
+
+		remapped.Set(t.FQTN(), t)
+	}
+
+	return remapped
+}
+
+func (client *Client) reverseRemapViewSchemas(views *orderedmap.Map[string, *model.View]) *orderedmap.Map[string, *model.View] {
+	if len(client.SchemaMap) == 0 {
+		return views
+	}
+
+	replacer := buildReverseDefReplacer(client.SchemaMap)
+	remapped := orderedmap.New[string, *model.View]()
+
+	for _, v := range views.CollectValues() {
+		v.Schema = client.ReverseRemapSchema(v.Schema)
+		v.Definition = replacer.Replace(v.Definition)
+		remapped.Set(v.FQVN(), v)
+	}
+
+	return remapped
+}

--- a/remap_test.go
+++ b/remap_test.go
@@ -35,6 +35,20 @@ func setupSchemaDB(t *testing.T, ctx context.Context, schema string, initSQL str
 	return conn.Config().ConnString()
 }
 
+func TestAfterApply(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"staging": "public"}}
+		assert.NoError(t, o.AfterApply())
+	})
+
+	t.Run("duplicate destinations", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"a": "public", "b": "public"}}
+		err := o.AfterApply()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate schema-map destination")
+	})
+}
+
 func TestRemapSchema(t *testing.T) {
 	t.Run("nil map", func(t *testing.T) {
 		o := &pistachio.Options{}

--- a/remap_test.go
+++ b/remap_test.go
@@ -1,0 +1,525 @@
+package pistachio_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+func setupSchemaDB(t *testing.T, ctx context.Context, schema string, initSQL string) string {
+	t.Helper()
+	conn := testutil.ConnectDB(t)
+
+	_, err := conn.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE")
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, "CREATE SCHEMA "+schema)
+	require.NoError(t, err)
+
+	if initSQL != "" {
+		_, err = conn.Exec(ctx, initSQL)
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = conn.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE")
+		conn.Close(ctx)
+	})
+
+	return conn.Config().ConnString()
+}
+
+func TestRemapSchema(t *testing.T) {
+	t.Run("nil map", func(t *testing.T) {
+		o := &pistachio.Options{}
+		assert.Equal(t, "public", o.RemapSchema("public"))
+	})
+
+	t.Run("mapped", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"myschema": "public"}}
+		assert.Equal(t, "public", o.RemapSchema("myschema"))
+	})
+
+	t.Run("unmapped", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"myschema": "public"}}
+		assert.Equal(t, "other", o.RemapSchema("other"))
+	})
+}
+
+func TestReverseRemapSchema(t *testing.T) {
+	t.Run("nil map", func(t *testing.T) {
+		o := &pistachio.Options{}
+		assert.Equal(t, "public", o.ReverseRemapSchema("public"))
+	})
+
+	t.Run("mapped", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"myschema": "public"}}
+		assert.Equal(t, "myschema", o.ReverseRemapSchema("public"))
+	})
+
+	t.Run("unmapped", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"myschema": "public"}}
+		assert.Equal(t, "other", o.ReverseRemapSchema("other"))
+	})
+}
+
+func TestDump_WithSchemaMap_QuotedSchema(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, `"My Schema"`, `
+CREATE TABLE "My Schema".users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX users_id_idx ON "My Schema".users (id);
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"My Schema"},
+		SchemaMap:  map[string]string{"My Schema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	t.Log(output)
+
+	assert.Contains(t, output, "CREATE TABLE public.users")
+	assert.Contains(t, output, "ON public.users")
+	assert.NotContains(t, output, `"My Schema"`)
+}
+
+func TestDump_WithSchemaMap(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW myschema.active_users AS SELECT id, name FROM myschema.users;
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	t.Log(output)
+
+	// Schema should be remapped to "public" in CREATE statements
+	assert.Contains(t, output, "CREATE TABLE public.users")
+	assert.Contains(t, output, "CREATE OR REPLACE VIEW public.active_users")
+	// Note: view definitions returned by PostgreSQL keep original schema names internally
+}
+
+func TestDump_WithSchemaMap_Files(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	files := got.Files()
+	assert.Contains(t, files, "public.users.sql")
+	assert.NotContains(t, files, "myschema.users.sql")
+}
+
+func TestPlan_WithSchemaMap(t *testing.T) {
+	ctx := context.Background()
+
+	// DB has myschema.users with (id), desired has public.users with (id, name)
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	t.Log(got)
+
+	// Should detect the diff and produce ALTER TABLE with the real DB schema
+	assert.Contains(t, got, "ALTER TABLE myschema.users ADD COLUMN name text;")
+}
+
+func TestPlan_WithSchemaMap_NoDiff(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	// No diff expected since schemas are remapped
+	assert.Empty(t, got)
+}
+
+func TestDump_WithoutSchemaMap(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE TABLE myschema.users")
+}
+
+func TestPlan_WithoutSchemaMap(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestDump_WithSchemaMap_ForeignKey(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE myschema.posts (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id),
+    CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES myschema.users(id)
+);
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	t.Log(output)
+
+	assert.Contains(t, output, "CREATE TABLE public.users")
+	assert.Contains(t, output, "CREATE TABLE public.posts")
+	assert.Contains(t, output, "ALTER TABLE ONLY public.posts")
+}
+
+func TestDump_WithSchemaMap_Index(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX users_name_idx ON myschema.users (name);
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	t.Log(output)
+
+	assert.Contains(t, output, "CREATE TABLE public.users")
+	assert.Contains(t, output, "users_name_idx")
+}
+
+func TestDump_WithSchemaMap_UnmappedSchema(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	// Map a different schema, myschema should remain unchanged
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"other": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE TABLE myschema.users")
+}
+
+func TestPlan_WithSchemaMap_UnmappedDesiredSchema(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	// Desired uses "other" schema which is not in the reverse map
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE other.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	// "other" schema is not reverse-mapped, so it won't match myschema
+	// This results in creating the "other" table and dropping "myschema" table
+	assert.Contains(t, got, "DROP TABLE myschema.users;")
+}
+
+func TestPlan_WithSchemaMap_ForeignKey(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE myschema.posts (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id),
+    CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES myschema.users(id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    title text,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);
+ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	t.Log(got)
+
+	assert.Contains(t, got, "ALTER TABLE myschema.posts ADD COLUMN title text;")
+}
+
+func TestPlan_WithSchemaMap_Index(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX users_name_idx ON public.users (name);
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	t.Log(got)
+
+	assert.Contains(t, got, "users_name_idx")
+}
+
+func TestPlan_WithSchemaMap_View(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	t.Log(got)
+
+	assert.Contains(t, got, "CREATE OR REPLACE VIEW myschema.active_users")
+}
+
+func TestApply_WithSchemaMap(t *testing.T) {
+	ctx := context.Background()
+
+	// DB has myschema.users with (id), desired has public.users with (id, name)
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.NoError(t, err)
+
+	// Verify: dump without schema map should show myschema with new column
+	verifyClient := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	got, err := verifyClient.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	t.Log(output)
+	assert.Contains(t, output, "name text")
+}

--- a/remap_test.go
+++ b/remap_test.go
@@ -52,6 +52,30 @@ func TestRemapSchema(t *testing.T) {
 	})
 }
 
+func TestValidateSchemaMap(t *testing.T) {
+	t.Run("nil map", func(t *testing.T) {
+		o := &pistachio.Options{}
+		assert.NoError(t, o.ValidateSchemaMap())
+	})
+
+	t.Run("single entry", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"staging": "public"}}
+		assert.NoError(t, o.ValidateSchemaMap())
+	})
+
+	t.Run("distinct destinations", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"a": "x", "b": "y"}}
+		assert.NoError(t, o.ValidateSchemaMap())
+	})
+
+	t.Run("duplicate destinations", func(t *testing.T) {
+		o := &pistachio.Options{SchemaMap: map[string]string{"a": "public", "b": "public"}}
+		err := o.ValidateSchemaMap()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate schema-map destination")
+	})
+}
+
 func TestReverseRemapSchema(t *testing.T) {
 	t.Run("nil map", func(t *testing.T) {
 		o := &pistachio.Options{}
@@ -121,10 +145,10 @@ CREATE VIEW myschema.active_users AS SELECT id, name FROM myschema.users;
 	output := got.String()
 	t.Log(output)
 
-	// Schema should be remapped to "public" in CREATE statements
+	// Schema references should be remapped to "public", including inside view definitions
 	assert.Contains(t, output, "CREATE TABLE public.users")
 	assert.Contains(t, output, "CREATE OR REPLACE VIEW public.active_users")
-	// Note: view definitions returned by PostgreSQL keep original schema names internally
+	assert.Contains(t, output, "FROM public.users")
 }
 
 func TestDump_WithSchemaMap_Files(t *testing.T) {


### PR DESCRIPTION
Allow users to remap schema names in dump/plan/apply via -m flag (e.g. -m staging=public). This enables managing databases whose schema name differs from the one used in SQL files.