### PR TITLE
Plan pre sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ pist plan schema.sql
 
 # Multiple files
 pist plan tables.sql views.sql
+
+# Include pre-SQL in the output
+pist plan schema.sql --pre-sql-file pre.sql
 ```
 
 ### apply

--- a/plan.go
+++ b/plan.go
@@ -46,17 +46,12 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 	stmts := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
 
-	var preSQL string
-	if options.PreSQLFile != "" {
+	if options.PreSQLFile != "" && len(stmts) > 0 {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)
 		if err != nil {
 			return "", fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
 		}
-		preSQL = string(rawPreSQL)
-	}
-
-	if preSQL != "" {
-		stmts = append([]string{preSQL}, stmts...)
+		stmts = append([]string{string(rawPreSQL)}, stmts...)
 	}
 
 	return strings.Join(stmts, "\n"), nil

--- a/plan.go
+++ b/plan.go
@@ -3,6 +3,7 @@ package pistachio
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/winebarrel/pistachio/catalog"
@@ -11,7 +12,8 @@ import (
 )
 
 type PlanOptions struct {
-	Files []string `arg:"" help:"Path to the desired schema SQL file(s)."`
+	Files      []string `arg:"" help:"Path to the desired schema SQL file(s)."`
+	PreSQLFile string   `type:"path" help:"Path to a SQL file to execute before applying changes."`
 }
 
 func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, error) {
@@ -43,6 +45,19 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 
 	stmts := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
+
+	var preSQL string
+	if options.PreSQLFile != "" {
+		rawPreSQL, err := os.ReadFile(options.PreSQLFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
+		}
+		preSQL = string(rawPreSQL)
+	}
+
+	if preSQL != "" {
+		stmts = append([]string{preSQL}, stmts...)
+	}
 
 	return strings.Join(stmts, "\n"), nil
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -88,6 +88,100 @@ func TestPlan_EmptySchemas(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPlan_WithPreSQLFile(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	tmpDir := t.TempDir()
+	desiredFile := filepath.Join(tmpDir, "desired.sql")
+	preSQLFile := filepath.Join(tmpDir, "pre.sql")
+
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+	require.NoError(t, os.WriteFile(preSQLFile, []byte(`SELECT 1;`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files:      []string{desiredFile},
+		PreSQLFile: preSQLFile,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got, "SELECT 1;")
+	assert.Contains(t, got, "CREATE TABLE public.users")
+
+	// pre-SQL should appear before diff statements
+	preSQLPos := strings.Index(got, "SELECT 1;")
+	diffPos := strings.Index(got, "CREATE TABLE public.users")
+	assert.Less(t, preSQLPos, diffPos)
+}
+
+func TestPlan_WithPreSQLFile_InvalidFile(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files:      []string{desiredFile},
+		PreSQLFile: "/nonexistent/pre.sql",
+	})
+	require.Error(t, err)
+}
+
+func TestPlan_WithPreSQLFile_NoDiff(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	tmpDir := t.TempDir()
+	desiredFile := filepath.Join(tmpDir, "desired.sql")
+	preSQLFile := filepath.Join(tmpDir, "pre.sql")
+
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+	require.NoError(t, os.WriteFile(preSQLFile, []byte(`SELECT 1;`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files:      []string{desiredFile},
+		PreSQLFile: preSQLFile,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got, "SELECT 1;")
+}
+
 func TestPlan_SchemalessDesired(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/plan_test.go
+++ b/plan_test.go
@@ -179,7 +179,7 @@ func TestPlan_WithPreSQLFile_NoDiff(t *testing.T) {
 		PreSQLFile: preSQLFile,
 	})
 	require.NoError(t, err)
-	assert.Contains(t, got, "SELECT 1;")
+	assert.Empty(t, got)
 }
 
 func TestPlan_SchemalessDesired(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for including a "pre-SQL" file when generating a schema plan, ensuring that the contents of the specified file are prepended to the generated SQL output if there are schema changes. It also introduces tests for this new feature and updates the documentation accordingly.

**Feature: Pre-SQL file support in planning**
* Added a `PreSQLFile` option to `PlanOptions` in `plan.go`, allowing users to specify a SQL file to be prepended to the generated plan output. If the file is provided and there are schema changes, its contents are included before the diff statements. [[1]](diffhunk://#diff-11ffedf6a81044546aa19c8009998208f5a7afec3cdff04ca4281117b5ec0da7R16) [[2]](diffhunk://#diff-11ffedf6a81044546aa19c8009998208f5a7afec3cdff04ca4281117b5ec0da7R49-R56)
* Updated the documentation in `README.md` to describe the new `--pre-sql-file` option for the `pist plan schema.sql` command.

**Testing: Pre-SQL file functionality**
* Added tests in `plan_test.go` to verify:
  * The pre-SQL file is included in the output and appears before diff statements.
  * Errors are handled when the pre-SQL file does not exist.
  * No output is produced if there are no schema changes, even if a pre-SQL file is specified.

**Internal changes**
* Imported the `os` package in `plan.go` for reading the pre-SQL file.