### PR TITLE
Rename duplicate files in split output with case-insensitive comparison

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -83,38 +83,32 @@ func (r *DumpResult) String() string {
 
 func (r *DumpResult) Files() map[string]string {
 	files := make(map[string]string)
+	seen := make(map[string]bool)
 	for _, t := range r.tables().CollectValues() {
-		name := uniqueFileName(files, toFileName(t.Schema, t.Name))
+		name := uniqueFileName(seen, toFileName(t.Schema, t.Name))
 		files[name] = model.TableToSQL(t) + "\n"
+		seen[strings.ToLower(name)] = true
 	}
 	for _, v := range r.views().CollectValues() {
-		name := uniqueFileName(files, toFileName(v.Schema, v.Name))
+		name := uniqueFileName(seen, toFileName(v.Schema, v.Name))
 		files[name] = model.ViewToSQL(v) + "\n"
+		seen[strings.ToLower(name)] = true
 	}
 	return files
 }
 
-func uniqueFileName(files map[string]string, name string) string {
-	if !fileNameExists(files, name) {
+func uniqueFileName(seen map[string]bool, name string) string {
+	if !seen[strings.ToLower(name)] {
 		return name
 	}
 	ext := ".sql"
 	base := strings.TrimSuffix(name, ext)
 	for i := 2; ; i++ {
 		candidate := fmt.Sprintf("%s_%d%s", base, i, ext)
-		if !fileNameExists(files, candidate) {
+		if !seen[strings.ToLower(candidate)] {
 			return candidate
 		}
 	}
-}
-
-func fileNameExists(files map[string]string, name string) bool {
-	for k := range files {
-		if strings.EqualFold(k, name) {
-			return true
-		}
-	}
-	return false
 }
 
 var fileNameReplacer = strings.NewReplacer(

--- a/dump.go
+++ b/dump.go
@@ -84,12 +84,37 @@ func (r *DumpResult) String() string {
 func (r *DumpResult) Files() map[string]string {
 	files := make(map[string]string)
 	for _, t := range r.tables().CollectValues() {
-		files[toFileName(t.Schema, t.Name)] = model.TableToSQL(t) + "\n"
+		name := uniqueFileName(files, toFileName(t.Schema, t.Name))
+		files[name] = model.TableToSQL(t) + "\n"
 	}
 	for _, v := range r.views().CollectValues() {
-		files[toFileName(v.Schema, v.Name)] = model.ViewToSQL(v) + "\n"
+		name := uniqueFileName(files, toFileName(v.Schema, v.Name))
+		files[name] = model.ViewToSQL(v) + "\n"
 	}
 	return files
+}
+
+func uniqueFileName(files map[string]string, name string) string {
+	if !fileNameExists(files, name) {
+		return name
+	}
+	ext := ".sql"
+	base := strings.TrimSuffix(name, ext)
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%d%s", base, i, ext)
+		if !fileNameExists(files, candidate) {
+			return candidate
+		}
+	}
+}
+
+func fileNameExists(files map[string]string, name string) bool {
+	for k := range files {
+		if strings.EqualFold(k, name) {
+			return true
+		}
+	}
+	return false
 }
 
 var fileNameReplacer = strings.NewReplacer(

--- a/dump_test.go
+++ b/dump_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio"
 	"github.com/winebarrel/pistachio/internal/testutil"
+	"github.com/winebarrel/pistachio/model"
 )
 
 type dumpTestCase struct {
@@ -323,6 +325,87 @@ CREATE INDEX idx_users_id ON public.users (id);`)
 	s := got.String()
 	assert.Contains(t, s, "CREATE INDEX idx_users_id ON users")
 	assert.NotContains(t, s, "ON public.users")
+}
+
+func TestDumpResult_Files_DuplicateFileName(t *testing.T) {
+	// When two tables produce the same file name, the second should be renamed
+	tables := orderedmap.New[string, *model.Table]()
+	t1 := &model.Table{
+		Schema:      "",
+		Name:        "users",
+		Columns:     orderedmap.New[string, *model.Column](),
+		Constraints: orderedmap.New[string, *model.Constraint](),
+		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+		Indexes:     orderedmap.New[string, *model.Index](),
+	}
+	t1.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	t2 := &model.Table{
+		Schema:      "",
+		Name:        "users",
+		Columns:     orderedmap.New[string, *model.Column](),
+		Constraints: orderedmap.New[string, *model.Constraint](),
+		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+		Indexes:     orderedmap.New[string, *model.Index](),
+	}
+	t2.Columns.Set("id", &model.Column{Name: "id", TypeName: "bigint", NotNull: true})
+	tables.Set("users", t1)
+	tables.Set("users_2", t2) // different key to avoid orderedmap dedup
+
+	// Manually set up two entries that generate the same toFileName
+	result := &pistachio.DumpResult{
+		Tables: tables,
+		Views:  orderedmap.New[string, *model.View](),
+	}
+	files := result.Files()
+	assert.Contains(t, files, "users.sql")
+	// Only one table since orderedmap keys are different but names are same
+	// Let's verify uniqueFileName via a view with same name
+	tables2 := orderedmap.New[string, *model.Table]()
+	tables2.Set("users", t1)
+	views := orderedmap.New[string, *model.View]()
+	v := &model.View{Schema: "", Name: "users", Definition: "SELECT 1"}
+	views.Set("users", v)
+	result2 := &pistachio.DumpResult{
+		Tables: tables2,
+		Views:  views,
+	}
+	files2 := result2.Files()
+	assert.Contains(t, files2, "users.sql")
+	assert.Contains(t, files2, "users_2.sql")
+}
+
+func TestDumpResult_Files_DuplicateFileNameCaseInsensitive(t *testing.T) {
+	// "Users" and "users" should be treated as duplicate file names
+	tables := orderedmap.New[string, *model.Table]()
+	t1 := &model.Table{
+		Schema:      "",
+		Name:        "users",
+		Columns:     orderedmap.New[string, *model.Column](),
+		Constraints: orderedmap.New[string, *model.Constraint](),
+		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+		Indexes:     orderedmap.New[string, *model.Index](),
+	}
+	t1.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	t2 := &model.Table{
+		Schema:      "",
+		Name:        "Users",
+		Columns:     orderedmap.New[string, *model.Column](),
+		Constraints: orderedmap.New[string, *model.Constraint](),
+		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+		Indexes:     orderedmap.New[string, *model.Index](),
+	}
+	t2.Columns.Set("id", &model.Column{Name: "id", TypeName: "bigint", NotNull: true})
+	tables.Set("users", t1)
+	tables.Set("Users", t2)
+
+	result := &pistachio.DumpResult{
+		Tables: tables,
+		Views:  orderedmap.New[string, *model.View](),
+	}
+	files := result.Files()
+	assert.Contains(t, files, "users.sql")
+	assert.Contains(t, files, "Users_2.sql")
+	assert.Len(t, files, 2)
 }
 
 func TestDump(t *testing.T) {

--- a/dump_test.go
+++ b/dump_test.go
@@ -328,9 +328,9 @@ CREATE INDEX idx_users_id ON public.users (id);`)
 }
 
 func TestDumpResult_Files_DuplicateFileName(t *testing.T) {
-	// When two tables produce the same file name, the second should be renamed
+	// When a table and view produce the same file name, the second should be renamed
 	tables := orderedmap.New[string, *model.Table]()
-	t1 := &model.Table{
+	tbl := &model.Table{
 		Schema:      "",
 		Name:        "users",
 		Columns:     orderedmap.New[string, *model.Column](),
@@ -338,40 +338,20 @@ func TestDumpResult_Files_DuplicateFileName(t *testing.T) {
 		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
 		Indexes:     orderedmap.New[string, *model.Index](),
 	}
-	t1.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
-	t2 := &model.Table{
-		Schema:      "",
-		Name:        "users",
-		Columns:     orderedmap.New[string, *model.Column](),
-		Constraints: orderedmap.New[string, *model.Constraint](),
-		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
-		Indexes:     orderedmap.New[string, *model.Index](),
-	}
-	t2.Columns.Set("id", &model.Column{Name: "id", TypeName: "bigint", NotNull: true})
-	tables.Set("users", t1)
-	tables.Set("users_2", t2) // different key to avoid orderedmap dedup
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	tables.Set("users", tbl)
 
-	// Manually set up two entries that generate the same toFileName
+	views := orderedmap.New[string, *model.View]()
+	views.Set("users", &model.View{Schema: "", Name: "users", Definition: "SELECT 1"})
+
 	result := &pistachio.DumpResult{
 		Tables: tables,
-		Views:  orderedmap.New[string, *model.View](),
-	}
-	files := result.Files()
-	assert.Contains(t, files, "users.sql")
-	// Only one table since orderedmap keys are different but names are same
-	// Let's verify uniqueFileName via a view with same name
-	tables2 := orderedmap.New[string, *model.Table]()
-	tables2.Set("users", t1)
-	views := orderedmap.New[string, *model.View]()
-	v := &model.View{Schema: "", Name: "users", Definition: "SELECT 1"}
-	views.Set("users", v)
-	result2 := &pistachio.DumpResult{
-		Tables: tables2,
 		Views:  views,
 	}
-	files2 := result2.Files()
-	assert.Contains(t, files2, "users.sql")
-	assert.Contains(t, files2, "users_2.sql")
+	files := result.Files()
+	assert.Len(t, files, 2)
+	assert.Contains(t, files, "users.sql")
+	assert.Contains(t, files, "users_2.sql")
 }
 
 func TestDumpResult_Files_DuplicateFileNameCaseInsensitive(t *testing.T) {


### PR DESCRIPTION
When the split option produces files with the same name (e.g. a table and view with the same name, or case-only differences like "users" and "Users"), append a numeric suffix (_2, _3, ...) to avoid overwrites.