### PR TITLE
Support enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Download the latest binary from [Releases](https://github.com/winebarrel/pistach
 Usage: pist <command> [flags]
 
 Flags:
-  -h, --help                  Show context-sensitive help.
+  -h, --help                   Show context-sensitive help.
   -c, --conn-string="postgres://postgres@localhost/postgres"
-                              PostgreSQL connection string. See
-                              https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                              ($PIST_CONN_STR)
-      --password=STRING       PostgreSQL password ($PIST_PASSWORD).
-  -n, --schemas=public,...    Schemas to inspect and modify ($PGSCHEMAS).
+                               PostgreSQL connection string. See
+                               https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+                               ($PIST_CONN_STR)
+      --password=STRING        PostgreSQL password ($PIST_PASSWORD).
+  -n, --schemas=public,...     Schemas to inspect and modify ($PGSCHEMAS).
   -m, --schema-map=KEY=VALUE;...
-                              Schema name mapping (e.g. -m old=new).
-  -I, --include=INCLUDE,...   Include only tables/views/enums matching the
-                              pattern (wildcard: *, ?).
-  -E, --exclude=EXCLUDE,...   Exclude tables/views/enums matching the pattern
-                              (wildcard: *, ?).
+                               Schema name mapping (e.g. -m old=new).
+  -I, --include=INCLUDE,...    Include only tables/views/enums matching the
+                               pattern (wildcard: *, ?).
+  -E, --exclude=EXCLUDE,...    Exclude tables/views/enums matching the pattern
+                               (wildcard: *, ?).
       --version
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Flags:
   -n, --schemas=public,...    Schemas to inspect and modify ($PGSCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
-  -I, --include=INCLUDE,...   Include only tables/views matching the pattern
-                              (wildcard: *, ?).
-  -E, --exclude=EXCLUDE,...   Exclude tables/views matching the pattern
+  -I, --include=INCLUDE,...   Include only tables/views/enums matching the
+                              pattern (wildcard: *, ?).
+  -E, --exclude=EXCLUDE,...   Exclude tables/views/enums matching the pattern
                               (wildcard: *, ?).
       --version
 
@@ -110,12 +110,12 @@ pist -n staging -m staging=public plan schema.sql
 pist -n staging -m staging=public apply schema.sql
 ```
 
-### Filtering tables/views
+### Filtering tables/views/enums
 
-Use `-I` / `--include` to include only matching tables/views, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against table/view names only (not schema-qualified names).
+Use `-I` / `--include` to include only matching tables/views/enums, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names).
 
 ```bash
-# Dump only tables/views matching "user*"
+# Dump only objects matching "user*"
 pist -I 'user*' dump
 
 # Plan changes excluding temporary tables
@@ -146,11 +146,11 @@ pist -n staging apply schema.sql
 
 ### Split dump
 
-Use `--split` to output each table/view as a separate file in the specified directory.
+Use `--split` to output each table/view/enum as a separate file in the specified directory.
 
 ```bash
 pist dump --split ./schema/
-# => ./schema/public.users.sql, ./schema/public.orders.sql, ...
+# => ./schema/public.status.sql, ./schema/public.users.sql, ./schema/public.orders.sql, ...
 ```
 
 ## Example
@@ -158,9 +158,12 @@ pist dump --split ./schema/
 Create a schema file:
 
 ```sql
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+
 CREATE TABLE public.users (
     id integer NOT NULL,
     name text NOT NULL,
+    status status NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );
 
@@ -188,7 +191,7 @@ pist apply schema.sql  # apply it
 Or split schema into multiple files and use them together:
 
 ```bash
-pist dump --split ./schema/       # dump per table/view
+pist dump --split ./schema/       # dump per table/view/enum
 pist plan ./schema/*.sql          # review the diff
 pist apply ./schema/*.sql         # apply it
 ```
@@ -198,12 +201,13 @@ pist apply ./schema/*.sql         # apply it
 
 ## Supported Objects
 
+- Enum types (`CREATE TYPE ... AS ENUM`, `ALTER TYPE ... ADD VALUE`)
 - Tables (including unlogged and partitioned tables)
 - Views
 - Columns (serial/bigserial/smallserial, identity, generated)
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
-- Comments (on tables, columns, views)
+- Comments (on tables, columns, views, types)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 

--- a/apply.go
+++ b/apply.go
@@ -39,12 +39,18 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to fetch views: %w", err)
 	}
 
+	currentEnums, err := cat.Enums(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch enums: %w", err)
+	}
+
 	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	stmts := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	stmts := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	stmts = append(stmts, diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))...)
 	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
 
 	var preSQL string

--- a/apply.go
+++ b/apply.go
@@ -49,9 +49,11 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	stmts := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	enumDiff := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	stmts := enumDiff.Stmts
 	stmts = append(stmts, diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))...)
 	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
+	stmts = append(stmts, enumDiff.DropStmts...)
 
 	var preSQL string
 	if options.PreSQLFile != "" {

--- a/apply.go
+++ b/apply.go
@@ -49,7 +49,10 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	enumDiff := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	enumDiff, err := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	if err != nil {
+		return err
+	}
 	stmts := enumDiff.Stmts
 	stmts = append(stmts, diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))...)
 	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)

--- a/catalog/enums.go
+++ b/catalog/enums.go
@@ -46,6 +46,7 @@ func (c *Catalog) ListEnums(ctx context.Context) ([]*model.Enum, error) {
 			JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
 			LEFT JOIN pg_catalog.pg_description d ON d.objoid = t.oid
 			AND d.classoid = 'pg_type'::regclass
+			AND d.objsubid = 0
 			LEFT JOIN dependency_extension de ON de.objid = t.oid
 		WHERE
 			t.typtype = 'e'

--- a/catalog/enums.go
+++ b/catalog/enums.go
@@ -1,0 +1,95 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func (c *Catalog) Enums(ctx context.Context) (*orderedmap.Map[string, *model.Enum], error) {
+	enums, err := c.ListEnums(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	enumByKey := orderedmap.New[string, *model.Enum]()
+	for _, e := range enums {
+		enumByKey.Set(e.FQEN(), e)
+	}
+
+	return enumByKey, nil
+}
+
+func (c *Catalog) ListEnums(ctx context.Context) ([]*model.Enum, error) {
+	q := `
+		WITH
+			dependency_extension AS (
+				SELECT DISTINCT
+					d.objid
+				FROM
+					pg_catalog.pg_depend d
+				WHERE
+					d.deptype = 'e'
+			)
+		SELECT
+			t.oid,
+			n.nspname,
+			t.typname,
+			array_agg(e.enumlabel ORDER BY e.enumsortorder) AS vals,
+			d.description
+		FROM
+			pg_catalog.pg_type t
+			JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+			JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
+			LEFT JOIN pg_catalog.pg_description d ON d.objoid = t.oid
+			AND d.classoid = 'pg_type'::regclass
+			LEFT JOIN dependency_extension de ON de.objid = t.oid
+		WHERE
+			t.typtype = 'e'
+			AND n.nspname = ANY(@schemas)
+			AND de.objid IS NULL
+		GROUP BY
+			t.oid,
+			n.nspname,
+			t.typname,
+			d.description
+		ORDER BY
+			n.nspname,
+			t.typname
+	`
+
+	args := pgx.NamedArgs{
+		"schemas": c.schemas,
+	}
+
+	rows, err := c.conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get enum info: %w", err)
+	}
+	defer rows.Close()
+
+	var enums []*model.Enum
+	for rows.Next() {
+		var e model.Enum
+		err := rows.Scan(
+			&e.OID,
+			&e.Schema,
+			&e.Name,
+			&e.Values,
+			&e.Comment,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("catalog: failed to scan enum info: %w", err)
+		}
+		enums = append(enums, &e)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: failed to scan enum info rows: %w", err)
+	}
+
+	return enums, nil
+}

--- a/catalog/enums_test.go
+++ b/catalog/enums_test.go
@@ -1,0 +1,77 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/catalog"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+func TestEnums(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	t.Run("empty", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, "")
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		enums, err := cat.Enums(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, enums.Len())
+	})
+
+	t.Run("single enum", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		enums, err := cat.Enums(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 1, enums.Len())
+
+		e, ok := enums.GetOk("public.status")
+		require.True(t, ok)
+		assert.Equal(t, "status", e.Name)
+		assert.Equal(t, "public", e.Schema)
+		assert.Equal(t, []string{"active", "inactive", "pending"}, e.Values)
+		assert.Nil(t, e.Comment)
+	})
+
+	t.Run("enum with comment", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TYPE public.status AS ENUM ('active', 'inactive');
+			COMMENT ON TYPE public.status IS 'User status';
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		enums, err := cat.Enums(ctx)
+		require.NoError(t, err)
+
+		e := enums.Get("public.status")
+		require.NotNil(t, e)
+		require.NotNil(t, e.Comment)
+		assert.Equal(t, "User status", *e.Comment)
+	})
+
+	t.Run("multiple enums", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TYPE public.status AS ENUM ('active', 'inactive');
+			CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		enums, err := cat.Enums(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, enums.Len())
+
+		_, ok := enums.GetOk("public.role")
+		assert.True(t, ok)
+		_, ok = enums.GetOk("public.status")
+		assert.True(t, ok)
+	})
+}

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/winebarrel/orderedmap"
@@ -12,7 +13,7 @@ type EnumDiffResult struct {
 	DropStmts []string
 }
 
-func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) *EnumDiffResult {
+func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) (*EnumDiffResult, error) {
 	result := &EnumDiffResult{}
 
 	// New enums
@@ -32,19 +33,11 @@ func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) *EnumDiffR
 			continue
 		}
 
-		// Add new enum values with correct positioning
-		for i, val := range desiredEnum.Values {
-			if !slices.Contains(currentEnum.Values, val) {
-				stmt := "ALTER TYPE " + k + " ADD VALUE " + model.QuoteLiteral(val)
-				// Find the preceding value in desired that exists in current for BEFORE/AFTER positioning
-				if after := findPrecedingExisting(desiredEnum.Values, i, currentEnum.Values); after != "" {
-					stmt += " AFTER " + model.QuoteLiteral(after)
-				} else if before := findFollowingExisting(desiredEnum.Values, i, currentEnum.Values); before != "" {
-					stmt += " BEFORE " + model.QuoteLiteral(before)
-				}
-				result.Stmts = append(result.Stmts, stmt+";")
-			}
+		stmts, err := diffEnumValues(k, currentEnum.Values, desiredEnum.Values)
+		if err != nil {
+			return nil, err
 		}
+		result.Stmts = append(result.Stmts, stmts...)
 
 		// Comment changes
 		if !equalPtr(currentEnum.Comment, desiredEnum.Comment) {
@@ -63,23 +56,84 @@ func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) *EnumDiffR
 		}
 	}
 
-	return result
+	return result, nil
 }
 
-// findPrecedingExisting finds the closest value before index i in desired that exists in current.
-func findPrecedingExisting(desired []string, i int, current []string) string {
+func diffEnumValues(fqen string, current, desired []string) ([]string, error) {
+	// Detect removed values (not supported by PostgreSQL)
+	for _, val := range current {
+		if !slices.Contains(desired, val) {
+			return nil, fmt.Errorf("cannot remove enum value %s from %s: PostgreSQL does not support removing enum values", model.QuoteLiteral(val), fqen)
+		}
+	}
+
+	// Detect reordering (not supported by PostgreSQL)
+	if isReordered(current, desired) {
+		return nil, fmt.Errorf("cannot reorder enum values in %s: PostgreSQL does not support reordering enum values", fqen)
+	}
+
+	// Add new enum values with correct positioning.
+	// Maintain a working slice that tracks values added so far,
+	// so later insertions can reference previously added values.
+	var stmts []string
+	working := slices.Clone(current)
+
+	for i, val := range desired {
+		if slices.Contains(working, val) {
+			continue
+		}
+
+		stmt := "ALTER TYPE " + fqen + " ADD VALUE " + model.QuoteLiteral(val)
+
+		after := findPrecedingExisting(desired, i, working)
+		if after != "" {
+			stmt += " AFTER " + model.QuoteLiteral(after)
+			// Insert into working after the anchor
+			idx := slices.Index(working, after)
+			working = slices.Insert(working, idx+1, val)
+		} else {
+			before := findFollowingExisting(desired, i, working)
+			if before != "" {
+				stmt += " BEFORE " + model.QuoteLiteral(before)
+				idx := slices.Index(working, before)
+				working = slices.Insert(working, idx, val)
+			} else {
+				working = append(working, val)
+			}
+		}
+
+		stmts = append(stmts, stmt+";")
+	}
+
+	return stmts, nil
+}
+
+// isReordered checks if existing values in current appear in a different
+// relative order in desired. New values in desired are ignored.
+func isReordered(current, desired []string) bool {
+	var desiredExisting []string
+	for _, v := range desired {
+		if slices.Contains(current, v) {
+			desiredExisting = append(desiredExisting, v)
+		}
+	}
+	return !slices.Equal(current, desiredExisting)
+}
+
+// findPrecedingExisting finds the closest value before index i in desired that exists in working.
+func findPrecedingExisting(desired []string, i int, working []string) string {
 	for j := i - 1; j >= 0; j-- {
-		if slices.Contains(current, desired[j]) {
+		if slices.Contains(working, desired[j]) {
 			return desired[j]
 		}
 	}
 	return ""
 }
 
-// findFollowingExisting finds the closest value after index i in desired that exists in current.
-func findFollowingExisting(desired []string, i int, current []string) string {
+// findFollowingExisting finds the closest value after index i in desired that exists in working.
+func findFollowingExisting(desired []string, i int, working []string) string {
 	for j := i + 1; j < len(desired); j++ {
-		if slices.Contains(current, desired[j]) {
+		if slices.Contains(working, desired[j]) {
 			return desired[j]
 		}
 	}

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -1,0 +1,56 @@
+package diff
+
+import (
+	"slices"
+
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) []string {
+	var stmts []string
+
+	// New enums
+	for k, desiredEnum := range desired.All() {
+		if _, ok := current.GetOk(k); !ok {
+			stmts = append(stmts, desiredEnum.SQL())
+			if commentSQL := desiredEnum.CommentSQL(); commentSQL != "" {
+				stmts = append(stmts, commentSQL)
+			}
+		}
+	}
+
+	// Modified enums (add new values, comment changes)
+	for k, desiredEnum := range desired.All() {
+		currentEnum, ok := current.GetOk(k)
+		if !ok {
+			continue
+		}
+
+		// Add new enum values
+		// Note: PostgreSQL only supports adding values, not removing or reordering
+		for _, val := range desiredEnum.Values {
+			if !slices.Contains(currentEnum.Values, val) {
+				stmts = append(stmts, "ALTER TYPE "+k+" ADD VALUE "+model.QuoteLiteral(val)+";")
+			}
+		}
+
+		// Comment changes
+		if !equalPtr(currentEnum.Comment, desiredEnum.Comment) {
+			if desiredEnum.Comment != nil {
+				stmts = append(stmts, "COMMENT ON TYPE "+k+" IS "+model.QuoteLiteral(*desiredEnum.Comment)+";")
+			} else {
+				stmts = append(stmts, "COMMENT ON TYPE "+k+" IS NULL;")
+			}
+		}
+	}
+
+	// Dropped enums
+	for k := range current.Keys() {
+		if _, ok := desired.GetOk(k); !ok {
+			stmts = append(stmts, "DROP TYPE "+k+";")
+		}
+	}
+
+	return stmts
+}

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -7,15 +7,20 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) []string {
-	var stmts []string
+type EnumDiffResult struct {
+	Stmts     []string
+	DropStmts []string
+}
+
+func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) *EnumDiffResult {
+	result := &EnumDiffResult{}
 
 	// New enums
 	for k, desiredEnum := range desired.All() {
 		if _, ok := current.GetOk(k); !ok {
-			stmts = append(stmts, desiredEnum.SQL())
+			result.Stmts = append(result.Stmts, desiredEnum.SQL())
 			if commentSQL := desiredEnum.CommentSQL(); commentSQL != "" {
-				stmts = append(stmts, commentSQL)
+				result.Stmts = append(result.Stmts, commentSQL)
 			}
 		}
 	}
@@ -27,20 +32,26 @@ func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) []string {
 			continue
 		}
 
-		// Add new enum values
-		// Note: PostgreSQL only supports adding values, not removing or reordering
-		for _, val := range desiredEnum.Values {
+		// Add new enum values with correct positioning
+		for i, val := range desiredEnum.Values {
 			if !slices.Contains(currentEnum.Values, val) {
-				stmts = append(stmts, "ALTER TYPE "+k+" ADD VALUE "+model.QuoteLiteral(val)+";")
+				stmt := "ALTER TYPE " + k + " ADD VALUE " + model.QuoteLiteral(val)
+				// Find the preceding value in desired that exists in current for BEFORE/AFTER positioning
+				if after := findPrecedingExisting(desiredEnum.Values, i, currentEnum.Values); after != "" {
+					stmt += " AFTER " + model.QuoteLiteral(after)
+				} else if before := findFollowingExisting(desiredEnum.Values, i, currentEnum.Values); before != "" {
+					stmt += " BEFORE " + model.QuoteLiteral(before)
+				}
+				result.Stmts = append(result.Stmts, stmt+";")
 			}
 		}
 
 		// Comment changes
 		if !equalPtr(currentEnum.Comment, desiredEnum.Comment) {
 			if desiredEnum.Comment != nil {
-				stmts = append(stmts, "COMMENT ON TYPE "+k+" IS "+model.QuoteLiteral(*desiredEnum.Comment)+";")
+				result.Stmts = append(result.Stmts, "COMMENT ON TYPE "+k+" IS "+model.QuoteLiteral(*desiredEnum.Comment)+";")
 			} else {
-				stmts = append(stmts, "COMMENT ON TYPE "+k+" IS NULL;")
+				result.Stmts = append(result.Stmts, "COMMENT ON TYPE "+k+" IS NULL;")
 			}
 		}
 	}
@@ -48,9 +59,29 @@ func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) []string {
 	// Dropped enums
 	for k := range current.Keys() {
 		if _, ok := desired.GetOk(k); !ok {
-			stmts = append(stmts, "DROP TYPE "+k+";")
+			result.DropStmts = append(result.DropStmts, "DROP TYPE "+k+";")
 		}
 	}
 
-	return stmts
+	return result
+}
+
+// findPrecedingExisting finds the closest value before index i in desired that exists in current.
+func findPrecedingExisting(desired []string, i int, current []string) string {
+	for j := i - 1; j >= 0; j-- {
+		if slices.Contains(current, desired[j]) {
+			return desired[j]
+		}
+	}
+	return ""
+}
+
+// findFollowingExisting finds the closest value after index i in desired that exists in current.
+func findFollowingExisting(desired []string, i int, current []string) string {
+	for j := i + 1; j < len(desired); j++ {
+		if slices.Contains(current, desired[j]) {
+			return desired[j]
+		}
+	}
+	return ""
 }

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -1,0 +1,120 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/diff"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func newEnumMap(enums ...*model.Enum) *orderedmap.Map[string, *model.Enum] {
+	m := orderedmap.New[string, *model.Enum]()
+	for _, e := range enums {
+		m.Set(e.FQEN(), e)
+	}
+	return m
+}
+
+func TestDiffEnums_CreateNew(t *testing.T) {
+	current := newEnumMap()
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	stmts := diff.DiffEnums(current, desired)
+	assert.Len(t, stmts, 1)
+	assert.Contains(t, stmts[0], "CREATE TYPE public.status AS ENUM")
+}
+
+func TestDiffEnums_DropExisting(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	desired := newEnumMap()
+	stmts := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"DROP TYPE public.status;"}, stmts)
+}
+
+func TestDiffEnums_AddValue(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive", "pending"},
+	})
+	stmts := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'pending';"}, stmts)
+}
+
+func TestDiffEnums_NoDiff(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	stmts := diff.DiffEnums(current, desired)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffEnums_AddComment(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active"},
+	})
+	comment := "User status"
+	desired := newEnumMap(&model.Enum{
+		Schema:  "public",
+		Name:    "status",
+		Values:  []string{"active"},
+		Comment: &comment,
+	})
+	stmts := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS 'User status';"}, stmts)
+}
+
+func TestDiffEnums_DropComment(t *testing.T) {
+	comment := "User status"
+	current := newEnumMap(&model.Enum{
+		Schema:  "public",
+		Name:    "status",
+		Values:  []string{"active"},
+		Comment: &comment,
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active"},
+	})
+	stmts := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS NULL;"}, stmts)
+}
+
+func TestDiffEnums_CreateWithComment(t *testing.T) {
+	current := newEnumMap()
+	comment := "User status"
+	desired := newEnumMap(&model.Enum{
+		Schema:  "public",
+		Name:    "status",
+		Values:  []string{"active"},
+		Comment: &comment,
+	})
+	stmts := diff.DiffEnums(current, desired)
+	assert.Len(t, stmts, 2)
+	assert.Contains(t, stmts[0], "CREATE TYPE public.status AS ENUM")
+	assert.Equal(t, "COMMENT ON TYPE public.status IS 'User status';", stmts[1])
+}

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -24,9 +24,10 @@ func TestDiffEnums_CreateNew(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive"},
 	})
-	stmts := diff.DiffEnums(current, desired)
-	assert.Len(t, stmts, 1)
-	assert.Contains(t, stmts[0], "CREATE TYPE public.status AS ENUM")
+	result := diff.DiffEnums(current, desired)
+	assert.Len(t, result.Stmts, 1)
+	assert.Contains(t, result.Stmts[0], "CREATE TYPE public.status AS ENUM")
+	assert.Empty(t, result.DropStmts)
 }
 
 func TestDiffEnums_DropExisting(t *testing.T) {
@@ -36,8 +37,9 @@ func TestDiffEnums_DropExisting(t *testing.T) {
 		Values: []string{"active", "inactive"},
 	})
 	desired := newEnumMap()
-	stmts := diff.DiffEnums(current, desired)
-	assert.Equal(t, []string{"DROP TYPE public.status;"}, stmts)
+	result := diff.DiffEnums(current, desired)
+	assert.Empty(t, result.Stmts)
+	assert.Equal(t, []string{"DROP TYPE public.status;"}, result.DropStmts)
 }
 
 func TestDiffEnums_AddValue(t *testing.T) {
@@ -51,8 +53,38 @@ func TestDiffEnums_AddValue(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive", "pending"},
 	})
-	stmts := diff.DiffEnums(current, desired)
-	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'pending';"}, stmts)
+	result := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';"}, result.Stmts)
+}
+
+func TestDiffEnums_AddValueMiddle(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "closed"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "pending", "closed"},
+	})
+	result := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'pending' AFTER 'active';"}, result.Stmts)
+}
+
+func TestDiffEnums_AddValueBeginning(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"new", "active", "inactive"},
+	})
+	result := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'new' BEFORE 'active';"}, result.Stmts)
 }
 
 func TestDiffEnums_NoDiff(t *testing.T) {
@@ -66,8 +98,9 @@ func TestDiffEnums_NoDiff(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive"},
 	})
-	stmts := diff.DiffEnums(current, desired)
-	assert.Empty(t, stmts)
+	result := diff.DiffEnums(current, desired)
+	assert.Empty(t, result.Stmts)
+	assert.Empty(t, result.DropStmts)
 }
 
 func TestDiffEnums_AddComment(t *testing.T) {
@@ -83,8 +116,8 @@ func TestDiffEnums_AddComment(t *testing.T) {
 		Values:  []string{"active"},
 		Comment: &comment,
 	})
-	stmts := diff.DiffEnums(current, desired)
-	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS 'User status';"}, stmts)
+	result := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS 'User status';"}, result.Stmts)
 }
 
 func TestDiffEnums_DropComment(t *testing.T) {
@@ -100,8 +133,8 @@ func TestDiffEnums_DropComment(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active"},
 	})
-	stmts := diff.DiffEnums(current, desired)
-	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS NULL;"}, stmts)
+	result := diff.DiffEnums(current, desired)
+	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS NULL;"}, result.Stmts)
 }
 
 func TestDiffEnums_CreateWithComment(t *testing.T) {
@@ -113,8 +146,8 @@ func TestDiffEnums_CreateWithComment(t *testing.T) {
 		Values:  []string{"active"},
 		Comment: &comment,
 	})
-	stmts := diff.DiffEnums(current, desired)
-	assert.Len(t, stmts, 2)
-	assert.Contains(t, stmts[0], "CREATE TYPE public.status AS ENUM")
-	assert.Equal(t, "COMMENT ON TYPE public.status IS 'User status';", stmts[1])
+	result := diff.DiffEnums(current, desired)
+	assert.Len(t, result.Stmts, 2)
+	assert.Contains(t, result.Stmts[0], "CREATE TYPE public.status AS ENUM")
+	assert.Equal(t, "COMMENT ON TYPE public.status IS 'User status';", result.Stmts[1])
 }

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/diff"
 	"github.com/winebarrel/pistachio/model"
@@ -24,7 +25,8 @@ func TestDiffEnums_CreateNew(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive"},
 	})
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "CREATE TYPE public.status AS ENUM")
 	assert.Empty(t, result.DropStmts)
@@ -37,7 +39,8 @@ func TestDiffEnums_DropExisting(t *testing.T) {
 		Values: []string{"active", "inactive"},
 	})
 	desired := newEnumMap()
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Equal(t, []string{"DROP TYPE public.status;"}, result.DropStmts)
 }
@@ -53,7 +56,8 @@ func TestDiffEnums_AddValue(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive", "pending"},
 	})
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';"}, result.Stmts)
 }
 
@@ -68,7 +72,8 @@ func TestDiffEnums_AddValueMiddle(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "pending", "closed"},
 	})
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'pending' AFTER 'active';"}, result.Stmts)
 }
 
@@ -83,8 +88,47 @@ func TestDiffEnums_AddValueBeginning(t *testing.T) {
 		Name:   "status",
 		Values: []string{"new", "active", "inactive"},
 	})
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'new' BEFORE 'active';"}, result.Stmts)
+}
+
+func TestDiffEnums_AddMultipleValues(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"a", "b"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"a", "b", "c", "d"},
+	})
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"ALTER TYPE public.status ADD VALUE 'c' AFTER 'b';",
+		"ALTER TYPE public.status ADD VALUE 'd' AFTER 'c';",
+	}, result.Stmts)
+}
+
+func TestDiffEnums_AddMultipleValuesMiddle(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"a", "d"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"a", "b", "c", "d"},
+	})
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"ALTER TYPE public.status ADD VALUE 'b' AFTER 'a';",
+		"ALTER TYPE public.status ADD VALUE 'c' AFTER 'b';",
+	}, result.Stmts)
 }
 
 func TestDiffEnums_NoDiff(t *testing.T) {
@@ -98,7 +142,8 @@ func TestDiffEnums_NoDiff(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive"},
 	})
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
 }
@@ -116,7 +161,8 @@ func TestDiffEnums_AddComment(t *testing.T) {
 		Values:  []string{"active"},
 		Comment: &comment,
 	})
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS 'User status';"}, result.Stmts)
 }
 
@@ -133,7 +179,8 @@ func TestDiffEnums_DropComment(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active"},
 	})
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS NULL;"}, result.Stmts)
 }
 
@@ -146,8 +193,43 @@ func TestDiffEnums_CreateWithComment(t *testing.T) {
 		Values:  []string{"active"},
 		Comment: &comment,
 	})
-	result := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 2)
 	assert.Contains(t, result.Stmts[0], "CREATE TYPE public.status AS ENUM")
 	assert.Equal(t, "COMMENT ON TYPE public.status IS 'User status';", result.Stmts[1])
+}
+
+func TestDiffEnums_RemoveValue_Error(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive", "pending"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	_, err := diff.DiffEnums(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot remove enum value")
+	assert.Contains(t, err.Error(), "public.status")
+}
+
+func TestDiffEnums_Reorder_Error(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive", "pending"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"inactive", "active", "pending"},
+	})
+	_, err := diff.DiffEnums(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot reorder enum values")
+	assert.Contains(t, err.Error(), "public.status")
 }

--- a/dump.go
+++ b/dump.go
@@ -18,6 +18,7 @@ type DumpOptions struct {
 type DumpResult struct {
 	Tables     *orderedmap.Map[string, *model.Table]
 	Views      *orderedmap.Map[string, *model.View]
+	Enums      *orderedmap.Map[string, *model.Enum]
 	OmitSchema bool
 }
 
@@ -68,10 +69,30 @@ func (r *DumpResult) views() *orderedmap.Map[string, *model.View] {
 	return views
 }
 
+func (r *DumpResult) enums() *orderedmap.Map[string, *model.Enum] {
+	if r.Enums == nil {
+		return orderedmap.New[string, *model.Enum]()
+	}
+	if !r.OmitSchema {
+		return r.Enums
+	}
+	enums := orderedmap.New[string, *model.Enum]()
+	for _, e := range r.Enums.CollectValues() {
+		copied := *e
+		copied.Schema = ""
+		enums.Set(e.FQEN(), &copied)
+	}
+	return enums
+}
+
 func (r *DumpResult) String() string {
 	var parts []string
+	enums := r.enums()
 	tables := r.tables()
 	views := r.views()
+	if enums.Len() > 0 {
+		parts = append(parts, model.EnumsToSQL(enums))
+	}
 	if tables.Len() > 0 {
 		parts = append(parts, model.TablesToSQL(tables))
 	}
@@ -84,6 +105,11 @@ func (r *DumpResult) String() string {
 func (r *DumpResult) Files() map[string]string {
 	files := make(map[string]string)
 	seen := make(map[string]bool)
+	for _, e := range r.enums().CollectValues() {
+		name := uniqueFileName(seen, toFileName(e.Schema, e.Name))
+		files[name] = model.EnumToSQL(e) + "\n"
+		seen[strings.ToLower(name)] = true
+	}
 	for _, t := range r.tables().CollectValues() {
 		name := uniqueFileName(seen, toFileName(t.Schema, t.Name))
 		files[name] = model.TableToSQL(t) + "\n"
@@ -150,9 +176,15 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 		return nil, fmt.Errorf("failed to fetch views: %w", err)
 	}
 
+	enums, err := catalog.Enums(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch enums: %w", err)
+	}
+
 	return &DumpResult{
 		Tables:     client.filterTables(client.remapTableSchemas(tables)),
 		Views:      client.filterViews(client.remapViewSchemas(views)),
+		Enums:      client.filterEnums(client.remapEnumSchemas(enums)),
 		OmitSchema: options.OmitSchema,
 	}, nil
 }

--- a/dump.go
+++ b/dump.go
@@ -11,7 +11,7 @@ import (
 )
 
 type DumpOptions struct {
-	Split      string `help:"Output each table/view as a separate file in the specified directory."`
+	Split      string `help:"Output each table/view/enum as a separate file in the specified directory."`
 	OmitSchema bool   `help:"Omit schema name from the dump output."`
 }
 

--- a/dump_test.go
+++ b/dump_test.go
@@ -291,6 +291,49 @@ COMMENT ON TABLE public.users IS 'User accounts';`)
 	assert.NotContains(t, s, "public.users")
 }
 
+func TestDumpResult_OmitSchema_Enum(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+COMMENT ON TYPE public.status IS 'User status';`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "CREATE TYPE status AS ENUM")
+	assert.NotContains(t, s, "public.status")
+	assert.Contains(t, s, "COMMENT ON TYPE status")
+}
+
+func TestDumpResult_OmitSchema_Enum_Files(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Contains(t, files, "status.sql")
+	assert.NotContains(t, files, "public.status.sql")
+	assert.Contains(t, files["status.sql"], "CREATE TYPE status AS ENUM")
+}
+
 func TestDump_OmitSchema_MultipleSchemas(t *testing.T) {
 	ctx := context.Background()
 	client := pistachio.NewClient(&pistachio.Options{

--- a/filter.go
+++ b/filter.go
@@ -32,3 +32,17 @@ func (client *Client) filterViews(views *orderedmap.Map[string, *model.View]) *o
 	}
 	return filtered
 }
+
+func (client *Client) filterEnums(enums *orderedmap.Map[string, *model.Enum]) *orderedmap.Map[string, *model.Enum] {
+	if len(client.Include) == 0 && len(client.Exclude) == 0 {
+		return enums
+	}
+
+	filtered := orderedmap.New[string, *model.Enum]()
+	for k, e := range enums.All() {
+		if client.MatchName(e.Name) {
+			filtered.Set(k, e)
+		}
+	}
+	return filtered
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -398,7 +398,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 	require.NoError(t, err)
 
-	assert.Contains(t, got, "ALTER TYPE public.status ADD VALUE 'pending';")
+	assert.Contains(t, got, "ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';")
 	assert.NotContains(t, got, "role")
 }
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -330,6 +330,114 @@ CREATE TABLE public.posts (
 	assert.NotContains(t, got, "posts")
 }
 
+func TestDump_IncludeEnum(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TYPE public.role AS ENUM ('admin', 'user');`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Include:    []string{"status"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE TYPE public.status AS ENUM")
+	assert.NotContains(t, output, "public.role")
+}
+
+func TestDump_ExcludeEnum(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TYPE public.role AS ENUM ('admin', 'user');`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Exclude:    []string{"role"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE TYPE public.status AS ENUM")
+	assert.NotContains(t, output, "public.role")
+}
+
+func TestPlan_IncludeEnum(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TYPE public.role AS ENUM ('admin', 'user');`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Include:    []string{"status"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "ALTER TYPE public.status ADD VALUE 'pending';")
+	assert.NotContains(t, got, "role")
+}
+
+func TestApply_IncludeEnum(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TYPE public.role AS ENUM ('admin', 'user');`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+		Include:    []string{"status"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.NoError(t, err)
+
+	// Verify: only status should have the new value
+	verifyClient := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := verifyClient.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "'pending'")
+	assert.NotContains(t, output, "'guest'")
+}
+
 func TestApply_Include(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/model/enum.go
+++ b/model/enum.go
@@ -1,0 +1,52 @@
+package model
+
+import (
+	"strings"
+
+	"github.com/winebarrel/orderedmap"
+)
+
+type Enum struct {
+	OID     uint32
+	Schema  string
+	Name    string
+	Values  []string
+	Comment *string
+}
+
+func (e Enum) FQEN() string {
+	return Ident(e.Schema, e.Name)
+}
+
+func (e Enum) SQL() string {
+	quoted := make([]string, len(e.Values))
+	for i, v := range e.Values {
+		quoted[i] = QuoteLiteral(v)
+	}
+	return "CREATE TYPE " + Ident(e.Schema, e.Name) + " AS ENUM (\n    " +
+		strings.Join(quoted, ",\n    ") + "\n);"
+}
+
+func (e Enum) CommentSQL() string {
+	if e.Comment != nil {
+		return "COMMENT ON TYPE " + Ident(e.Schema, e.Name) + " IS " + QuoteLiteral(*e.Comment) + ";"
+	}
+	return ""
+}
+
+func EnumToSQL(e *Enum) string {
+	parts := []string{"-- " + e.FQEN(), e.SQL()}
+	if s := e.CommentSQL(); s != "" {
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func EnumsToSQL(enums *orderedmap.Map[string, *Enum]) string {
+	return strings.Join(
+		orderedmap.TransformSlice(enums, func(_ string, e *Enum) string {
+			return EnumToSQL(e)
+		}),
+		"\n\n",
+	)
+}

--- a/model/enum_test.go
+++ b/model/enum_test.go
@@ -1,0 +1,87 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestEnum_FQEN(t *testing.T) {
+	e := &model.Enum{Schema: "public", Name: "status"}
+	assert.Equal(t, "public.status", e.FQEN())
+}
+
+func TestEnum_FQEN_QuotedIdentifier(t *testing.T) {
+	e := &model.Enum{Schema: "public", Name: "My Type"}
+	assert.Equal(t, `public."My Type"`, e.FQEN())
+}
+
+func TestEnum_SQL(t *testing.T) {
+	e := &model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive", "pending"},
+	}
+	expected := "CREATE TYPE public.status AS ENUM (\n" +
+		"    'active',\n" +
+		"    'inactive',\n" +
+		"    'pending'\n" +
+		");"
+	assert.Equal(t, expected, e.SQL())
+}
+
+func TestEnum_CommentSQL(t *testing.T) {
+	comment := "User status"
+	e := &model.Enum{
+		Schema:  "public",
+		Name:    "status",
+		Values:  []string{"active"},
+		Comment: &comment,
+	}
+	assert.Equal(t, "COMMENT ON TYPE public.status IS 'User status';", e.CommentSQL())
+}
+
+func TestEnum_CommentSQL_NoComment(t *testing.T) {
+	e := &model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active"},
+	}
+	assert.Equal(t, "", e.CommentSQL())
+}
+
+func TestEnumToSQL(t *testing.T) {
+	comment := "User status"
+	e := &model.Enum{
+		Schema:  "public",
+		Name:    "status",
+		Values:  []string{"active", "inactive"},
+		Comment: &comment,
+	}
+	expected := "-- public.status\n" +
+		"CREATE TYPE public.status AS ENUM (\n" +
+		"    'active',\n" +
+		"    'inactive'\n" +
+		");\n" +
+		"COMMENT ON TYPE public.status IS 'User status';"
+	assert.Equal(t, expected, model.EnumToSQL(e))
+}
+
+func TestEnumsToSQL(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	enums.Set("public.status", &model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	enums.Set("public.role", &model.Enum{
+		Schema: "public",
+		Name:   "role",
+		Values: []string{"admin", "user"},
+	})
+	got := model.EnumsToSQL(enums)
+	assert.Contains(t, got, "CREATE TYPE public.status AS ENUM")
+	assert.Contains(t, got, "CREATE TYPE public.role AS ENUM")
+}

--- a/options.go
+++ b/options.go
@@ -10,8 +10,8 @@ type Options struct {
 	Password   string            `env:"PIST_PASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PGSCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
-	Include    []string          `short:"I" help:"Include only tables/views matching the pattern (wildcard: *, ?)."`
-	Exclude    []string          `short:"E" help:"Exclude tables/views matching the pattern (wildcard: *, ?)."`
+	Include    []string          `short:"I" help:"Include only tables/views/enums matching the pattern (wildcard: *, ?)."`
+	Exclude    []string          `short:"E" help:"Exclude tables/views/enums matching the pattern (wildcard: *, ?)."`
 }
 
 func (o *Options) MatchName(name string) bool {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -13,6 +13,7 @@ import (
 type ParseResult struct {
 	Tables *orderedmap.Map[string, *model.Table]
 	Views  *orderedmap.Map[string, *model.View]
+	Enums  *orderedmap.Map[string, *model.Enum]
 }
 
 func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error {
@@ -74,11 +75,21 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 
 	tables := orderedmap.New[string, *model.Table]()
 	views := orderedmap.New[string, *model.View]()
+	enums := orderedmap.New[string, *model.Enum]()
 
 	for _, rawStmt := range result.Stmts {
 		node := rawStmt.Stmt
 
 		switch {
+		case node.GetCreateEnumStmt() != nil:
+			enum, err := parseCreateEnumStmt(node.GetCreateEnumStmt(), defaultSchema)
+			if err != nil {
+				return nil, err
+			}
+			if err := setUnique(enums, enum.FQEN(), "enum", enum); err != nil {
+				return nil, err
+			}
+
 		case node.GetCreateStmt() != nil:
 			table, err := parseCreateStmt(node.GetCreateStmt(), defaultSchema)
 			if err != nil {
@@ -137,11 +148,11 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 
 		case node.GetCommentStmt() != nil:
 			cs := node.GetCommentStmt()
-			parseCommentStmt(cs, defaultSchema, tables, views)
+			parseCommentStmt(cs, defaultSchema, tables, views, enums)
 		}
 	}
 
-	return &ParseResult{Tables: tables, Views: views}, nil
+	return &ParseResult{Tables: tables, Views: views, Enums: enums}, nil
 }
 
 func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Table, error) {
@@ -452,7 +463,41 @@ func parseViewStmt(vs *pg_query.ViewStmt, defaultSchema string) (*model.View, er
 	}, nil
 }
 
-func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View]) {
+func parseCreateEnumStmt(es *pg_query.CreateEnumStmt, defaultSchema string) (*model.Enum, error) {
+	schema := defaultSchema
+	name := ""
+
+	for i, n := range es.TypeName {
+		if s := n.GetString_(); s != nil {
+			if i == len(es.TypeName)-1 {
+				name = s.Sval
+			} else {
+				schema = s.Sval
+			}
+		}
+	}
+
+	var values []string
+	for _, v := range es.Vals {
+		if s := v.GetString_(); s != nil {
+			values = append(values, s.Sval)
+		}
+	}
+
+	return &model.Enum{
+		Schema: schema,
+		Name:   name,
+		Values: values,
+	}, nil
+}
+
+func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View], enums *orderedmap.Map[string, *model.Enum]) {
+	// COMMENT ON TYPE uses TypeName, not a list
+	if cs.Objtype == pg_query.ObjectType_OBJECT_TYPE {
+		parseCommentOnType(cs, defaultSchema, enums)
+		return
+	}
+
 	items := cs.Object.GetList().GetItems()
 	if len(items) == 0 {
 		return
@@ -520,6 +565,37 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 					col.Comment = nil
 				}
 			}
+		}
+	}
+}
+
+func parseCommentOnType(cs *pg_query.CommentStmt, defaultSchema string, enums *orderedmap.Map[string, *model.Enum]) {
+	tn := cs.Object.GetTypeName()
+	if tn == nil {
+		return
+	}
+	var names []string
+	for _, n := range tn.Names {
+		if s := n.GetString_(); s != nil {
+			names = append(names, s.Sval)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	schema := defaultSchema
+	typeName := names[0]
+	if len(names) >= 2 {
+		schema = names[0]
+		typeName = names[1]
+	}
+	fqen := model.Ident(schema, typeName)
+	if e, ok := enums.GetOk(fqen); ok {
+		if cs.Comment != "" {
+			c := cs.Comment
+			e.Comment = &c
+		} else {
+			e.Comment = nil
 		}
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1006,3 +1006,95 @@ COMMENT ON VIEW active_users IS 'Active users';`
 	require.NotNil(t, v.Comment)
 	assert.Equal(t, "Active users", *v.Comment)
 }
+
+func TestParseSQL_Enum(t *testing.T) {
+	sql := `CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Enums.Len())
+
+	e, ok := result.Enums.GetOk("public.status")
+	require.True(t, ok)
+	assert.Equal(t, "status", e.Name)
+	assert.Equal(t, "public", e.Schema)
+	assert.Equal(t, []string{"active", "inactive", "pending"}, e.Values)
+
+	expected := "-- public.status\n" +
+		"CREATE TYPE public.status AS ENUM (\n" +
+		"    'active',\n" +
+		"    'inactive',\n" +
+		"    'pending'\n" +
+		");"
+	got := model.EnumsToSQL(result.Enums)
+	assert.Equal(t, expected, got)
+}
+
+func TestParseSQL_EnumWithComment(t *testing.T) {
+	sql := `CREATE TYPE public.status AS ENUM ('active', 'inactive');
+COMMENT ON TYPE public.status IS 'User status';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	e, ok := result.Enums.GetOk("public.status")
+	require.True(t, ok)
+	require.NotNil(t, e.Comment)
+	assert.Equal(t, "User status", *e.Comment)
+}
+
+func TestParseSQL_EnumCommentRemove(t *testing.T) {
+	sql := `CREATE TYPE public.status AS ENUM ('active', 'inactive');
+COMMENT ON TYPE public.status IS 'User status';
+COMMENT ON TYPE public.status IS '';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	e, ok := result.Enums.GetOk("public.status")
+	require.True(t, ok)
+	assert.Nil(t, e.Comment)
+}
+
+func TestParseSQLWithSchema_Enum(t *testing.T) {
+	sql := `CREATE TYPE status AS ENUM ('active', 'inactive');
+COMMENT ON TYPE status IS 'User status';`
+
+	result, err := parser.ParseSQLWithSchema(sql, "myschema")
+	require.NoError(t, err)
+
+	e, ok := result.Enums.GetOk("myschema.status")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", e.Schema)
+	assert.Equal(t, "status", e.Name)
+	require.NotNil(t, e.Comment)
+	assert.Equal(t, "User status", *e.Comment)
+}
+
+func TestParseSQL_EnumSchemaQualified(t *testing.T) {
+	sql := `CREATE TYPE myschema.status AS ENUM ('active', 'inactive');`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	e, ok := result.Enums.GetOk("myschema.status")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", e.Schema)
+	assert.Equal(t, "status", e.Name)
+}
+
+func TestParseSQL_DuplicateEnum(t *testing.T) {
+	sql := `CREATE TYPE public.status AS ENUM ('active');
+CREATE TYPE public.status AS ENUM ('inactive');`
+
+	_, err := parser.ParseSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate enum")
+}
+
+func TestParseSQL_CommentOnUnknownEnum(t *testing.T) {
+	sql := `COMMENT ON TYPE public.nonexistent IS 'test';`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Enums.Len())
+}

--- a/plan.go
+++ b/plan.go
@@ -48,7 +48,10 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	enumDiff := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	enumDiff, err := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	if err != nil {
+		return "", err
+	}
 	stmts := enumDiff.Stmts
 	stmts = append(stmts, diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))...)
 	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)

--- a/plan.go
+++ b/plan.go
@@ -38,12 +38,18 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to fetch views: %w", err)
 	}
 
+	currentEnums, err := cat.Enums(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch enums: %w", err)
+	}
+
 	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	stmts := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	stmts := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	stmts = append(stmts, diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))...)
 	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
 
 	if options.PreSQLFile != "" && len(stmts) > 0 {

--- a/plan.go
+++ b/plan.go
@@ -48,9 +48,11 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	stmts := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	enumDiff := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	stmts := enumDiff.Stmts
 	stmts = append(stmts, diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))...)
 	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
+	stmts = append(stmts, enumDiff.DropStmts...)
 
 	if options.PreSQLFile != "" && len(stmts) > 0 {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)

--- a/remap.go
+++ b/remap.go
@@ -128,3 +128,33 @@ func (client *Client) reverseRemapViewSchemas(views *orderedmap.Map[string, *mod
 
 	return remapped
 }
+
+func (client *Client) remapEnumSchemas(enums *orderedmap.Map[string, *model.Enum]) *orderedmap.Map[string, *model.Enum] {
+	if len(client.SchemaMap) == 0 {
+		return enums
+	}
+
+	remapped := orderedmap.New[string, *model.Enum]()
+
+	for _, e := range enums.CollectValues() {
+		e.Schema = client.RemapSchema(e.Schema)
+		remapped.Set(e.FQEN(), e)
+	}
+
+	return remapped
+}
+
+func (client *Client) reverseRemapEnumSchemas(enums *orderedmap.Map[string, *model.Enum]) *orderedmap.Map[string, *model.Enum] {
+	if len(client.SchemaMap) == 0 {
+		return enums
+	}
+
+	remapped := orderedmap.New[string, *model.Enum]()
+
+	for _, e := range enums.CollectValues() {
+		e.Schema = client.ReverseRemapSchema(e.Schema)
+		remapped.Set(e.FQEN(), e)
+	}
+
+	return remapped
+}

--- a/remap_test.go
+++ b/remap_test.go
@@ -618,6 +618,99 @@ CREATE TABLE myschema.users (
 	assert.Empty(t, got)
 }
 
+func TestDump_WithSchemaMap_Enum(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE TYPE public.status AS ENUM")
+	assert.NotContains(t, output, "myschema.status")
+}
+
+func TestPlan_WithSchemaMap_Enum(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "ALTER TYPE myschema.status ADD VALUE 'pending';")
+}
+
+func TestPlan_WithSchemaMap_Enum_NoDiff(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TYPE public.status AS ENUM ('active', 'inactive');`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestApply_WithSchemaMap_Enum(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.NoError(t, err)
+
+	verifyClient := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	got, err := verifyClient.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, got.String(), "'pending'")
+}
+
 func TestApply_SchemalessDesired_CustomSchema(t *testing.T) {
 	ctx := context.Background()
 

--- a/remap_test.go
+++ b/remap_test.go
@@ -658,7 +658,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 	require.NoError(t, err)
 
-	assert.Contains(t, got, "ALTER TYPE myschema.status ADD VALUE 'pending';")
+	assert.Contains(t, got, "ALTER TYPE myschema.status ADD VALUE 'pending' AFTER 'inactive';")
 }
 
 func TestPlan_WithSchemaMap_Enum_NoDiff(t *testing.T) {

--- a/testdata/apply/add_enum_value.yml
+++ b/testdata/apply/add_enum_value.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+applied: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive',
+      'pending'
+  );

--- a/testdata/apply/create_enum.yml
+++ b/testdata/apply/create_enum.yml
@@ -1,0 +1,10 @@
+init: ""
+desired: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+applied: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive',
+      'pending'
+  );

--- a/testdata/dump/enum.yml
+++ b/testdata/dump/enum.yml
@@ -1,0 +1,9 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+dump: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive',
+      'pending'
+  );

--- a/testdata/dump/enum_and_table.yml
+++ b/testdata/dump/enum_and_table.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      status public.status NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+dump: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      status status NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/dump/enum_with_comment.yml
+++ b/testdata/dump/enum_with_comment.yml
@@ -1,0 +1,10 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+  COMMENT ON TYPE public.status IS 'User status';
+dump: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+  COMMENT ON TYPE public.status IS 'User status';

--- a/testdata/plan/add_enum_comment.yml
+++ b/testdata/plan/add_enum_comment.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+  COMMENT ON TYPE public.status IS 'User status';
+plan: |
+  COMMENT ON TYPE public.status IS 'User status';

--- a/testdata/plan/add_enum_value.yml
+++ b/testdata/plan/add_enum_value.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+plan: |
+  ALTER TYPE public.status ADD VALUE 'pending';

--- a/testdata/plan/add_enum_value.yml
+++ b/testdata/plan/add_enum_value.yml
@@ -3,4 +3,4 @@ init: |
 desired: |
   CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
 plan: |
-  ALTER TYPE public.status ADD VALUE 'pending';
+  ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';

--- a/testdata/plan/create_enum.yml
+++ b/testdata/plan/create_enum.yml
@@ -1,0 +1,9 @@
+init: ""
+desired: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+plan: |
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive',
+      'pending'
+  );

--- a/testdata/plan/drop_enum.yml
+++ b/testdata/plan/drop_enum.yml
@@ -1,0 +1,5 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: ""
+plan: |
+  DROP TYPE public.status;

--- a/testdata/plan/no_diff_enum.yml
+++ b/testdata/plan/no_diff_enum.yml
@@ -1,0 +1,5 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+plan: ""


### PR DESCRIPTION
This pull request adds comprehensive support for PostgreSQL enum types (created with `CREATE TYPE ... AS ENUM`) to the codebase. It enables dumping, filtering, diffing, and applying changes for enums, similar to how tables and views are handled. The documentation and tests have also been updated to reflect and verify these new capabilities.

The most important changes are:

**Enum support in core functionality:**

* Added a new `Enum` model (`model/enum.go`) and corresponding methods to handle enums, including SQL generation and comment support.
* Implemented enum discovery in the catalog with `Catalog.Enums` and `Catalog.ListEnums` methods (`catalog/enums.go`), along with tests (`catalog/enums_test.go`). [[1]](diffhunk://#diff-fc2a41d60c045e41f5df1b0aae63d0dc56b69016cd322316a2210185a361d9b4R1-R95) [[2]](diffhunk://#diff-61ec92f756aa14efbcac0dc72ae3ee2af60e9416732d3105895f9ffb1ba35bc1R1-R77)
* Updated the dump process to include enums, both in aggregated output and split files, and added relevant tests (`dump.go`, `dump_test.go`). [[1]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR21) [[2]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR72-R95) [[3]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR108-R112) [[4]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR179-R187) [[5]](diffhunk://#diff-65c94d2eace406c5aa180f845d514576956230d81c8b42cf4d14f773981cfe12R294-R336)

**Diff and apply enhancements:**

* Added `DiffEnums` to compute SQL statements for creating, altering, and dropping enums, including adding values and comments (`diff/enums.go`), with comprehensive test coverage (`diff/enums_test.go`). [[1]](diffhunk://#diff-95cf34f104f2d0bf8f5fc6c26eeae554bc68950f6be9d7e57e43822260f5bbdeR1-R56) [[2]](diffhunk://#diff-674588e812759633033fa8a99041fd13b55f728be4e7d1ab415be8967af5a54bR1-R120)
* Updated the apply logic to handle enum diffs before tables and views (`apply.go`).

**Filtering and CLI improvements:**

* Extended filtering logic so `--include` and `--exclude` patterns now also match enums (`filter.go`), and updated documentation and CLI help to reflect this (`README.md`). [[1]](diffhunk://#diff-8a6290ede135299ac187338deaf28c9f658a4e45634d78c9e2ef113bbbd7ef67R35-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R39) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R118) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R166) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L191-R194)

**Documentation updates:**

* Documented enum support in the "Supported Objects" and usage examples in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R204-R210) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R166)

**Testing and validation:**

* Added dedicated tests for enum model methods and SQL generation (`model/enum_test.go`).

These changes collectively provide first-class support for PostgreSQL enums throughout the tool, from schema inspection and diffing to migration and documentation.