### PR TITLE
Add fmt command to format SQL files into canonical form

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ pist fmt -w schema.sql
 pist fmt --check schema.sql
 ```
 
+> [!NOTE]
+> `dump` output uses PostgreSQL's own formatting (e.g. `pg_get_viewdef`), while `fmt` normalizes through the pg_query parser. This means `dump` output may not pass `fmt --check` directly. Run `fmt -w` once after the initial `dump` to normalize, then use `--check` in CI going forward.
+
 ### Schema name mapping
 
 Use `-m` / `--schema-map` to remap schema names. This is useful when you want to manage a database whose schema name differs from the one used in your SQL files.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ pist fmt tables.sql views.sql
 
 # Overwrite file(s) in place
 pist fmt -w schema.sql
+
+# Check if files are formatted (exit 1 if not, useful for CI)
+pist fmt --check schema.sql
 ```
 
 ### Schema name mapping

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Commands:
   dump [flags]
     Dump the current database schema as SQL.
 
+  fmt <files> ... [flags]
+    Format SQL file(s) into canonical form.
+
 Run "pist <command> --help" for more information on a command.
 ```
 
@@ -90,6 +93,21 @@ Dump the current database schema as SQL. Output can be used directly as a schema
 
 ```bash
 pist dump
+```
+
+### fmt
+
+Format SQL file(s) into the canonical form used by `dump`. Useful for normalizing hand-written schema files.
+
+```bash
+# Print formatted SQL to stdout
+pist fmt schema.sql
+
+# Format multiple files to stdout (combined)
+pist fmt tables.sql views.sql
+
+# Overwrite file(s) in place
+pist fmt -w schema.sql
 ```
 
 ### Schema name mapping

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -379,29 +379,11 @@ func TestFmt_Run_InvalidFile(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestFmt_Run_Write_InvalidFile(t *testing.T) {
-	client := pistachio.NewClient(&pistachio.Options{
-		Schemas: []string{"public"},
-	})
-
-	var buf bytes.Buffer
-	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{"/nonexistent/file.sql"}, Write: true}}
-	err := cmd.Run(client, &buf)
-	require.Error(t, err)
-}
-
 func TestFmt_Run_WriteError(t *testing.T) {
-	// Create a read-only directory so WriteFile fails
 	tmpDir := t.TempDir()
 	readonlyDir := filepath.Join(tmpDir, "readonly")
-	require.NoError(t, os.MkdirAll(readonlyDir, 0o555))
-
-	// Input file must be readable but the write target must fail.
-	// Since -w writes back to the same files, put a readable file in a read-only dir.
+	require.NoError(t, os.MkdirAll(readonlyDir, 0o755))
 	inputFile := filepath.Join(readonlyDir, "test.sql")
-	// Write before making it read-only won't work since dir is already 0o555.
-	// Instead: create file first, then make dir read-only.
-	require.NoError(t, os.Chmod(readonlyDir, 0o755))
 	require.NoError(t, os.WriteFile(inputFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o444))
 	require.NoError(t, os.Chmod(readonlyDir, 0o555))
 	t.Cleanup(func() { os.Chmod(readonlyDir, 0o755) })
@@ -429,11 +411,8 @@ func TestFmt_Run_Write(t *testing.T) {
 	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{tmpFile}, Write: true}}
 	err := cmd.Run(client, &buf)
 	require.NoError(t, err)
-
-	// stdout should be empty when writing to file
 	assert.Empty(t, buf.String())
 
-	// File should be formatted
 	content, err := os.ReadFile(tmpFile)
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "CREATE TABLE public.users")

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -368,6 +368,44 @@ func TestFmt_Run(t *testing.T) {
 	assert.Contains(t, buf.String(), "    id integer NOT NULL")
 }
 
+func TestFmt_Run_InvalidFile(t *testing.T) {
+	client := pistachio.NewClient(&pistachio.Options{
+		Schemas: []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{"/nonexistent/file.sql"}}}
+	err := cmd.Run(client, &buf)
+	require.Error(t, err)
+}
+
+func TestFmt_Run_WriteError(t *testing.T) {
+	// Create a read-only directory so WriteFile fails
+	tmpDir := t.TempDir()
+	readonlyDir := filepath.Join(tmpDir, "readonly")
+	require.NoError(t, os.MkdirAll(readonlyDir, 0o555))
+
+	// Input file must be readable but the write target must fail.
+	// Since -w writes back to the same files, put a readable file in a read-only dir.
+	inputFile := filepath.Join(readonlyDir, "test.sql")
+	// Write before making it read-only won't work since dir is already 0o555.
+	// Instead: create file first, then make dir read-only.
+	require.NoError(t, os.Chmod(readonlyDir, 0o755))
+	require.NoError(t, os.WriteFile(inputFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o444))
+	require.NoError(t, os.Chmod(readonlyDir, 0o555))
+	t.Cleanup(func() { os.Chmod(readonlyDir, 0o755) })
+
+	client := pistachio.NewClient(&pistachio.Options{
+		Schemas: []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{inputFile}, Write: true}}
+	err := cmd.Run(client, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write")
+}
+
 func TestFmt_Run_Write(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "test.sql")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o644))

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -381,9 +380,6 @@ func TestFmt_Run_InvalidFile(t *testing.T) {
 }
 
 func TestFmt_Run_WriteError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("chmod-based write error test not supported on Windows")
-	}
 	tmpDir := t.TempDir()
 	readonlyDir := filepath.Join(tmpDir, "readonly")
 	require.NoError(t, os.MkdirAll(readonlyDir, 0o755))

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -379,6 +379,17 @@ func TestFmt_Run_InvalidFile(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestFmt_Run_Write_InvalidFile(t *testing.T) {
+	client := pistachio.NewClient(&pistachio.Options{
+		Schemas: []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{"/nonexistent/file.sql"}, Write: true}}
+	err := cmd.Run(client, &buf)
+	require.Error(t, err)
+}
+
 func TestFmt_Run_WriteError(t *testing.T) {
 	// Create a read-only directory so WriteFile fails
 	tmpDir := t.TempDir()

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -455,4 +455,3 @@ func TestFmt_Run_Check_NotFormatted(t *testing.T) {
 	assert.Contains(t, notFormatted.Error(), tmpFile)
 	assert.Contains(t, buf.String(), tmpFile)
 }
-

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -418,3 +418,39 @@ func TestFmt_Run_Write(t *testing.T) {
 	assert.Contains(t, string(content), "CREATE TABLE public.users")
 	assert.Contains(t, string(content), "    id integer NOT NULL")
 }
+
+func TestFmt_Run_Check_Formatted(t *testing.T) {
+	// Already formatted file
+	tmpFile := filepath.Join(t.TempDir(), "test.sql")
+	formatted := "-- public.users\nCREATE TABLE public.users (\n    id integer NOT NULL,\n    CONSTRAINT users_pkey PRIMARY KEY (id)\n);\n"
+	require.NoError(t, os.WriteFile(tmpFile, []byte(formatted), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		Schemas: []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{tmpFile}, Check: true}}
+	err := cmd.Run(client, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestFmt_Run_Check_NotFormatted(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.sql")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		Schemas: []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{tmpFile}, Check: true}}
+	err := cmd.Run(client, &buf)
+	require.Error(t, err)
+
+	var notFormatted *command.ErrNotFormatted
+	require.ErrorAs(t, err, &notFormatted)
+	assert.Len(t, notFormatted.Files, 1)
+	assert.Contains(t, buf.String(), tmpFile)
+}

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -380,6 +381,9 @@ func TestFmt_Run_InvalidFile(t *testing.T) {
 }
 
 func TestFmt_Run_WriteError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based write error test not supported on Windows")
+	}
 	tmpDir := t.TempDir()
 	readonlyDir := filepath.Join(tmpDir, "readonly")
 	require.NoError(t, os.MkdirAll(readonlyDir, 0o755))

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -452,5 +452,7 @@ func TestFmt_Run_Check_NotFormatted(t *testing.T) {
 	var notFormatted *command.ErrNotFormatted
 	require.ErrorAs(t, err, &notFormatted)
 	assert.Len(t, notFormatted.Files, 1)
+	assert.Contains(t, notFormatted.Error(), tmpFile)
 	assert.Contains(t, buf.String(), tmpFile)
 }
+

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -351,3 +351,42 @@ func TestApply_Run(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
 }
+
+func TestFmt_Run(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.sql")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		Schemas: []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{tmpFile}}}
+	err := cmd.Run(client, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+	assert.Contains(t, buf.String(), "    id integer NOT NULL")
+}
+
+func TestFmt_Run_Write(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.sql")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		Schemas: []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Fmt{FmtOptions: pistachio.FmtOptions{Files: []string{tmpFile}, Write: true}}
+	err := cmd.Run(client, &buf)
+	require.NoError(t, err)
+
+	// stdout should be empty when writing to file
+	assert.Empty(t, buf.String())
+
+	// File should be formatted
+	content, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "CREATE TABLE public.users")
+	assert.Contains(t, string(content), "    id integer NOT NULL")
+}

--- a/cmd/command/fmt.go
+++ b/cmd/command/fmt.go
@@ -13,15 +13,43 @@ type Fmt struct {
 	pistachio.FmtOptions
 }
 
+// ErrNotFormatted is returned when --check finds unformatted files.
+type ErrNotFormatted struct {
+	Files []string
+}
+
+func (e *ErrNotFormatted) Error() string {
+	return fmt.Sprintf("files not formatted: %s", strings.Join(e.Files, ", "))
+}
+
 func (cmd *Fmt) Run(client *pistachio.Client, w io.Writer) error {
 	results, err := client.Format(&cmd.FmtOptions)
 	if err != nil {
 		return err
 	}
 
+	if cmd.Check {
+		var unformatted []string
+		for _, path := range cmd.Files {
+			original, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("failed to read %s: %w", path, err)
+			}
+			if strings.TrimSpace(string(original)) != strings.TrimSpace(results[path]) {
+				unformatted = append(unformatted, path)
+			}
+		}
+		if len(unformatted) > 0 {
+			for _, path := range unformatted {
+				fmt.Fprintln(w, path) //nolint:errcheck
+			}
+			return &ErrNotFormatted{Files: unformatted}
+		}
+		return nil
+	}
+
 	if cmd.Write {
 		for path, content := range results {
-			// Preserve original file permissions
 			mode := os.FileMode(0o644)
 			if info, err := os.Stat(path); err == nil {
 				mode = info.Mode()

--- a/cmd/command/fmt.go
+++ b/cmd/command/fmt.go
@@ -21,7 +21,12 @@ func (cmd *Fmt) Run(client *pistachio.Client, w io.Writer) error {
 
 	if cmd.Write {
 		for path, content := range results {
-			if err := os.WriteFile(path, []byte(content+"\n"), 0o644); err != nil {
+			// Preserve original file permissions
+			mode := os.FileMode(0o644)
+			if info, err := os.Stat(path); err == nil {
+				mode = info.Mode()
+			}
+			if err := os.WriteFile(path, []byte(content+"\n"), mode); err != nil {
 				return fmt.Errorf("failed to write %s: %w", path, err)
 			}
 		}

--- a/cmd/command/fmt.go
+++ b/cmd/command/fmt.go
@@ -1,0 +1,38 @@
+package command
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/winebarrel/pistachio"
+)
+
+type Fmt struct {
+	pistachio.FmtOptions
+}
+
+func (cmd *Fmt) Run(client *pistachio.Client, w io.Writer) error {
+	defaultSchema := "public"
+	if len(client.Schemas) > 0 {
+		defaultSchema = client.Schemas[0]
+	}
+
+	result, err := pistachio.FmtSQL(&cmd.FmtOptions, defaultSchema)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Write {
+		content := result + "\n"
+		for _, path := range cmd.Files {
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				return fmt.Errorf("failed to write %s: %w", path, err)
+			}
+		}
+		return nil
+	}
+
+	fmt.Fprintln(w, result) //nolint:errcheck
+	return nil
+}

--- a/cmd/command/fmt.go
+++ b/cmd/command/fmt.go
@@ -35,7 +35,8 @@ func (cmd *Fmt) Run(client *pistachio.Client, w io.Writer) error {
 			if err != nil {
 				return fmt.Errorf("failed to read %s: %w", path, err)
 			}
-			if strings.TrimSpace(string(original)) != strings.TrimSpace(results[path]) {
+			expected := results[path] + "\n"
+			if string(original) != expected {
 				unformatted = append(unformatted, path)
 			}
 		}
@@ -49,7 +50,8 @@ func (cmd *Fmt) Run(client *pistachio.Client, w io.Writer) error {
 	}
 
 	if cmd.Write {
-		for path, content := range results {
+		for _, path := range cmd.Files {
+			content := results[path]
 			mode := os.FileMode(0o644)
 			if info, err := os.Stat(path); err == nil {
 				mode = info.Mode()

--- a/cmd/command/fmt.go
+++ b/cmd/command/fmt.go
@@ -13,24 +13,23 @@ type Fmt struct {
 }
 
 func (cmd *Fmt) Run(client *pistachio.Client, w io.Writer) error {
-	defaultSchema := "public"
-	if len(client.Schemas) > 0 {
-		defaultSchema = client.Schemas[0]
-	}
-
-	result, err := pistachio.FmtSQL(&cmd.FmtOptions, defaultSchema)
-	if err != nil {
-		return err
-	}
-
 	if cmd.Write {
-		content := result + "\n"
+		// Format each file individually and write back
 		for _, path := range cmd.Files {
-			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			result, err := client.FormatFile(path)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(path, []byte(result+"\n"), 0o644); err != nil {
 				return fmt.Errorf("failed to write %s: %w", path, err)
 			}
 		}
 		return nil
+	}
+
+	result, err := client.Format(&cmd.FmtOptions)
+	if err != nil {
+		return err
 	}
 
 	fmt.Fprintln(w, result) //nolint:errcheck

--- a/cmd/command/fmt.go
+++ b/cmd/command/fmt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/winebarrel/pistachio"
 )
@@ -13,25 +14,25 @@ type Fmt struct {
 }
 
 func (cmd *Fmt) Run(client *pistachio.Client, w io.Writer) error {
+	results, err := client.Format(&cmd.FmtOptions)
+	if err != nil {
+		return err
+	}
+
 	if cmd.Write {
-		// Format each file individually and write back
-		for _, path := range cmd.Files {
-			result, err := client.FormatFile(path)
-			if err != nil {
-				return err
-			}
-			if err := os.WriteFile(path, []byte(result+"\n"), 0o644); err != nil {
+		for path, content := range results {
+			if err := os.WriteFile(path, []byte(content+"\n"), 0o644); err != nil {
 				return fmt.Errorf("failed to write %s: %w", path, err)
 			}
 		}
 		return nil
 	}
 
-	result, err := client.Format(&cmd.FmtOptions)
-	if err != nil {
-		return err
+	// Print all results to stdout
+	var parts []string
+	for _, path := range cmd.Files {
+		parts = append(parts, results[path])
 	}
-
-	fmt.Fprintln(w, result) //nolint:errcheck
+	fmt.Fprintln(w, strings.Join(parts, "\n\n")) //nolint:errcheck
 	return nil
 }

--- a/cmd/pist/main.go
+++ b/cmd/pist/main.go
@@ -19,6 +19,7 @@ var cli struct {
 	Apply command.Apply `cmd:"" help:"Apply schema changes to the database."`
 	Plan  command.Plan  `cmd:"" help:"Print the schema diff SQL without applying it."`
 	Dump  command.Dump  `cmd:"" help:"Dump the current database schema as SQL."`
+	Fmt   command.Fmt   `cmd:"" help:"Format SQL file(s) into canonical form."`
 }
 
 func main() {

--- a/dump.go
+++ b/dump.go
@@ -86,7 +86,7 @@ func (r *DumpResult) enums() *orderedmap.Map[string, *model.Enum] {
 }
 
 func (r *DumpResult) String() string {
-	return FormatSchemaSQL(r.enums(), r.tables(), r.views())
+	return formatSchemaSQL(r.enums(), r.tables(), r.views())
 }
 
 func (r *DumpResult) Files() map[string]string {

--- a/dump.go
+++ b/dump.go
@@ -86,20 +86,7 @@ func (r *DumpResult) enums() *orderedmap.Map[string, *model.Enum] {
 }
 
 func (r *DumpResult) String() string {
-	var parts []string
-	enums := r.enums()
-	tables := r.tables()
-	views := r.views()
-	if enums.Len() > 0 {
-		parts = append(parts, model.EnumsToSQL(enums))
-	}
-	if tables.Len() > 0 {
-		parts = append(parts, model.TablesToSQL(tables))
-	}
-	if views.Len() > 0 {
-		parts = append(parts, model.ViewsToSQL(views))
-	}
-	return strings.Join(parts, "\n\n")
+	return FormatSchemaSQL(r.enums(), r.tables(), r.views())
 }
 
 func (r *DumpResult) Files() map[string]string {

--- a/fmt.go
+++ b/fmt.go
@@ -13,34 +13,22 @@ type FmtOptions struct {
 	Write bool     `short:"w" help:"Write result to source file(s) instead of stdout."`
 }
 
-// Format formats the combined SQL from the provided files and returns the result as a string.
-func (client *Client) Format(options *FmtOptions) (string, error) {
-	return FmtSQL(options.Files, client.Schemas[0])
-}
+// Format formats SQL files and returns the results. When multiple files are
+// provided, each file is formatted independently and returned as a map from
+// file path to formatted SQL.
+func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
+	defaultSchema := client.Schemas[0]
+	results := make(map[string]string, len(options.Files))
 
-// FormatFile formats a single SQL file and returns the result as a string.
-func (client *Client) FormatFile(path string) (string, error) {
-	return FmtSQLFile(path, client.Schemas[0])
-}
-
-// FmtSQL formats the combined SQL from the provided files and returns the result as a string.
-func FmtSQL(files []string, defaultSchema string) (string, error) {
-	result, err := parser.ParseSQLFilesWithSchema(files, defaultSchema)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse SQL file: %w", err)
+	for _, path := range options.Files {
+		result, err := parser.ParseSQLFileWithSchema(path, defaultSchema)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse SQL file: %w", err)
+		}
+		results[path] = formatParseResult(result)
 	}
 
-	return formatParseResult(result), nil
-}
-
-// FmtSQLFile formats a single SQL file and returns the result as a string.
-func FmtSQLFile(path string, defaultSchema string) (string, error) {
-	result, err := parser.ParseSQLFileWithSchema(path, defaultSchema)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse SQL file: %w", err)
-	}
-
-	return formatParseResult(result), nil
+	return results, nil
 }
 
 func formatParseResult(result *parser.ParseResult) string {

--- a/fmt.go
+++ b/fmt.go
@@ -1,0 +1,34 @@
+package pistachio
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/winebarrel/pistachio/model"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+type FmtOptions struct {
+	Files []string `arg:"" help:"Path to the SQL file(s) to format."`
+	Write bool     `short:"w" help:"Write result to source file(s) instead of stdout."`
+}
+
+func FmtSQL(options *FmtOptions, defaultSchema string) (string, error) {
+	result, err := parser.ParseSQLFilesWithSchema(options.Files, defaultSchema)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse SQL file: %w", err)
+	}
+
+	var parts []string
+	if result.Enums.Len() > 0 {
+		parts = append(parts, model.EnumsToSQL(result.Enums))
+	}
+	if result.Tables.Len() > 0 {
+		parts = append(parts, model.TablesToSQL(result.Tables))
+	}
+	if result.Views.Len() > 0 {
+		parts = append(parts, model.ViewsToSQL(result.Views))
+	}
+
+	return strings.Join(parts, "\n\n"), nil
+}

--- a/fmt.go
+++ b/fmt.go
@@ -29,15 +29,15 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse SQL file %q: %w", path, err)
 		}
-		results[path] = FormatSchemaSQL(result.Enums, result.Tables, result.Views)
+		results[path] = formatSchemaSQL(result.Enums, result.Tables, result.Views)
 	}
 
 	return results, nil
 }
 
-// FormatSchemaSQL formats enums, tables, and views into canonical SQL output.
+// formatSchemaSQL formats enums, tables, and views into canonical SQL output.
 // This is the shared formatting logic used by both dump and fmt.
-func FormatSchemaSQL(
+func formatSchemaSQL(
 	enums *orderedmap.Map[string, *model.Enum],
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],

--- a/fmt.go
+++ b/fmt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/parser"
 )
@@ -13,9 +14,8 @@ type FmtOptions struct {
 	Write bool     `short:"w" help:"Write result to source file(s) instead of stdout."`
 }
 
-// Format formats SQL files and returns the results. When multiple files are
-// provided, each file is formatted independently and returned as a map from
-// file path to formatted SQL.
+// Format formats SQL files and returns the results. Each file is formatted
+// independently and returned as a map from file path to formatted SQL.
 func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 	if len(client.Schemas) == 0 {
 		return nil, fmt.Errorf("no schemas configured")
@@ -28,23 +28,28 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse SQL file %q: %w", path, err)
 		}
-		results[path] = formatParseResult(result)
+		results[path] = FormatSchemaSQL(result.Enums, result.Tables, result.Views)
 	}
 
 	return results, nil
 }
 
-func formatParseResult(result *parser.ParseResult) string {
+// FormatSchemaSQL formats enums, tables, and views into canonical SQL output.
+// This is the shared formatting logic used by both dump and fmt.
+func FormatSchemaSQL(
+	enums *orderedmap.Map[string, *model.Enum],
+	tables *orderedmap.Map[string, *model.Table],
+	views *orderedmap.Map[string, *model.View],
+) string {
 	var parts []string
-	if result.Enums.Len() > 0 {
-		parts = append(parts, model.EnumsToSQL(result.Enums))
+	if enums.Len() > 0 {
+		parts = append(parts, model.EnumsToSQL(enums))
 	}
-	if result.Tables.Len() > 0 {
-		parts = append(parts, model.TablesToSQL(result.Tables))
+	if tables.Len() > 0 {
+		parts = append(parts, model.TablesToSQL(tables))
 	}
-	if result.Views.Len() > 0 {
-		parts = append(parts, model.ViewsToSQL(result.Views))
+	if views.Len() > 0 {
+		parts = append(parts, model.ViewsToSQL(views))
 	}
-
 	return strings.Join(parts, "\n\n")
 }

--- a/fmt.go
+++ b/fmt.go
@@ -13,12 +13,37 @@ type FmtOptions struct {
 	Write bool     `short:"w" help:"Write result to source file(s) instead of stdout."`
 }
 
-func FmtSQL(options *FmtOptions, defaultSchema string) (string, error) {
-	result, err := parser.ParseSQLFilesWithSchema(options.Files, defaultSchema)
+// Format formats the combined SQL from the provided files and returns the result as a string.
+func (client *Client) Format(options *FmtOptions) (string, error) {
+	return FmtSQL(options.Files, client.Schemas[0])
+}
+
+// FormatFile formats a single SQL file and returns the result as a string.
+func (client *Client) FormatFile(path string) (string, error) {
+	return FmtSQLFile(path, client.Schemas[0])
+}
+
+// FmtSQL formats the combined SQL from the provided files and returns the result as a string.
+func FmtSQL(files []string, defaultSchema string) (string, error) {
+	result, err := parser.ParseSQLFilesWithSchema(files, defaultSchema)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
+	return formatParseResult(result), nil
+}
+
+// FmtSQLFile formats a single SQL file and returns the result as a string.
+func FmtSQLFile(path string, defaultSchema string) (string, error) {
+	result, err := parser.ParseSQLFileWithSchema(path, defaultSchema)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse SQL file: %w", err)
+	}
+
+	return formatParseResult(result), nil
+}
+
+func formatParseResult(result *parser.ParseResult) string {
 	var parts []string
 	if result.Enums.Len() > 0 {
 		parts = append(parts, model.EnumsToSQL(result.Enums))
@@ -30,5 +55,5 @@ func FmtSQL(options *FmtOptions, defaultSchema string) (string, error) {
 		parts = append(parts, model.ViewsToSQL(result.Views))
 	}
 
-	return strings.Join(parts, "\n\n"), nil
+	return strings.Join(parts, "\n\n")
 }

--- a/fmt.go
+++ b/fmt.go
@@ -11,8 +11,8 @@ import (
 
 type FmtOptions struct {
 	Files []string `arg:"" help:"Path to the SQL file(s) to format."`
-	Write bool     `short:"w" help:"Write result to source file(s) instead of stdout."`
-	Check bool     `help:"Check if files are formatted. Exit with non-zero status if any file needs formatting."`
+	Write bool     `short:"w" xor:"mode" help:"Write result to source file(s) instead of stdout."`
+	Check bool     `xor:"mode" help:"Check if files are formatted. Exit with non-zero status if any file needs formatting."`
 }
 
 // Format formats SQL files and returns the results. Each file is formatted

--- a/fmt.go
+++ b/fmt.go
@@ -17,13 +17,16 @@ type FmtOptions struct {
 // provided, each file is formatted independently and returned as a map from
 // file path to formatted SQL.
 func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
+	if len(client.Schemas) == 0 {
+		return nil, fmt.Errorf("no schemas configured")
+	}
 	defaultSchema := client.Schemas[0]
 	results := make(map[string]string, len(options.Files))
 
 	for _, path := range options.Files {
 		result, err := parser.ParseSQLFileWithSchema(path, defaultSchema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse SQL file: %w", err)
+			return nil, fmt.Errorf("failed to parse SQL file %q: %w", path, err)
 		}
 		results[path] = formatParseResult(result)
 	}

--- a/fmt.go
+++ b/fmt.go
@@ -43,13 +43,13 @@ func FormatSchemaSQL(
 	views *orderedmap.Map[string, *model.View],
 ) string {
 	var parts []string
-	if enums.Len() > 0 {
+	if enums != nil && enums.Len() > 0 {
 		parts = append(parts, model.EnumsToSQL(enums))
 	}
-	if tables.Len() > 0 {
+	if tables != nil && tables.Len() > 0 {
 		parts = append(parts, model.TablesToSQL(tables))
 	}
-	if views.Len() > 0 {
+	if views != nil && views.Len() > 0 {
 		parts = append(parts, model.ViewsToSQL(views))
 	}
 	return strings.Join(parts, "\n\n")

--- a/fmt.go
+++ b/fmt.go
@@ -12,6 +12,7 @@ import (
 type FmtOptions struct {
 	Files []string `arg:"" help:"Path to the SQL file(s) to format."`
 	Write bool     `short:"w" help:"Write result to source file(s) instead of stdout."`
+	Check bool     `help:"Check if files are formatted. Exit with non-zero status if any file needs formatting."`
 }
 
 // Format formats SQL files and returns the results. Each file is formatted

--- a/fmt_test.go
+++ b/fmt_test.go
@@ -1,0 +1,61 @@
+package pistachio_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio"
+)
+
+type fmtTestCase struct {
+	Input    string `yaml:"input"`
+	Expected string `yaml:"expected"`
+}
+
+func TestFmtSQL(t *testing.T) {
+	files, err := filepath.Glob("testdata/fmt/*.yml")
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	for _, file := range files {
+		name := strings.TrimSuffix(filepath.Base(file), ".yml")
+		t.Run(name, func(t *testing.T) {
+			tc := loadYAML[fmtTestCase](t, file)
+
+			tmpFile := filepath.Join(t.TempDir(), "input.sql")
+			require.NoError(t, os.WriteFile(tmpFile, []byte(tc.Input), 0o644))
+
+			got, err := pistachio.FmtSQL(&pistachio.FmtOptions{Files: []string{tmpFile}}, "public")
+			require.NoError(t, err)
+			assert.Equal(t, strings.TrimSpace(tc.Expected), strings.TrimSpace(got))
+		})
+	}
+}
+
+func TestFmtSQL_InvalidFile(t *testing.T) {
+	_, err := pistachio.FmtSQL(&pistachio.FmtOptions{Files: []string{"/nonexistent/file.sql"}}, "public")
+	require.Error(t, err)
+}
+
+func TestFmtSQL_InvalidSQL(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "bad.sql")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("NOT VALID SQL {{{}}}"), 0o644))
+
+	_, err := pistachio.FmtSQL(&pistachio.FmtOptions{Files: []string{tmpFile}}, "public")
+	require.Error(t, err)
+}
+
+func TestFmtSQL_Write(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.sql")
+	input := `CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`
+	require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+	got, err := pistachio.FmtSQL(&pistachio.FmtOptions{Files: []string{tmpFile}}, "public")
+	require.NoError(t, err)
+	assert.Contains(t, got, "CREATE TABLE public.users")
+	assert.Contains(t, got, "    id integer NOT NULL")
+}

--- a/fmt_test.go
+++ b/fmt_test.go
@@ -16,7 +16,7 @@ type fmtTestCase struct {
 	Expected string `yaml:"expected"`
 }
 
-func TestFmtSQL(t *testing.T) {
+func TestFormat(t *testing.T) {
 	files, err := filepath.Glob("testdata/fmt/*.yml")
 	require.NoError(t, err)
 	require.NotEmpty(t, files)
@@ -29,33 +29,42 @@ func TestFmtSQL(t *testing.T) {
 			tmpFile := filepath.Join(t.TempDir(), "input.sql")
 			require.NoError(t, os.WriteFile(tmpFile, []byte(tc.Input), 0o644))
 
-			got, err := pistachio.FmtSQL(&pistachio.FmtOptions{Files: []string{tmpFile}}, "public")
+			client := pistachio.NewClient(&pistachio.Options{Schemas: []string{"public"}})
+			got, err := client.Format(&pistachio.FmtOptions{Files: []string{tmpFile}})
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.Expected), strings.TrimSpace(got))
 		})
 	}
 }
 
-func TestFmtSQL_InvalidFile(t *testing.T) {
-	_, err := pistachio.FmtSQL(&pistachio.FmtOptions{Files: []string{"/nonexistent/file.sql"}}, "public")
+func TestFormat_InvalidFile(t *testing.T) {
+	client := pistachio.NewClient(&pistachio.Options{Schemas: []string{"public"}})
+	_, err := client.Format(&pistachio.FmtOptions{Files: []string{"/nonexistent/file.sql"}})
 	require.Error(t, err)
 }
 
-func TestFmtSQL_InvalidSQL(t *testing.T) {
+func TestFormat_InvalidSQL(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "bad.sql")
 	require.NoError(t, os.WriteFile(tmpFile, []byte("NOT VALID SQL {{{}}}"), 0o644))
 
-	_, err := pistachio.FmtSQL(&pistachio.FmtOptions{Files: []string{tmpFile}}, "public")
+	client := pistachio.NewClient(&pistachio.Options{Schemas: []string{"public"}})
+	_, err := client.Format(&pistachio.FmtOptions{Files: []string{tmpFile}})
 	require.Error(t, err)
 }
 
-func TestFmtSQL_Write(t *testing.T) {
+func TestFormatFile(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "test.sql")
-	input := `CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`
-	require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o644))
 
-	got, err := pistachio.FmtSQL(&pistachio.FmtOptions{Files: []string{tmpFile}}, "public")
+	client := pistachio.NewClient(&pistachio.Options{Schemas: []string{"public"}})
+	got, err := client.FormatFile(tmpFile)
 	require.NoError(t, err)
 	assert.Contains(t, got, "CREATE TABLE public.users")
 	assert.Contains(t, got, "    id integer NOT NULL")
+}
+
+func TestFormatFile_InvalidFile(t *testing.T) {
+	client := pistachio.NewClient(&pistachio.Options{Schemas: []string{"public"}})
+	_, err := client.FormatFile("/nonexistent/file.sql")
+	require.Error(t, err)
 }

--- a/fmt_test.go
+++ b/fmt_test.go
@@ -30,9 +30,9 @@ func TestFormat(t *testing.T) {
 			require.NoError(t, os.WriteFile(tmpFile, []byte(tc.Input), 0o644))
 
 			client := pistachio.NewClient(&pistachio.Options{Schemas: []string{"public"}})
-			got, err := client.Format(&pistachio.FmtOptions{Files: []string{tmpFile}})
+			results, err := client.Format(&pistachio.FmtOptions{Files: []string{tmpFile}})
 			require.NoError(t, err)
-			assert.Equal(t, strings.TrimSpace(tc.Expected), strings.TrimSpace(got))
+			assert.Equal(t, strings.TrimSpace(tc.Expected), strings.TrimSpace(results[tmpFile]))
 		})
 	}
 }
@@ -52,19 +52,17 @@ func TestFormat_InvalidSQL(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestFormatFile(t *testing.T) {
-	tmpFile := filepath.Join(t.TempDir(), "test.sql")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o644))
+func TestFormat_MultipleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := filepath.Join(tmpDir, "a.sql")
+	file2 := filepath.Join(tmpDir, "b.sql")
+	require.NoError(t, os.WriteFile(file1, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o644))
+	require.NoError(t, os.WriteFile(file2, []byte(`CREATE TABLE public.posts (id integer NOT NULL, CONSTRAINT posts_pkey PRIMARY KEY (id));`), 0o644))
 
 	client := pistachio.NewClient(&pistachio.Options{Schemas: []string{"public"}})
-	got, err := client.FormatFile(tmpFile)
+	results, err := client.Format(&pistachio.FmtOptions{Files: []string{file1, file2}})
 	require.NoError(t, err)
-	assert.Contains(t, got, "CREATE TABLE public.users")
-	assert.Contains(t, got, "    id integer NOT NULL")
-}
-
-func TestFormatFile_InvalidFile(t *testing.T) {
-	client := pistachio.NewClient(&pistachio.Options{Schemas: []string{"public"}})
-	_, err := client.FormatFile("/nonexistent/file.sql")
-	require.Error(t, err)
+	assert.Len(t, results, 2)
+	assert.Contains(t, results[file1], "CREATE TABLE public.users")
+	assert.Contains(t, results[file2], "CREATE TABLE public.posts")
 }

--- a/fmt_test.go
+++ b/fmt_test.go
@@ -52,6 +52,16 @@ func TestFormat_InvalidSQL(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestFormat_EmptySchemas(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.sql")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(`CREATE TABLE public.users (id integer NOT NULL);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{Schemas: []string{}})
+	_, err := client.Format(&pistachio.FmtOptions{Files: []string{tmpFile}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no schemas configured")
+}
+
 func TestFormat_MultipleFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	file1 := filepath.Join(tmpDir, "a.sql")

--- a/testdata/fmt/empty.yml
+++ b/testdata/fmt/empty.yml
@@ -1,0 +1,2 @@
+input: ""
+expected: ""

--- a/testdata/fmt/enum.yml
+++ b/testdata/fmt/enum.yml
@@ -1,0 +1,9 @@
+input: |
+  CREATE TYPE public.status AS ENUM ('active','inactive','pending');
+expected: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive',
+      'pending'
+  );

--- a/testdata/fmt/mixed.yml
+++ b/testdata/fmt/mixed.yml
@@ -1,0 +1,21 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, name text NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  CREATE TYPE public.status AS ENUM ('active','inactive');
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE name IS NOT NULL;
+expected: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id, name FROM public.users WHERE name IS NOT NULL;

--- a/testdata/fmt/simple_table.yml
+++ b/testdata/fmt/simple_table.yml
@@ -1,0 +1,9 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, name text NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/fmt/view.yml
+++ b/testdata/fmt/view.yml
@@ -1,0 +1,13 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  CREATE VIEW public.active_users AS SELECT id FROM public.users;
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id FROM public.users;

--- a/testdata/fmt/with_index_and_fk.yml
+++ b/testdata/fmt/with_index_and_fk.yml
@@ -1,0 +1,21 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  CREATE TABLE public.posts (id integer NOT NULL, user_id integer NOT NULL, CONSTRAINT posts_pkey PRIMARY KEY (id));
+  CREATE INDEX idx_posts_user_id ON public.posts (user_id);
+  ALTER TABLE public.posts ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.posts
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_posts_user_id ON public.posts USING btree (user_id);
+
+  ALTER TABLE ONLY public.posts ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users (id);


### PR DESCRIPTION
pist fmt schema.sql       # print formatted SQL to stdout
pist fmt -w schema.sql    # overwrite file in place

Parses input SQL and re-emits it in the same canonical format used by dump (enums first, then tables with indexes/FKs, then views).