### PR TITLE
Fix false diffs in FK and CHECK constraints normalization

### DIFF
--- a/catalog/indexes.go
+++ b/catalog/indexes.go
@@ -17,6 +17,8 @@ func (c *Catalog) ListIndexes(ctx context.Context) ([]*model.Index, error) {
 					con.conindid
 				FROM
 					pg_catalog.pg_constraint con
+				WHERE
+					con.contype IN ('p', 'u', 'x')
 			),
 			-- https://www.postgresql.org/docs/current/catalog-pg-depend.html
 			dependency_extension AS (

--- a/catalog/indexes_test.go
+++ b/catalog/indexes_test.go
@@ -141,6 +141,33 @@ func TestListIndexes(t *testing.T) {
 		assert.Contains(t, idx.Definition, "lower")
 	})
 
+	t.Run("unique index referenced by foreign key not excluded", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.groups (
+				id integer NOT NULL,
+				code text NOT NULL,
+				CONSTRAINT groups_pkey PRIMARY KEY (id)
+			);
+			CREATE UNIQUE INDEX idx_groups_code ON public.groups (code);
+			CREATE TABLE public.members (
+				id integer NOT NULL,
+				group_code text NOT NULL,
+				CONSTRAINT members_pkey PRIMARY KEY (id),
+				CONSTRAINT members_group_code_fkey FOREIGN KEY (group_code) REFERENCES public.groups(code)
+			);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.groups")
+		// The unique index should not be excluded just because a FK references it
+		idx, ok := tbl.Indexes.GetOk("idx_groups_code")
+		require.True(t, ok)
+		assert.Contains(t, idx.Definition, "UNIQUE")
+	})
+
 	t.Run("constraint index excluded", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE TABLE public.users (

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -60,14 +60,14 @@ func diffTable(current, desired *model.Table) []string {
 	// so skip diffing them to avoid false DROP statements.
 	if desired.PartitionOf != nil && desired.PartitionBound != nil {
 		stmts = append(stmts, diffIndexes(current.Indexes, desired.Indexes)...)
-		stmts = append(stmts, diffForeignKeys(fqtn, current.ForeignKeys, desired.ForeignKeys)...)
+		stmts = append(stmts, diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)...)
 		return stmts
 	}
 
 	stmts = append(stmts, diffColumns(fqtn, current.Columns, desired.Columns)...)
 	stmts = append(stmts, diffConstraints(fqtn, current.Constraints, desired.Constraints)...)
 	stmts = append(stmts, diffIndexes(current.Indexes, desired.Indexes)...)
-	stmts = append(stmts, diffForeignKeys(fqtn, current.ForeignKeys, desired.ForeignKeys)...)
+	stmts = append(stmts, diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)...)
 	stmts = append(stmts, diffComments(current, desired)...)
 
 	return stmts
@@ -232,14 +232,14 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) []strin
 	return stmts
 }
 
-func diffForeignKeys(fqtn string, current, desired *orderedmap.Map[string, *model.ForeignKey]) []string {
+func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[string, *model.ForeignKey]) []string {
 	var stmts []string
 
 	// Drop removed or changed FKs
 	for name := range current.All() {
 		desiredFk, ok := desired.GetOk(name)
 		currentFk := current.Get(name)
-		if !ok || !equalFKDef(currentFk.Definition, desiredFk.Definition) {
+		if !ok || !equalFKDef(currentFk.Definition, desiredFk.Definition, schema) {
 			stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP CONSTRAINT "+model.Ident(name)+";")
 		}
 	}
@@ -247,7 +247,7 @@ func diffForeignKeys(fqtn string, current, desired *orderedmap.Map[string, *mode
 	// Add new or changed FKs
 	for name, desiredFk := range desired.All() {
 		currentFk, ok := current.GetOk(name)
-		if !ok || !equalFKDef(currentFk.Definition, desiredFk.Definition) {
+		if !ok || !equalFKDef(currentFk.Definition, desiredFk.Definition, schema) {
 			stmts = append(stmts, desiredFk.SQL())
 		}
 	}
@@ -351,24 +351,26 @@ func parseFKDef(def string) (*pg_query.Constraint, error) {
 }
 
 // normalizeFKSchema normalizes the referenced table's schema name in a FK
-// constraint node so that an empty schema (implicit public) is treated
-// the same as an explicit "public" schema.
-func normalizeFKSchema(con *pg_query.Constraint) {
+// constraint node so that an empty schema (implicit via search_path) is
+// treated the same as the explicit schema of the owning table.
+func normalizeFKSchema(con *pg_query.Constraint, schema string) {
 	if con.Pktable != nil && con.Pktable.Schemaname == "" {
-		con.Pktable.Schemaname = "public"
+		con.Pktable.Schemaname = schema
 	}
 }
 
 // equalFKDef compares two FK constraint definitions by their parse trees,
 // so that formatting differences do not cause false diffs.
-func equalFKDef(a, b string) bool {
+// schema is the schema of the table that owns the FK constraint and is used
+// to fill in an implicit (empty) schema on the referenced table.
+func equalFKDef(a, b, schema string) bool {
 	nodeA, errA := parseFKDef(a)
 	nodeB, errB := parseFKDef(b)
 	if errA != nil || errB != nil {
 		return a == b
 	}
-	normalizeFKSchema(nodeA)
-	normalizeFKSchema(nodeB)
+	normalizeFKSchema(nodeA, schema)
+	normalizeFKSchema(nodeB, schema)
 	return proto.Equal(nodeA, nodeB)
 }
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -197,7 +197,7 @@ func normalizeCheckExpr(node *pg_query.Node) *pg_query.Node {
 	case *pg_query.Node_TypeCast:
 		tc := n.TypeCast
 		tc.Arg = normalizeCheckExpr(tc.Arg)
-		if isTextTypeName(tc.TypeName) && tc.Arg.GetAConst() != nil {
+		if isTextLikeTypeName(tc.TypeName) {
 			return tc.Arg
 		}
 	case *pg_query.Node_AExpr:
@@ -249,14 +249,20 @@ func normalizeCheckExpr(node *pg_query.Node) *pg_query.Node {
 	return node
 }
 
-// isTextTypeName returns true if the TypeName refers to the built-in text type.
-func isTextTypeName(tn *pg_query.TypeName) bool {
+// isTextLikeTypeName returns true if the TypeName refers to a text-like type
+// (text, text[], varchar, character varying, or their array forms).
+// pg_get_constraintdef adds these casts on expressions that are already
+// text-typed, so stripping them avoids false diffs.
+func isTextLikeTypeName(tn *pg_query.TypeName) bool {
 	if tn == nil {
 		return false
 	}
 	for _, n := range tn.Names {
-		if s := n.GetString_(); s != nil && s.Sval == "text" {
-			return true
+		if s := n.GetString_(); s != nil {
+			switch s.Sval {
+			case "text", "varchar":
+				return true
+			}
 		}
 	}
 	return false

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -187,7 +187,7 @@ func normalizeConstraintDef(def string) (string, error) {
 
 // normalizeCheckExpr recursively normalizes a CHECK constraint expression
 // so that semantically equivalent definitions compare as equal:
-//   - Strips redundant ::text casts on string constants (added by pg_get_constraintdef).
+//   - Strips casts to text-like types (text, varchar), which pg_get_constraintdef adds.
 //   - Converts = ANY(ARRAY[...]) to IN (...) (PostgreSQL internal representation).
 func normalizeCheckExpr(node *pg_query.Node) *pg_query.Node {
 	if node == nil {

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -164,13 +164,102 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 
 // normalizeConstraintDef normalizes a constraint definition by parsing
 // and deparsing it through pg_query to eliminate formatting differences.
+// It also normalizes AST-level differences introduced by pg_get_constraintdef
+// (e.g. explicit ::text casts on string literals, = ANY(ARRAY[...]) vs IN (...)).
 func normalizeConstraintDef(def string) (string, error) {
 	sql := "ALTER TABLE _t ADD CONSTRAINT _c " + def
 	result, err := pg_query.Parse(sql)
 	if err != nil {
 		return "", err
 	}
+	as := result.Stmts[0].Stmt.GetAlterTableStmt()
+	if as != nil {
+		cmd := as.Cmds[0].GetAlterTableCmd()
+		if cmd != nil {
+			con := cmd.Def.GetConstraint()
+			if con != nil {
+				con.RawExpr = normalizeCheckExpr(con.RawExpr)
+			}
+		}
+	}
 	return pg_query.Deparse(result)
+}
+
+// normalizeCheckExpr recursively normalizes a CHECK constraint expression
+// so that semantically equivalent definitions compare as equal:
+//   - Strips redundant ::text casts on string constants (added by pg_get_constraintdef).
+//   - Converts = ANY(ARRAY[...]) to IN (...) (PostgreSQL internal representation).
+func normalizeCheckExpr(node *pg_query.Node) *pg_query.Node {
+	if node == nil {
+		return nil
+	}
+	switch n := node.Node.(type) {
+	case *pg_query.Node_TypeCast:
+		tc := n.TypeCast
+		tc.Arg = normalizeCheckExpr(tc.Arg)
+		if isTextTypeName(tc.TypeName) && tc.Arg.GetAConst() != nil {
+			return tc.Arg
+		}
+	case *pg_query.Node_AExpr:
+		ae := n.AExpr
+		ae.Lexpr = normalizeCheckExpr(ae.Lexpr)
+		ae.Rexpr = normalizeCheckExpr(ae.Rexpr)
+		if ae.Kind == pg_query.A_Expr_Kind_AEXPR_OP_ANY {
+			if arr := ae.Rexpr.GetAArrayExpr(); arr != nil {
+				ae.Kind = pg_query.A_Expr_Kind_AEXPR_IN
+				ae.Rexpr = &pg_query.Node{
+					Node: &pg_query.Node_List{
+						List: &pg_query.List{Items: arr.Elements},
+					},
+				}
+			}
+		}
+	case *pg_query.Node_BoolExpr:
+		for i, arg := range n.BoolExpr.Args {
+			n.BoolExpr.Args[i] = normalizeCheckExpr(arg)
+		}
+	case *pg_query.Node_AArrayExpr:
+		for i, elem := range n.AArrayExpr.Elements {
+			n.AArrayExpr.Elements[i] = normalizeCheckExpr(elem)
+		}
+	case *pg_query.Node_List:
+		for i, item := range n.List.Items {
+			n.List.Items[i] = normalizeCheckExpr(item)
+		}
+	case *pg_query.Node_FuncCall:
+		for i, arg := range n.FuncCall.Args {
+			n.FuncCall.Args[i] = normalizeCheckExpr(arg)
+		}
+	case *pg_query.Node_NullTest:
+		n.NullTest.Arg = normalizeCheckExpr(n.NullTest.Arg)
+	case *pg_query.Node_CoalesceExpr:
+		for i, arg := range n.CoalesceExpr.Args {
+			n.CoalesceExpr.Args[i] = normalizeCheckExpr(arg)
+		}
+	case *pg_query.Node_CaseExpr:
+		n.CaseExpr.Arg = normalizeCheckExpr(n.CaseExpr.Arg)
+		n.CaseExpr.Defresult = normalizeCheckExpr(n.CaseExpr.Defresult)
+		for _, when := range n.CaseExpr.Args {
+			if w := when.GetCaseWhen(); w != nil {
+				w.Expr = normalizeCheckExpr(w.Expr)
+				w.Result = normalizeCheckExpr(w.Result)
+			}
+		}
+	}
+	return node
+}
+
+// isTextTypeName returns true if the TypeName refers to the built-in text type.
+func isTextTypeName(tn *pg_query.TypeName) bool {
+	if tn == nil {
+		return false
+	}
+	for _, n := range tn.Names {
+		if s := n.GetString_(); s != nil && s.Sval == "text" {
+			return true
+		}
+	}
+	return false
 }
 
 // equalConstraintDef compares two constraint definitions by normalizing

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -394,8 +394,9 @@ func equalPtr[T comparable](a, b *T) bool {
 
 // normalizeIndexDef normalizes an index definition by parsing it,
 // clearing the schema, and deparsing it back to a canonical string.
-// This avoids false diffs caused by formatting differences or
-// protobuf location metadata.
+// It also canonicalises the default sort order so that explicit ASC
+// (the default) matches an omitted order, and explicit NULLS LAST
+// for ASC / NULLS FIRST for DESC matches an omitted nulls clause.
 func normalizeIndexDef(def string) (string, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {
@@ -407,6 +408,28 @@ func normalizeIndexDef(def string) (string, error) {
 	}
 	if is.Relation != nil {
 		is.Relation.Schemaname = ""
+	}
+	for _, p := range is.IndexParams {
+		ie := p.GetIndexElem()
+		if ie == nil {
+			continue
+		}
+		// Canonicalise sort order: SORTBY_ASC and SORTBY_DEFAULT are equivalent.
+		if ie.Ordering == pg_query.SortByDir_SORTBY_ASC {
+			ie.Ordering = pg_query.SortByDir_SORTBY_DEFAULT
+		}
+		// Canonicalise nulls order: NULLS LAST is the default for ASC/DEFAULT,
+		// NULLS FIRST is the default for DESC.
+		switch ie.Ordering {
+		case pg_query.SortByDir_SORTBY_DEFAULT:
+			if ie.NullsOrdering == pg_query.SortByNulls_SORTBY_NULLS_LAST {
+				ie.NullsOrdering = pg_query.SortByNulls_SORTBY_NULLS_DEFAULT
+			}
+		case pg_query.SortByDir_SORTBY_DESC:
+			if ie.NullsOrdering == pg_query.SortByNulls_SORTBY_NULLS_FIRST {
+				ie.NullsOrdering = pg_query.SortByNulls_SORTBY_NULLS_DEFAULT
+			}
+		}
 	}
 	return pg_query.Deparse(result)
 }

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -543,6 +543,21 @@ func TestEqualConstraintDef_inVsAnyArray(t *testing.T) {
 	))
 }
 
+func TestEqualConstraintDef_varcharCastInAnyArray(t *testing.T) {
+	// pg_get_constraintdef may use ::character varying and ::text[] casts
+	assert.True(t, equalConstraintDef(
+		"CHECK ((status::text = ANY (ARRAY['active'::character varying, 'pending'::character varying]::text[])))",
+		"CHECK (status IN ('active', 'pending'))",
+	))
+}
+
+func TestEqualConstraintDef_varcharCastWithoutArrayCast(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK ((status = ANY (ARRAY['active'::character varying, 'pending'::character varying])))",
+		"CHECK (status IN ('active', 'pending'))",
+	))
+}
+
 func TestEqualConstraintDef_inVsAnyArray_different(t *testing.T) {
 	assert.False(t, equalConstraintDef(
 		"CHECK ((status = ANY (ARRAY['active'::text, 'pending'::text])))",

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -290,7 +290,7 @@ func TestDiffForeignKeys_add(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts := diffForeignKeys("public.orders", current, desired)
+	stmts := diffForeignKeys("public.orders", "public", current, desired)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "ADD CONSTRAINT fk_user")
 }
@@ -304,7 +304,7 @@ func TestDiffForeignKeys_drop(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 
-	stmts := diffForeignKeys("public.orders", current, desired)
+	stmts := diffForeignKeys("public.orders", "public", current, desired)
 	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, stmts)
 }
 
@@ -389,13 +389,13 @@ func TestEqualDefault(t *testing.T) {
 func TestEqualFKDef(t *testing.T) {
 	a := "FOREIGN KEY (user_id) REFERENCES users(id)"
 	b := "FOREIGN KEY (user_id) REFERENCES users (id)"
-	assert.True(t, equalFKDef(a, b))
+	assert.True(t, equalFKDef(a, b, "public"))
 }
 
 func TestEqualFKDef_different(t *testing.T) {
 	a := "FOREIGN KEY (user_id) REFERENCES users(id)"
 	b := "FOREIGN KEY (user_id) REFERENCES orders(id)"
-	assert.False(t, equalFKDef(a, b))
+	assert.False(t, equalFKDef(a, b, "public"))
 }
 
 func TestDiffTables_newTable_withForeignKey(t *testing.T) {
@@ -420,13 +420,25 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 func TestEqualFKDef_implicitPublicSchema(t *testing.T) {
 	a := "FOREIGN KEY (user_id) REFERENCES users(id)"
 	b := "FOREIGN KEY (user_id) REFERENCES public.users(id)"
-	assert.True(t, equalFKDef(a, b))
+	assert.True(t, equalFKDef(a, b, "public"))
+}
+
+func TestEqualFKDef_implicitNonPublicSchema(t *testing.T) {
+	a := "FOREIGN KEY (item_id) REFERENCES items(id)"
+	b := "FOREIGN KEY (item_id) REFERENCES myapp.items(id)"
+	assert.True(t, equalFKDef(a, b, "myapp"))
+}
+
+func TestEqualFKDef_implicitNonPublicSchema_different(t *testing.T) {
+	a := "FOREIGN KEY (item_id) REFERENCES items(id)"
+	b := "FOREIGN KEY (item_id) REFERENCES other.items(id)"
+	assert.False(t, equalFKDef(a, b, "myapp"))
 }
 
 func TestEqualFKDef_parseError(t *testing.T) {
 	// When both fail to parse, falls back to string comparison
-	assert.True(t, equalFKDef("not sql", "not sql"))
-	assert.False(t, equalFKDef("not sql", "other"))
+	assert.True(t, equalFKDef("not sql", "not sql", "public"))
+	assert.False(t, equalFKDef("not sql", "other", "public"))
 }
 
 func TestEqualDefault_parseError(t *testing.T) {
@@ -455,7 +467,7 @@ func TestDiffForeignKeys_change(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts := diffForeignKeys("public.orders", current, desired)
+	stmts := diffForeignKeys("public.orders", "public", current, desired)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", stmts[0])
 	assert.Contains(t, stmts[1], "ADD CONSTRAINT fk_user")

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -520,6 +520,14 @@ func TestEqualConstraintDef_different(t *testing.T) {
 	))
 }
 
+func TestEqualConstraintDef_nonTextCastPreserved(t *testing.T) {
+	// ::integer cast is semantically meaningful and must not be stripped
+	assert.False(t, equalConstraintDef(
+		"CHECK (val > '0'::integer)",
+		"CHECK (val > '0')",
+	))
+}
+
 func TestEqualConstraintDef_textCastOnRegex(t *testing.T) {
 	// pg_get_constraintdef adds ::text to string literals
 	assert.True(t, equalConstraintDef(

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -748,6 +748,53 @@ func TestDiffTables_indexWhereClauseSchemaInsensitive(t *testing.T) {
 	assert.Empty(t, stmts)
 }
 
+func TestEqualIndexDef_explicitAscVsDefault(t *testing.T) {
+	// ASC is the default sort order; pg_get_indexdef omits it
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON t USING btree (col1 DESC, col2)",
+		"CREATE INDEX idx ON t USING btree (col1 DESC, col2 ASC)",
+	))
+}
+
+func TestEqualIndexDef_allDefault(t *testing.T) {
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON t USING btree (col1)",
+		"CREATE INDEX idx ON t USING btree (col1 ASC)",
+	))
+}
+
+func TestEqualIndexDef_descNullsFirst(t *testing.T) {
+	// NULLS FIRST is the default for DESC; pg_get_indexdef omits it
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON t USING btree (col1 DESC)",
+		"CREATE INDEX idx ON t USING btree (col1 DESC NULLS FIRST)",
+	))
+}
+
+func TestEqualIndexDef_ascNullsLast(t *testing.T) {
+	// NULLS LAST is the default for ASC; pg_get_indexdef omits it
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON t USING btree (col1)",
+		"CREATE INDEX idx ON t USING btree (col1 ASC NULLS LAST)",
+	))
+}
+
+func TestEqualIndexDef_descNullsLast_notEqual(t *testing.T) {
+	// NULLS LAST for DESC is non-default, must not be treated as equal
+	assert.False(t, equalIndexDef(
+		"CREATE INDEX idx ON t USING btree (col1 DESC)",
+		"CREATE INDEX idx ON t USING btree (col1 DESC NULLS LAST)",
+	))
+}
+
+func TestEqualIndexDef_ascNullsFirst_notEqual(t *testing.T) {
+	// NULLS FIRST for ASC is non-default, must not be treated as equal
+	assert.False(t, equalIndexDef(
+		"CREATE INDEX idx ON t USING btree (col1)",
+		"CREATE INDEX idx ON t USING btree (col1 ASC NULLS FIRST)",
+	))
+}
+
 func TestEqualIndexDef_different(t *testing.T) {
 	assert.False(t, equalIndexDef(
 		"CREATE INDEX idx ON public.users USING btree (id)",

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -520,9 +520,108 @@ func TestEqualConstraintDef_different(t *testing.T) {
 	))
 }
 
+func TestEqualConstraintDef_textCastOnRegex(t *testing.T) {
+	// pg_get_constraintdef adds ::text to string literals
+	assert.True(t, equalConstraintDef(
+		"CHECK ((code ~ '^[0-9a-f]{64}$'::text))",
+		"CHECK (code ~ '^[0-9a-f]{64}$')",
+	))
+}
+
+func TestEqualConstraintDef_textCastOnNotEmpty(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK ((name <> ''::text))",
+		"CHECK (name <> '')",
+	))
+}
+
+func TestEqualConstraintDef_inVsAnyArray(t *testing.T) {
+	// pg_get_constraintdef returns = ANY(ARRAY[...]) for IN (...)
+	assert.True(t, equalConstraintDef(
+		"CHECK ((status = ANY (ARRAY['active'::text, 'pending'::text])))",
+		"CHECK (status IN ('active', 'pending'))",
+	))
+}
+
+func TestEqualConstraintDef_inVsAnyArray_different(t *testing.T) {
+	assert.False(t, equalConstraintDef(
+		"CHECK ((status = ANY (ARRAY['active'::text, 'pending'::text])))",
+		"CHECK (status IN ('active', 'closed'))",
+	))
+}
+
+func TestEqualConstraintDef_textCastInBoolExpr(t *testing.T) {
+	// AND/OR combining multiple conditions with ::text casts
+	assert.True(t, equalConstraintDef(
+		"CHECK (((name <> ''::text) AND (code ~ '^[0-9]+$'::text)))",
+		"CHECK (name <> '' AND code ~ '^[0-9]+$')",
+	))
+}
+
+func TestEqualConstraintDef_textCastInFuncCall(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK ((length((name)::text) > 0))",
+		"CHECK (length(name::text) > 0)",
+	))
+}
+
+func TestEqualConstraintDef_textCastInCoalesce(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK ((COALESCE(name, ''::text) <> ''::text))",
+		"CHECK (COALESCE(name, '') <> '')",
+	))
+}
+
+func TestEqualConstraintDef_textCastInNullTest(t *testing.T) {
+	// NullTest recurse - ensure it doesn't break
+	assert.True(t, equalConstraintDef(
+		"CHECK ((name IS NOT NULL))",
+		"CHECK (name IS NOT NULL)",
+	))
+}
+
+func TestEqualConstraintDef_textCastInCase(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK (((CASE WHEN (kind = 'a'::text) THEN 1 ELSE 0 END) > 0))",
+		"CHECK ((CASE WHEN kind = 'a' THEN 1 ELSE 0 END) > 0)",
+	))
+}
+
 func TestEqualConstraintDef_parseError(t *testing.T) {
 	assert.True(t, equalConstraintDef(")))invalid", ")))invalid"))
 	assert.False(t, equalConstraintDef(")))invalid", ")))other"))
+}
+
+func TestDiffConstraints_noChangeWithTextCast(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("chk_name", &model.Constraint{
+		Name:       "chk_name",
+		Definition: "CHECK ((name <> ''::text))",
+	})
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("chk_name", &model.Constraint{
+		Name:       "chk_name",
+		Definition: "CHECK (name <> '')",
+	})
+
+	stmts := diffConstraints("public.items", current, desired)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffConstraints_noChangeWithInVsAny(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("chk_status", &model.Constraint{
+		Name:       "chk_status",
+		Definition: "CHECK ((status = ANY (ARRAY['active'::text, 'pending'::text])))",
+	})
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("chk_status", &model.Constraint{
+		Name:       "chk_status",
+		Definition: "CHECK (status IN ('active', 'pending'))",
+	})
+
+	stmts := diffConstraints("public.items", current, desired)
+	assert.Empty(t, stmts)
 }
 
 func TestDiffConstraints_noChangeWithFormattingDiff(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -552,7 +552,7 @@ func parseInlineForeignKey(con *pg_query.Constraint, schema, table, defaultSchem
 			Columns:    columns,
 			Deferrable: con.Deferrable,
 			Deferred:   con.Initdeferred,
-			Validated:  true,
+			Validated:  !con.SkipValidation,
 		},
 		Schema:    schema,
 		Table:     table,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -187,12 +187,22 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 
 		case elt.GetConstraint() != nil:
 			con := elt.GetConstraint()
-			constraint, err := parseTableConstraint(con)
-			if err != nil {
-				return nil, err
-			}
-			if constraint != nil {
-				table.Constraints.Set(constraint.Name, constraint)
+			if con.Contype == pg_query.ConstrType_CONSTR_FOREIGN {
+				fk, err := parseInlineForeignKey(con, schema, cs.Relation.Relname, defaultSchema)
+				if err != nil {
+					return nil, err
+				}
+				if fk != nil {
+					table.ForeignKeys.Set(fk.Name, fk)
+				}
+			} else {
+				constraint, err := parseTableConstraint(con)
+				if err != nil {
+					return nil, err
+				}
+				if constraint != nil {
+					table.Constraints.Set(constraint.Name, constraint)
+				}
 			}
 		}
 	}
@@ -502,6 +512,53 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 	}
 
 	return nil, nil, nil
+}
+
+// parseInlineForeignKey builds a ForeignKey from an inline FOREIGN KEY
+// constraint inside a CREATE TABLE statement.
+func parseInlineForeignKey(con *pg_query.Constraint, schema, table, defaultSchema string) (*model.ForeignKey, error) {
+	if con.Conname == "" {
+		return nil, nil
+	}
+
+	def, err := deparseConstraintDef(con)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deparse constraint %s: %w", con.Conname, err)
+	}
+
+	var refSchema, refTable *string
+	if con.Pktable != nil {
+		rs := con.Pktable.Schemaname
+		if rs == "" {
+			rs = defaultSchema
+		}
+		refSchema = &rs
+		rt := con.Pktable.Relname
+		refTable = &rt
+	}
+
+	var columns []string
+	for _, attr := range con.FkAttrs {
+		if s := attr.GetString_(); s != nil {
+			columns = append(columns, s.Sval)
+		}
+	}
+
+	return &model.ForeignKey{
+		Constraint: model.Constraint{
+			Name:       con.Conname,
+			Type:       model.ConstraintType('f'),
+			Definition: def,
+			Columns:    columns,
+			Deferrable: con.Deferrable,
+			Deferred:   con.Initdeferred,
+			Validated:  true,
+		},
+		Schema:    schema,
+		Table:     table,
+		RefSchema: refSchema,
+		RefTable:  refTable,
+	}, nil
 }
 
 // Deparse helpers

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -318,15 +318,16 @@ CREATE TABLE myapp.items (
 }
 
 func TestParseSQL_InlineForeignKeyUnnamed(t *testing.T) {
-	// Unnamed inline FK constraints should be skipped (same as other unnamed constraints)
+	// Unnamed table-level FK constraints should be skipped
 	sql := `CREATE TABLE public.groups (
     id integer NOT NULL,
     CONSTRAINT groups_pkey PRIMARY KEY (id)
 );
 CREATE TABLE public.members (
     id integer NOT NULL,
-    group_id integer NOT NULL REFERENCES public.groups(id),
-    CONSTRAINT members_pkey PRIMARY KEY (id)
+    group_id integer NOT NULL,
+    CONSTRAINT members_pkey PRIMARY KEY (id),
+    FOREIGN KEY (group_id) REFERENCES public.groups(id)
 );`
 
 	result, err := parser.ParseSQL(sql)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -263,6 +263,80 @@ ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCE
 	assert.Equal(t, []string{"user_id"}, fk.Columns)
 }
 
+func TestParseSQL_InlineForeignKey(t *testing.T) {
+	sql := `CREATE TABLE public.groups (
+    id integer NOT NULL,
+    CONSTRAINT groups_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.members (
+    id integer NOT NULL,
+    group_id integer NOT NULL,
+    CONSTRAINT members_pkey PRIMARY KEY (id),
+    CONSTRAINT members_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id)
+);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.members")
+	require.True(t, ok)
+	fk, ok := tbl.ForeignKeys.GetOk("members_group_id_fkey")
+	require.True(t, ok)
+	assert.True(t, fk.Validated)
+	assert.Equal(t, "public", fk.Schema)
+	assert.Equal(t, "members", fk.Table)
+	assert.Equal(t, "public", *fk.RefSchema)
+	assert.Equal(t, "groups", *fk.RefTable)
+	assert.Equal(t, []string{"group_id"}, fk.Columns)
+	assert.Contains(t, fk.Definition, "FOREIGN KEY (group_id)")
+}
+
+func TestParseSQL_InlineForeignKeyWithSchema(t *testing.T) {
+	sql := `CREATE TABLE myapp.categories (
+    id integer NOT NULL,
+    CONSTRAINT categories_pkey PRIMARY KEY (id)
+);
+CREATE TABLE myapp.items (
+    id integer NOT NULL,
+    category_id integer NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id),
+    CONSTRAINT items_category_id_fkey FOREIGN KEY (category_id) REFERENCES myapp.categories(id)
+);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("myapp.items")
+	require.True(t, ok)
+	fk, ok := tbl.ForeignKeys.GetOk("items_category_id_fkey")
+	require.True(t, ok)
+	assert.Equal(t, "myapp", fk.Schema)
+	assert.Equal(t, "items", fk.Table)
+	assert.Equal(t, "myapp", *fk.RefSchema)
+	assert.Equal(t, "categories", *fk.RefTable)
+	assert.Equal(t, []string{"category_id"}, fk.Columns)
+}
+
+func TestParseSQL_InlineForeignKeyUnnamed(t *testing.T) {
+	// Unnamed inline FK constraints should be skipped (same as other unnamed constraints)
+	sql := `CREATE TABLE public.groups (
+    id integer NOT NULL,
+    CONSTRAINT groups_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.members (
+    id integer NOT NULL,
+    group_id integer NOT NULL REFERENCES public.groups(id),
+    CONSTRAINT members_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.members")
+	require.True(t, ok)
+	assert.Equal(t, 0, tbl.ForeignKeys.Len())
+}
+
 func TestParseSQL_TablespaceOnCreate(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,


### PR DESCRIPTION
This pull request introduces several improvements to PostgreSQL schema diffing and parsing logic, focusing on making comparisons of constraints, indexes, and foreign keys more robust against irrelevant formatting and internal representation differences. It also fixes and extends test coverage for these cases. The main changes are grouped below:

**Constraint and Index Comparison Robustness:**

* Enhanced normalization of CHECK constraint definitions to ignore irrelevant differences such as explicit `::text` casts, and to treat `IN (...)` and `= ANY(ARRAY[...])` as equivalent, reducing false-positive diffs. Added recursive normalization for various expression node types. (`diff/tables.go`, `diff/tables_test.go`) ([diff/tables.goR167-R270](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248R167-R270), Facfb971L508R520)
* Improved index definition normalization to treat explicit and default sort orders (`ASC`, `DESC`) and their associated nulls ordering consistently, so that omitted defaults do not cause spurious diffs. (`diff/tables.go`, `diff/tables_test.go`) [[1]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L302-R399) [[2]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248R412-R433) [[3]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeR759-R805)

**Foreign Key Handling and Schema Normalization:**

* Changed foreign key diffing logic to treat implicit and explicit schema names as equivalent, using the owning table's schema as the default. This prevents unnecessary changes when the schema is omitted due to `search_path`. (`diff/tables.go`, `diff/tables_test.go`) [[1]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L354-R491) [[2]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L235-R345) [[3]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeL392-R398) [[4]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeL423-R441)
* Updated the parser to correctly handle inline foreign key constraints in `CREATE TABLE` statements, ensuring they are properly parsed and added to the table model. (`parser/parser.go`) [[1]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R190-R198) [[2]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R208)

**Test Coverage:**

* Added and updated a comprehensive suite of tests to verify that constraint and index diffs are not triggered by irrelevant formatting differences, and that foreign key comparisons behave correctly with implicit/explicit schema names and various edge cases. (`diff/tables_test.go`) [[1]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeR523-R649) [[2]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeR759-R805) [[3]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeL392-R398) [[4]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeL423-R441)

**Minor Improvements:**

* The index listing query now explicitly restricts constraints to primary, unique, and exclusion types for clarity and correctness. (`catalog/indexes.go`)
* Minor test improvements to ensure unique indexes referenced by foreign keys are not incorrectly excluded. (`catalog/indexes_test.go`)

These changes collectively make schema diffs more accurate and less sensitive to irrelevant differences, improving the reliability of schema migrations and reviews.