### PR TITLE
Support rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,48 @@ pist -n staging plan schema.sql   # schema-less SQL is treated as "staging"
 pist -n staging apply schema.sql
 ```
 
+### Renaming objects
+
+Use `-- pist:rename-from <old_name>` directives to rename objects instead of dropping and recreating them.
+
+**Tables, views, enums:**
+
+```sql
+-- pist:rename-from public.old_status
+CREATE TYPE public.new_status AS ENUM ('active', 'inactive');
+
+-- pist:rename-from public.old_users
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+-- pist:rename-from public.old_view
+CREATE VIEW public.new_view AS SELECT 1;
+```
+
+**Columns, constraints, indexes** (inside `CREATE TABLE` or before `CREATE INDEX` / `ALTER TABLE ADD CONSTRAINT`):
+
+```sql
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    -- pist:rename-from name
+    display_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    -- pist:rename-from users_name_key
+    CONSTRAINT users_display_name_key UNIQUE (display_name)
+);
+
+-- pist:rename-from idx_users_name
+CREATE INDEX idx_users_display_name ON public.users (display_name);
+
+-- pist:rename-from fk_old_name
+ALTER TABLE public.orders ADD CONSTRAINT fk_new_name FOREIGN KEY (user_id) REFERENCES public.users(id);
+```
+
+> [!TIP]
+> Rename directives that have already been applied are silently skipped, so you can safely leave them in your schema files until cleanup.
+
 ### Split dump
 
 Use `--split` to output each table/view/enum as a separate file in the specified directory.
@@ -208,6 +250,7 @@ pist apply ./schema/*.sql         # apply it
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
 - Comments (on tables, columns, views, types)
+- Renaming (tables, views, enums, columns, constraints, indexes via `-- pist:rename-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ pist apply ./schema/*.sql         # apply it
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
 - Comments (on tables, columns, views, types)
-- Renaming (tables, views, enums, columns, constraints, indexes via `-- pist:rename-from` directive)
+- Renaming (tables, views, enums, columns, constraints, foreign keys, indexes via `-- pist:rename-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 

--- a/apply.go
+++ b/apply.go
@@ -54,8 +54,19 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return err
 	}
 	stmts := enumDiff.Stmts
-	stmts = append(stmts, diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))...)
-	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
+
+	tableStmts, err := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	if err != nil {
+		return err
+	}
+	stmts = append(stmts, tableStmts...)
+
+	viewStmts, err := diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))
+	if err != nil {
+		return err
+	}
+	stmts = append(stmts, viewStmts...)
+
 	stmts = append(stmts, enumDiff.DropStmts...)
 
 	var preSQL string

--- a/apply.go
+++ b/apply.go
@@ -57,13 +57,13 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 
 	tableStmts, err := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to diff tables: %w", err)
 	}
 	stmts = append(stmts, tableStmts...)
 
 	viewStmts, err := diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to diff views: %w", err)
 	}
 	stmts = append(stmts, viewStmts...)
 

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -16,6 +16,13 @@ type EnumDiffResult struct {
 func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) (*EnumDiffResult, error) {
 	result := &EnumDiffResult{}
 
+	// Detect renames
+	renameStmts, current, err := detectEnumRenames(current, desired)
+	if err != nil {
+		return nil, err
+	}
+	result.Stmts = append(result.Stmts, renameStmts...)
+
 	// New enums
 	for k, desiredEnum := range desired.All() {
 		if _, ok := current.GetOk(k); !ok {

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -292,6 +292,24 @@ func TestDiffEnums_RenameAlreadyApplied(t *testing.T) {
 	assert.Empty(t, result.DropStmts)
 }
 
+func TestDiffEnums_RenameCrossSchema_Error(t *testing.T) {
+	oldName := "other.status"
+	current := newEnumMap(&model.Enum{
+		Schema: "other",
+		Name:   "status",
+		Values: []string{"active"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema:     "public",
+		Name:       "user_status",
+		RenameFrom: &oldName,
+		Values:     []string{"active"},
+	})
+	_, err := diff.DiffEnums(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-schema rename")
+}
+
 func TestDiffEnums_RenameSourceNotFound(t *testing.T) {
 	oldName := "public.nonexistent"
 	current := newEnumMap()

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -273,6 +273,24 @@ func TestDiffEnums_RenameAndAddValue(t *testing.T) {
 	assert.Contains(t, result.Stmts[1], "ADD VALUE 'pending'")
 }
 
+func TestDiffEnums_RenameSelfRename_Skipped(t *testing.T) {
+	oldName := "public.status"
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema:     "public",
+		Name:       "status",
+		RenameFrom: &oldName,
+		Values:     []string{"active"},
+	})
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+}
+
 func TestDiffEnums_RenameAlreadyApplied(t *testing.T) {
 	oldName := "public.old_status"
 	current := newEnumMap(&model.Enum{

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -233,3 +233,75 @@ func TestDiffEnums_Reorder_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot reorder enum values")
 	assert.Contains(t, err.Error(), "public.status")
 }
+
+func TestDiffEnums_Rename(t *testing.T) {
+	oldName := "public.status"
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema:     "public",
+		Name:       "user_status",
+		RenameFrom: &oldName,
+		Values:     []string{"active", "inactive"},
+	})
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TYPE public.status RENAME TO user_status;"}, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffEnums_RenameAndAddValue(t *testing.T) {
+	oldName := "public.status"
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema:     "public",
+		Name:       "user_status",
+		RenameFrom: &oldName,
+		Values:     []string{"active", "inactive", "pending"},
+	})
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
+	assert.Len(t, result.Stmts, 2)
+	assert.Equal(t, "ALTER TYPE public.status RENAME TO user_status;", result.Stmts[0])
+	assert.Contains(t, result.Stmts[1], "ADD VALUE 'pending'")
+}
+
+func TestDiffEnums_RenameAlreadyApplied(t *testing.T) {
+	oldName := "public.old_status"
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "user_status",
+		Values: []string{"active", "inactive"},
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema:     "public",
+		Name:       "user_status",
+		RenameFrom: &oldName,
+		Values:     []string{"active", "inactive"},
+	})
+	result, err := diff.DiffEnums(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffEnums_RenameSourceNotFound(t *testing.T) {
+	oldName := "public.nonexistent"
+	current := newEnumMap()
+	desired := newEnumMap(&model.Enum{
+		Schema:     "public",
+		Name:       "user_status",
+		RenameFrom: &oldName,
+		Values:     []string{"active"},
+	})
+	_, err := diff.DiffEnums(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source")
+}

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -310,6 +310,23 @@ func TestDiffEnums_RenameCrossSchema_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
 
+func TestDiffEnums_RenameDestinationExists_Error(t *testing.T) {
+	oldName := "public.status"
+	current := newEnumMap(
+		&model.Enum{Schema: "public", Name: "status", Values: []string{"active"}},
+		&model.Enum{Schema: "public", Name: "user_status", Values: []string{"a"}},
+	)
+	desired := newEnumMap(&model.Enum{
+		Schema:     "public",
+		Name:       "user_status",
+		RenameFrom: &oldName,
+		Values:     []string{"active"},
+	})
+	_, err := diff.DiffEnums(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
 func TestDiffEnums_RenameSourceNotFound(t *testing.T) {
 	oldName := "public.nonexistent"
 	current := newEnumMap()

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -23,19 +23,20 @@ func detectEnumRenames(current, desired *orderedmap.Map[string, *model.Enum]) ([
 
 		oldEnum, ok := adjusted.GetOk(oldKey)
 		if !ok {
-			// If already renamed (new key exists in current), skip silently
 			if _, exists := adjusted.GetOk(newKey); exists {
 				continue
 			}
 			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
 		}
 
+		if oldEnum.Schema != desiredEnum.Schema {
+			return nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
+		}
+
 		stmts = append(stmts, "ALTER TYPE "+oldKey+" RENAME TO "+model.Ident(desiredEnum.Name)+";")
 
-		// Re-key in adjusted current: remove old, insert new with updated name
 		adjusted.Delete(oldKey)
 		renamed := *oldEnum
-		renamed.Schema = desiredEnum.Schema
 		renamed.Name = desiredEnum.Name
 		adjusted.Set(newKey, &renamed)
 	}
@@ -62,12 +63,42 @@ func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) 
 			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
 		}
 
+		if oldTable.Schema != desiredTable.Schema {
+			return nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
+		}
+
+		oldFQTN := oldTable.FQTN()
+		newFQTN := model.Ident(oldTable.Schema, desiredTable.Name)
+
 		stmts = append(stmts, "ALTER TABLE "+oldKey+" RENAME TO "+model.Ident(desiredTable.Name)+";")
 
 		adjusted.Delete(oldKey)
 		renamed := *oldTable
-		renamed.Schema = desiredTable.Schema
 		renamed.Name = desiredTable.Name
+
+		// Update index definitions to reflect the new table name
+		if renamed.Indexes.Len() > 0 {
+			newIndexes := orderedmap.New[string, *model.Index]()
+			for idxName, idx := range renamed.Indexes.All() {
+				idxCopy := *idx
+				idxCopy.Table = desiredTable.Name
+				idxCopy.Definition = strings.ReplaceAll(idx.Definition, " ON "+oldFQTN+" ", " ON "+newFQTN+" ")
+				newIndexes.Set(idxName, &idxCopy)
+			}
+			renamed.Indexes = newIndexes
+		}
+
+		// Update FK definitions to reflect the new table name
+		if renamed.ForeignKeys.Len() > 0 {
+			newFKs := orderedmap.New[string, *model.ForeignKey]()
+			for fkName, fk := range renamed.ForeignKeys.All() {
+				fkCopy := *fk
+				fkCopy.Table = desiredTable.Name
+				newFKs.Set(fkName, &fkCopy)
+			}
+			renamed.ForeignKeys = newFKs
+		}
+
 		adjusted.Set(newKey, &renamed)
 	}
 
@@ -93,11 +124,14 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
 		}
 
+		if oldView.Schema != desiredView.Schema {
+			return nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
+		}
+
 		stmts = append(stmts, "ALTER VIEW "+oldKey+" RENAME TO "+model.Ident(desiredView.Name)+";")
 
 		adjusted.Delete(oldKey)
 		renamed := *oldView
-		renamed.Schema = desiredView.Schema
 		renamed.Name = desiredView.Name
 		adjusted.Set(newKey, &renamed)
 	}

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -19,6 +19,10 @@ func detectEnumRenames(current, desired *orderedmap.Map[string, *model.Enum]) ([
 		}
 		oldKey := *desiredEnum.RenameFrom
 
+		if oldKey == newKey {
+			continue
+		}
+
 		oldEnum, ok := adjusted.GetOk(oldKey)
 		if !ok {
 			if _, exists := adjusted.GetOk(newKey); exists {
@@ -64,6 +68,10 @@ func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) 
 			continue
 		}
 		oldKey := *desiredTable.RenameFrom
+
+		if oldKey == newKey {
+			continue
+		}
 
 		oldTable, ok := adjusted.GetOk(oldKey)
 		if !ok {
@@ -148,6 +156,10 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 		}
 		oldKey := *desiredView.RenameFrom
 
+		if oldKey == newKey {
+			continue
+		}
+
 		oldView, ok := adjusted.GetOk(oldKey)
 		if !ok {
 			if _, exists := adjusted.GetOk(newKey); exists {
@@ -194,6 +206,10 @@ func detectColumnRenames(fqtn string, current, desired *orderedmap.Map[string, *
 		}
 		oldName := *desiredCol.RenameFrom
 
+		if oldName == newName {
+			continue
+		}
+
 		oldCol, ok := adjusted.GetOk(oldName)
 		if !ok {
 			if _, exists := adjusted.GetOk(newName); exists {
@@ -230,6 +246,10 @@ func detectConstraintRenames(fqtn string, current, desired *orderedmap.Map[strin
 		}
 		oldName := *desiredCon.RenameFrom
 
+		if oldName == newName {
+			continue
+		}
+
 		oldCon, ok := adjusted.GetOk(oldName)
 		if !ok {
 			if _, exists := adjusted.GetOk(newName); exists {
@@ -265,6 +285,10 @@ func detectIndexRenames(current, desired *orderedmap.Map[string, *model.Index]) 
 			continue
 		}
 		oldName := *desiredIdx.RenameFrom
+
+		if oldName == newName {
+			continue
+		}
 
 		oldIdx, ok := adjusted.GetOk(oldName)
 		if !ok {
@@ -321,6 +345,10 @@ func detectForeignKeyRenames(fqtn string, current, desired *orderedmap.Map[strin
 			continue
 		}
 		oldName := *desiredFK.RenameFrom
+
+		if oldName == newName {
+			continue
+		}
 
 		oldFK, ok := adjusted.GetOk(oldName)
 		if !ok {

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
 )
 
 // detectEnumRenames finds desired enums with RenameFrom that match a current enum.
-// Returns RENAME statements and a new "current" map where the renamed entry's key
-// has been updated to the new FQEN.
 func detectEnumRenames(current, desired *orderedmap.Map[string, *model.Enum]) ([]string, *orderedmap.Map[string, *model.Enum], error) {
 	var stmts []string
 	adjusted := cloneMap(current)
@@ -27,6 +26,12 @@ func detectEnumRenames(current, desired *orderedmap.Map[string, *model.Enum]) ([
 				continue
 			}
 			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+		}
+
+		if oldKey != newKey {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				return nil, nil, fmt.Errorf("cannot rename %s to %s: destination already exists", oldKey, newKey)
+			}
 		}
 
 		if oldEnum.Schema != desiredEnum.Schema {
@@ -63,12 +68,15 @@ func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) 
 			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
 		}
 
+		if oldKey != newKey {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				return nil, nil, fmt.Errorf("cannot rename %s to %s: destination already exists", oldKey, newKey)
+			}
+		}
+
 		if oldTable.Schema != desiredTable.Schema {
 			return nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
 		}
-
-		oldFQTN := oldTable.FQTN()
-		newFQTN := model.Ident(oldTable.Schema, desiredTable.Name)
 
 		stmts = append(stmts, "ALTER TABLE "+oldKey+" RENAME TO "+model.Ident(desiredTable.Name)+";")
 
@@ -76,19 +84,19 @@ func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) 
 		renamed := *oldTable
 		renamed.Name = desiredTable.Name
 
-		// Update index definitions to reflect the new table name
+		// Update index definitions to reflect the new table name via pg_query parse/deparse
 		if renamed.Indexes.Len() > 0 {
 			newIndexes := orderedmap.New[string, *model.Index]()
 			for idxName, idx := range renamed.Indexes.All() {
 				idxCopy := *idx
 				idxCopy.Table = desiredTable.Name
-				idxCopy.Definition = strings.ReplaceAll(idx.Definition, " ON "+oldFQTN+" ", " ON "+newFQTN+" ")
+				idxCopy.Definition = updateIndexTableName(idx.Definition, desiredTable.Name)
 				newIndexes.Set(idxName, &idxCopy)
 			}
 			renamed.Indexes = newIndexes
 		}
 
-		// Update FK definitions to reflect the new table name
+		// Update FK table name
 		if renamed.ForeignKeys.Len() > 0 {
 			newFKs := orderedmap.New[string, *model.ForeignKey]()
 			for fkName, fk := range renamed.ForeignKeys.All() {
@@ -103,6 +111,25 @@ func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) 
 	}
 
 	return stmts, adjusted, nil
+}
+
+// updateIndexTableName parses an index definition, updates the table name,
+// and deparses it back to canonical SQL.
+func updateIndexTableName(def string, newTableName string) string {
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return def // fallback to original
+	}
+	is := result.Stmts[0].Stmt.GetIndexStmt()
+	if is == nil || is.Relation == nil {
+		return def
+	}
+	is.Relation.Relname = newTableName
+	deparsed, err := pg_query.Deparse(result)
+	if err != nil {
+		return def
+	}
+	return deparsed
 }
 
 // detectViewRenames finds desired views with RenameFrom that match a current view.
@@ -122,6 +149,12 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 				continue
 			}
 			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+		}
+
+		if oldKey != newKey {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				return nil, nil, fmt.Errorf("cannot rename %s to %s: destination already exists", oldKey, newKey)
+			}
 		}
 
 		if oldView.Schema != desiredView.Schema {
@@ -156,6 +189,12 @@ func detectColumnRenames(fqtn string, current, desired *orderedmap.Map[string, *
 				continue
 			}
 			return nil, nil, fmt.Errorf("rename source column %s not found in %s", model.Ident(oldName), fqtn)
+		}
+
+		if oldName != newName {
+			if _, exists := adjusted.GetOk(newName); exists {
+				return nil, nil, fmt.Errorf("cannot rename column %s to %s in %s: destination already exists", model.Ident(oldName), model.Ident(newName), fqtn)
+			}
 		}
 
 		stmts = append(stmts, "ALTER TABLE "+fqtn+" RENAME COLUMN "+model.Ident(oldName)+" TO "+model.Ident(newName)+";")
@@ -223,12 +262,30 @@ func detectIndexRenames(current, desired *orderedmap.Map[string, *model.Index]) 
 		adjusted.Delete(oldName)
 		renamed := *oldIdx
 		renamed.Name = newName
-		// Update definition to reflect the new index name
-		renamed.Definition = strings.Replace(renamed.Definition, model.Ident(oldName), model.Ident(newName), 1)
+		// Update definition to reflect the new index name via pg_query parse/deparse
+		renamed.Definition = updateIndexName(renamed.Definition, newName)
 		adjusted.Set(newName, &renamed)
 	}
 
 	return stmts, adjusted, nil
+}
+
+// updateIndexName parses an index definition, updates the index name, and deparses.
+func updateIndexName(def string, newName string) string {
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return strings.Replace(def, model.Ident(newName), model.Ident(newName), 1) // fallback
+	}
+	is := result.Stmts[0].Stmt.GetIndexStmt()
+	if is == nil {
+		return def
+	}
+	is.Idxname = newName
+	deparsed, err := pg_query.Deparse(result)
+	if err != nil {
+		return def
+	}
+	return deparsed
 }
 
 // detectForeignKeyRenames finds desired foreign keys with RenameFrom that match a current FK.

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -1,0 +1,237 @@
+package diff
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// detectEnumRenames finds desired enums with RenameFrom that match a current enum.
+// Returns RENAME statements and a new "current" map where the renamed entry's key
+// has been updated to the new FQEN.
+func detectEnumRenames(current, desired *orderedmap.Map[string, *model.Enum]) ([]string, *orderedmap.Map[string, *model.Enum], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newKey, desiredEnum := range desired.All() {
+		if desiredEnum.RenameFrom == nil {
+			continue
+		}
+		oldKey := *desiredEnum.RenameFrom
+
+		oldEnum, ok := adjusted.GetOk(oldKey)
+		if !ok {
+			// If already renamed (new key exists in current), skip silently
+			if _, exists := adjusted.GetOk(newKey); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+		}
+
+		stmts = append(stmts, "ALTER TYPE "+oldKey+" RENAME TO "+model.Ident(desiredEnum.Name)+";")
+
+		// Re-key in adjusted current: remove old, insert new with updated name
+		adjusted.Delete(oldKey)
+		renamed := *oldEnum
+		renamed.Schema = desiredEnum.Schema
+		renamed.Name = desiredEnum.Name
+		adjusted.Set(newKey, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}
+
+// detectTableRenames finds desired tables with RenameFrom that match a current table.
+func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) ([]string, *orderedmap.Map[string, *model.Table], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newKey, desiredTable := range desired.All() {
+		if desiredTable.RenameFrom == nil {
+			continue
+		}
+		oldKey := *desiredTable.RenameFrom
+
+		oldTable, ok := adjusted.GetOk(oldKey)
+		if !ok {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+		}
+
+		stmts = append(stmts, "ALTER TABLE "+oldKey+" RENAME TO "+model.Ident(desiredTable.Name)+";")
+
+		adjusted.Delete(oldKey)
+		renamed := *oldTable
+		renamed.Schema = desiredTable.Schema
+		renamed.Name = desiredTable.Name
+		adjusted.Set(newKey, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}
+
+// detectViewRenames finds desired views with RenameFrom that match a current view.
+func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([]string, *orderedmap.Map[string, *model.View], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newKey, desiredView := range desired.All() {
+		if desiredView.RenameFrom == nil {
+			continue
+		}
+		oldKey := *desiredView.RenameFrom
+
+		oldView, ok := adjusted.GetOk(oldKey)
+		if !ok {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+		}
+
+		stmts = append(stmts, "ALTER VIEW "+oldKey+" RENAME TO "+model.Ident(desiredView.Name)+";")
+
+		adjusted.Delete(oldKey)
+		renamed := *oldView
+		renamed.Schema = desiredView.Schema
+		renamed.Name = desiredView.Name
+		adjusted.Set(newKey, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}
+
+// detectColumnRenames finds desired columns with RenameFrom that match a current column.
+func detectColumnRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Column]) ([]string, *orderedmap.Map[string, *model.Column], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newName, desiredCol := range desired.All() {
+		if desiredCol.RenameFrom == nil {
+			continue
+		}
+		oldName := *desiredCol.RenameFrom
+
+		oldCol, ok := adjusted.GetOk(oldName)
+		if !ok {
+			if _, exists := adjusted.GetOk(newName); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source column %s not found in %s", model.Ident(oldName), fqtn)
+		}
+
+		stmts = append(stmts, "ALTER TABLE "+fqtn+" RENAME COLUMN "+model.Ident(oldName)+" TO "+model.Ident(newName)+";")
+
+		adjusted.Delete(oldName)
+		renamed := *oldCol
+		renamed.Name = newName
+		adjusted.Set(newName, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}
+
+// detectConstraintRenames finds desired constraints with RenameFrom that match a current constraint.
+func detectConstraintRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Constraint]) ([]string, *orderedmap.Map[string, *model.Constraint], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newName, desiredCon := range desired.All() {
+		if desiredCon.RenameFrom == nil {
+			continue
+		}
+		oldName := *desiredCon.RenameFrom
+
+		oldCon, ok := adjusted.GetOk(oldName)
+		if !ok {
+			if _, exists := adjusted.GetOk(newName); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source constraint %s not found in %s", model.Ident(oldName), fqtn)
+		}
+
+		stmts = append(stmts, "ALTER TABLE "+fqtn+" RENAME CONSTRAINT "+model.Ident(oldName)+" TO "+model.Ident(newName)+";")
+
+		adjusted.Delete(oldName)
+		renamed := *oldCon
+		renamed.Name = newName
+		adjusted.Set(newName, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}
+
+// detectIndexRenames finds desired indexes with RenameFrom that match a current index.
+func detectIndexRenames(current, desired *orderedmap.Map[string, *model.Index]) ([]string, *orderedmap.Map[string, *model.Index], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newName, desiredIdx := range desired.All() {
+		if desiredIdx.RenameFrom == nil {
+			continue
+		}
+		oldName := *desiredIdx.RenameFrom
+
+		oldIdx, ok := adjusted.GetOk(oldName)
+		if !ok {
+			if _, exists := adjusted.GetOk(newName); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source index %s not found", model.Ident(oldName))
+		}
+
+		stmts = append(stmts, "ALTER INDEX "+model.Ident(oldIdx.Schema, oldName)+" RENAME TO "+model.Ident(newName)+";")
+
+		adjusted.Delete(oldName)
+		renamed := *oldIdx
+		renamed.Name = newName
+		// Update definition to reflect the new index name
+		renamed.Definition = strings.Replace(renamed.Definition, model.Ident(oldName), model.Ident(newName), 1)
+		adjusted.Set(newName, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}
+
+// detectForeignKeyRenames finds desired foreign keys with RenameFrom that match a current FK.
+func detectForeignKeyRenames(fqtn string, current, desired *orderedmap.Map[string, *model.ForeignKey]) ([]string, *orderedmap.Map[string, *model.ForeignKey], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newName, desiredFK := range desired.All() {
+		if desiredFK.RenameFrom == nil {
+			continue
+		}
+		oldName := *desiredFK.RenameFrom
+
+		oldFK, ok := adjusted.GetOk(oldName)
+		if !ok {
+			if _, exists := adjusted.GetOk(newName); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source foreign key %s not found in %s", model.Ident(oldName), fqtn)
+		}
+
+		stmts = append(stmts, "ALTER TABLE "+fqtn+" RENAME CONSTRAINT "+model.Ident(oldName)+" TO "+model.Ident(newName)+";")
+
+		adjusted.Delete(oldName)
+		renamed := *oldFK
+		renamed.Name = newName
+		adjusted.Set(newName, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}
+
+// cloneMap creates a shallow copy of an orderedmap.
+func cloneMap[K comparable, V any](m *orderedmap.Map[K, V]) *orderedmap.Map[K, V] {
+	clone := orderedmap.New[K, V]()
+	for k, v := range m.All() {
+		clone.Set(k, v)
+	}
+	return clone
+}

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -103,7 +103,11 @@ func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) 
 			for idxName, idx := range renamed.Indexes.All() {
 				idxCopy := *idx
 				idxCopy.Table = desiredTable.Name
-				idxCopy.Definition = updateIndexTableName(idx.Definition, desiredTable.Name)
+				updatedDef, err := updateIndexTableName(idx.Definition, desiredTable.Name)
+				if err != nil {
+					return nil, nil, err
+				}
+				idxCopy.Definition = updatedDef
 				newIndexes.Set(idxName, &idxCopy)
 			}
 			renamed.Indexes = newIndexes
@@ -128,21 +132,21 @@ func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) 
 
 // updateIndexTableName parses an index definition, updates the table name,
 // and deparses it back to canonical SQL.
-func updateIndexTableName(def string, newTableName string) string {
+func updateIndexTableName(def string, newTableName string) (string, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {
-		return def // fallback to original
+		return "", fmt.Errorf("failed to parse index definition: %w", err)
 	}
 	is := result.Stmts[0].Stmt.GetIndexStmt()
 	if is == nil || is.Relation == nil {
-		return def
+		return "", fmt.Errorf("failed to parse index definition: expected IndexStmt with relation")
 	}
 	is.Relation.Relname = newTableName
 	deparsed, err := pg_query.Deparse(result)
 	if err != nil {
-		return def
+		return "", fmt.Errorf("failed to deparse index definition: %w", err)
 	}
-	return deparsed
+	return deparsed, nil
 }
 
 // detectViewRenames finds desired views with RenameFrom that match a current view.
@@ -310,7 +314,11 @@ func detectIndexRenames(current, desired *orderedmap.Map[string, *model.Index]) 
 		renamed := *oldIdx
 		renamed.Name = newName
 		// Update definition to reflect the new index name via pg_query parse/deparse
-		renamed.Definition = updateIndexName(renamed.Definition, newName)
+		updatedDef, err := updateIndexName(renamed.Definition, newName)
+		if err != nil {
+			return nil, nil, err
+		}
+		renamed.Definition = updatedDef
 		adjusted.Set(newName, &renamed)
 	}
 
@@ -318,21 +326,21 @@ func detectIndexRenames(current, desired *orderedmap.Map[string, *model.Index]) 
 }
 
 // updateIndexName parses an index definition, updates the index name, and deparses.
-func updateIndexName(def string, newName string) string {
+func updateIndexName(def string, newName string) (string, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {
-		return def
+		return "", fmt.Errorf("failed to parse index definition: %w", err)
 	}
 	is := result.Stmts[0].Stmt.GetIndexStmt()
 	if is == nil {
-		return def
+		return "", fmt.Errorf("failed to parse index definition: expected IndexStmt")
 	}
 	is.Idxname = newName
 	deparsed, err := pg_query.Deparse(result)
 	if err != nil {
-		return def
+		return "", fmt.Errorf("failed to deparse index definition: %w", err)
 	}
-	return deparsed
+	return deparsed, nil
 }
 
 // detectForeignKeyRenames finds desired foreign keys with RenameFrom that match a current FK.

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -49,6 +49,12 @@ func detectEnumRenames(current, desired *orderedmap.Map[string, *model.Enum]) ([
 }
 
 // detectTableRenames finds desired tables with RenameFrom that match a current table.
+//
+// NOTE: After a table rename, other objects that reference the old table name
+// (e.g. foreign keys in other tables, view definitions) are not updated in the
+// adjusted current state. PostgreSQL automatically updates these on RENAME, so
+// running plan/apply a second time after a rename will produce a clean diff.
+// A single plan may emit redundant DROP/CREATE for dependent objects.
 func detectTableRenames(current, desired *orderedmap.Map[string, *model.Table]) ([]string, *orderedmap.Map[string, *model.Table], error) {
 	var stmts []string
 	adjusted := cloneMap(current)
@@ -172,6 +178,12 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 }
 
 // detectColumnRenames finds desired columns with RenameFrom that match a current column.
+//
+// NOTE: After a column rename, constraint/index/FK definitions that reference the
+// old column name are not updated in the adjusted current state. PostgreSQL
+// automatically updates these on RENAME COLUMN, so running plan/apply a second
+// time will produce a clean diff. A single plan may emit redundant DROP/ADD for
+// dependent constraints or indexes.
 func detectColumnRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Column]) ([]string, *orderedmap.Map[string, *model.Column], error) {
 	var stmts []string
 	adjusted := cloneMap(current)

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -2,7 +2,6 @@ package diff
 
 import (
 	"fmt"
-	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
@@ -227,6 +226,12 @@ func detectConstraintRenames(fqtn string, current, desired *orderedmap.Map[strin
 			return nil, nil, fmt.Errorf("rename source constraint %s not found in %s", model.Ident(oldName), fqtn)
 		}
 
+		if oldName != newName {
+			if _, exists := adjusted.GetOk(newName); exists {
+				return nil, nil, fmt.Errorf("cannot rename constraint %s to %s in %s: destination already exists", model.Ident(oldName), model.Ident(newName), fqtn)
+			}
+		}
+
 		stmts = append(stmts, "ALTER TABLE "+fqtn+" RENAME CONSTRAINT "+model.Ident(oldName)+" TO "+model.Ident(newName)+";")
 
 		adjusted.Delete(oldName)
@@ -257,6 +262,12 @@ func detectIndexRenames(current, desired *orderedmap.Map[string, *model.Index]) 
 			return nil, nil, fmt.Errorf("rename source index %s not found", model.Ident(oldName))
 		}
 
+		if oldName != newName {
+			if _, exists := adjusted.GetOk(newName); exists {
+				return nil, nil, fmt.Errorf("cannot rename index %s to %s: destination already exists", model.Ident(oldName), model.Ident(newName))
+			}
+		}
+
 		stmts = append(stmts, "ALTER INDEX "+model.Ident(oldIdx.Schema, oldName)+" RENAME TO "+model.Ident(newName)+";")
 
 		adjusted.Delete(oldName)
@@ -274,7 +285,7 @@ func detectIndexRenames(current, desired *orderedmap.Map[string, *model.Index]) 
 func updateIndexName(def string, newName string) string {
 	result, err := pg_query.Parse(def)
 	if err != nil {
-		return strings.Replace(def, model.Ident(newName), model.Ident(newName), 1) // fallback
+		return def
 	}
 	is := result.Stmts[0].Stmt.GetIndexStmt()
 	if is == nil {
@@ -305,6 +316,12 @@ func detectForeignKeyRenames(fqtn string, current, desired *orderedmap.Map[strin
 				continue
 			}
 			return nil, nil, fmt.Errorf("rename source foreign key %s not found in %s", model.Ident(oldName), fqtn)
+		}
+
+		if oldName != newName {
+			if _, exists := adjusted.GetOk(newName); exists {
+				return nil, nil, fmt.Errorf("cannot rename foreign key %s to %s in %s: destination already exists", model.Ident(oldName), model.Ident(newName), fqtn)
+			}
 		}
 
 		stmts = append(stmts, "ALTER TABLE "+fqtn+" RENAME CONSTRAINT "+model.Ident(oldName)+" TO "+model.Ident(newName)+";")

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -10,8 +10,15 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func DiffTables(current, desired *orderedmap.Map[string, *model.Table]) []string {
+func DiffTables(current, desired *orderedmap.Map[string, *model.Table]) ([]string, error) {
 	var stmts []string
+
+	// Detect renames
+	renameStmts, current, err := detectTableRenames(current, desired)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, renameStmts...)
 
 	// New tables
 	for k, v := range desired.All() {
@@ -24,7 +31,11 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table]) []string
 	// Modified tables
 	for k, desiredTable := range desired.All() {
 		if currentTable, ok := current.GetOk(k); ok {
-			stmts = append(stmts, diffTable(currentTable, desiredTable)...)
+			tableStmts, err := diffTable(currentTable, desiredTable)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, tableStmts...)
 		}
 	}
 
@@ -35,7 +46,7 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table]) []string
 		}
 	}
 
-	return stmts
+	return stmts, nil
 }
 
 func newTableExtras(t *model.Table) []string {
@@ -52,29 +63,64 @@ func newTableExtras(t *model.Table) []string {
 	return stmts
 }
 
-func diffTable(current, desired *model.Table) []string {
+func diffTable(current, desired *model.Table) ([]string, error) {
 	var stmts []string
 	fqtn := desired.FQTN()
 
 	// Partition children inherit columns and constraints from the parent,
 	// so skip diffing them to avoid false DROP statements.
 	if desired.PartitionOf != nil && desired.PartitionBound != nil {
-		stmts = append(stmts, diffIndexes(current.Indexes, desired.Indexes)...)
-		stmts = append(stmts, diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)...)
-		return stmts
+		idxStmts, err := diffIndexes(current.Indexes, desired.Indexes)
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, idxStmts...)
+		fkStmts, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, fkStmts...)
+		return stmts, nil
 	}
 
-	stmts = append(stmts, diffColumns(fqtn, current.Columns, desired.Columns)...)
-	stmts = append(stmts, diffConstraints(fqtn, current.Constraints, desired.Constraints)...)
-	stmts = append(stmts, diffIndexes(current.Indexes, desired.Indexes)...)
-	stmts = append(stmts, diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)...)
+	colStmts, err := diffColumns(fqtn, current.Columns, desired.Columns)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, colStmts...)
+
+	conStmts, err := diffConstraints(fqtn, current.Constraints, desired.Constraints)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, conStmts...)
+
+	idxStmts, err := diffIndexes(current.Indexes, desired.Indexes)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, idxStmts...)
+
+	fkStmts, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, fkStmts...)
+
 	stmts = append(stmts, diffComments(current, desired)...)
 
-	return stmts
+	return stmts, nil
 }
 
-func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column]) []string {
+func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column]) ([]string, error) {
 	var stmts []string
+
+	// Detect renames
+	renameStmts, current, err := detectColumnRenames(fqtn, current, desired)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, renameStmts...)
 
 	// Add new columns
 	for name, col := range desired.All() {
@@ -97,7 +143,7 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 		}
 	}
 
-	return stmts
+	return stmts, nil
 }
 
 func addColumnSQL(fqtn string, col *model.Column) string {
@@ -283,8 +329,15 @@ func equalConstraintDef(a, b string) bool {
 	return normA == normB
 }
 
-func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *model.Constraint]) []string {
+func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *model.Constraint]) ([]string, error) {
 	var stmts []string
+
+	// Detect renames
+	renameStmts, current, err := detectConstraintRenames(fqtn, current, desired)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, renameStmts...)
 
 	// Drop removed or changed constraints
 	for name, currentCon := range current.All() {
@@ -302,11 +355,18 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 		}
 	}
 
-	return stmts
+	return stmts, nil
 }
 
-func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) []string {
+func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) ([]string, error) {
 	var stmts []string
+
+	// Detect renames
+	renameStmts, current, err := detectIndexRenames(current, desired)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, renameStmts...)
 
 	// Drop removed or changed indexes
 	for name, currentIdx := range current.All() {
@@ -324,11 +384,18 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) []strin
 		}
 	}
 
-	return stmts
+	return stmts, nil
 }
 
-func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[string, *model.ForeignKey]) []string {
+func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[string, *model.ForeignKey]) ([]string, error) {
 	var stmts []string
+
+	// Detect renames
+	renameStmts, current, err := detectForeignKeyRenames(fqtn, current, desired)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, renameStmts...)
 
 	// Drop removed or changed FKs
 	for name := range current.All() {
@@ -347,7 +414,7 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 		}
 	}
 
-	return stmts
+	return stmts, nil
 }
 
 func diffComments(current, desired *model.Table) []string {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -868,3 +868,228 @@ func TestDiffTables_indexSchemaInsensitive(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
+
+func TestDiffTables_renameTable(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "users")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	current.Set("public.users", ct)
+
+	oldName := "public.users"
+	dt := newTable("public", "accounts")
+	dt.RenameFrom = &oldName
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	desired.Set("public.accounts", dt)
+
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, stmts)
+}
+
+func TestDiffTables_renameTable_alreadyApplied(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "accounts")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	current.Set("public.accounts", ct)
+
+	oldName := "public.users"
+	dt := newTable("public", "accounts")
+	dt.RenameFrom = &oldName
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	desired.Set("public.accounts", dt)
+
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffColumns_renameColumn(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text"})
+
+	oldName := "name"
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
+
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.users RENAME COLUMN name TO display_name;"}, stmts)
+}
+
+func TestDiffColumns_renameColumn_alreadyApplied(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("display_name", &model.Column{Name: "display_name", TypeName: "text"})
+
+	oldName := "name"
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
+
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffConstraints_rename(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("old_con", &model.Constraint{Name: "old_con", Definition: "UNIQUE (code)"})
+
+	oldName := "old_con"
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
+
+	stmts, err := diffConstraints("public.users", current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.users RENAME CONSTRAINT old_con TO new_con;"}, stmts)
+}
+
+func TestDiffIndexes_rename(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("old_idx", &model.Index{Schema: "public", Name: "old_idx", Table: "users", Definition: "CREATE INDEX old_idx ON public.users USING btree (name)"})
+
+	oldName := "old_idx"
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
+
+	stmts, err := diffIndexes(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, stmts)
+}
+
+func TestDiffConstraints_rename_alreadyApplied(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("new_con", &model.Constraint{Name: "new_con", Definition: "UNIQUE (code)"})
+
+	oldName := "old_con"
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
+
+	stmts, err := diffConstraints("public.users", current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffConstraints_rename_sourceNotFound(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+
+	oldName := "nonexistent"
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
+
+	_, err := diffConstraints("public.users", current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source constraint")
+}
+
+func TestDiffIndexes_rename_alreadyApplied(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
+
+	oldName := "old_idx"
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
+
+	stmts, err := diffIndexes(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffIndexes_rename_sourceNotFound(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+
+	oldName := "nonexistent"
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
+
+	_, err := diffIndexes(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source index")
+}
+
+func TestDiffForeignKeys_rename(t *testing.T) {
+	current := orderedmap.New[string, *model.ForeignKey]()
+	current.Set("old_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "old_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	oldName := "old_fk"
+	desired := orderedmap.New[string, *model.ForeignKey]()
+	desired.Set("new_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME CONSTRAINT old_fk TO new_fk;"}, stmts)
+}
+
+func TestDiffForeignKeys_rename_alreadyApplied(t *testing.T) {
+	current := orderedmap.New[string, *model.ForeignKey]()
+	current.Set("new_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "new_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	oldName := "old_fk"
+	desired := orderedmap.New[string, *model.ForeignKey]()
+	desired.Set("new_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffForeignKeys_rename_sourceNotFound(t *testing.T) {
+	current := orderedmap.New[string, *model.ForeignKey]()
+
+	oldName := "nonexistent"
+	desired := orderedmap.New[string, *model.ForeignKey]()
+	desired.Set("new_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	_, err := diffForeignKeys("public.orders", "public", current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source foreign key")
+}
+
+func TestDiffTables_renameTable_sourceNotFound(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	oldName := "public.nonexistent"
+	dt := newTable("public", "accounts")
+	dt.RenameFrom = &oldName
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	desired.Set("public.accounts", dt)
+
+	_, err := DiffTables(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source")
+}
+
+func TestDiffColumns_renameColumn_sourceNotFound(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+
+	oldName := "nonexistent"
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
+
+	_, err := diffColumns("public.users", current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source column")
+}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -995,6 +995,80 @@ func TestDiffTables_renameTable_alreadyApplied(t *testing.T) {
 	assert.Empty(t, stmts)
 }
 
+func TestDiffTables_renameTable_withIndex(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "users")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	ct.Columns.Set("name", &model.Column{Name: "name", TypeName: "text"})
+	ct.Indexes.Set("idx_users_name", &model.Index{Schema: "public", Name: "idx_users_name", Table: "users", Definition: "CREATE INDEX idx_users_name ON public.users USING btree (name)"})
+	current.Set("public.users", ct)
+
+	oldName := "public.users"
+	dt := newTable("public", "accounts")
+	dt.RenameFrom = &oldName
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	dt.Columns.Set("name", &model.Column{Name: "name", TypeName: "text"})
+	dt.Indexes.Set("idx_users_name", &model.Index{Schema: "public", Name: "idx_users_name", Table: "accounts", Definition: "CREATE INDEX idx_users_name ON public.accounts USING btree (name)"})
+	desired.Set("public.accounts", dt)
+
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
+	// Should only rename the table, no DROP/CREATE index
+	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, stmts)
+}
+
+func TestDiffTables_renameTable_withFK(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "orders")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	ct.Columns.Set("user_id", &model.Column{Name: "user_id", TypeName: "integer"})
+	ct.ForeignKeys.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	current.Set("public.orders", ct)
+
+	oldName := "public.orders"
+	dt := newTable("public", "purchases")
+	dt.RenameFrom = &oldName
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	dt.Columns.Set("user_id", &model.Column{Name: "user_id", TypeName: "integer"})
+	dt.ForeignKeys.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "purchases",
+	})
+	desired.Set("public.purchases", dt)
+
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME TO purchases;"}, stmts)
+}
+
+func TestDiffTables_renameTable_crossSchema_error(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "users")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	current.Set("public.users", ct)
+
+	oldName := "public.users"
+	dt := newTable("other", "users")
+	dt.RenameFrom = &oldName
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	desired.Set("other.users", dt)
+
+	_, err := DiffTables(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-schema rename")
+}
+
 func TestDiffColumns_renameColumn(t *testing.T) {
 	current := orderedmap.New[string, *model.Column]()
 	current.Set("name", &model.Column{Name: "name", TypeName: "text"})

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1050,6 +1050,43 @@ func TestDiffTables_renameTable_withFK(t *testing.T) {
 	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME TO purchases;"}, stmts)
 }
 
+func TestDiffTables_renameTable_destinationExists_error(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct1 := newTable("public", "users")
+	ct1.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	current.Set("public.users", ct1)
+
+	ct2 := newTable("public", "accounts")
+	ct2.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	current.Set("public.accounts", ct2)
+
+	oldName := "public.users"
+	dt := newTable("public", "accounts")
+	dt.RenameFrom = &oldName
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	desired.Set("public.accounts", dt)
+
+	_, err := DiffTables(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
+func TestDiffColumns_renameColumn_destinationExists_error(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text"})
+	current.Set("display_name", &model.Column{Name: "display_name", TypeName: "text"})
+
+	oldName := "name"
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
+
+	_, err := diffColumns("public.users", current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
 func TestDiffTables_renameTable_crossSchema_error(t *testing.T) {
 	current := orderedmap.New[string, *model.Table]()
 	desired := orderedmap.New[string, *model.Table]()

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -976,6 +976,85 @@ func TestDiffTables_renameTable(t *testing.T) {
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, stmts)
 }
 
+func TestDiffTables_renameTable_selfRename_skipped(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "users")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	current.Set("public.users", ct)
+
+	oldName := "public.users"
+	dt := newTable("public", "users")
+	dt.RenameFrom = &oldName
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	desired.Set("public.users", dt)
+
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffColumns_renameColumn_selfRename_skipped(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text"})
+
+	oldName := "name"
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", RenameFrom: &oldName, TypeName: "text"})
+
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffConstraints_rename_selfRename_skipped(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("con", &model.Constraint{Name: "con", Definition: "UNIQUE (code)"})
+
+	oldName := "con"
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("con", &model.Constraint{Name: "con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
+
+	stmts, err := diffConstraints("public.users", current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffIndexes_rename_selfRename_skipped(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx", &model.Index{Schema: "public", Name: "idx", Table: "users", Definition: "CREATE INDEX idx ON public.users USING btree (name)"})
+
+	oldName := "idx"
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx", &model.Index{Schema: "public", Name: "idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX idx ON public.users USING btree (name)"})
+
+	stmts, err := diffIndexes(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffForeignKeys_rename_selfRename_skipped(t *testing.T) {
+	current := orderedmap.New[string, *model.ForeignKey]()
+	current.Set("fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	oldName := "fk"
+	desired := orderedmap.New[string, *model.ForeignKey]()
+	desired.Set("fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
 func TestDiffTables_renameTable_alreadyApplied(t *testing.T) {
 	current := orderedmap.New[string, *model.Table]()
 	desired := orderedmap.New[string, *model.Table]()

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1266,6 +1266,60 @@ func TestDiffForeignKeys_rename_sourceNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
 
+func TestDiffConstraints_rename_destinationExists_error(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("old_con", &model.Constraint{Name: "old_con", Definition: "UNIQUE (code)"})
+	current.Set("new_con", &model.Constraint{Name: "new_con", Definition: "UNIQUE (name)"})
+
+	oldName := "old_con"
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
+
+	_, err := diffConstraints("public.users", current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
+func TestDiffIndexes_rename_destinationExists_error(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("old_idx", &model.Index{Schema: "public", Name: "old_idx", Table: "users", Definition: "CREATE INDEX old_idx ON public.users USING btree (name)"})
+	current.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (id)"})
+
+	oldName := "old_idx"
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
+
+	_, err := diffIndexes(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
+func TestDiffForeignKeys_rename_destinationExists_error(t *testing.T) {
+	current := orderedmap.New[string, *model.ForeignKey]()
+	current.Set("old_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "old_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	current.Set("new_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "new_fk", Definition: "FOREIGN KEY (item_id) REFERENCES public.items(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	oldName := "old_fk"
+	desired := orderedmap.New[string, *model.ForeignKey]()
+	desired.Set("new_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	_, err := diffForeignKeys("public.orders", "public", current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
 func TestDiffTables_renameTable_sourceNotFound(t *testing.T) {
 	current := orderedmap.New[string, *model.Table]()
 	desired := orderedmap.New[string, *model.Table]()

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1082,6 +1082,25 @@ func TestDiffTables_renameTable_sourceNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "rename source")
 }
 
+func TestDiffTables_renameColumn_error_propagates(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	ct := newTable("public", "users")
+	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	current.Set("public.users", ct)
+
+	oldName := "nonexistent"
+	dt := newTable("public", "users")
+	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	dt.Columns.Set("new_col", &model.Column{Name: "new_col", RenameFrom: &oldName, TypeName: "text"})
+	desired.Set("public.users", dt)
+
+	_, err := DiffTables(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source column")
+}
+
 func TestDiffColumns_renameColumn_sourceNotFound(t *testing.T) {
 	current := orderedmap.New[string, *model.Column]()
 

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
 )
@@ -32,7 +33,8 @@ func TestDiffTables_newTable(t *testing.T) {
 	tbl.Constraints.Set("users_pkey", &model.Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
 	desired.Set("public.users", tbl)
 
-	stmts := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE TABLE public.users")
 }
@@ -47,7 +49,8 @@ func TestDiffTables_newTable_withExtras(t *testing.T) {
 	tbl.Comment = ptr("Users table")
 	desired.Set("public.users", tbl)
 
-	stmts := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 3)
 	assert.Contains(t, stmts[0], "CREATE TABLE")
 	assert.Contains(t, stmts[1], "CREATE INDEX idx_name")
@@ -60,7 +63,8 @@ func TestDiffTables_dropTable(t *testing.T) {
 
 	current.Set("public.users", newTable("public", "users"))
 
-	stmts := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP TABLE public.users;"}, stmts)
 }
 
@@ -76,7 +80,8 @@ func TestDiffTables_noChange(t *testing.T) {
 	tbl2.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 	desired.Set("public.users", tbl2)
 
-	stmts := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
 
@@ -88,7 +93,8 @@ func TestDiffColumns_addColumn(t *testing.T) {
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ADD COLUMN name text NOT NULL;", stmts[0])
 }
@@ -101,7 +107,8 @@ func TestDiffColumns_dropColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users DROP COLUMN name;", stmts[0])
 }
@@ -113,7 +120,8 @@ func TestDiffColumns_alterType(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;", stmts[0])
 }
@@ -125,7 +133,8 @@ func TestDiffColumns_alterType_withCollation(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], `COLLATE "en_US"`)
 }
@@ -137,7 +146,8 @@ func TestDiffColumns_alterDefault_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer", Default: ptr("0")})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age SET DEFAULT 0;", stmts[0])
 }
@@ -149,7 +159,8 @@ func TestDiffColumns_alterDefault_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer"})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age DROP DEFAULT;", stmts[0])
 }
@@ -161,7 +172,8 @@ func TestDiffColumns_alterNotNull_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;", stmts[0])
 }
@@ -173,7 +185,8 @@ func TestDiffColumns_alterNotNull_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;", stmts[0])
 }
@@ -185,7 +198,8 @@ func TestDiffColumns_identitySkipsNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", Identity: model.ColumnIdentity('a')})
 
-	stmts := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
 
@@ -226,7 +240,8 @@ func TestDiffConstraints_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)"})
 
-	stmts := diffConstraints("public.users", current, desired)
+	stmts, err := diffConstraints("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0);"}, stmts)
 }
 
@@ -235,7 +250,8 @@ func TestDiffConstraints_drop(t *testing.T) {
 	current.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)"})
 	desired := orderedmap.New[string, *model.Constraint]()
 
-	stmts := diffConstraints("public.users", current, desired)
+	stmts, err := diffConstraints("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users DROP CONSTRAINT chk_age;"}, stmts)
 }
 
@@ -245,7 +261,8 @@ func TestDiffConstraints_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age >= 18)"})
 
-	stmts := diffConstraints("public.users", current, desired)
+	stmts, err := diffConstraints("public.users", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_age;", stmts[0])
 	assert.Equal(t, "ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age >= 18);", stmts[1])
@@ -256,7 +273,8 @@ func TestDiffIndexes_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 
-	stmts := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE INDEX idx_name ON public.users USING btree (name);"}, stmts)
 }
 
@@ -265,7 +283,8 @@ func TestDiffIndexes_drop(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	stmts := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, stmts)
 }
 
@@ -275,7 +294,8 @@ func TestDiffIndexes_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	stmts := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "DROP INDEX public.idx_name;", stmts[0])
 	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING hash (name);", stmts[1])
@@ -290,7 +310,8 @@ func TestDiffForeignKeys_add(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts := diffForeignKeys("public.orders", "public", current, desired)
+	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "ADD CONSTRAINT fk_user")
 }
@@ -304,7 +325,8 @@ func TestDiffForeignKeys_drop(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 
-	stmts := diffForeignKeys("public.orders", "public", current, desired)
+	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, stmts)
 }
 
@@ -411,7 +433,8 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 	})
 	desired.Set("public.orders", tbl)
 
-	stmts := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Contains(t, stmts[0], "CREATE TABLE")
 	assert.Contains(t, stmts[1], "ADD CONSTRAINT fk_user")
@@ -467,7 +490,8 @@ func TestDiffForeignKeys_change(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts := diffForeignKeys("public.orders", "public", current, desired)
+	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", stmts[0])
 	assert.Contains(t, stmts[1], "ADD CONSTRAINT fk_user")
@@ -486,7 +510,8 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	desired.PartitionBound = &bound
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
 
-	stmts := diffTable(current, desired)
+	stmts, err := diffTable(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE INDEX idx_new")
 }
@@ -627,7 +652,8 @@ func TestDiffConstraints_noChangeWithTextCast(t *testing.T) {
 		Definition: "CHECK (name <> '')",
 	})
 
-	stmts := diffConstraints("public.items", current, desired)
+	stmts, err := diffConstraints("public.items", current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
 
@@ -643,7 +669,8 @@ func TestDiffConstraints_noChangeWithInVsAny(t *testing.T) {
 		Definition: "CHECK (status IN ('active', 'pending'))",
 	})
 
-	stmts := diffConstraints("public.items", current, desired)
+	stmts, err := diffConstraints("public.items", current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
 
@@ -659,7 +686,8 @@ func TestDiffConstraints_noChangeWithFormattingDiff(t *testing.T) {
 		Definition: "CHECK (kind = ANY(ARRAY['x'::text, 'y'::text]))",
 	})
 
-	stmts := diffConstraints("public.items", current, desired)
+	stmts, err := diffConstraints("public.items", current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
 
@@ -752,7 +780,8 @@ func TestDiffTables_indexWhereClauseSchemaInsensitive(t *testing.T) {
 	})
 	desired.Set("public.products", dt)
 
-	stmts := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
 
@@ -835,6 +864,7 @@ func TestDiffTables_indexSchemaInsensitive(t *testing.T) {
 	dt.Indexes.Set("idx", &model.Index{Schema: "", Name: "idx", Table: "users", Definition: "CREATE INDEX idx ON users USING btree (id)"})
 	desired.Set("public.users", dt)
 
-	stmts := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -516,6 +516,94 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	assert.Contains(t, stmts[0], "CREATE INDEX idx_new")
 }
 
+func TestDiffTable_partitionChild_indexRenameError(t *testing.T) {
+	parent := "public.events"
+	bound := "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')"
+
+	current := newTable("public", "events_2024")
+	current.PartitionOf = &parent
+	current.PartitionBound = &bound
+
+	desired := newTable("public", "events_2024")
+	desired.PartitionOf = &parent
+	desired.PartitionBound = &bound
+	oldName := "nonexistent"
+	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", RenameFrom: &oldName, Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
+
+	_, err := diffTable(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source index")
+}
+
+func TestDiffTable_partitionChild_fkRenameError(t *testing.T) {
+	parent := "public.events"
+	bound := "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')"
+
+	current := newTable("public", "events_2024")
+	current.PartitionOf = &parent
+	current.PartitionBound = &bound
+
+	desired := newTable("public", "events_2024")
+	desired.PartitionOf = &parent
+	desired.PartitionBound = &bound
+	oldName := "nonexistent"
+	desired.ForeignKeys.Set("fk_new", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_new", RenameFrom: &oldName, Definition: "FOREIGN KEY (id) REFERENCES public.events(id)"},
+		Schema:     "public",
+		Table:      "events_2024",
+	})
+
+	_, err := diffTable(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source foreign key")
+}
+
+func TestDiffTable_constraintRenameError(t *testing.T) {
+	current := newTable("public", "users")
+	current.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+
+	desired := newTable("public", "users")
+	desired.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	oldName := "nonexistent"
+	desired.Constraints.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (id)"})
+
+	_, err := diffTable(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source constraint")
+}
+
+func TestDiffTable_indexRenameError(t *testing.T) {
+	current := newTable("public", "users")
+	current.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+
+	desired := newTable("public", "users")
+	desired.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	oldName := "nonexistent"
+	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", RenameFrom: &oldName, Definition: "CREATE INDEX idx_new ON public.users (id)"})
+
+	_, err := diffTable(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source index")
+}
+
+func TestDiffTable_fkRenameError(t *testing.T) {
+	current := newTable("public", "users")
+	current.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+
+	desired := newTable("public", "users")
+	desired.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	oldName := "nonexistent"
+	desired.ForeignKeys.Set("fk_new", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_new", RenameFrom: &oldName, Definition: "FOREIGN KEY (id) REFERENCES public.other(id)"},
+		Schema:     "public",
+		Table:      "users",
+	})
+
+	_, err := diffTable(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source foreign key")
+}
+
 func TestEqualConstraintDef_same(t *testing.T) {
 	assert.True(t, equalConstraintDef(
 		"PRIMARY KEY (id)",

--- a/diff/views.go
+++ b/diff/views.go
@@ -33,8 +33,15 @@ func equalViewDef(a, b string) bool {
 	return normA == normB
 }
 
-func DiffViews(current, desired *orderedmap.Map[string, *model.View]) []string {
+func DiffViews(current, desired *orderedmap.Map[string, *model.View]) ([]string, error) {
 	var stmts []string
+
+	// Detect renames
+	renameStmts, current, err := detectViewRenames(current, desired)
+	if err != nil {
+		return nil, err
+	}
+	stmts = append(stmts, renameStmts...)
 
 	// New or modified views (CREATE OR REPLACE)
 	for k, desiredView := range desired.All() {
@@ -67,5 +74,5 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View]) []string {
 		}
 	}
 
-	return stmts
+	return stmts, nil
 }

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -101,6 +101,19 @@ func TestDiffViews_rename(t *testing.T) {
 	assert.Equal(t, []string{"ALTER VIEW public.v1 RENAME TO v2;"}, stmts)
 }
 
+func TestDiffViews_rename_selfRename_skipped(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+
+	oldName := "public.v1"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", RenameFrom: &oldName, Definition: "SELECT 1"})
+
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
 func TestDiffViews_rename_alreadyApplied(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.v2", &model.View{Schema: "public", Name: "v2", Definition: "SELECT 1"})

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -114,6 +114,19 @@ func TestDiffViews_rename_alreadyApplied(t *testing.T) {
 	assert.Empty(t, stmts)
 }
 
+func TestDiffViews_rename_crossSchema_error(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+
+	oldName := "public.v1"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("other.v2", &model.View{Schema: "other", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
+
+	_, err := DiffViews(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-schema rename")
+}
+
 func TestDiffViews_rename_sourceNotFound(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -114,6 +114,20 @@ func TestDiffViews_rename_alreadyApplied(t *testing.T) {
 	assert.Empty(t, stmts)
 }
 
+func TestDiffViews_rename_destinationExists_error(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+	current.Set("public.v2", &model.View{Schema: "public", Name: "v2", Definition: "SELECT 2"})
+
+	oldName := "public.v1"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
+
+	_, err := DiffViews(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
 func TestDiffViews_rename_crossSchema_error(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
 )
@@ -13,7 +14,8 @@ func TestDiffViews_newView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE OR REPLACE VIEW public.v1")
 }
@@ -23,7 +25,8 @@ func TestDiffViews_dropView(t *testing.T) {
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 	desired := orderedmap.New[string, *model.View]()
 
-	stmts := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP VIEW public.v1;"}, stmts)
 }
 
@@ -33,7 +36,8 @@ func TestDiffViews_modifyView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 2"})
 
-	stmts := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE OR REPLACE VIEW public.v1")
 }
@@ -44,7 +48,8 @@ func TestDiffViews_noChange(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
 
@@ -54,7 +59,8 @@ func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
 
@@ -64,7 +70,8 @@ func TestDiffViews_commentAdd(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", Comment: ptr("my view")})
 
-	stmts := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS 'my view';", stmts[0])
 }
@@ -75,7 +82,8 @@ func TestDiffViews_commentDrop(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS NULL;", stmts[0])
 }

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -88,6 +88,44 @@ func TestDiffViews_commentDrop(t *testing.T) {
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS NULL;", stmts[0])
 }
 
+func TestDiffViews_rename(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+
+	oldName := "public.v1"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
+
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER VIEW public.v1 RENAME TO v2;"}, stmts)
+}
+
+func TestDiffViews_rename_alreadyApplied(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v2", &model.View{Schema: "public", Name: "v2", Definition: "SELECT 1"})
+
+	oldName := "public.v1"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
+
+	stmts, err := DiffViews(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffViews_rename_sourceNotFound(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+
+	oldName := "public.nonexistent"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
+
+	_, err := DiffViews(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source")
+}
+
 func TestNormalizeViewDef(t *testing.T) {
 	got, err := normalizeViewDef("SELECT   1")
 	assert.NoError(t, err)

--- a/model/column.go
+++ b/model/column.go
@@ -34,6 +34,7 @@ func (b ColumnGenerated) IsVirtualGeneratedColumn() bool {
 
 type Column struct {
 	Name        string
+	RenameFrom  *string
 	TypeName    string
 	NotNull     bool
 	Default     *string

--- a/model/constraint.go
+++ b/model/constraint.go
@@ -37,6 +37,7 @@ func (b ConstraintType) IsExclusionConstraint() bool {
 type Constraint struct {
 	OID        uint32
 	Name       string
+	RenameFrom *string
 	Type       ConstraintType
 	Definition string
 	Columns    []string

--- a/model/enum.go
+++ b/model/enum.go
@@ -7,11 +7,12 @@ import (
 )
 
 type Enum struct {
-	OID     uint32
-	Schema  string
-	Name    string
-	Values  []string
-	Comment *string
+	OID        uint32
+	Schema     string
+	Name       string
+	RenameFrom *string
+	Values     []string
+	Comment    *string
 }
 
 func (e Enum) FQEN() string {

--- a/model/index.go
+++ b/model/index.go
@@ -4,6 +4,7 @@ type Index struct {
 	OID        uint32
 	Schema     string
 	Name       string
+	RenameFrom *string
 	Table      string
 	Definition string
 	TableSpace *string

--- a/model/table.go
+++ b/model/table.go
@@ -11,6 +11,7 @@ type Table struct {
 	OID            uint32
 	Schema         string
 	Name           string
+	RenameFrom     *string
 	TableSpace     *string
 	Unlogged       bool
 	Partitioned    bool

--- a/model/view.go
+++ b/model/view.go
@@ -10,6 +10,7 @@ type View struct {
 	OID        uint32
 	Schema     string
 	Name       string
+	RenameFrom *string
 	Definition string
 	Comment    *string
 }

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -25,14 +25,14 @@ func QualifyRenameFrom(value, defaultSchema string) string {
 }
 
 // unquoteIdent strips surrounding double quotes from a SQL identifier and
-// unescapes doubled double-quotes ("" → "). Returns the input unchanged
-// if it is not quoted.
+// unescapes doubled double-quotes ("" → "). For unquoted identifiers,
+// folds to lowercase to match PostgreSQL's behavior.
 func unquoteIdent(s string) string {
 	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
 		inner := s[1 : len(s)-1]
 		return strings.ReplaceAll(inner, `""`, `"`)
 	}
-	return s
+	return strings.ToLower(s)
 }
 
 // normalizeDirectiveValue normalizes a rename-from directive value by
@@ -250,7 +250,7 @@ func extractConstraintName(line string) string {
 	if len(fields) == 0 {
 		return ""
 	}
-	return fields[0]
+	return strings.ToLower(fields[0])
 }
 
 // extractColumnName extracts the column name from a column definition line.
@@ -272,7 +272,7 @@ func extractColumnName(line string) string {
 		return ""
 	}
 
-	// Unquoted identifier: first word
+	// Unquoted identifier: first word, folded to lowercase per PostgreSQL behavior
 	fields := strings.Fields(line)
 	if len(fields) == 0 {
 		return ""
@@ -281,5 +281,5 @@ func extractColumnName(line string) string {
 	name := fields[0]
 	// Remove trailing comma if present
 	name = strings.TrimSuffix(name, ",")
-	return name
+	return strings.ToLower(name)
 }

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -11,12 +11,17 @@ import (
 var renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:rename-from[ \t]+(.+?)[ \t]*$`)
 
 // QualifyRenameFrom qualifies a rename-from value with the default schema
-// if it does not already contain a schema (dot separator).
+// if it does not already contain a schema. Quoted identifiers containing
+// dots (e.g. `"a.b"`) are treated as a single identifier.
 func QualifyRenameFrom(value, defaultSchema string) string {
-	if strings.Contains(value, ".") {
-		return value
+	parts := splitQualifiedName(value)
+	for i, p := range parts {
+		parts[i] = unquoteIdent(p)
 	}
-	return defaultSchema + "." + value
+	if len(parts) >= 2 {
+		return model.Ident(parts...)
+	}
+	return model.Ident(defaultSchema, parts[0])
 }
 
 // unquoteIdent strips surrounding double quotes from a SQL identifier and
@@ -33,16 +38,21 @@ func unquoteIdent(s string) string {
 // normalizeDirectiveValue normalizes a rename-from directive value by
 // unquoting each part and re-quoting via model.Ident to match the
 // canonical identifier format used by the parser and diff layer.
-// e.g. `"My Schema"."Old Name"` → `"My Schema"."Old Name"` (canonical)
-//
-//	`public.old_name`       → `public.old_name` (unchanged)
-//	`"Old Name"`            → `"Old Name"` (canonical)
+// Used for schema-qualified names (tables, views, enums).
 func normalizeDirectiveValue(s string) string {
 	parts := splitQualifiedName(s)
 	for i, p := range parts {
 		parts[i] = unquoteIdent(p)
 	}
 	return model.Ident(parts...)
+}
+
+// normalizeUnqualifiedDirective normalizes a rename-from directive value
+// for unqualified names (columns, constraints, indexes, foreign keys)
+// by unquoting the identifier. The result matches the unquoted name
+// used as orderedmap keys by the parser.
+func normalizeUnqualifiedDirective(s string) string {
+	return unquoteIdent(s)
 }
 
 // splitQualifiedName splits a potentially schema-qualified name into parts,
@@ -102,7 +112,7 @@ func ExtractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]s
 		matches := renameDirectivePattern.FindAllStringSubmatch(leading, -1)
 		if len(matches) > 0 {
 			// Use the last match (closest to the actual SQL statement)
-			directives[loc] = normalizeDirectiveValue(matches[len(matches)-1][1])
+			directives[loc] = matches[len(matches)-1][1]
 		}
 	}
 
@@ -156,7 +166,7 @@ func ExtractInlineDirectives(rawCreateTableSQL string) *InlineDirectives {
 		trimmed := strings.TrimSpace(line)
 
 		if m := renameDirectivePattern.FindStringSubmatch(line); m != nil {
-			pendingRename = normalizeDirectiveValue(m[1])
+			pendingRename = normalizeUnqualifiedDirective(m[1])
 			continue
 		}
 

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -49,10 +49,14 @@ func normalizeDirectiveValue(s string) string {
 
 // normalizeUnqualifiedDirective normalizes a rename-from directive value
 // for unqualified names (columns, constraints, indexes, foreign keys)
-// by unquoting the identifier. The result matches the unquoted name
-// used as orderedmap keys by the parser.
+// by unquoting the identifier. If a schema-qualified name is provided
+// (e.g. "public.old_idx"), only the last part is used.
+// The result matches the unquoted name used as orderedmap keys by the parser.
 func normalizeUnqualifiedDirective(s string) string {
-	return unquoteIdent(s)
+	parts := splitQualifiedName(s)
+	// Use the last part (the actual name, ignoring any schema prefix)
+	last := parts[len(parts)-1]
+	return unquoteIdent(last)
 }
 
 // splitQualifiedName splits a potentially schema-qualified name into parts,

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -9,6 +9,15 @@ import (
 
 var renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:rename-from[ \t]+(.+?)[ \t]*$`)
 
+// QualifyRenameFrom qualifies a rename-from value with the default schema
+// if it does not already contain a schema (dot separator).
+func QualifyRenameFrom(value, defaultSchema string) string {
+	if strings.Contains(value, ".") {
+		return value
+	}
+	return defaultSchema + "." + value
+}
+
 // unquoteIdent strips surrounding double quotes from a SQL identifier and
 // unescapes doubled double-quotes ("" → "). Returns the input unchanged
 // if it is not quoted.

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/winebarrel/pistachio/model"
 )
 
 var renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:rename-from[ \t]+(.+?)[ \t]*$`)
@@ -30,18 +31,18 @@ func unquoteIdent(s string) string {
 }
 
 // normalizeDirectiveValue normalizes a rename-from directive value by
-// unquoting each part of a potentially schema-qualified name.
-// e.g. `"My Schema"."Old Name"` → `My Schema.Old Name`
+// unquoting each part and re-quoting via model.Ident to match the
+// canonical identifier format used by the parser and diff layer.
+// e.g. `"My Schema"."Old Name"` → `"My Schema"."Old Name"` (canonical)
 //
 //	`public.old_name`       → `public.old_name` (unchanged)
-//	`"Old Name"`            → `Old Name`
+//	`"Old Name"`            → `"Old Name"` (canonical)
 func normalizeDirectiveValue(s string) string {
-	// Split on dots, but respect quoted identifiers
 	parts := splitQualifiedName(s)
 	for i, p := range parts {
 		parts[i] = unquoteIdent(p)
 	}
-	return strings.Join(parts, ".")
+	return model.Ident(parts...)
 }
 
 // splitQualifiedName splits a potentially schema-qualified name into parts,
@@ -141,7 +142,14 @@ func ExtractInlineDirectives(rawCreateTableSQL string) *InlineDirectives {
 		Columns:     make(map[string]string),
 		Constraints: make(map[string]string),
 	}
-	lines := strings.Split(rawCreateTableSQL, "\n")
+
+	// Only scan lines inside the column/constraint list (after the opening parenthesis)
+	parenIdx := strings.Index(rawCreateTableSQL, "(")
+	if parenIdx < 0 {
+		return result
+	}
+	body := rawCreateTableSQL[parenIdx:]
+	lines := strings.Split(body, "\n")
 
 	var pendingRename string
 	for _, line := range lines {
@@ -181,6 +189,30 @@ func ExtractColumnDirectives(rawCreateTableSQL string) map[string]string {
 	return ExtractInlineDirectives(rawCreateTableSQL).Columns
 }
 
+// scanQuotedIdent scans a quoted identifier from the start of s, handling ""
+// escape sequences. Returns the unquoted name and true if successful.
+func scanQuotedIdent(s string) (string, bool) {
+	if len(s) == 0 || s[0] != '"' {
+		return "", false
+	}
+	var name strings.Builder
+	for i := 1; i < len(s); i++ {
+		if s[i] == '"' {
+			if i+1 < len(s) && s[i+1] == '"' {
+				// Escaped double quote
+				name.WriteByte('"')
+				i++
+			} else {
+				// End of quoted identifier
+				return name.String(), true
+			}
+		} else {
+			name.WriteByte(s[i])
+		}
+	}
+	return "", false
+}
+
 // extractConstraintName extracts the constraint name from a CONSTRAINT line.
 // e.g. "CONSTRAINT users_pkey PRIMARY KEY (id)" → "users_pkey"
 func extractConstraintName(line string) string {
@@ -191,9 +223,9 @@ func extractConstraintName(line string) string {
 	}
 	rest := strings.TrimSpace(line[len("CONSTRAINT "):])
 	if strings.HasPrefix(rest, `"`) {
-		end := strings.Index(rest[1:], `"`)
-		if end >= 0 {
-			return rest[1 : end+1]
+		name, ok := scanQuotedIdent(rest)
+		if ok {
+			return name
 		}
 		return ""
 	}
@@ -216,10 +248,9 @@ func extractColumnName(line string) string {
 	}
 
 	if strings.HasPrefix(line, `"`) {
-		// Quoted identifier
-		end := strings.Index(line[1:], `"`)
-		if end >= 0 {
-			return line[1 : end+1]
+		name, ok := scanQuotedIdent(line)
+		if ok {
+			return name
 		}
 		return ""
 	}

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -1,0 +1,170 @@
+package parser
+
+import (
+	"regexp"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+var renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:rename-from[ \t]+(.+?)[ \t]*$`)
+
+// ExtractStmtDirectives scans raw SQL for `-- pist:rename-from <name>` comments
+// that appear in each statement's raw text region (including leading comments).
+// pg_query includes leading comments in StmtLocation/StmtLen, so we scan the
+// raw text of each statement for the directive.
+// Returns a map from StmtLocation to the old name string.
+func ExtractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]string {
+	directives := make(map[int32]string)
+
+	for _, stmt := range stmts {
+		loc := stmt.StmtLocation
+		end := loc + stmt.StmtLen
+		if end > int32(len(rawSQL)) {
+			end = int32(len(rawSQL))
+		}
+
+		region := rawSQL[loc:end]
+
+		// Only scan the leading comment block before the actual SQL keyword.
+		// Find where the first non-comment, non-whitespace content starts.
+		leadingEnd := findLeadingCommentEnd(region)
+		leading := region[:leadingEnd]
+
+		matches := renameDirectivePattern.FindAllStringSubmatch(leading, -1)
+		if len(matches) > 0 {
+			// Use the last match (closest to the actual SQL statement)
+			directives[loc] = matches[len(matches)-1][1]
+		}
+	}
+
+	return directives
+}
+
+// findLeadingCommentEnd returns the byte offset where leading comments/whitespace
+// end and the actual SQL statement begins.
+func findLeadingCommentEnd(s string) int {
+	lines := strings.Split(s, "\n")
+	offset := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			offset += len(line) + 1 // +1 for \n
+		} else {
+			break
+		}
+	}
+	if offset > len(s) {
+		offset = len(s)
+	}
+	return offset
+}
+
+// InlineDirectives holds rename directives for columns and constraints within a CREATE TABLE.
+type InlineDirectives struct {
+	Columns     map[string]string // new column name → old column name
+	Constraints map[string]string // new constraint name → old constraint name
+}
+
+// ExtractInlineDirectives scans the raw text of a CREATE TABLE statement for
+// `-- pist:rename-from <old_name>` directives that appear on lines immediately
+// before column or constraint definitions.
+func ExtractInlineDirectives(rawCreateTableSQL string) *InlineDirectives {
+	result := &InlineDirectives{
+		Columns:     make(map[string]string),
+		Constraints: make(map[string]string),
+	}
+	lines := strings.Split(rawCreateTableSQL, "\n")
+
+	var pendingRename string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if m := renameDirectivePattern.FindStringSubmatch(line); m != nil {
+			pendingRename = m[1]
+			continue
+		}
+
+		if pendingRename != "" && trimmed != "" && !strings.HasPrefix(trimmed, "--") {
+			upper := strings.ToUpper(trimmed)
+			if strings.HasPrefix(upper, "CONSTRAINT ") {
+				conName := extractConstraintName(trimmed)
+				if conName != "" {
+					result.Constraints[conName] = pendingRename
+				}
+			} else {
+				colName := extractColumnName(trimmed)
+				if colName != "" {
+					result.Columns[colName] = pendingRename
+				}
+			}
+			pendingRename = ""
+		} else if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			// Skip blank lines and other comments, keep pending
+		} else {
+			pendingRename = ""
+		}
+	}
+
+	return result
+}
+
+// ExtractColumnDirectives is a convenience wrapper for backward compatibility.
+func ExtractColumnDirectives(rawCreateTableSQL string) map[string]string {
+	return ExtractInlineDirectives(rawCreateTableSQL).Columns
+}
+
+// extractConstraintName extracts the constraint name from a CONSTRAINT line.
+// e.g. "CONSTRAINT users_pkey PRIMARY KEY (id)" → "users_pkey"
+func extractConstraintName(line string) string {
+	line = strings.TrimSpace(line)
+	upper := strings.ToUpper(line)
+	if !strings.HasPrefix(upper, "CONSTRAINT ") {
+		return ""
+	}
+	rest := strings.TrimSpace(line[len("CONSTRAINT "):])
+	if strings.HasPrefix(rest, `"`) {
+		end := strings.Index(rest[1:], `"`)
+		if end >= 0 {
+			return rest[1 : end+1]
+		}
+		return ""
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// extractColumnName extracts the column name from a column definition line.
+// Handles both unquoted identifiers and quoted identifiers ("My Column").
+func extractColumnName(line string) string {
+	line = strings.TrimSpace(line)
+
+	// Skip CONSTRAINT lines
+	upper := strings.ToUpper(line)
+	if strings.HasPrefix(upper, "CONSTRAINT ") {
+		return ""
+	}
+
+	if strings.HasPrefix(line, `"`) {
+		// Quoted identifier
+		end := strings.Index(line[1:], `"`)
+		if end >= 0 {
+			return line[1 : end+1]
+		}
+		return ""
+	}
+
+	// Unquoted identifier: first word
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	name := fields[0]
+	// Remove trailing comma if present
+	name = strings.TrimSuffix(name, ",")
+	return name
+}

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -9,6 +9,64 @@ import (
 
 var renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:rename-from[ \t]+(.+?)[ \t]*$`)
 
+// unquoteIdent strips surrounding double quotes from a SQL identifier and
+// unescapes doubled double-quotes ("" → "). Returns the input unchanged
+// if it is not quoted.
+func unquoteIdent(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		inner := s[1 : len(s)-1]
+		return strings.ReplaceAll(inner, `""`, `"`)
+	}
+	return s
+}
+
+// normalizeDirectiveValue normalizes a rename-from directive value by
+// unquoting each part of a potentially schema-qualified name.
+// e.g. `"My Schema"."Old Name"` → `My Schema.Old Name`
+//
+//	`public.old_name`       → `public.old_name` (unchanged)
+//	`"Old Name"`            → `Old Name`
+func normalizeDirectiveValue(s string) string {
+	// Split on dots, but respect quoted identifiers
+	parts := splitQualifiedName(s)
+	for i, p := range parts {
+		parts[i] = unquoteIdent(p)
+	}
+	return strings.Join(parts, ".")
+}
+
+// splitQualifiedName splits a potentially schema-qualified name into parts,
+// respecting quoted identifiers. e.g. `"My Schema"."Old Name"` → [`"My Schema"`, `"Old Name"`]
+func splitQualifiedName(s string) []string {
+	var parts []string
+	var current strings.Builder
+	inQuote := false
+
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if ch == '"' {
+			if inQuote && i+1 < len(s) && s[i+1] == '"' {
+				// Escaped double quote
+				current.WriteByte('"')
+				current.WriteByte('"')
+				i++
+			} else {
+				inQuote = !inQuote
+				current.WriteByte(ch)
+			}
+		} else if ch == '.' && !inQuote {
+			parts = append(parts, current.String())
+			current.Reset()
+		} else {
+			current.WriteByte(ch)
+		}
+	}
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	return parts
+}
+
 // ExtractStmtDirectives scans raw SQL for `-- pist:rename-from <name>` comments
 // that appear in each statement's raw text region (including leading comments).
 // pg_query includes leading comments in StmtLocation/StmtLen, so we scan the
@@ -34,7 +92,7 @@ func ExtractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]s
 		matches := renameDirectivePattern.FindAllStringSubmatch(leading, -1)
 		if len(matches) > 0 {
 			// Use the last match (closest to the actual SQL statement)
-			directives[loc] = matches[len(matches)-1][1]
+			directives[loc] = normalizeDirectiveValue(matches[len(matches)-1][1])
 		}
 	}
 
@@ -81,7 +139,7 @@ func ExtractInlineDirectives(rawCreateTableSQL string) *InlineDirectives {
 		trimmed := strings.TrimSpace(line)
 
 		if m := renameDirectivePattern.FindStringSubmatch(line); m != nil {
-			pendingRename = m[1]
+			pendingRename = normalizeDirectiveValue(m[1])
 			continue
 		}
 

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -79,14 +79,14 @@ func splitQualifiedName(s string) []string {
 				current.WriteByte(ch)
 			}
 		} else if ch == '.' && !inQuote {
-			parts = append(parts, current.String())
+			parts = append(parts, strings.TrimSpace(current.String()))
 			current.Reset()
 		} else {
 			current.WriteByte(ch)
 		}
 	}
 	if current.Len() > 0 {
-		parts = append(parts, current.String())
+		parts = append(parts, strings.TrimSpace(current.String()))
 	}
 	return parts
 }
@@ -116,7 +116,10 @@ func ExtractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]s
 		matches := renameDirectivePattern.FindAllStringSubmatch(leading, -1)
 		if len(matches) > 0 {
 			// Use the last match (closest to the actual SQL statement)
-			directives[loc] = matches[len(matches)-1][1]
+			renameFrom := strings.TrimSpace(matches[len(matches)-1][1])
+			if renameFrom != "" {
+				directives[loc] = renameFrom
+			}
 		}
 	}
 

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -69,6 +69,15 @@ CREATE TABLE public.users (id integer NOT NULL);`
 		assert.Equal(t, "old_name", dirs[result.Stmts[0].StmtLocation])
 	})
 
+	t.Run("whitespace-only directive ignored", func(t *testing.T) {
+		sql := `-- pist:rename-from
+CREATE TABLE public.users (id integer NOT NULL);`
+		result, err := pg_query.Parse(sql)
+		require.NoError(t, err)
+		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		assert.Empty(t, dirs)
+	})
+
 	t.Run("regular comment ignored", func(t *testing.T) {
 		sql := `-- this is a regular comment
 CREATE TABLE public.users (id integer NOT NULL);`
@@ -171,6 +180,11 @@ func TestExtractConstraintName(t *testing.T) {
 	assert.Equal(t, "My Con", extractConstraintName(`CONSTRAINT "My Con" UNIQUE (code)`))
 	assert.Equal(t, "", extractConstraintName("id integer NOT NULL"))
 	assert.Equal(t, "", extractConstraintName(""))
+}
+
+func TestSplitQualifiedName_SpacesAroundDot(t *testing.T) {
+	parts := splitQualifiedName("public . old_table")
+	assert.Equal(t, []string{"public", "old_table"}, parts)
 }
 
 func TestNormalizeDirectiveValue(t *testing.T) {

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -186,6 +186,9 @@ func TestNormalizeUnqualifiedDirective(t *testing.T) {
 	assert.Equal(t, "old_name", normalizeUnqualifiedDirective("old_name"))
 	assert.Equal(t, "Old Name", normalizeUnqualifiedDirective(`"Old Name"`))
 	assert.Equal(t, `has"quote`, normalizeUnqualifiedDirective(`"has""quote"`))
+	// Schema-qualified: take last part only
+	assert.Equal(t, "old_idx", normalizeUnqualifiedDirective("public.old_idx"))
+	assert.Equal(t, "Old Name", normalizeUnqualifiedDirective(`public."Old Name"`))
 }
 
 func TestQualifyRenameFrom(t *testing.T) {

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -120,7 +120,7 @@ func TestExtractColumnDirectives(t *testing.T) {
     "New Name" text NOT NULL
 );`
 		dirs := ExtractColumnDirectives(sql)
-		assert.Equal(t, "Old Name", dirs["New Name"])
+		assert.Equal(t, `"Old Name"`, dirs["New Name"])
 	})
 
 	t.Run("constraint line skipped", func(t *testing.T) {
@@ -175,10 +175,10 @@ func TestExtractConstraintName(t *testing.T) {
 
 func TestNormalizeDirectiveValue(t *testing.T) {
 	assert.Equal(t, "public.old_name", normalizeDirectiveValue("public.old_name"))
-	assert.Equal(t, "Old Name", normalizeDirectiveValue(`"Old Name"`))
-	assert.Equal(t, "My Schema.Old Name", normalizeDirectiveValue(`"My Schema"."Old Name"`))
-	assert.Equal(t, "public.Old Name", normalizeDirectiveValue(`public."Old Name"`))
-	assert.Equal(t, `has"quote`, normalizeDirectiveValue(`"has""quote"`))
+	assert.Equal(t, `"Old Name"`, normalizeDirectiveValue(`"Old Name"`))
+	assert.Equal(t, `"My Schema"."Old Name"`, normalizeDirectiveValue(`"My Schema"."Old Name"`))
+	assert.Equal(t, `public."Old Name"`, normalizeDirectiveValue(`public."Old Name"`))
+	assert.Equal(t, `"has""quote"`, normalizeDirectiveValue(`"has""quote"`))
 	assert.Equal(t, "simple", normalizeDirectiveValue("simple"))
 }
 
@@ -195,7 +195,26 @@ CREATE TABLE public.users (id integer NOT NULL);`
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 	dirs := ExtractStmtDirectives(sql, result.Stmts)
-	assert.Equal(t, "My Schema.Old Name", dirs[result.Stmts[0].StmtLocation])
+	assert.Equal(t, `"My Schema"."Old Name"`, dirs[result.Stmts[0].StmtLocation])
+}
+
+func TestScanQuotedIdent(t *testing.T) {
+	name, ok := scanQuotedIdent(`"My Name" text NOT NULL`)
+	assert.True(t, ok)
+	assert.Equal(t, "My Name", name)
+
+	name, ok = scanQuotedIdent(`"has""quote" text`)
+	assert.True(t, ok)
+	assert.Equal(t, `has"quote`, name)
+
+	_, ok = scanQuotedIdent(`not_quoted`)
+	assert.False(t, ok)
+
+	_, ok = scanQuotedIdent(`"unterminated`)
+	assert.False(t, ok)
+
+	_, ok = scanQuotedIdent(``)
+	assert.False(t, ok)
 }
 
 func TestExtractColumnName(t *testing.T) {

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -120,7 +120,7 @@ func TestExtractColumnDirectives(t *testing.T) {
     "New Name" text NOT NULL
 );`
 		dirs := ExtractColumnDirectives(sql)
-		assert.Equal(t, `"Old Name"`, dirs["New Name"])
+		assert.Equal(t, "Old Name", dirs["New Name"])
 	})
 
 	t.Run("constraint line skipped", func(t *testing.T) {
@@ -182,11 +182,19 @@ func TestNormalizeDirectiveValue(t *testing.T) {
 	assert.Equal(t, "simple", normalizeDirectiveValue("simple"))
 }
 
+func TestNormalizeUnqualifiedDirective(t *testing.T) {
+	assert.Equal(t, "old_name", normalizeUnqualifiedDirective("old_name"))
+	assert.Equal(t, "Old Name", normalizeUnqualifiedDirective(`"Old Name"`))
+	assert.Equal(t, `has"quote`, normalizeUnqualifiedDirective(`"has""quote"`))
+}
+
 func TestQualifyRenameFrom(t *testing.T) {
 	assert.Equal(t, "public.old_name", QualifyRenameFrom("old_name", "public"))
 	assert.Equal(t, "public.old_name", QualifyRenameFrom("public.old_name", "public"))
 	assert.Equal(t, "myschema.old_name", QualifyRenameFrom("myschema.old_name", "public"))
-	assert.Equal(t, "public.Old Name", QualifyRenameFrom("Old Name", "public"))
+	assert.Equal(t, `public."Old Name"`, QualifyRenameFrom(`"Old Name"`, "public"))
+	// Quoted identifier containing a dot should be treated as single name
+	assert.Equal(t, `public."a.b"`, QualifyRenameFrom(`"a.b"`, "public"))
 }
 
 func TestExtractStmtDirectives_QuotedName(t *testing.T) {

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -1,0 +1,182 @@
+package parser
+
+import (
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractStmtDirectives(t *testing.T) {
+	t.Run("single directive", func(t *testing.T) {
+		sql := `-- pist:rename-from public.old_status
+CREATE TYPE public.new_status AS ENUM ('active', 'inactive');`
+		result, err := pg_query.Parse(sql)
+		require.NoError(t, err)
+		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		assert.Len(t, dirs, 1)
+		assert.Equal(t, "public.old_status", dirs[result.Stmts[0].StmtLocation])
+	})
+
+	t.Run("multiple directives", func(t *testing.T) {
+		sql := `-- pist:rename-from public.old_status
+CREATE TYPE public.new_status AS ENUM ('active');
+-- pist:rename-from public.old_users
+CREATE TABLE public.users (id integer NOT NULL);`
+		result, err := pg_query.Parse(sql)
+		require.NoError(t, err)
+		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		assert.Len(t, dirs, 2)
+		assert.Equal(t, "public.old_status", dirs[result.Stmts[0].StmtLocation])
+		assert.Equal(t, "public.old_users", dirs[result.Stmts[1].StmtLocation])
+	})
+
+	t.Run("no directives", func(t *testing.T) {
+		sql := `CREATE TABLE public.users (id integer NOT NULL);`
+		result, err := pg_query.Parse(sql)
+		require.NoError(t, err)
+		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		assert.Empty(t, dirs)
+	})
+
+	t.Run("directive only on second statement", func(t *testing.T) {
+		sql := `CREATE TABLE public.users (id integer NOT NULL);
+-- pist:rename-from public.old_posts
+CREATE TABLE public.posts (id integer NOT NULL);`
+		result, err := pg_query.Parse(sql)
+		require.NoError(t, err)
+		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		assert.Len(t, dirs, 1)
+		assert.Equal(t, "public.old_posts", dirs[result.Stmts[1].StmtLocation])
+	})
+
+	t.Run("directive with extra whitespace", func(t *testing.T) {
+		sql := `  -- pist:rename-from  public.old_name
+CREATE TABLE public.users (id integer NOT NULL);`
+		result, err := pg_query.Parse(sql)
+		require.NoError(t, err)
+		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		assert.Equal(t, "public.old_name", dirs[result.Stmts[0].StmtLocation])
+	})
+
+	t.Run("unqualified name", func(t *testing.T) {
+		sql := `-- pist:rename-from old_name
+CREATE TABLE public.users (id integer NOT NULL);`
+		result, err := pg_query.Parse(sql)
+		require.NoError(t, err)
+		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		assert.Equal(t, "old_name", dirs[result.Stmts[0].StmtLocation])
+	})
+
+	t.Run("regular comment ignored", func(t *testing.T) {
+		sql := `-- this is a regular comment
+CREATE TABLE public.users (id integer NOT NULL);`
+		result, err := pg_query.Parse(sql)
+		require.NoError(t, err)
+		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		assert.Empty(t, dirs)
+	})
+}
+
+func TestExtractColumnDirectives(t *testing.T) {
+	t.Run("single column directive", func(t *testing.T) {
+		sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    -- pist:rename-from name
+    display_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+		dirs := ExtractColumnDirectives(sql)
+		assert.Len(t, dirs, 1)
+		assert.Equal(t, "name", dirs["display_name"])
+	})
+
+	t.Run("multiple column directives", func(t *testing.T) {
+		sql := `CREATE TABLE public.users (
+    -- pist:rename-from uid
+    id integer NOT NULL,
+    -- pist:rename-from name
+    display_name text NOT NULL
+);`
+		dirs := ExtractColumnDirectives(sql)
+		assert.Len(t, dirs, 2)
+		assert.Equal(t, "uid", dirs["id"])
+		assert.Equal(t, "name", dirs["display_name"])
+	})
+
+	t.Run("no directives", func(t *testing.T) {
+		sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL
+);`
+		dirs := ExtractColumnDirectives(sql)
+		assert.Empty(t, dirs)
+	})
+
+	t.Run("quoted column name", func(t *testing.T) {
+		sql := `CREATE TABLE public.users (
+    -- pist:rename-from "Old Name"
+    "New Name" text NOT NULL
+);`
+		dirs := ExtractColumnDirectives(sql)
+		assert.Equal(t, `"Old Name"`, dirs[`New Name`])
+	})
+
+	t.Run("constraint line skipped", func(t *testing.T) {
+		sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    -- pist:rename-from old_col
+    new_col text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+		dirs := ExtractColumnDirectives(sql)
+		assert.Len(t, dirs, 1)
+		assert.Equal(t, "old_col", dirs["new_col"])
+	})
+}
+
+func TestExtractInlineDirectives_Constraint(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    code text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    -- pist:rename-from users_code_key
+    CONSTRAINT users_code_unique UNIQUE (code)
+);`
+	dirs := ExtractInlineDirectives(sql)
+	assert.Empty(t, dirs.Columns)
+	assert.Len(t, dirs.Constraints, 1)
+	assert.Equal(t, "users_code_key", dirs.Constraints["users_code_unique"])
+}
+
+func TestExtractInlineDirectives_Mixed(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    -- pist:rename-from name
+    display_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    -- pist:rename-from old_unique
+    CONSTRAINT new_unique UNIQUE (display_name)
+);`
+	dirs := ExtractInlineDirectives(sql)
+	assert.Len(t, dirs.Columns, 1)
+	assert.Equal(t, "name", dirs.Columns["display_name"])
+	assert.Len(t, dirs.Constraints, 1)
+	assert.Equal(t, "old_unique", dirs.Constraints["new_unique"])
+}
+
+func TestExtractConstraintName(t *testing.T) {
+	assert.Equal(t, "users_pkey", extractConstraintName("CONSTRAINT users_pkey PRIMARY KEY (id)"))
+	assert.Equal(t, "My Con", extractConstraintName(`CONSTRAINT "My Con" UNIQUE (code)`))
+	assert.Equal(t, "", extractConstraintName("id integer NOT NULL"))
+	assert.Equal(t, "", extractConstraintName(""))
+}
+
+func TestExtractColumnName(t *testing.T) {
+	assert.Equal(t, "id", extractColumnName("id integer NOT NULL,"))
+	assert.Equal(t, "name", extractColumnName("name text NOT NULL"))
+	assert.Equal(t, "My Col", extractColumnName(`"My Col" text NOT NULL,`))
+	assert.Equal(t, "", extractColumnName("CONSTRAINT users_pkey PRIMARY KEY (id)"))
+	assert.Equal(t, "", extractColumnName(""))
+}

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -120,7 +120,7 @@ func TestExtractColumnDirectives(t *testing.T) {
     "New Name" text NOT NULL
 );`
 		dirs := ExtractColumnDirectives(sql)
-		assert.Equal(t, `"Old Name"`, dirs[`New Name`])
+		assert.Equal(t, "Old Name", dirs["New Name"])
 	})
 
 	t.Run("constraint line skipped", func(t *testing.T) {
@@ -171,6 +171,24 @@ func TestExtractConstraintName(t *testing.T) {
 	assert.Equal(t, "My Con", extractConstraintName(`CONSTRAINT "My Con" UNIQUE (code)`))
 	assert.Equal(t, "", extractConstraintName("id integer NOT NULL"))
 	assert.Equal(t, "", extractConstraintName(""))
+}
+
+func TestNormalizeDirectiveValue(t *testing.T) {
+	assert.Equal(t, "public.old_name", normalizeDirectiveValue("public.old_name"))
+	assert.Equal(t, "Old Name", normalizeDirectiveValue(`"Old Name"`))
+	assert.Equal(t, "My Schema.Old Name", normalizeDirectiveValue(`"My Schema"."Old Name"`))
+	assert.Equal(t, "public.Old Name", normalizeDirectiveValue(`public."Old Name"`))
+	assert.Equal(t, `has"quote`, normalizeDirectiveValue(`"has""quote"`))
+	assert.Equal(t, "simple", normalizeDirectiveValue("simple"))
+}
+
+func TestExtractStmtDirectives_QuotedName(t *testing.T) {
+	sql := `-- pist:rename-from "My Schema"."Old Name"
+CREATE TABLE public.users (id integer NOT NULL);`
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+	dirs := ExtractStmtDirectives(sql, result.Stmts)
+	assert.Equal(t, "My Schema.Old Name", dirs[result.Stmts[0].StmtLocation])
 }
 
 func TestExtractColumnName(t *testing.T) {

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -180,6 +180,8 @@ func TestExtractConstraintName(t *testing.T) {
 	assert.Equal(t, "My Con", extractConstraintName(`CONSTRAINT "My Con" UNIQUE (code)`))
 	assert.Equal(t, "", extractConstraintName("id integer NOT NULL"))
 	assert.Equal(t, "", extractConstraintName(""))
+	// Unquoted names are lowercased
+	assert.Equal(t, "users_pkey", extractConstraintName("CONSTRAINT Users_Pkey PRIMARY KEY (id)"))
 }
 
 func TestSplitQualifiedName_SpacesAroundDot(t *testing.T) {
@@ -203,6 +205,8 @@ func TestNormalizeUnqualifiedDirective(t *testing.T) {
 	// Schema-qualified: take last part only
 	assert.Equal(t, "old_idx", normalizeUnqualifiedDirective("public.old_idx"))
 	assert.Equal(t, "Old Name", normalizeUnqualifiedDirective(`public."Old Name"`))
+	// Unquoted names are lowercased
+	assert.Equal(t, "oldcolumn", normalizeUnqualifiedDirective("OldColumn"))
 }
 
 func TestQualifyRenameFrom(t *testing.T) {
@@ -248,4 +252,6 @@ func TestExtractColumnName(t *testing.T) {
 	assert.Equal(t, "My Col", extractColumnName(`"My Col" text NOT NULL,`))
 	assert.Equal(t, "", extractColumnName("CONSTRAINT users_pkey PRIMARY KEY (id)"))
 	assert.Equal(t, "", extractColumnName(""))
+	// Unquoted names are lowercased
+	assert.Equal(t, "displayname", extractColumnName("DisplayName text NOT NULL"))
 }

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -182,6 +182,13 @@ func TestNormalizeDirectiveValue(t *testing.T) {
 	assert.Equal(t, "simple", normalizeDirectiveValue("simple"))
 }
 
+func TestQualifyRenameFrom(t *testing.T) {
+	assert.Equal(t, "public.old_name", QualifyRenameFrom("old_name", "public"))
+	assert.Equal(t, "public.old_name", QualifyRenameFrom("public.old_name", "public"))
+	assert.Equal(t, "myschema.old_name", QualifyRenameFrom("myschema.old_name", "public"))
+	assert.Equal(t, "public.Old Name", QualifyRenameFrom("Old Name", "public"))
+}
+
 func TestExtractStmtDirectives_QuotedName(t *testing.T) {
 	sql := `-- pist:rename-from "My Schema"."Old Name"
 CREATE TABLE public.users (id integer NOT NULL);`

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -153,7 +153,8 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if renameFrom != "" {
-				idx.RenameFrom = &renameFrom
+				unquoted := normalizeUnqualifiedDirective(renameFrom)
+				idx.RenameFrom = &unquoted
 			}
 			fqtn := model.Ident(idx.Schema, idx.Table)
 			if t, ok := tables.GetOk(fqtn); ok {
@@ -180,14 +181,16 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			}
 			if fk != nil {
 				if renameFrom != "" {
-					fk.RenameFrom = &renameFrom
+					unquoted := normalizeUnqualifiedDirective(renameFrom)
+					fk.RenameFrom = &unquoted
 				}
 				if err := setUnique(t.ForeignKeys, fk.Name, "foreign key", fk); err != nil {
 					return nil, err
 				}
 			} else if con != nil {
 				if renameFrom != "" {
-					con.RenameFrom = &renameFrom
+					unquoted := normalizeUnqualifiedDirective(renameFrom)
+					con.RenameFrom = &unquoted
 				}
 				if err := setUnique(t.Constraints, con.Name, "constraint", con); err != nil {
 					return nil, err

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -90,7 +90,8 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if renameFrom != "" {
-				enum.RenameFrom = &renameFrom
+				qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+				enum.RenameFrom = &qualified
 			}
 			if err := setUnique(enums, enum.FQEN(), "enum", enum); err != nil {
 				return nil, err
@@ -102,7 +103,8 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if renameFrom != "" {
-				table.RenameFrom = &renameFrom
+				qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+				table.RenameFrom = &qualified
 			}
 
 			// Extract column/constraint-level directives from raw SQL
@@ -138,7 +140,8 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if renameFrom != "" {
-				view.RenameFrom = &renameFrom
+				qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+				view.RenameFrom = &qualified
 			}
 			if err := setUnique(views, view.FQVN(), "view", view); err != nil {
 				return nil, err

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -77,14 +77,20 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	views := orderedmap.New[string, *model.View]()
 	enums := orderedmap.New[string, *model.Enum]()
 
+	stmtDirectives := ExtractStmtDirectives(sql, result.Stmts)
+
 	for _, rawStmt := range result.Stmts {
 		node := rawStmt.Stmt
+		renameFrom := stmtDirectives[rawStmt.StmtLocation]
 
 		switch {
 		case node.GetCreateEnumStmt() != nil:
 			enum, err := parseCreateEnumStmt(node.GetCreateEnumStmt(), defaultSchema)
 			if err != nil {
 				return nil, err
+			}
+			if renameFrom != "" {
+				enum.RenameFrom = &renameFrom
 			}
 			if err := setUnique(enums, enum.FQEN(), "enum", enum); err != nil {
 				return nil, err
@@ -95,6 +101,33 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if err != nil {
 				return nil, err
 			}
+			if renameFrom != "" {
+				table.RenameFrom = &renameFrom
+			}
+
+			// Extract column/constraint-level directives from raw SQL
+			stmtEnd := rawStmt.StmtLocation + rawStmt.StmtLen
+			if stmtEnd > int32(len(sql)) {
+				stmtEnd = int32(len(sql))
+			}
+			rawStmtSQL := sql[rawStmt.StmtLocation:stmtEnd]
+			inlineDirectives := ExtractInlineDirectives(rawStmtSQL)
+			for colName, oldName := range inlineDirectives.Columns {
+				if col, ok := table.Columns.GetOk(colName); ok {
+					old := oldName
+					col.RenameFrom = &old
+				}
+			}
+			for conName, oldName := range inlineDirectives.Constraints {
+				if con, ok := table.Constraints.GetOk(conName); ok {
+					old := oldName
+					con.RenameFrom = &old
+				} else if fk, ok := table.ForeignKeys.GetOk(conName); ok {
+					old := oldName
+					fk.RenameFrom = &old
+				}
+			}
+
 			if err := setUnique(tables, table.FQTN(), "table", table); err != nil {
 				return nil, err
 			}
@@ -104,6 +137,9 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if err != nil {
 				return nil, err
 			}
+			if renameFrom != "" {
+				view.RenameFrom = &renameFrom
+			}
 			if err := setUnique(views, view.FQVN(), "view", view); err != nil {
 				return nil, err
 			}
@@ -112,6 +148,9 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			idx, err := parseIndexStmt(node.GetIndexStmt(), rawStmt, defaultSchema)
 			if err != nil {
 				return nil, err
+			}
+			if renameFrom != "" {
+				idx.RenameFrom = &renameFrom
 			}
 			fqtn := model.Ident(idx.Schema, idx.Table)
 			if t, ok := tables.GetOk(fqtn); ok {
@@ -137,10 +176,16 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if fk != nil {
+				if renameFrom != "" {
+					fk.RenameFrom = &renameFrom
+				}
 				if err := setUnique(t.ForeignKeys, fk.Name, "foreign key", fk); err != nil {
 					return nil, err
 				}
 			} else if con != nil {
+				if renameFrom != "" {
+					con.RenameFrom = &renameFrom
+				}
 				if err := setUnique(t.Constraints, con.Name, "constraint", con); err != nil {
 					return nil, err
 				}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1243,6 +1243,36 @@ ALTER TABLE public.users ADD CONSTRAINT new_unique UNIQUE (code);`
 	assert.Equal(t, "old_unique", *con.RenameFrom)
 }
 
+func TestParseSQLWithSchema_RenameDirective_Qualifies(t *testing.T) {
+	sql := `-- pist:rename-from old_status
+CREATE TYPE new_status AS ENUM ('active', 'inactive');
+-- pist:rename-from old_users
+CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:rename-from old_view
+CREATE VIEW new_view AS SELECT 1;`
+
+	result, err := parser.ParseSQLWithSchema(sql, "myschema")
+	require.NoError(t, err)
+
+	e, ok := result.Enums.GetOk("myschema.new_status")
+	require.True(t, ok)
+	require.NotNil(t, e.RenameFrom)
+	assert.Equal(t, "myschema.old_status", *e.RenameFrom)
+
+	tbl, ok := result.Tables.GetOk("myschema.users")
+	require.True(t, ok)
+	require.NotNil(t, tbl.RenameFrom)
+	assert.Equal(t, "myschema.old_users", *tbl.RenameFrom)
+
+	v, ok := result.Views.GetOk("myschema.new_view")
+	require.True(t, ok)
+	require.NotNil(t, v.RenameFrom)
+	assert.Equal(t, "myschema.old_view", *v.RenameFrom)
+}
+
 func TestParseSQL_NoRenameDirective(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1098,3 +1098,163 @@ func TestParseSQL_CommentOnUnknownEnum(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.Enums.Len())
 }
+
+func TestParseSQL_RenameDirective_Enum(t *testing.T) {
+	sql := `-- pist:rename-from public.old_status
+CREATE TYPE public.new_status AS ENUM ('active', 'inactive');`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	e, ok := result.Enums.GetOk("public.new_status")
+	require.True(t, ok)
+	require.NotNil(t, e.RenameFrom)
+	assert.Equal(t, "public.old_status", *e.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_Table(t *testing.T) {
+	sql := `-- pist:rename-from public.old_users
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	require.NotNil(t, tbl.RenameFrom)
+	assert.Equal(t, "public.old_users", *tbl.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_View(t *testing.T) {
+	sql := `-- pist:rename-from public.old_view
+CREATE VIEW public.new_view AS SELECT 1;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	v, ok := result.Views.GetOk("public.new_view")
+	require.True(t, ok)
+	require.NotNil(t, v.RenameFrom)
+	assert.Equal(t, "public.old_view", *v.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_Column(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    -- pist:rename-from name
+    display_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	col, ok := tbl.Columns.GetOk("display_name")
+	require.True(t, ok)
+	require.NotNil(t, col.RenameFrom)
+	assert.Equal(t, "name", *col.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_Index(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:rename-from idx_old
+CREATE INDEX idx_new ON public.users (name);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	idx, ok := tbl.Indexes.GetOk("idx_new")
+	require.True(t, ok)
+	require.NotNil(t, idx.RenameFrom)
+	assert.Equal(t, "idx_old", *idx.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_Constraint(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    code text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    -- pist:rename-from old_unique
+    CONSTRAINT new_unique UNIQUE (code)
+);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	con, ok := tbl.Constraints.GetOk("new_unique")
+	require.True(t, ok)
+	require.NotNil(t, con.RenameFrom)
+	assert.Equal(t, "old_unique", *con.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_ForeignKey(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id)
+);
+-- pist:rename-from old_fk
+ALTER TABLE public.orders ADD CONSTRAINT new_fk FOREIGN KEY (user_id) REFERENCES public.users(id);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.orders")
+	require.True(t, ok)
+	fk, ok := tbl.ForeignKeys.GetOk("new_fk")
+	require.True(t, ok)
+	require.NotNil(t, fk.RenameFrom)
+	assert.Equal(t, "old_fk", *fk.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_AlterTableConstraint(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    code text NOT NULL
+);
+-- pist:rename-from old_unique
+ALTER TABLE public.users ADD CONSTRAINT new_unique UNIQUE (code);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	con, ok := tbl.Constraints.GetOk("new_unique")
+	require.True(t, ok)
+	require.NotNil(t, con.RenameFrom)
+	assert.Equal(t, "old_unique", *con.RenameFrom)
+}
+
+func TestParseSQL_NoRenameDirective(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl := result.Tables.Get("public.users")
+	assert.Nil(t, tbl.RenameFrom)
+	col, _ := tbl.Columns.GetOk("name")
+	assert.Nil(t, col.RenameFrom)
+}

--- a/plan.go
+++ b/plan.go
@@ -53,8 +53,19 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", err
 	}
 	stmts := enumDiff.Stmts
-	stmts = append(stmts, diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))...)
-	stmts = append(stmts, diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))...)
+
+	tableStmts, err := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	if err != nil {
+		return "", err
+	}
+	stmts = append(stmts, tableStmts...)
+
+	viewStmts, err := diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))
+	if err != nil {
+		return "", err
+	}
+	stmts = append(stmts, viewStmts...)
+
 	stmts = append(stmts, enumDiff.DropStmts...)
 
 	if options.PreSQLFile != "" && len(stmts) > 0 {

--- a/plan.go
+++ b/plan.go
@@ -56,13 +56,13 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 
 	tableStmts, err := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to diff tables: %w", err)
 	}
 	stmts = append(stmts, tableStmts...)
 
 	viewStmts, err := diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to diff views: %w", err)
 	}
 	stmts = append(stmts, viewStmts...)
 

--- a/testdata/apply/rename_column.yml
+++ b/testdata/apply/rename_column.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:rename-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/rename_enum.yml
+++ b/testdata/apply/rename_enum.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: |
+  -- pist:rename-from public.status
+  CREATE TYPE public.user_status AS ENUM ('active', 'inactive');
+applied: |
+  -- public.user_status
+  CREATE TYPE public.user_status AS ENUM (
+      'active',
+      'inactive'
+  );

--- a/testdata/apply/rename_table.yml
+++ b/testdata/apply/rename_table.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pist:rename-from public.users
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.accounts
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/rename_table_and_column.yml
+++ b/testdata/apply/rename_table_and_column.yml
@@ -1,0 +1,21 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pist:rename-from public.users
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      -- pist:rename-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.accounts
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/rename_table_and_fk.yml
+++ b/testdata/apply/rename_table_and_fk.yml
@@ -1,0 +1,39 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:rename-from public.orders
+  CREATE TABLE public.purchases (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  -- pist:rename-from fk_user
+  ALTER TABLE public.purchases ADD CONSTRAINT fk_buyer FOREIGN KEY (user_id) REFERENCES public.users(id);
+applied: |
+  -- public.purchases
+  CREATE TABLE public.purchases (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE ONLY public.purchases ADD CONSTRAINT fk_buyer FOREIGN KEY (user_id) REFERENCES users(id);
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/rename_table_and_index.yml
+++ b/testdata/apply/rename_table_and_index.yml
@@ -1,0 +1,24 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+desired: |
+  -- pist:rename-from public.users
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:rename-from idx_users_name
+  CREATE INDEX idx_accounts_name ON public.accounts (name);
+applied: |
+  -- public.accounts
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_accounts_name ON public.accounts USING btree (name);

--- a/testdata/plan/rename_column.yml
+++ b/testdata/plan/rename_column.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:rename-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users RENAME COLUMN name TO display_name;

--- a/testdata/plan/rename_constraint.yml
+++ b/testdata/plan/rename_constraint.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_code_key UNIQUE (code)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      -- pist:rename-from users_code_key
+      CONSTRAINT users_code_unique UNIQUE (code)
+  );
+plan: |
+  ALTER TABLE public.users RENAME CONSTRAINT users_code_key TO users_code_unique;

--- a/testdata/plan/rename_enum.yml
+++ b/testdata/plan/rename_enum.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: |
+  -- pist:rename-from public.status
+  CREATE TYPE public.user_status AS ENUM ('active', 'inactive');
+plan: |
+  ALTER TYPE public.status RENAME TO user_status;

--- a/testdata/plan/rename_index.yml
+++ b/testdata/plan/rename_index.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:rename-from idx_users_name
+  CREATE INDEX idx_users_display_name ON public.users (name);
+plan: |
+  ALTER INDEX public.idx_users_name RENAME TO idx_users_display_name;

--- a/testdata/plan/rename_table.yml
+++ b/testdata/plan/rename_table.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pist:rename-from public.users
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users RENAME TO accounts;

--- a/testdata/plan/rename_table_and_column.yml
+++ b/testdata/plan/rename_table_and_column.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pist:rename-from public.users
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      -- pist:rename-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users RENAME TO accounts;
+  ALTER TABLE public.accounts RENAME COLUMN name TO display_name;

--- a/testdata/plan/rename_table_and_fk.yml
+++ b/testdata/plan/rename_table_and_fk.yml
@@ -1,0 +1,27 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:rename-from public.orders
+  CREATE TABLE public.purchases (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  -- pist:rename-from fk_user
+  ALTER TABLE public.purchases ADD CONSTRAINT fk_buyer FOREIGN KEY (user_id) REFERENCES public.users(id);
+plan: |
+  ALTER TABLE public.orders RENAME TO purchases;
+  ALTER TABLE public.purchases RENAME CONSTRAINT fk_user TO fk_buyer;

--- a/testdata/plan/rename_table_and_index.yml
+++ b/testdata/plan/rename_table_and_index.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+desired: |
+  -- pist:rename-from public.users
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:rename-from idx_users_name
+  CREATE INDEX idx_accounts_name ON public.accounts (name);
+plan: |
+  ALTER TABLE public.users RENAME TO accounts;
+  ALTER INDEX public.idx_users_name RENAME TO idx_accounts_name;


### PR DESCRIPTION
This pull request adds comprehensive support for renaming schema objects (such as tables, views, enums, columns, constraints, indexes, and foreign keys) using a new `-- pist:rename-from` directive, and refactors the diff logic to handle these renames safely and explicitly. It also updates the codebase to propagate errors from diff operations, ensuring that issues (such as missing rename sources) are reported. The documentation and tests are expanded to cover these new rename capabilities.

**Rename support and diff logic refactor:**

* Added a new `diff/rename.go` module implementing detection and SQL generation for renaming enums, tables, views, columns, constraints, indexes, and foreign keys, with robust error handling for missing sources and already-applied renames.
* Refactored `diff/tables.go` and related diff functions (`DiffTables`, `diffTable`, `diffColumns`, `diffConstraints`, `diffIndexes`, `diffForeignKeys`) to call the new rename detection functions, propagate errors, and return error-aware results instead of plain string slices. [[1]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L13-R22) [[2]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L27-R38) [[3]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L38-R49) [[4]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L55-R124) [[5]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L100-R146) [[6]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L286-R341) [[7]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L305-R370) [[8]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L327-R399) [[9]](diffhunk://#diff-4e9ae5bc102aa4ad86a3802ee0d096151965cfde5faec693456b273da7708248L350-R417)
* Updated the main `Apply` logic to handle errors from diff operations and ensure statements are only appended on success.

**Documentation and user guidance:**

* Expanded the `README.md` with a new section on renaming objects, showing examples for all supported object types, and added the rename feature to the supported features list. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R147-R188) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R253)

**Testing improvements:**

* Added thorough unit tests for enum renaming scenarios, including successful renames, renames with value addition, already-applied renames, and error cases for missing sources.
* Updated table diff tests to use the new error-aware API and assert on error-free execution. [[1]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeR7) [[2]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeL35-R37) [[3]](diffhunk://#diff-987c05ebf7edee2ab86ff26d9942bfa6c4832b0d64e9559ffc1cdccb324a89aeL50-R53)

These changes collectively make schema migrations safer and more ergonomic, especially when objects need to be renamed without destructive drops or manual intervention.