### PR TITLE
Include object name in unnamed constraint error messages

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -224,7 +224,7 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 					}
 				}
 			} else {
-				constraint, err := parseTableConstraint(con)
+				constraint, err := parseTableConstraint(con, table.Name)
 				if err != nil {
 					return nil, err
 				}
@@ -324,7 +324,7 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 			continue
 		}
 		if con.Conname == "" {
-			return fmt.Errorf("unnamed constraint on column %q is not supported (type: %s)", cd.Colname, con.Contype)
+			return fmt.Errorf("unnamed constraint on column %q in table %q is not supported (type: %s)", cd.Colname, table.Name, con.Contype)
 		}
 		switch con.Contype {
 		case pg_query.ConstrType_CONSTR_FOREIGN:
@@ -343,7 +343,7 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 			}
 		case pg_query.ConstrType_CONSTR_PRIMARY, pg_query.ConstrType_CONSTR_UNIQUE,
 			pg_query.ConstrType_CONSTR_CHECK, pg_query.ConstrType_CONSTR_EXCLUSION:
-			constraint, err := parseTableConstraint(con)
+			constraint, err := parseTableConstraint(con, table.Name)
 			if err != nil {
 				return err
 			}
@@ -357,9 +357,9 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 	return nil
 }
 
-func parseTableConstraint(con *pg_query.Constraint) (*model.Constraint, error) {
+func parseTableConstraint(con *pg_query.Constraint, tableName string) (*model.Constraint, error) {
 	if con.Conname == "" {
-		return nil, fmt.Errorf("unnamed constraints are not supported (type: %s)", con.Contype)
+		return nil, fmt.Errorf("unnamed constraint on table %q is not supported (type: %s)", tableName, con.Contype)
 	}
 
 	var conType model.ConstraintType
@@ -584,7 +584,7 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 		}
 
 		// Non-FK constraint (PRIMARY KEY, UNIQUE, CHECK, etc.)
-		constraint, err := parseTableConstraint(con)
+		constraint, err := parseTableConstraint(con, as.Relation.Relname)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -599,7 +599,7 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 // constraint inside a CREATE TABLE statement.
 func parseInlineForeignKey(con *pg_query.Constraint, schema, table, defaultSchema string) (*model.ForeignKey, error) {
 	if con.Conname == "" {
-		return nil, fmt.Errorf("unnamed FOREIGN KEY constraints are not supported")
+		return nil, fmt.Errorf("unnamed FOREIGN KEY constraints are not supported (table: %s)", table)
 	}
 
 	def, err := deparseConstraintDef(con)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -599,7 +599,7 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 // constraint inside a CREATE TABLE statement.
 func parseInlineForeignKey(con *pg_query.Constraint, schema, table, defaultSchema string) (*model.ForeignKey, error) {
 	if con.Conname == "" {
-		return nil, fmt.Errorf("unnamed FOREIGN KEY constraints are not supported (table: %s)", table)
+		return nil, fmt.Errorf("unnamed FOREIGN KEY constraint on table %q is not supported", table)
 	}
 
 	def, err := deparseConstraintDef(con)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -332,7 +332,7 @@ CREATE TABLE public.members (
 
 	_, err := parser.ParseSQL(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unnamed FOREIGN KEY constraints are not supported")
+	assert.Contains(t, err.Error(), "unnamed FOREIGN KEY constraints are not supported (table: members)")
 }
 
 func TestParseSQL_ColumnLevelNamedCheck(t *testing.T) {
@@ -595,7 +595,7 @@ func TestParseSQL_UnnamedConstraintError(t *testing.T) {
 );`
 	_, err := parser.ParseSQL(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unnamed constraints are not supported")
+	assert.Contains(t, err.Error(), "unnamed constraint on table \"items\" is not supported")
 }
 
 func TestParseSQL_CommentRemove(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -332,7 +332,7 @@ CREATE TABLE public.members (
 
 	_, err := parser.ParseSQL(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unnamed FOREIGN KEY constraints are not supported (table: members)")
+	assert.Contains(t, err.Error(), "unnamed FOREIGN KEY constraint on table \"members\" is not supported")
 }
 
 func TestParseSQL_ColumnLevelNamedCheck(t *testing.T) {


### PR DESCRIPTION
This pull request improves error messages related to unnamed constraints in the SQL parser, making them more descriptive by including the table and column names where applicable. It also updates function signatures to pass table names for better error context and adjusts related tests accordingly.

**Error Message Improvements:**

* Error messages for unnamed constraints now include the table name, providing clearer context for debugging [[1]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L360-R362) [[2]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L602-R602) [[3]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L327-R327).
* Error messages for unnamed column-level constraints now include both the column and table names.

**Function Signature Updates:**

* The `parseTableConstraint` function now takes a `tableName` parameter to enable more informative error messages [[1]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L360-R362) [[2]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L227-R227) [[3]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L346-R346) [[4]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L587-R587).

**Test Adjustments:**

* Tests in `parser/parser_test.go` are updated to expect the new, more descriptive error messages [[1]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL335-R335) [[2]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL598-R598).