### PR TITLE
Show "No changes" as comment

### DIFF
--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -21,7 +21,7 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 	}
 
 	if buf.Len() == 0 {
-		fmt.Fprintln(w, "No changes") //nolint:errcheck
+		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {
 		w.Write(buf.Bytes()) //nolint:errcheck
 	}

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -282,7 +282,7 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Equal(t, "No changes\n", buf.String())
+	assert.Equal(t, "-- No changes\n", buf.String())
 }
 
 func TestApply_Run_NoChanges(t *testing.T) {
@@ -308,7 +308,7 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Equal(t, "No changes\n", buf.String())
+	assert.Equal(t, "-- No changes\n", buf.String())
 }
 
 func TestApply_Run_Error(t *testing.T) {

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -19,7 +19,7 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 	}
 
 	if plan == "" {
-		fmt.Fprintln(w, "No changes") //nolint:errcheck
+		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {
 		fmt.Fprintln(w, plan) //nolint:errcheck
 	}


### PR DESCRIPTION
This pull request updates the output message shown when there are no changes detected in the `plan` and `apply` commands. The message now uses a clearer format, and the corresponding tests have been updated to match.

Output message formatting:

* Changed the output from `"No changes"` to `"-- No changes"` in both the `Plan` and `Apply` command implementations to provide a more distinct and standardized message. (`cmd/command/plan.go`, `cmd/command/apply.go`) [[1]](diffhunk://#diff-92b4b561c88ccc00657cf1e8f706348821ccdc3e2728cfb2bd741252015e477fL22-R22) [[2]](diffhunk://#diff-d5747f2387e3182f5df03f76bddcc659bdc424e69dfc95d5974c88bffbcc6739L24-R24)

Test updates:

* Updated tests `TestPlan_Run_NoChanges` and `TestApply_Run_NoChanges` to expect the new `"-- No changes\n"` output, ensuring test accuracy with the new message format. (`cmd/command/command_test.go`) [[1]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L285-R285) [[2]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L311-R311)