### PR TITLE
Update env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Flags:
   -c, --conn-string="postgres://postgres@localhost/postgres"
                               PostgreSQL connection string. See
                               https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                              ($DATABASE_URL)
-      --password=STRING       PostgreSQL password ($PGPASSWORD).
+                              ($PIST_CONN_STR)
+      --password=STRING       PostgreSQL password ($PIST_PASSWORD).
   -n, --schemas=public,...    Schemas to inspect and modify ($PGSCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -11,7 +11,7 @@ import (
 
 func ConnectDB(t *testing.T) *pgx.Conn {
 	t.Helper()
-	connString := os.Getenv("DATABASE_URL")
+	connString := os.Getenv("PIST_CONN_STR")
 	if connString == "" {
 		connString = "postgres://postgres@localhost/postgres"
 	}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -11,7 +11,7 @@ import (
 
 func ConnectDB(t *testing.T) *pgx.Conn {
 	t.Helper()
-	connString := os.Getenv("PIST_CONN_STR")
+	connString := os.Getenv("TEST_PIST_CONN_STR")
 	if connString == "" {
 		connString = "postgres://postgres@localhost/postgres"
 	}

--- a/options.go
+++ b/options.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Options struct {
-	ConnString string            `short:"c" env:"DATABASE_URL" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
-	Password   string            `env:"PGPASSWORD" help:"PostgreSQL password."`
+	ConnString string            `short:"c" env:"PIST_CONN_STR" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
+	Password   string            `env:"PIST_PASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PGSCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
 	Include    []string          `short:"I" help:"Include only tables/views matching the pattern (wildcard: *, ?)."`


### PR DESCRIPTION
This pull request standardizes the environment variable names used for database connection configuration, replacing the previous `DATABASE_URL` and `PGPASSWORD` with `PIST_CONN_STR` and `PIST_PASSWORD` respectively. This change affects documentation, configuration, and test utilities to ensure consistency across the codebase.

**Configuration and Environment Variable Updates:**

* Updated the `Options` struct in `options.go` to use `PIST_CONN_STR` for the connection string and `PIST_PASSWORD` for the password, replacing the previous environment variables.
* Updated the `README.md` documentation to reflect the new environment variable names: `PIST_CONN_STR` for the connection string and `PIST_PASSWORD` for the password.
* Modified the test utility in `internal/testutil/testutil.go` to use `PIST_CONN_STR` instead of `DATABASE_URL` when connecting to the database.