### PR TITLE
Fix false diffs in dump/plan roundtrip

### DIFF
--- a/diff/tables.go
+++ b/diff/tables.go
@@ -162,13 +162,39 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 	return stmts
 }
 
+// normalizeConstraintDef normalizes a constraint definition by parsing
+// and deparsing it through pg_query to eliminate formatting differences.
+func normalizeConstraintDef(def string) (string, error) {
+	sql := "ALTER TABLE _t ADD CONSTRAINT _c " + def
+	result, err := pg_query.Parse(sql)
+	if err != nil {
+		return "", err
+	}
+	return pg_query.Deparse(result)
+}
+
+// equalConstraintDef compares two constraint definitions by normalizing
+// them through pg_query parse/deparse, so that formatting differences
+// (e.g. extra parentheses, spacing) do not cause false diffs.
+func equalConstraintDef(a, b string) bool {
+	if a == b {
+		return true
+	}
+	normA, errA := normalizeConstraintDef(a)
+	normB, errB := normalizeConstraintDef(b)
+	if errA != nil || errB != nil {
+		return a == b
+	}
+	return normA == normB
+}
+
 func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *model.Constraint]) []string {
 	var stmts []string
 
 	// Drop removed or changed constraints
 	for name, currentCon := range current.All() {
 		desiredCon, ok := desired.GetOk(name)
-		if !ok || currentCon.Definition != desiredCon.Definition {
+		if !ok || !equalConstraintDef(currentCon.Definition, desiredCon.Definition) {
 			stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP CONSTRAINT "+model.Ident(name)+";")
 		}
 	}
@@ -176,7 +202,7 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 	// Add new or changed constraints
 	for name, desiredCon := range desired.All() {
 		currentCon, ok := current.GetOk(name)
-		if !ok || currentCon.Definition != desiredCon.Definition {
+		if !ok || !equalConstraintDef(currentCon.Definition, desiredCon.Definition) {
 			stmts = append(stmts, "ALTER TABLE "+fqtn+" ADD CONSTRAINT "+model.Ident(name)+" "+desiredCon.Definition+";")
 		}
 	}
@@ -271,38 +297,35 @@ func equalPtr[T comparable](a, b *T) bool {
 	return *a == *b
 }
 
-// parseIndexDef parses an index definition string into a pg_query IndexStmt node.
-func parseIndexDef(def string) (*pg_query.IndexStmt, error) {
+// normalizeIndexDef normalizes an index definition by parsing it,
+// clearing the schema, and deparsing it back to a canonical string.
+// This avoids false diffs caused by formatting differences or
+// protobuf location metadata.
+func normalizeIndexDef(def string) (string, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	is := result.Stmts[0].Stmt.GetIndexStmt()
 	if is == nil {
-		return nil, fmt.Errorf("unexpected parse result for index definition: %s", def)
+		return "", fmt.Errorf("unexpected parse result for index definition: %s", def)
 	}
-	return is, nil
-}
-
-// clearIndexSchema clears the schema name in an IndexStmt so that
-// index definitions are compared without regard to schema qualification.
-func clearIndexSchema(is *pg_query.IndexStmt) {
 	if is.Relation != nil {
 		is.Relation.Schemaname = ""
 	}
+	return pg_query.Deparse(result)
 }
 
-// equalIndexDef compares two index definitions by their parse trees,
-// so that schema qualification differences do not cause false diffs.
+// equalIndexDef compares two index definitions by normalizing them
+// through pg_query parse/deparse, so that schema qualification and
+// formatting differences do not cause false diffs.
 func equalIndexDef(a, b string) bool {
-	nodeA, errA := parseIndexDef(a)
-	nodeB, errB := parseIndexDef(b)
+	normA, errA := normalizeIndexDef(a)
+	normB, errB := normalizeIndexDef(b)
 	if errA != nil || errB != nil {
 		return a == b
 	}
-	clearIndexSchema(nodeA)
-	clearIndexSchema(nodeB)
-	return proto.Equal(nodeA, nodeB)
+	return normA == normB
 }
 
 // parseFKDef parses a FK constraint definition string into a pg_query Constraint node.

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -479,6 +479,56 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	assert.Contains(t, stmts[0], "CREATE INDEX idx_new")
 }
 
+func TestEqualConstraintDef_same(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"PRIMARY KEY (id)",
+		"PRIMARY KEY (id)",
+	))
+}
+
+func TestEqualConstraintDef_formattingDiff(t *testing.T) {
+	// pg_get_constraintdef may return extra parentheses compared to pg_query deparse
+	assert.True(t, equalConstraintDef(
+		"CHECK ((kind = ANY (ARRAY['a'::text, 'b'::text])))",
+		"CHECK (kind = ANY(ARRAY['a'::text, 'b'::text]))",
+	))
+}
+
+func TestEqualConstraintDef_castFormattingDiff(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK (((color)::text = ANY ((ARRAY['red'::character varying, 'blue'::character varying])::text[])))",
+		"CHECK (color::text = ANY(ARRAY['red'::varchar, 'blue'::varchar]::text[]))",
+	))
+}
+
+func TestEqualConstraintDef_different(t *testing.T) {
+	assert.False(t, equalConstraintDef(
+		"CHECK (age > 0)",
+		"CHECK (age >= 18)",
+	))
+}
+
+func TestEqualConstraintDef_parseError(t *testing.T) {
+	assert.True(t, equalConstraintDef(")))invalid", ")))invalid"))
+	assert.False(t, equalConstraintDef(")))invalid", ")))other"))
+}
+
+func TestDiffConstraints_noChangeWithFormattingDiff(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("chk_kind", &model.Constraint{
+		Name:       "chk_kind",
+		Definition: "CHECK ((kind = ANY (ARRAY['x'::text, 'y'::text])))",
+	})
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("chk_kind", &model.Constraint{
+		Name:       "chk_kind",
+		Definition: "CHECK (kind = ANY(ARRAY['x'::text, 'y'::text]))",
+	})
+
+	stmts := diffConstraints("public.items", current, desired)
+	assert.Empty(t, stmts)
+}
+
 func TestEqualIndexDef_sameSchema(t *testing.T) {
 	assert.True(t, equalIndexDef(
 		"CREATE INDEX idx ON public.users USING btree (id)",
@@ -506,6 +556,70 @@ func TestEqualIndexDef_differentSchemas(t *testing.T) {
 		"CREATE INDEX idx ON myschema.users USING btree (id)",
 		"CREATE INDEX idx ON public.users USING btree (id)",
 	))
+}
+
+func TestEqualIndexDef_whereClauseSchemaVsNoSchema(t *testing.T) {
+	assert.True(t, equalIndexDef(
+		"CREATE UNIQUE INDEX idx ON myschema.products USING btree (sku) WHERE removed_at IS NULL AND sku IS NOT NULL",
+		"CREATE UNIQUE INDEX idx ON products USING btree (sku) WHERE removed_at IS NULL AND sku IS NOT NULL",
+	))
+}
+
+func TestEqualIndexDef_whereClauseFormattingDiff(t *testing.T) {
+	// pg_get_indexdef may return extra parentheses in WHERE clause
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON myschema.products USING btree (group_id) WHERE ((group_id IS NOT NULL))",
+		"CREATE INDEX idx ON products USING btree (group_id) WHERE group_id IS NOT NULL",
+	))
+}
+
+func TestEqualIndexDef_whereClauseWithCast(t *testing.T) {
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON myschema.events USING btree (created_at) WHERE ((kind)::text = 'done'::text)",
+		"CREATE INDEX idx ON events USING btree (created_at) WHERE kind::text = 'done'::text",
+	))
+}
+
+func TestEqualIndexDef_whereClauseBooleanCondition(t *testing.T) {
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON myschema.tasks USING btree (priority) WHERE ((visible = true))",
+		"CREATE INDEX idx ON tasks USING btree (priority) WHERE visible = true",
+	))
+}
+
+func TestEqualIndexDef_whereClauseMultipleConditions(t *testing.T) {
+	assert.True(t, equalIndexDef(
+		"CREATE UNIQUE INDEX idx ON myschema.tasks USING btree (kind, seq) WHERE ((visible = true) AND (seq > 0))",
+		"CREATE UNIQUE INDEX idx ON tasks USING btree (kind, seq) WHERE visible = true AND seq > 0",
+	))
+}
+
+func TestDiffTables_indexWhereClauseSchemaInsensitive(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "products")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	ct.Indexes.Set("idx", &model.Index{
+		Schema:     "public",
+		Name:       "idx",
+		Table:      "products",
+		Definition: "CREATE UNIQUE INDEX idx ON public.products USING btree (sku) WHERE ((removed_at IS NULL) AND (sku IS NOT NULL))",
+	})
+	current.Set("public.products", ct)
+
+	dt := newTable("public", "products")
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	dt.Indexes.Set("idx", &model.Index{
+		Schema:     "",
+		Name:       "idx",
+		Table:      "products",
+		Definition: "CREATE UNIQUE INDEX idx ON products USING btree (sku) WHERE removed_at IS NULL AND sku IS NOT NULL",
+	})
+	desired.Set("public.products", dt)
+
+	stmts := DiffTables(current, desired)
+	assert.Empty(t, stmts)
 }
 
 func TestEqualIndexDef_different(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -536,7 +536,11 @@ func deparseTypeName(tn *pg_query.TypeName) (string, error) {
 	if lastParen < 0 {
 		return "", fmt.Errorf("unexpected deparse output for type: %s", sql)
 	}
-	return normalizeTypeName(strings.TrimSpace(rest[:lastParen])), nil
+	typeName := strings.TrimSpace(rest[:lastParen])
+	// pg_query may qualify built-in types with "pg_catalog." (e.g. json → pg_catalog.json).
+	// Strip the prefix so the result matches format_type() output.
+	typeName = strings.TrimPrefix(typeName, "pg_catalog.")
+	return normalizeTypeName(typeName), nil
 }
 
 var typeAliases = map[string]string{
@@ -553,6 +557,7 @@ var typeAliases = map[string]string{
 	"timestamptz": "timestamp with time zone",
 	"time":        "time without time zone",
 	"timetz":      "time with time zone",
+	"varbit":      "bit varying",
 	"decimal":     "numeric",
 	"float":       "double precision",
 	"serial":      "integer",

--- a/testdata/parser/json_column.yml
+++ b/testdata/parser/json_column.yml
@@ -1,0 +1,15 @@
+input: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      payload json NOT NULL,
+      metadata jsonb,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+expected: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      payload json NOT NULL,
+      metadata jsonb,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );


### PR DESCRIPTION
- Strip pg_catalog. prefix in deparseTypeName so built-in types like json are not emitted as pg_catalog.json
- Add varbit -> bit varying type alias
- Replace proto.Equal with parse/deparse normalization in equalIndexDef to avoid false diffs caused by location metadata differences in WHERE clauses
- Add equalConstraintDef using parse/deparse normalization to replace direct string comparison in diffConstraints, fixing false diffs from formatting differences between pg_get_constraintdef and pg_query