### PR TITLE
Add omit schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ pist -n staging -m staging=public plan schema.sql
 pist -n staging -m staging=public apply schema.sql
 ```
 
+### Omit schema
+
+Use `--omit-schema` to omit schema names from the dump output.
+
+```bash
+pist dump --omit-schema
+# => CREATE TABLE users (...) instead of CREATE TABLE public.users (...)
+
+pist dump --omit-schema --split ./schema/
+# => ./schema/users.sql, ./schema/orders.sql, ...
+```
+
+When schema is omitted in SQL files, `plan` and `apply` use the schema specified by `-n`:
+
+```bash
+pist -n staging plan schema.sql   # schema-less SQL is treated as "staging"
+pist -n staging apply schema.sql
+```
+
 ### Split dump
 
 Use `--split` to output each table/view as a separate file in the specified directory.

--- a/apply.go
+++ b/apply.go
@@ -39,7 +39,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to fetch views: %w", err)
 	}
 
-	desired, err := parser.ParseSQLFiles(options.Files)
+	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}

--- a/apply_test.go
+++ b/apply_test.go
@@ -185,6 +185,37 @@ func TestApply_NoDiff(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestApply_SchemalessDesired(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.NoError(t, err)
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, got.String(), "name text")
+}
+
 func TestApply_ExecError(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -190,7 +190,7 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) []strin
 	// Drop removed or changed indexes
 	for name, currentIdx := range current.All() {
 		desiredIdx, ok := desired.GetOk(name)
-		if !ok || currentIdx.Definition != desiredIdx.Definition {
+		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			stmts = append(stmts, "DROP INDEX "+model.Ident(currentIdx.Schema, name)+";")
 		}
 	}
@@ -198,7 +198,7 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) []strin
 	// Add new or changed indexes
 	for name, desiredIdx := range desired.All() {
 		currentIdx, ok := current.GetOk(name)
-		if !ok || currentIdx.Definition != desiredIdx.Definition {
+		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			stmts = append(stmts, desiredIdx.Definition+";")
 		}
 	}
@@ -269,6 +269,40 @@ func equalPtr[T comparable](a, b *T) bool {
 		return false
 	}
 	return *a == *b
+}
+
+// parseIndexDef parses an index definition string into a pg_query IndexStmt node.
+func parseIndexDef(def string) (*pg_query.IndexStmt, error) {
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return nil, err
+	}
+	is := result.Stmts[0].Stmt.GetIndexStmt()
+	if is == nil {
+		return nil, fmt.Errorf("unexpected parse result for index definition: %s", def)
+	}
+	return is, nil
+}
+
+// normalizeIndexSchema normalizes the table's schema name in an IndexStmt
+// so that an empty schema (implicit public) is treated the same as an explicit "public" schema.
+func normalizeIndexSchema(is *pg_query.IndexStmt) {
+	if is.Relation != nil && is.Relation.Schemaname == "" {
+		is.Relation.Schemaname = "public"
+	}
+}
+
+// equalIndexDef compares two index definitions by their parse trees,
+// so that schema qualification differences do not cause false diffs.
+func equalIndexDef(a, b string) bool {
+	nodeA, errA := parseIndexDef(a)
+	nodeB, errB := parseIndexDef(b)
+	if errA != nil || errB != nil {
+		return a == b
+	}
+	normalizeIndexSchema(nodeA)
+	normalizeIndexSchema(nodeB)
+	return proto.Equal(nodeA, nodeB)
 }
 
 // parseFKDef parses a FK constraint definition string into a pg_query Constraint node.

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -284,11 +284,11 @@ func parseIndexDef(def string) (*pg_query.IndexStmt, error) {
 	return is, nil
 }
 
-// normalizeIndexSchema normalizes the table's schema name in an IndexStmt
-// so that an empty schema (implicit public) is treated the same as an explicit "public" schema.
-func normalizeIndexSchema(is *pg_query.IndexStmt) {
-	if is.Relation != nil && is.Relation.Schemaname == "" {
-		is.Relation.Schemaname = "public"
+// clearIndexSchema clears the schema name in an IndexStmt so that
+// index definitions are compared without regard to schema qualification.
+func clearIndexSchema(is *pg_query.IndexStmt) {
+	if is.Relation != nil {
+		is.Relation.Schemaname = ""
 	}
 }
 
@@ -300,8 +300,8 @@ func equalIndexDef(a, b string) bool {
 	if errA != nil || errB != nil {
 		return a == b
 	}
-	normalizeIndexSchema(nodeA)
-	normalizeIndexSchema(nodeB)
+	clearIndexSchema(nodeA)
+	clearIndexSchema(nodeB)
 	return proto.Equal(nodeA, nodeB)
 }
 

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -505,6 +505,12 @@ func TestEqualIndexDef_parseError(t *testing.T) {
 	assert.True(t, equalIndexDef("NOT VALID SQL", "NOT VALID SQL"))
 }
 
+func TestEqualIndexDef_notIndexStmt(t *testing.T) {
+	// Valid SQL but not an INDEX statement — falls back to string comparison
+	assert.False(t, equalIndexDef("SELECT 1", "CREATE INDEX idx ON users (id)"))
+	assert.True(t, equalIndexDef("SELECT 1", "SELECT 1"))
+}
+
 func TestDiffTables_indexSchemaInsensitive(t *testing.T) {
 	current := orderedmap.New[string, *model.Table]()
 	desired := orderedmap.New[string, *model.Table]()

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -478,3 +478,47 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE INDEX idx_new")
 }
+
+func TestEqualIndexDef_sameSchema(t *testing.T) {
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON public.users USING btree (id)",
+		"CREATE INDEX idx ON public.users USING btree (id)",
+	))
+}
+
+func TestEqualIndexDef_schemaVsNoSchema(t *testing.T) {
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON public.users USING btree (id)",
+		"CREATE INDEX idx ON users USING btree (id)",
+	))
+}
+
+func TestEqualIndexDef_different(t *testing.T) {
+	assert.False(t, equalIndexDef(
+		"CREATE INDEX idx ON public.users USING btree (id)",
+		"CREATE INDEX idx ON public.users USING btree (name)",
+	))
+}
+
+func TestEqualIndexDef_parseError(t *testing.T) {
+	assert.False(t, equalIndexDef("NOT VALID SQL", "CREATE INDEX idx ON users (id)"))
+	assert.True(t, equalIndexDef("NOT VALID SQL", "NOT VALID SQL"))
+}
+
+func TestDiffTables_indexSchemaInsensitive(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "users")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	ct.Indexes.Set("idx", &model.Index{Schema: "public", Name: "idx", Table: "users", Definition: "CREATE INDEX idx ON public.users USING btree (id)"})
+	current.Set("public.users", ct)
+
+	dt := newTable("public", "users")
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	dt.Indexes.Set("idx", &model.Index{Schema: "", Name: "idx", Table: "users", Definition: "CREATE INDEX idx ON users USING btree (id)"})
+	desired.Set("public.users", dt)
+
+	stmts := DiffTables(current, desired)
+	assert.Empty(t, stmts)
+}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -493,6 +493,21 @@ func TestEqualIndexDef_schemaVsNoSchema(t *testing.T) {
 	))
 }
 
+func TestEqualIndexDef_customSchemaVsNoSchema(t *testing.T) {
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON myschema.users USING btree (id)",
+		"CREATE INDEX idx ON users USING btree (id)",
+	))
+}
+
+func TestEqualIndexDef_differentSchemas(t *testing.T) {
+	// Different schemas should still be equal — schema is ignored in comparison
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON myschema.users USING btree (id)",
+		"CREATE INDEX idx ON public.users USING btree (id)",
+	))
+}
+
 func TestEqualIndexDef_different(t *testing.T) {
 	assert.False(t, equalIndexDef(
 		"CREATE INDEX idx ON public.users USING btree (id)",

--- a/dump.go
+++ b/dump.go
@@ -106,6 +106,10 @@ func toFileName(schema, name string) string {
 }
 
 func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResult, error) {
+	if options.OmitSchema && len(client.Schemas) > 1 {
+		return nil, fmt.Errorf("--omit-schema cannot be used with multiple schemas")
+	}
+
 	conn, err := client.connect()
 	if err != nil {
 		return nil, err

--- a/dump.go
+++ b/dump.go
@@ -11,40 +11,98 @@ import (
 )
 
 type DumpOptions struct {
-	Split string `help:"Output each table/view as a separate file in the specified directory."`
+	Split      string `help:"Output each table/view as a separate file in the specified directory."`
+	OmitSchema bool   `help:"Omit schema name from the dump output."`
 }
 
 type DumpResult struct {
-	Tables *orderedmap.Map[string, *model.Table]
-	Views  *orderedmap.Map[string, *model.View]
+	Tables     *orderedmap.Map[string, *model.Table]
+	Views      *orderedmap.Map[string, *model.View]
+	OmitSchema bool
+}
+
+func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
+	if !r.OmitSchema {
+		return r.Tables
+	}
+	tables := orderedmap.New[string, *model.Table]()
+	for _, t := range r.Tables.CollectValues() {
+		copied := *t
+		fqtn := t.FQTN()
+		tableName := model.Ident(t.Name)
+		copied.Schema = ""
+		if copied.ForeignKeys.Len() > 0 {
+			fks := orderedmap.New[string, *model.ForeignKey]()
+			for _, fk := range copied.ForeignKeys.CollectValues() {
+				fkCopied := *fk
+				fkCopied.Schema = ""
+				fks.Set(fk.Name, &fkCopied)
+			}
+			copied.ForeignKeys = fks
+		}
+		if copied.Indexes.Len() > 0 {
+			idxs := orderedmap.New[string, *model.Index]()
+			for _, idx := range copied.Indexes.CollectValues() {
+				idxCopied := *idx
+				idxCopied.Schema = ""
+				idxCopied.Definition = strings.ReplaceAll(idx.Definition, " ON "+fqtn+" ", " ON "+tableName+" ")
+				idxs.Set(idx.Name, &idxCopied)
+			}
+			copied.Indexes = idxs
+		}
+		tables.Set(fqtn, &copied)
+	}
+	return tables
+}
+
+func (r *DumpResult) views() *orderedmap.Map[string, *model.View] {
+	if !r.OmitSchema {
+		return r.Views
+	}
+	views := orderedmap.New[string, *model.View]()
+	for _, v := range r.Views.CollectValues() {
+		copied := *v
+		copied.Schema = ""
+		views.Set(v.FQVN(), &copied)
+	}
+	return views
 }
 
 func (r *DumpResult) String() string {
 	var parts []string
-	if r.Tables.Len() > 0 {
-		parts = append(parts, model.TablesToSQL(r.Tables))
+	tables := r.tables()
+	views := r.views()
+	if tables.Len() > 0 {
+		parts = append(parts, model.TablesToSQL(tables))
 	}
-	if r.Views.Len() > 0 {
-		parts = append(parts, model.ViewsToSQL(r.Views))
+	if views.Len() > 0 {
+		parts = append(parts, model.ViewsToSQL(views))
 	}
 	return strings.Join(parts, "\n\n")
 }
 
 func (r *DumpResult) Files() map[string]string {
 	files := make(map[string]string)
-	for _, t := range r.Tables.CollectValues() {
+	for _, t := range r.tables().CollectValues() {
 		files[toFileName(t.Schema, t.Name)] = model.TableToSQL(t) + "\n"
 	}
-	for _, v := range r.Views.CollectValues() {
+	for _, v := range r.views().CollectValues() {
 		files[toFileName(v.Schema, v.Name)] = model.ViewToSQL(v) + "\n"
 	}
 	return files
 }
 
-var fileNameReplacer = strings.NewReplacer(`"`, "", " ", "_")
+var fileNameReplacer = strings.NewReplacer(
+	`"`, "",
+	" ", "_",
+)
 
 func toFileName(schema, name string) string {
-	return fileNameReplacer.Replace(schema+"."+name) + ".sql"
+	base := name
+	if schema != "" {
+		base = schema + "." + name
+	}
+	return fileNameReplacer.Replace(base) + ".sql"
 }
 
 func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResult, error) {
@@ -70,7 +128,8 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 	}
 
 	return &DumpResult{
-		Tables: client.remapTableSchemas(tables),
-		Views:  client.remapViewSchemas(views),
+		Tables:     client.remapTableSchemas(tables),
+		Views:      client.remapViewSchemas(views),
+		OmitSchema: options.OmitSchema,
 	}, nil
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -186,6 +186,133 @@ CREATE TABLE public."My Table" (
 	assert.Contains(t, files, "public.My_Table.sql")
 }
 
+func TestDumpResult_OmitSchema_String(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "CREATE TABLE users")
+	assert.NotContains(t, s, "public.users")
+	assert.Contains(t, s, "CREATE OR REPLACE VIEW active_users")
+	assert.NotContains(t, s, "public.active_users")
+}
+
+func TestDumpResult_OmitSchema_Files(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Contains(t, files, "users.sql")
+	assert.NotContains(t, files, "public.users.sql")
+	assert.Contains(t, files["users.sql"], "CREATE TABLE users")
+}
+
+func TestDumpResult_OmitSchema_ForeignKey(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "ALTER TABLE ONLY orders")
+	assert.NotContains(t, s, "public.orders")
+}
+
+func TestDumpResult_OmitSchema_Comment(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+COMMENT ON TABLE public.users IS 'User accounts';`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "COMMENT ON TABLE users")
+	assert.NotContains(t, s, "public.users")
+}
+
+func TestDumpResult_OmitSchema_Index(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_id ON public.users (id);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "CREATE INDEX idx_users_id ON users")
+	assert.NotContains(t, s, "ON public.users")
+}
+
 func TestDump(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/dump_test.go
+++ b/dump_test.go
@@ -289,6 +289,18 @@ COMMENT ON TABLE public.users IS 'User accounts';`)
 	assert.NotContains(t, s, "public.users")
 }
 
+func TestDump_OmitSchema_MultipleSchemas(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "postgres://postgres@localhost/postgres",
+		Schemas:    []string{"public", "other"},
+	})
+
+	_, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--omit-schema cannot be used with multiple schemas")
+}
+
 func TestDumpResult_OmitSchema_Index(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/model/util.go
+++ b/model/util.go
@@ -10,10 +10,13 @@ import (
 var safeIdentifierPattern = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
 
 func Ident(names ...string) string {
-	idents := make([]string, len(names))
+	var idents []string
 
-	for i, n := range names {
-		idents[i] = quoteIdent(n)
+	for _, n := range names {
+		if n == "" {
+			continue
+		}
+		idents = append(idents, quoteIdent(n))
 	}
 
 	return strings.Join(idents, ".")

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -23,7 +23,11 @@ func TestIdent_uppercase(t *testing.T) {
 }
 
 func TestIdent_empty(t *testing.T) {
-	assert.Equal(t, `""`, Ident(""))
+	assert.Equal(t, "", Ident(""))
+}
+
+func TestIdent_emptySchema(t *testing.T) {
+	assert.Equal(t, "users", Ident("", "users"))
 }
 
 func TestIdent_withSpecialChars(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -363,7 +363,7 @@ func parseViewStmt(vs *pg_query.ViewStmt, defaultSchema string) (*model.View, er
 
 func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View]) {
 	items := cs.Object.GetList().GetItems()
-	if len(items) < 2 {
+	if len(items) == 0 {
 		return
 	}
 
@@ -408,6 +408,9 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 			}
 		}
 	case pg_query.ObjectType_OBJECT_COLUMN:
+		if len(names) < 2 {
+			return
+		}
 		schema := defaultSchema
 		tableName := names[0]
 		colName := names[1]

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -25,15 +25,23 @@ func ReadSQLFile(path string) (string, error) {
 }
 
 func ParseSQLFile(path string) (*ParseResult, error) {
+	return ParseSQLFileWithSchema(path, "public")
+}
+
+func ParseSQLFileWithSchema(path string, defaultSchema string) (*ParseResult, error) {
 	sql, err := ReadSQLFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return ParseSQL(sql)
+	return ParseSQLWithSchema(sql, defaultSchema)
 }
 
 func ParseSQLFiles(paths []string) (*ParseResult, error) {
+	return ParseSQLFilesWithSchema(paths, "public")
+}
+
+func ParseSQLFilesWithSchema(paths []string, defaultSchema string) (*ParseResult, error) {
 	var sqls []string
 	for _, path := range paths {
 		sql, err := ReadSQLFile(path)
@@ -43,10 +51,14 @@ func ParseSQLFiles(paths []string) (*ParseResult, error) {
 		sqls = append(sqls, sql)
 	}
 
-	return ParseSQL(strings.Join(sqls, "\n"))
+	return ParseSQLWithSchema(strings.Join(sqls, "\n"), defaultSchema)
 }
 
 func ParseSQL(sql string) (*ParseResult, error) {
+	return ParseSQLWithSchema(sql, "public")
+}
+
+func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) {
 	result, err := pg_query.Parse(sql)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SQL: %w", err)
@@ -60,21 +72,21 @@ func ParseSQL(sql string) (*ParseResult, error) {
 
 		switch {
 		case node.GetCreateStmt() != nil:
-			table, err := parseCreateStmt(node.GetCreateStmt())
+			table, err := parseCreateStmt(node.GetCreateStmt(), defaultSchema)
 			if err != nil {
 				return nil, err
 			}
 			tables.Set(table.FQTN(), table)
 
 		case node.GetViewStmt() != nil:
-			view, err := parseViewStmt(node.GetViewStmt())
+			view, err := parseViewStmt(node.GetViewStmt(), defaultSchema)
 			if err != nil {
 				return nil, err
 			}
 			views.Set(view.FQVN(), view)
 
 		case node.GetIndexStmt() != nil:
-			idx, err := parseIndexStmt(node.GetIndexStmt(), rawStmt)
+			idx, err := parseIndexStmt(node.GetIndexStmt(), rawStmt, defaultSchema)
 			if err != nil {
 				return nil, err
 			}
@@ -87,7 +99,7 @@ func ParseSQL(sql string) (*ParseResult, error) {
 			as := node.GetAlterTableStmt()
 			schema := as.Relation.Schemaname
 			if schema == "" {
-				schema = "public"
+				schema = defaultSchema
 			}
 			fqtn := model.Ident(schema, as.Relation.Relname)
 			t, ok := tables.GetOk(fqtn)
@@ -95,7 +107,7 @@ func ParseSQL(sql string) (*ParseResult, error) {
 				continue
 			}
 
-			con, fk, err := parseAlterTableConstraint(as)
+			con, fk, err := parseAlterTableConstraint(as, defaultSchema)
 			if err != nil {
 				return nil, err
 			}
@@ -107,17 +119,17 @@ func ParseSQL(sql string) (*ParseResult, error) {
 
 		case node.GetCommentStmt() != nil:
 			cs := node.GetCommentStmt()
-			parseCommentStmt(cs, tables, views)
+			parseCommentStmt(cs, defaultSchema, tables, views)
 		}
 	}
 
 	return &ParseResult{Tables: tables, Views: views}, nil
 }
 
-func parseCreateStmt(cs *pg_query.CreateStmt) (*model.Table, error) {
+func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Table, error) {
 	schema := cs.Relation.Schemaname
 	if schema == "" {
-		schema = "public"
+		schema = defaultSchema
 	}
 
 	table := &model.Table{
@@ -149,7 +161,7 @@ func parseCreateStmt(cs *pg_query.CreateStmt) (*model.Table, error) {
 		if rv != nil {
 			parentSchema := rv.Schemaname
 			if parentSchema == "" {
-				parentSchema = "public"
+				parentSchema = defaultSchema
 			}
 			parent := model.Ident(parentSchema, rv.Relname)
 			table.PartitionOf = &parent
@@ -296,7 +308,7 @@ func parseTableConstraint(con *pg_query.Constraint) (*model.Constraint, error) {
 	}, nil
 }
 
-func parseIndexStmt(is *pg_query.IndexStmt, rawStmt *pg_query.RawStmt) (*model.Index, error) {
+func parseIndexStmt(is *pg_query.IndexStmt, rawStmt *pg_query.RawStmt, defaultSchema string) (*model.Index, error) {
 	result := &pg_query.ParseResult{
 		Stmts: []*pg_query.RawStmt{{Stmt: rawStmt.Stmt}},
 	}
@@ -307,7 +319,7 @@ func parseIndexStmt(is *pg_query.IndexStmt, rawStmt *pg_query.RawStmt) (*model.I
 
 	schema := is.Relation.Schemaname
 	if schema == "" {
-		schema = "public"
+		schema = defaultSchema
 	}
 
 	var tablespace *string
@@ -325,10 +337,10 @@ func parseIndexStmt(is *pg_query.IndexStmt, rawStmt *pg_query.RawStmt) (*model.I
 	}, nil
 }
 
-func parseViewStmt(vs *pg_query.ViewStmt) (*model.View, error) {
+func parseViewStmt(vs *pg_query.ViewStmt, defaultSchema string) (*model.View, error) {
 	schema := vs.View.Schemaname
 	if schema == "" {
-		schema = "public"
+		schema = defaultSchema
 	}
 
 	// Deparse the SELECT query
@@ -349,7 +361,7 @@ func parseViewStmt(vs *pg_query.ViewStmt) (*model.View, error) {
 	}, nil
 }
 
-func parseCommentStmt(cs *pg_query.CommentStmt, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View]) {
+func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View]) {
 	items := cs.Object.GetList().GetItems()
 	if len(items) < 2 {
 		return
@@ -364,7 +376,7 @@ func parseCommentStmt(cs *pg_query.CommentStmt, tables *orderedmap.Map[string, *
 
 	switch cs.Objtype {
 	case pg_query.ObjectType_OBJECT_TABLE:
-		schema := "public"
+		schema := defaultSchema
 		tableName := names[0]
 		if len(names) >= 2 {
 			schema = names[0]
@@ -380,7 +392,7 @@ func parseCommentStmt(cs *pg_query.CommentStmt, tables *orderedmap.Map[string, *
 			}
 		}
 	case pg_query.ObjectType_OBJECT_VIEW:
-		schema := "public"
+		schema := defaultSchema
 		viewName := names[0]
 		if len(names) >= 2 {
 			schema = names[0]
@@ -396,7 +408,7 @@ func parseCommentStmt(cs *pg_query.CommentStmt, tables *orderedmap.Map[string, *
 			}
 		}
 	case pg_query.ObjectType_OBJECT_COLUMN:
-		schema := "public"
+		schema := defaultSchema
 		tableName := names[0]
 		colName := names[1]
 		if len(names) >= 3 {
@@ -418,7 +430,7 @@ func parseCommentStmt(cs *pg_query.CommentStmt, tables *orderedmap.Map[string, *
 	}
 }
 
-func parseAlterTableConstraint(as *pg_query.AlterTableStmt) (*model.Constraint, *model.ForeignKey, error) {
+func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string) (*model.Constraint, *model.ForeignKey, error) {
 	for _, cmdNode := range as.Cmds {
 		cmd := cmdNode.GetAlterTableCmd()
 		if cmd == nil || cmd.Subtype != pg_query.AlterTableType_AT_AddConstraint {
@@ -431,7 +443,7 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt) (*model.Constraint, 
 
 		schema := as.Relation.Schemaname
 		if schema == "" {
-			schema = "public"
+			schema = defaultSchema
 		}
 
 		def, err := deparseConstraintDef(con)
@@ -444,7 +456,7 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt) (*model.Constraint, 
 			if con.Pktable != nil {
 				rs := con.Pktable.Schemaname
 				if rs == "" {
-					rs = "public"
+					rs = defaultSchema
 				}
 				refSchema = &rs
 				rt := con.Pktable.Relname

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -470,3 +470,97 @@ ALTER TABLE myschema.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFEREN
 	assert.Equal(t, "myschema", fk.Schema)
 	assert.Equal(t, "myschema", *fk.RefSchema)
 }
+
+func TestParseSQLWithSchema_DefaultSchema(t *testing.T) {
+	sql := `CREATE TABLE users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON users (name);
+CREATE VIEW active_users AS SELECT id, name FROM users;
+COMMENT ON TABLE users IS 'User accounts';
+COMMENT ON COLUMN users.name IS 'User name';`
+
+	result, err := parser.ParseSQLWithSchema(sql, "myschema")
+	require.NoError(t, err)
+
+	// Table defaults to myschema
+	tbl, ok := result.Tables.GetOk("myschema.users")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", tbl.Schema)
+
+	// Index defaults to myschema
+	idx, ok := tbl.Indexes.GetOk("idx_users_name")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", idx.Schema)
+
+	// View defaults to myschema
+	v, ok := result.Views.GetOk("myschema.active_users")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", v.Schema)
+
+	// Table comment
+	require.NotNil(t, tbl.Comment)
+	assert.Equal(t, "User accounts", *tbl.Comment)
+
+	// Column comment
+	col, ok := tbl.Columns.GetOk("name")
+	require.True(t, ok)
+	require.NotNil(t, col.Comment)
+	assert.Equal(t, "User name", *col.Comment)
+}
+
+func TestParseSQLWithSchema_AlterTable(t *testing.T) {
+	sql := `CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id)
+);
+ALTER TABLE orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id);`
+
+	result, err := parser.ParseSQLWithSchema(sql, "myschema")
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("myschema.orders")
+	require.True(t, ok)
+	fk, ok := tbl.ForeignKeys.GetOk("fk_user")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", fk.Schema)
+	assert.Equal(t, "myschema", *fk.RefSchema)
+}
+
+func TestParseSQLWithSchema_InheritedTable(t *testing.T) {
+	sql := `CREATE TABLE events (
+    id integer NOT NULL,
+    created_at date NOT NULL
+) PARTITION BY RANGE (created_at);
+CREATE TABLE events_2024 PARTITION OF events
+    FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');`
+
+	result, err := parser.ParseSQLWithSchema(sql, "myschema")
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("myschema.events_2024")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", tbl.Schema)
+	require.NotNil(t, tbl.PartitionOf)
+	assert.Contains(t, *tbl.PartitionOf, "myschema")
+}
+
+func TestParseSQLWithSchema_ViewComment(t *testing.T) {
+	sql := `CREATE VIEW active_users AS SELECT 1;
+COMMENT ON VIEW active_users IS 'Active users';`
+
+	result, err := parser.ParseSQLWithSchema(sql, "myschema")
+	require.NoError(t, err)
+
+	v, ok := result.Views.GetOk("myschema.active_users")
+	require.True(t, ok)
+	require.NotNil(t, v.Comment)
+	assert.Equal(t, "Active users", *v.Comment)
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -191,6 +191,53 @@ COMMENT ON TABLE myschema.users IS 'Users table';`
 	assert.Equal(t, "Users table", *tbl.Comment)
 }
 
+func TestParseSQL_CommentOnTable_Schemaless(t *testing.T) {
+	sql := `CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+COMMENT ON TABLE users IS 'Users table';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	require.NotNil(t, tbl.Comment)
+	assert.Equal(t, "Users table", *tbl.Comment)
+}
+
+func TestParseSQL_CommentOnColumn_Schemaless(t *testing.T) {
+	sql := `CREATE TABLE users (
+    id integer NOT NULL,
+    name text
+);
+COMMENT ON COLUMN users.name IS 'User name';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	col, ok := tbl.Columns.GetOk("name")
+	require.True(t, ok)
+	require.NotNil(t, col.Comment)
+	assert.Equal(t, "User name", *col.Comment)
+}
+
+func TestParseSQL_CommentOnView_Schemaless(t *testing.T) {
+	sql := `CREATE VIEW active_users AS SELECT 1;
+COMMENT ON VIEW active_users IS 'Active users';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	v, ok := result.Views.GetOk("public.active_users")
+	require.True(t, ok)
+	require.NotNil(t, v.Comment)
+	assert.Equal(t, "Active users", *v.Comment)
+}
+
 func TestParseSQL_ForeignKeyNotValid(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,

--- a/plan.go
+++ b/plan.go
@@ -36,7 +36,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to fetch views: %w", err)
 	}
 
-	desired, err := parser.ParseSQLFiles(options.Files)
+	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -88,6 +88,62 @@ func TestPlan_EmptySchemas(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPlan_SchemalessDesired(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	// Desired SQL without schema qualification
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
+}
+
+func TestPlan_SchemalessDesired_NoDiff(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
 func TestPlan(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/remap_test.go
+++ b/remap_test.go
@@ -561,3 +561,89 @@ CREATE TABLE myschema.users (
 	t.Log(output)
 	assert.Contains(t, output, "name text")
 }
+
+func TestPlan_SchemalessDesired_CustomSchema(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	// Desired SQL without schema - should use -n schema ("myschema")
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	t.Log(got)
+
+	assert.Contains(t, got, "ALTER TABLE myschema.users ADD COLUMN name text;")
+}
+
+func TestPlan_SchemalessDesired_CustomSchema_NoDiff(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestApply_SchemalessDesired_CustomSchema(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.NoError(t, err)
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, got.String(), "name text")
+}


### PR DESCRIPTION
This pull request introduces improved handling for schema-qualified and schema-less SQL in both parsing and dumping, with a focus on supporting an "omit schema" mode throughout the codebase. The most important changes are the addition of the `--omit-schema` option for dumps, normalization of schema handling in parsing and diffing, and enhancements to index comparison logic. Extensive tests are added to ensure correctness of the new behavior.

**Schema omission and dump improvements:**

* Added a `--omit-schema` option to the dump command, which outputs SQL without schema names; updated `DumpOptions`, `DumpResult`, and related logic to support schema-less output for tables, views, indexes, foreign keys, and comments. [[1]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR15-R105) [[2]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR133) [[3]](diffhunk://#diff-65c94d2eace406c5aa180f845d514576956230d81c8b42cf4d14f773981cfe12R189-R315)
* Updated the documentation in `README.md` to describe the new `--omit-schema` feature and its interaction with `plan` and `apply`.

**Schema-aware SQL parsing:**

* Refactored SQL parsing functions to accept a `defaultSchema` parameter, ensuring that schema-less SQL is correctly parsed and associated with the intended schema; updated all relevant parser functions and their call sites. [[1]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R28-R44) [[2]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L46-R61) [[3]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L63-R89) [[4]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L90-R110) [[5]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L110-R132) [[6]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L152-R164) [[7]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L299-R311) [[8]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L310-R322) [[9]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L328-R343) [[10]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L352-R366) [[11]](diffhunk://#diff-86ae12b12a6a3e85fd29fb29e6745818c470d89b611f10125ad5761a707e5a76L42-R42)

**Index diffing and comparison enhancements:**

* Improved index diffing to compare index definitions by parse tree rather than string equality, making index comparison robust to schema qualification differences; added normalization so that an empty schema is treated as "public". [[1]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L193-R201) [[2]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248R274-R307)
* Added comprehensive tests for schema-insensitive index comparison and diffing.

**Utility and test updates:**

* Updated the `Ident` utility to skip empty schema names, ensuring correct identifier formatting for schema-less objects. [[1]](diffhunk://#diff-094bc76614005c184d08f2c71abfeb961c6398a8b65fa8529b68d8adc3a89806L13-R19) [[2]](diffhunk://#diff-c0ab435789d33081d39b472136b9ad29189fb35ebc36e9a45f72ee04680ba731L26-R30)
* Added and updated tests to cover schema-less parsing, dumping, and identifier formatting, including new test cases for `apply`, `dump`, and identifier utilities. [[1]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939R188-R218) [[2]](diffhunk://#diff-65c94d2eace406c5aa180f845d514576956230d81c8b42cf4d14f773981cfe12R189-R315) [[3]](diffhunk://#diff-c0ab435789d33081d39b472136b9ad29189fb35ebc36e9a45f72ee04680ba731L26-R30)

These changes ensure consistent and correct handling of schema-qualified and schema-less SQL throughout the tool, enabling workflows that require omitting schema names from SQL files.