### PR TITLE
Return error for unnamed constraints instead of silently skipping

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -289,8 +289,17 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema, defaultSchema string) error {
 	for _, conNode := range cd.Constraints {
 		con := conNode.GetConstraint()
-		if con == nil || con.Conname == "" {
+		if con == nil {
 			continue
+		}
+		// Skip column-attribute constraints (NOT NULL, DEFAULT, IDENTITY, GENERATED)
+		switch con.Contype {
+		case pg_query.ConstrType_CONSTR_NOTNULL, pg_query.ConstrType_CONSTR_DEFAULT,
+			pg_query.ConstrType_CONSTR_IDENTITY, pg_query.ConstrType_CONSTR_GENERATED:
+			continue
+		}
+		if con.Conname == "" {
+			return fmt.Errorf("unnamed constraint on column %q is not supported (type: %s)", cd.Colname, con.Contype)
 		}
 		switch con.Contype {
 		case pg_query.ConstrType_CONSTR_FOREIGN:
@@ -321,7 +330,7 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 
 func parseTableConstraint(con *pg_query.Constraint) (*model.Constraint, error) {
 	if con.Conname == "" {
-		return nil, nil
+		return nil, fmt.Errorf("unnamed constraints are not supported (type: %s)", con.Contype)
 	}
 
 	var conType model.ConstraintType
@@ -561,7 +570,7 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 // constraint inside a CREATE TABLE statement.
 func parseInlineForeignKey(con *pg_query.Constraint, schema, table, defaultSchema string) (*model.ForeignKey, error) {
 	if con.Conname == "" {
-		return nil, nil
+		return nil, fmt.Errorf("unnamed FOREIGN KEY constraints are not supported")
 	}
 
 	def, err := deparseConstraintDef(con)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -283,9 +283,10 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 }
 
 // extractColumnConstraints extracts named constraints from a column definition
-// (e.g. PRIMARY KEY, UNIQUE, CHECK, FOREIGN KEY) and adds them to the table.
-// Column-level constraints that have no explicit name are skipped because
-// PostgreSQL auto-generates names that cannot be predicted from the SQL file.
+// (e.g. PRIMARY KEY, UNIQUE, CHECK, EXCLUSION, FOREIGN KEY) and adds them to
+// the table. Column-attribute constraints (NOT NULL, DEFAULT, IDENTITY,
+// GENERATED) are skipped as they are handled by parseColumnDef.
+// Unnamed non-attribute constraints return an error.
 func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema, defaultSchema string) error {
 	for _, conNode := range cd.Constraints {
 		con := conNode.GetConstraint()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -445,15 +445,36 @@ CREATE TABLE public.items (
 }
 
 func TestParseSQL_ColumnLevelUnnamedConstraintsError(t *testing.T) {
-	// Unnamed column-level PRIMARY KEY should return an error
-	sql := `CREATE TABLE public.items (
-    id integer PRIMARY KEY,
-    name text NOT NULL
-);`
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "PRIMARY KEY",
+			sql:  `CREATE TABLE public.items (id integer PRIMARY KEY);`,
+		},
+		{
+			name: "UNIQUE",
+			sql:  `CREATE TABLE public.items (id integer NOT NULL, code text UNIQUE);`,
+		},
+		{
+			name: "CHECK",
+			sql:  `CREATE TABLE public.items (id integer NOT NULL, val integer CHECK (val > 0));`,
+		},
+		{
+			name: "FOREIGN KEY",
+			sql: `CREATE TABLE public.groups (id integer NOT NULL, CONSTRAINT groups_pkey PRIMARY KEY (id));
+CREATE TABLE public.items (id integer NOT NULL, group_id integer REFERENCES public.groups(id));`,
+		},
+	}
 
-	_, err := parser.ParseSQL(sql)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unnamed constraint")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parser.ParseSQL(tt.sql)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unnamed constraint")
+		})
+	}
 }
 
 func TestParseSQL_TablespaceOnCreate(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -318,7 +318,7 @@ CREATE TABLE myapp.items (
 }
 
 func TestParseSQL_InlineForeignKeyUnnamed(t *testing.T) {
-	// Unnamed table-level FK constraints should be skipped
+	// Unnamed table-level FK constraints should return an error
 	sql := `CREATE TABLE public.groups (
     id integer NOT NULL,
     CONSTRAINT groups_pkey PRIMARY KEY (id)
@@ -330,12 +330,9 @@ CREATE TABLE public.members (
     FOREIGN KEY (group_id) REFERENCES public.groups(id)
 );`
 
-	result, err := parser.ParseSQL(sql)
-	require.NoError(t, err)
-
-	tbl, ok := result.Tables.GetOk("public.members")
-	require.True(t, ok)
-	assert.Equal(t, 0, tbl.ForeignKeys.Len())
+	_, err := parser.ParseSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unnamed FOREIGN KEY constraints are not supported")
 }
 
 func TestParseSQL_ColumnLevelNamedCheck(t *testing.T) {
@@ -447,26 +444,16 @@ CREATE TABLE public.items (
 	assert.Equal(t, []string{"group_id"}, fk.Columns)
 }
 
-func TestParseSQL_ColumnLevelUnnamedConstraintsSkipped(t *testing.T) {
-	// Unnamed column-level PRIMARY KEY, UNIQUE, CHECK, FK should all be skipped
-	sql := `CREATE TABLE public.groups (
-    id integer NOT NULL,
-    CONSTRAINT groups_pkey PRIMARY KEY (id)
-);
-CREATE TABLE public.items (
+func TestParseSQL_ColumnLevelUnnamedConstraintsError(t *testing.T) {
+	// Unnamed column-level PRIMARY KEY should return an error
+	sql := `CREATE TABLE public.items (
     id integer PRIMARY KEY,
-    name text UNIQUE,
-    val integer CHECK (val > 0),
-    group_id integer REFERENCES public.groups(id)
+    name text NOT NULL
 );`
 
-	result, err := parser.ParseSQL(sql)
-	require.NoError(t, err)
-
-	tbl, ok := result.Tables.GetOk("public.items")
-	require.True(t, ok)
-	assert.Equal(t, 0, tbl.Constraints.Len())
-	assert.Equal(t, 0, tbl.ForeignKeys.Len())
+	_, err := parser.ParseSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unnamed constraint")
 }
 
 func TestParseSQL_TablespaceOnCreate(t *testing.T) {
@@ -578,19 +565,16 @@ CREATE VIEW public.v2 AS SELECT name FROM users;`
 	assert.Equal(t, 2, result.Views.Len())
 }
 
-func TestParseSQL_UnnamedConstraintSkipped(t *testing.T) {
-	// An unnamed table constraint (no CONSTRAINT name) is skipped by parseTableConstraint
+func TestParseSQL_UnnamedConstraintError(t *testing.T) {
+	// An unnamed table constraint should return an error
 	sql := `CREATE TABLE public.items (
     id integer NOT NULL,
     name text,
     PRIMARY KEY (id)
 );`
-	result, err := parser.ParseSQL(sql)
-	require.NoError(t, err)
-
-	tbl := result.Tables.Get("public.items")
-	require.NotNil(t, tbl)
-	assert.Equal(t, 0, tbl.Constraints.Len())
+	_, err := parser.ParseSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unnamed constraints are not supported")
 }
 
 func TestParseSQL_CommentRemove(t *testing.T) {


### PR DESCRIPTION
Unnamed PRIMARY KEY, UNIQUE, CHECK, EXCLUSION, and FOREIGN KEY constraints now produce an explicit parse error, making it clear that all constraints must be named.