### PR TITLE
Add include exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Flags:
   -n, --schemas=public,...    Schemas to inspect and modify ($PGSCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
+  -I, --include=INCLUDE,...   Include only tables/views matching the pattern
+                              (wildcard: *, ?).
+  -E, --exclude=EXCLUDE,...   Exclude tables/views matching the pattern
+                              (wildcard: *, ?).
       --version
 
 Commands:
@@ -101,6 +105,21 @@ You can also use it with `plan` and `apply`. The desired SQL files use the mappe
 # schema.sql uses "public" as the schema name
 pist -n staging -m staging=public plan schema.sql
 pist -n staging -m staging=public apply schema.sql
+```
+
+### Filtering tables/views
+
+Use `-I` / `--include` to include only matching tables/views, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards.
+
+```bash
+# Dump only tables/views matching "user*"
+pist -I 'user*' dump
+
+# Plan changes excluding temporary tables
+pist -E 'tmp_*' plan schema.sql
+
+# Combine include and exclude
+pist -I 'user*' -E 'user_tmp' apply schema.sql
 ```
 
 ### Omit schema

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pist -n staging -m staging=public apply schema.sql
 
 ### Filtering tables/views
 
-Use `-I` / `--include` to include only matching tables/views, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards.
+Use `-I` / `--include` to include only matching tables/views, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against table/view names only (not schema-qualified names).
 
 ```bash
 # Dump only tables/views matching "user*"

--- a/apply.go
+++ b/apply.go
@@ -44,8 +44,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	stmts := diff.DiffTables(currentTables, client.reverseRemapTableSchemas(desired.Tables))
-	stmts = append(stmts, diff.DiffViews(currentViews, client.reverseRemapViewSchemas(desired.Views))...)
+	stmts := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
 
 	var preSQL string
 	if options.PreSQLFile != "" {

--- a/dump.go
+++ b/dump.go
@@ -132,8 +132,8 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 	}
 
 	return &DumpResult{
-		Tables:     client.remapTableSchemas(tables),
-		Views:      client.remapViewSchemas(views),
+		Tables:     client.filterTables(client.remapTableSchemas(tables)),
+		Views:      client.filterViews(client.remapViewSchemas(views)),
 		OmitSchema: options.OmitSchema,
 	}, nil
 }

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,34 @@
+package pistachio
+
+import (
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func (client *Client) filterTables(tables *orderedmap.Map[string, *model.Table]) *orderedmap.Map[string, *model.Table] {
+	if len(client.Include) == 0 && len(client.Exclude) == 0 {
+		return tables
+	}
+
+	filtered := orderedmap.New[string, *model.Table]()
+	for k, t := range tables.All() {
+		if client.MatchName(t.Name) {
+			filtered.Set(k, t)
+		}
+	}
+	return filtered
+}
+
+func (client *Client) filterViews(views *orderedmap.Map[string, *model.View]) *orderedmap.Map[string, *model.View] {
+	if len(client.Include) == 0 && len(client.Exclude) == 0 {
+		return views
+	}
+
+	filtered := orderedmap.New[string, *model.View]()
+	for k, v := range views.All() {
+		if client.MatchName(v.Name) {
+			filtered.Set(k, v)
+		}
+	}
+	return filtered
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,348 @@
+package pistachio_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+func TestMatchName(t *testing.T) {
+	t.Run("no filters", func(t *testing.T) {
+		o := &pistachio.Options{}
+		assert.True(t, o.MatchName("users"))
+	})
+
+	t.Run("include match", func(t *testing.T) {
+		o := &pistachio.Options{Include: []string{"users"}}
+		assert.True(t, o.MatchName("users"))
+		assert.False(t, o.MatchName("posts"))
+	})
+
+	t.Run("include wildcard", func(t *testing.T) {
+		o := &pistachio.Options{Include: []string{"user*"}}
+		assert.True(t, o.MatchName("users"))
+		assert.True(t, o.MatchName("user_roles"))
+		assert.False(t, o.MatchName("posts"))
+	})
+
+	t.Run("exclude match", func(t *testing.T) {
+		o := &pistachio.Options{Exclude: []string{"posts"}}
+		assert.True(t, o.MatchName("users"))
+		assert.False(t, o.MatchName("posts"))
+	})
+
+	t.Run("exclude wildcard", func(t *testing.T) {
+		o := &pistachio.Options{Exclude: []string{"tmp_*"}}
+		assert.True(t, o.MatchName("users"))
+		assert.False(t, o.MatchName("tmp_backup"))
+	})
+
+	t.Run("include and exclude", func(t *testing.T) {
+		o := &pistachio.Options{Include: []string{"user*"}, Exclude: []string{"user_tmp"}}
+		assert.True(t, o.MatchName("users"))
+		assert.True(t, o.MatchName("user_roles"))
+		assert.False(t, o.MatchName("user_tmp"))
+		assert.False(t, o.MatchName("posts"))
+	})
+
+	t.Run("multiple include patterns", func(t *testing.T) {
+		o := &pistachio.Options{Include: []string{"users", "posts"}}
+		assert.True(t, o.MatchName("users"))
+		assert.True(t, o.MatchName("posts"))
+		assert.False(t, o.MatchName("orders"))
+	})
+
+	t.Run("question mark wildcard", func(t *testing.T) {
+		o := &pistachio.Options{Include: []string{"user?"}}
+		assert.True(t, o.MatchName("users"))
+		assert.False(t, o.MatchName("user_roles"))
+	})
+}
+
+func TestDump_Include(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Include:    []string{"users"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE TABLE public.users")
+	assert.NotContains(t, output, "public.posts")
+	assert.NotContains(t, output, "active_users")
+}
+
+func TestDump_Exclude(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Exclude:    []string{"posts"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE TABLE public.users")
+	assert.NotContains(t, output, "public.posts")
+}
+
+func TestDump_IncludeWildcard(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.user_roles (
+    id integer NOT NULL,
+    CONSTRAINT user_roles_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Include:    []string{"user*"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE TABLE public.users")
+	assert.Contains(t, output, "CREATE TABLE public.user_roles")
+	assert.NotContains(t, output, "public.posts")
+}
+
+func TestDump_NoFilters(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "public.users")
+	assert.Contains(t, output, "public.posts")
+	assert.Contains(t, output, "public.active_users")
+}
+
+func TestDump_ExcludeView(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;
+CREATE VIEW public.tmp_view AS SELECT 1;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Exclude:    []string{"tmp_*"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "active_users")
+	assert.NotContains(t, output, "tmp_view")
+}
+
+func TestPlan_Include(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    title text,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Include:    []string{"users"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
+	assert.NotContains(t, got, "posts")
+}
+
+func TestPlan_Exclude(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    title text,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Exclude:    []string{"posts"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
+	assert.NotContains(t, got, "posts")
+}
+
+func TestApply_Include(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    title text,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Include:    []string{"users"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.NoError(t, err)
+
+	// Verify: only users should have the new column
+	verifyClient := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := verifyClient.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "name text")
+	assert.NotContains(t, output, "title text")
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -13,6 +13,39 @@ import (
 	"github.com/winebarrel/pistachio/internal/testutil"
 )
 
+func TestValidatePatterns(t *testing.T) {
+	t.Run("valid patterns", func(t *testing.T) {
+		o := &pistachio.Options{Include: []string{"user*", "post?"}, Exclude: []string{"tmp_*"}}
+		assert.NoError(t, o.ValidatePatterns())
+	})
+
+	t.Run("invalid include pattern", func(t *testing.T) {
+		o := &pistachio.Options{Include: []string{"[invalid"}}
+		err := o.ValidatePatterns()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--include")
+	})
+
+	t.Run("invalid exclude pattern", func(t *testing.T) {
+		o := &pistachio.Options{Exclude: []string{"[invalid"}}
+		err := o.ValidatePatterns()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--exclude")
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		o := &pistachio.Options{}
+		assert.NoError(t, o.ValidatePatterns())
+	})
+}
+
+func TestAfterApply_InvalidPattern(t *testing.T) {
+	o := &pistachio.Options{Include: []string{"[bad"}}
+	err := o.AfterApply()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--include")
+}
+
 func TestMatchName(t *testing.T) {
 	t.Run("no filters", func(t *testing.T) {
 		o := &pistachio.Options{}

--- a/options.go
+++ b/options.go
@@ -2,7 +2,7 @@ package pistachio
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 )
 
 type Options struct {
@@ -18,7 +18,7 @@ func (o *Options) MatchName(name string) bool {
 	if len(o.Include) > 0 {
 		matched := false
 		for _, pattern := range o.Include {
-			if ok, _ := filepath.Match(pattern, name); ok {
+			if ok, _ := path.Match(pattern, name); ok {
 				matched = true
 				break
 			}
@@ -28,7 +28,7 @@ func (o *Options) MatchName(name string) bool {
 		}
 	}
 	for _, pattern := range o.Exclude {
-		if ok, _ := filepath.Match(pattern, name); ok {
+		if ok, _ := path.Match(pattern, name); ok {
 			return false
 		}
 	}
@@ -36,7 +36,24 @@ func (o *Options) MatchName(name string) bool {
 }
 
 func (o *Options) AfterApply() error {
-	return o.ValidateSchemaMap()
+	if err := o.ValidateSchemaMap(); err != nil {
+		return err
+	}
+	return o.ValidatePatterns()
+}
+
+func (o *Options) ValidatePatterns() error {
+	for _, pattern := range o.Include {
+		if _, err := path.Match(pattern, ""); err != nil {
+			return fmt.Errorf("invalid --include pattern %q: %w", pattern, err)
+		}
+	}
+	for _, pattern := range o.Exclude {
+		if _, err := path.Match(pattern, ""); err != nil {
+			return fmt.Errorf("invalid --exclude pattern %q: %w", pattern, err)
+		}
+	}
+	return nil
 }
 
 func (o *Options) ValidateSchemaMap() error {

--- a/options.go
+++ b/options.go
@@ -1,12 +1,38 @@
 package pistachio
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 type Options struct {
 	ConnString string            `short:"c" env:"DATABASE_URL" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
 	Password   string            `env:"PGPASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PGSCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
+	Include    []string          `short:"I" help:"Include only tables/views matching the pattern (wildcard: *, ?)."`
+	Exclude    []string          `short:"E" help:"Exclude tables/views matching the pattern (wildcard: *, ?)."`
+}
+
+func (o *Options) MatchName(name string) bool {
+	if len(o.Include) > 0 {
+		matched := false
+		for _, pattern := range o.Include {
+			if ok, _ := filepath.Match(pattern, name); ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	for _, pattern := range o.Exclude {
+		if ok, _ := filepath.Match(pattern, name); ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (o *Options) AfterApply() error {

--- a/plan.go
+++ b/plan.go
@@ -41,8 +41,8 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	stmts := diff.DiffTables(currentTables, client.reverseRemapTableSchemas(desired.Tables))
-	stmts = append(stmts, diff.DiffViews(currentViews, client.reverseRemapViewSchemas(desired.Views))...)
+	stmts := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
 
 	return strings.Join(stmts, "\n"), nil
 }


### PR DESCRIPTION
This pull request adds support for filtering tables and views by name using include and exclude patterns, improving flexibility when dumping, planning, or applying schema changes. Users can now specify which tables/views to operate on using `-I`/`--include` and `-E`/`--exclude` flags with wildcard support. The implementation includes updates to the CLI, core logic, and comprehensive tests.

**Filtering functionality:**

- Added `Include` and `Exclude` options to the `Options` struct, and implemented the `MatchName` method to support filtering by patterns with wildcards (`*`, `?`). (`options.go` [options.goL3-R35](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L3-R35))
- Introduced `filterTables` and `filterViews` methods in the `Client` to apply these filters to tables and views in all relevant operations. (`filter.go` [filter.goR1-R34](diffhunk://#diff-8a6290ede135299ac187338deaf28c9f658a4e45634d78c9e2ef113bbbd7ef67R1-R34))
- Updated `Plan`, `Apply`, and `Dump` methods to use the new filtering logic, ensuring only matching tables/views are processed. (`plan.go` [[1]](diffhunk://#diff-11ffedf6a81044546aa19c8009998208f5a7afec3cdff04ca4281117b5ec0da7L44-R45) `apply.go` [[2]](diffhunk://#diff-86ae12b12a6a3e85fd29fb29e6745818c470d89b611f10125ad5761a707e5a76L47-R48) `dump.go` [[3]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdL135-R136)

**Documentation:**

- Updated the `README.md` to document the new `-I`/`--include` and `-E`/`--exclude` flags, with usage examples and explanations of pattern matching. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R110-R124)

**Testing:**

- Added comprehensive tests for the filtering logic and its integration with `Dump`, `Plan`, and `Apply` commands, covering various include/exclude scenarios and wildcards. (`filter_test.go` [filter_test.goR1-R348](diffhunk://#diff-9635073470f3135fbde7bab58122873c8c5f1eaf18ce6a56bbd314786a586904R1-R348))