### PR TITLE
Move --include/--exclude from global options to subcommand options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,15 @@ Download the latest binary from [Releases](https://github.com/winebarrel/pistach
 Usage: pist <command> [flags]
 
 Flags:
-  -h, --help                   Show context-sensitive help.
+  -h, --help                  Show context-sensitive help.
   -c, --conn-string="postgres://postgres@localhost/postgres"
-                               PostgreSQL connection string. See
-                               https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                               ($PIST_CONN_STR)
-      --password=STRING        PostgreSQL password ($PIST_PASSWORD).
-  -n, --schemas=public,...     Schemas to inspect and modify ($PGSCHEMAS).
+                              PostgreSQL connection string. See
+                              https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+                              ($PIST_CONN_STR)
+      --password=STRING       PostgreSQL password ($PIST_PASSWORD).
+  -n, --schemas=public,...    Schemas to inspect and modify ($PGSCHEMAS).
   -m, --schema-map=KEY=VALUE;...
-                               Schema name mapping (e.g. -m old=new).
-  -I, --include=INCLUDE,...    Include only tables/views/enums matching the
-                               pattern (wildcard: *, ?).
-  -E, --exclude=EXCLUDE,...    Exclude tables/views/enums matching the pattern
-                               (wildcard: *, ?).
+                              Schema name mapping (e.g. -m old=new).
       --version
 
 Commands:
@@ -136,17 +132,17 @@ pist -n staging -m staging=public apply schema.sql
 
 ### Filtering tables/views/enums
 
-Use `-I` / `--include` to include only matching tables/views/enums, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names).
+Use `-I` / `--include` to include only matching tables/views/enums, or `-E` / `--exclude` to exclude them. These flags are available on the `dump`, `plan`, and `apply` subcommands. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names).
 
 ```bash
 # Dump only objects matching "user*"
-pist -I 'user*' dump
+pist dump -I 'user*'
 
 # Plan changes excluding temporary tables
-pist -E 'tmp_*' plan schema.sql
+pist plan -E 'tmp_*' schema.sql
 
 # Combine include and exclude
-pist -I 'user*' -E 'user_tmp' apply schema.sql
+pist apply -I 'user*' -E 'user_tmp' schema.sql
 ```
 
 ### Omit schema

--- a/apply.go
+++ b/apply.go
@@ -12,6 +12,7 @@ import (
 )
 
 type ApplyOptions struct {
+	FilterOptions
 	Files      []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQLFile string   `type:"path" help:"Path to a SQL file to execute before applying changes."`
 	WithTx     bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
@@ -49,19 +50,19 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	enumDiff, err := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
 	if err != nil {
 		return err
 	}
 	stmts := enumDiff.Stmts
 
-	tableStmts, err := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	if err != nil {
 		return fmt.Errorf("failed to diff tables: %w", err)
 	}
 	stmts = append(stmts, tableStmts...)
 
-	viewStmts, err := diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))
+	viewStmts, err := diff.DiffViews(options.filterViews(currentViews), options.filterViews(client.reverseRemapViewSchemas(desired.Views)))
 	if err != nil {
 		return fmt.Errorf("failed to diff views: %w", err)
 	}

--- a/dump.go
+++ b/dump.go
@@ -11,6 +11,7 @@ import (
 )
 
 type DumpOptions struct {
+	FilterOptions
 	Split      string `help:"Output each table/view/enum as a separate file in the specified directory."`
 	OmitSchema bool   `help:"Omit schema name from the dump output."`
 }
@@ -169,9 +170,9 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 	}
 
 	return &DumpResult{
-		Tables:     client.filterTables(client.remapTableSchemas(tables)),
-		Views:      client.filterViews(client.remapViewSchemas(views)),
-		Enums:      client.filterEnums(client.remapEnumSchemas(enums)),
+		Tables:     options.filterTables(client.remapTableSchemas(tables)),
+		Views:      options.filterViews(client.remapViewSchemas(views)),
+		Enums:      options.filterEnums(client.remapEnumSchemas(enums)),
 		OmitSchema: options.OmitSchema,
 	}, nil
 }

--- a/filter.go
+++ b/filter.go
@@ -5,42 +5,42 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-func (client *Client) filterTables(tables *orderedmap.Map[string, *model.Table]) *orderedmap.Map[string, *model.Table] {
-	if len(client.Include) == 0 && len(client.Exclude) == 0 {
+func (f *FilterOptions) filterTables(tables *orderedmap.Map[string, *model.Table]) *orderedmap.Map[string, *model.Table] {
+	if len(f.Include) == 0 && len(f.Exclude) == 0 {
 		return tables
 	}
 
 	filtered := orderedmap.New[string, *model.Table]()
 	for k, t := range tables.All() {
-		if client.MatchName(t.Name) {
+		if f.MatchName(t.Name) {
 			filtered.Set(k, t)
 		}
 	}
 	return filtered
 }
 
-func (client *Client) filterViews(views *orderedmap.Map[string, *model.View]) *orderedmap.Map[string, *model.View] {
-	if len(client.Include) == 0 && len(client.Exclude) == 0 {
+func (f *FilterOptions) filterViews(views *orderedmap.Map[string, *model.View]) *orderedmap.Map[string, *model.View] {
+	if len(f.Include) == 0 && len(f.Exclude) == 0 {
 		return views
 	}
 
 	filtered := orderedmap.New[string, *model.View]()
 	for k, v := range views.All() {
-		if client.MatchName(v.Name) {
+		if f.MatchName(v.Name) {
 			filtered.Set(k, v)
 		}
 	}
 	return filtered
 }
 
-func (client *Client) filterEnums(enums *orderedmap.Map[string, *model.Enum]) *orderedmap.Map[string, *model.Enum] {
-	if len(client.Include) == 0 && len(client.Exclude) == 0 {
+func (f *FilterOptions) filterEnums(enums *orderedmap.Map[string, *model.Enum]) *orderedmap.Map[string, *model.Enum] {
+	if len(f.Include) == 0 && len(f.Exclude) == 0 {
 		return enums
 	}
 
 	filtered := orderedmap.New[string, *model.Enum]()
 	for k, e := range enums.All() {
-		if client.MatchName(e.Name) {
+		if f.MatchName(e.Name) {
 			filtered.Set(k, e)
 		}
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -120,7 +120,7 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"users"}}})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -149,7 +149,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude:    []string{"posts"}}})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude: []string{"posts"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -181,7 +181,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"user*"}}})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"user*"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -238,7 +238,7 @@ CREATE VIEW public.tmp_view AS SELECT 1;`)
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude:    []string{"tmp_*"}}})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude: []string{"tmp_*"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -278,7 +278,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"users"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
@@ -317,7 +317,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Exclude:    []string{"posts"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Exclude: []string{"posts"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
@@ -338,7 +338,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user');`)
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"status"}}})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -360,7 +360,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user');`)
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude:    []string{"role"}}})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude: []string{"role"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -386,7 +386,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"status"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';")
@@ -411,7 +411,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"status"}}, Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: only status should have the new value
@@ -460,7 +460,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"users"}}, Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: only users should have the new column

--- a/filter_test.go
+++ b/filter_test.go
@@ -39,9 +39,14 @@ func TestValidatePatterns(t *testing.T) {
 	})
 }
 
-func TestAfterApply_InvalidPattern(t *testing.T) {
+func TestFilterOptions_AfterApply_Valid(t *testing.T) {
+	o := &pistachio.FilterOptions{Include: []string{"user*"}}
+	assert.NoError(t, o.AfterApply())
+}
+
+func TestFilterOptions_AfterApply_Invalid(t *testing.T) {
 	o := &pistachio.FilterOptions{Include: []string{"[bad"}}
-	err := o.ValidatePatterns()
+	err := o.AfterApply()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--include")
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -15,70 +15,70 @@ import (
 
 func TestValidatePatterns(t *testing.T) {
 	t.Run("valid patterns", func(t *testing.T) {
-		o := &pistachio.Options{Include: []string{"user*", "post?"}, Exclude: []string{"tmp_*"}}
+		o := &pistachio.FilterOptions{Include: []string{"user*", "post?"}, Exclude: []string{"tmp_*"}}
 		assert.NoError(t, o.ValidatePatterns())
 	})
 
 	t.Run("invalid include pattern", func(t *testing.T) {
-		o := &pistachio.Options{Include: []string{"[invalid"}}
+		o := &pistachio.FilterOptions{Include: []string{"[invalid"}}
 		err := o.ValidatePatterns()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--include")
 	})
 
 	t.Run("invalid exclude pattern", func(t *testing.T) {
-		o := &pistachio.Options{Exclude: []string{"[invalid"}}
+		o := &pistachio.FilterOptions{Exclude: []string{"[invalid"}}
 		err := o.ValidatePatterns()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--exclude")
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		o := &pistachio.Options{}
+		o := &pistachio.FilterOptions{}
 		assert.NoError(t, o.ValidatePatterns())
 	})
 }
 
 func TestAfterApply_InvalidPattern(t *testing.T) {
-	o := &pistachio.Options{Include: []string{"[bad"}}
-	err := o.AfterApply()
+	o := &pistachio.FilterOptions{Include: []string{"[bad"}}
+	err := o.ValidatePatterns()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--include")
 }
 
 func TestMatchName(t *testing.T) {
 	t.Run("no filters", func(t *testing.T) {
-		o := &pistachio.Options{}
+		o := &pistachio.FilterOptions{}
 		assert.True(t, o.MatchName("users"))
 	})
 
 	t.Run("include match", func(t *testing.T) {
-		o := &pistachio.Options{Include: []string{"users"}}
+		o := &pistachio.FilterOptions{Include: []string{"users"}}
 		assert.True(t, o.MatchName("users"))
 		assert.False(t, o.MatchName("posts"))
 	})
 
 	t.Run("include wildcard", func(t *testing.T) {
-		o := &pistachio.Options{Include: []string{"user*"}}
+		o := &pistachio.FilterOptions{Include: []string{"user*"}}
 		assert.True(t, o.MatchName("users"))
 		assert.True(t, o.MatchName("user_roles"))
 		assert.False(t, o.MatchName("posts"))
 	})
 
 	t.Run("exclude match", func(t *testing.T) {
-		o := &pistachio.Options{Exclude: []string{"posts"}}
+		o := &pistachio.FilterOptions{Exclude: []string{"posts"}}
 		assert.True(t, o.MatchName("users"))
 		assert.False(t, o.MatchName("posts"))
 	})
 
 	t.Run("exclude wildcard", func(t *testing.T) {
-		o := &pistachio.Options{Exclude: []string{"tmp_*"}}
+		o := &pistachio.FilterOptions{Exclude: []string{"tmp_*"}}
 		assert.True(t, o.MatchName("users"))
 		assert.False(t, o.MatchName("tmp_backup"))
 	})
 
 	t.Run("include and exclude", func(t *testing.T) {
-		o := &pistachio.Options{Include: []string{"user*"}, Exclude: []string{"user_tmp"}}
+		o := &pistachio.FilterOptions{Include: []string{"user*"}, Exclude: []string{"user_tmp"}}
 		assert.True(t, o.MatchName("users"))
 		assert.True(t, o.MatchName("user_roles"))
 		assert.False(t, o.MatchName("user_tmp"))
@@ -86,14 +86,14 @@ func TestMatchName(t *testing.T) {
 	})
 
 	t.Run("multiple include patterns", func(t *testing.T) {
-		o := &pistachio.Options{Include: []string{"users", "posts"}}
+		o := &pistachio.FilterOptions{Include: []string{"users", "posts"}}
 		assert.True(t, o.MatchName("users"))
 		assert.True(t, o.MatchName("posts"))
 		assert.False(t, o.MatchName("orders"))
 	})
 
 	t.Run("question mark wildcard", func(t *testing.T) {
-		o := &pistachio.Options{Include: []string{"user?"}}
+		o := &pistachio.FilterOptions{Include: []string{"user?"}}
 		assert.True(t, o.MatchName("users"))
 		assert.False(t, o.MatchName("user_roles"))
 	})
@@ -118,10 +118,9 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Include:    []string{"users"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"users"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -148,10 +147,9 @@ CREATE TABLE public.posts (
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Exclude:    []string{"posts"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude:    []string{"posts"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -181,10 +179,9 @@ CREATE TABLE public.posts (
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Include:    []string{"user*"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"user*"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -239,10 +236,9 @@ CREATE VIEW public.tmp_view AS SELECT 1;`)
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Exclude:    []string{"tmp_*"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude:    []string{"tmp_*"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -280,10 +276,9 @@ CREATE TABLE public.posts (
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Include:    []string{"users"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"users"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
@@ -320,10 +315,9 @@ CREATE TABLE public.posts (
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Exclude:    []string{"posts"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Exclude:    []string{"posts"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
@@ -342,10 +336,9 @@ CREATE TYPE public.role AS ENUM ('admin', 'user');`)
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Include:    []string{"status"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"status"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -365,10 +358,9 @@ CREATE TYPE public.role AS ENUM ('admin', 'user');`)
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Exclude:    []string{"role"},
 	})
 
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{FilterOptions: pistachio.FilterOptions{Exclude:    []string{"role"}}})
 	require.NoError(t, err)
 
 	output := got.String()
@@ -392,10 +384,9 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Include:    []string{"status"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"status"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';")
@@ -418,10 +409,9 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Include:    []string{"status"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"status"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: only status should have the new value
@@ -468,10 +458,9 @@ CREATE TABLE public.posts (
 	client := pistachio.NewClient(&pistachio.Options{
 		ConnString: conn.Config().ConnString(),
 		Schemas:    []string{"public"},
-		Include:    []string{"users"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{FilterOptions: pistachio.FilterOptions{Include:    []string{"users"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: only users should have the new column

--- a/options.go
+++ b/options.go
@@ -38,6 +38,10 @@ func (f *FilterOptions) MatchName(name string) bool {
 	return true
 }
 
+func (f *FilterOptions) AfterApply() error {
+	return f.ValidatePatterns()
+}
+
 func (f *FilterOptions) ValidatePatterns() error {
 	for _, pattern := range f.Include {
 		if _, err := path.Match(pattern, ""); err != nil {

--- a/options.go
+++ b/options.go
@@ -10,14 +10,17 @@ type Options struct {
 	Password   string            `env:"PIST_PASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PGSCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
-	Include    []string          `short:"I" help:"Include only tables/views/enums matching the pattern (wildcard: *, ?)."`
-	Exclude    []string          `short:"E" help:"Exclude tables/views/enums matching the pattern (wildcard: *, ?)."`
 }
 
-func (o *Options) MatchName(name string) bool {
-	if len(o.Include) > 0 {
+type FilterOptions struct {
+	Include []string `short:"I" help:"Include only tables/views/enums matching the pattern (wildcard: *, ?)."`
+	Exclude []string `short:"E" help:"Exclude tables/views/enums matching the pattern (wildcard: *, ?)."`
+}
+
+func (f *FilterOptions) MatchName(name string) bool {
+	if len(f.Include) > 0 {
 		matched := false
-		for _, pattern := range o.Include {
+		for _, pattern := range f.Include {
 			if ok, _ := path.Match(pattern, name); ok {
 				matched = true
 				break
@@ -27,7 +30,7 @@ func (o *Options) MatchName(name string) bool {
 			return false
 		}
 	}
-	for _, pattern := range o.Exclude {
+	for _, pattern := range f.Exclude {
 		if ok, _ := path.Match(pattern, name); ok {
 			return false
 		}
@@ -35,25 +38,22 @@ func (o *Options) MatchName(name string) bool {
 	return true
 }
 
-func (o *Options) AfterApply() error {
-	if err := o.ValidateSchemaMap(); err != nil {
-		return err
-	}
-	return o.ValidatePatterns()
-}
-
-func (o *Options) ValidatePatterns() error {
-	for _, pattern := range o.Include {
+func (f *FilterOptions) ValidatePatterns() error {
+	for _, pattern := range f.Include {
 		if _, err := path.Match(pattern, ""); err != nil {
 			return fmt.Errorf("invalid --include pattern %q: %w", pattern, err)
 		}
 	}
-	for _, pattern := range o.Exclude {
+	for _, pattern := range f.Exclude {
 		if _, err := path.Match(pattern, ""); err != nil {
 			return fmt.Errorf("invalid --exclude pattern %q: %w", pattern, err)
 		}
 	}
 	return nil
+}
+
+func (o *Options) AfterApply() error {
+	return o.ValidateSchemaMap()
 }
 
 func (o *Options) ValidateSchemaMap() error {

--- a/plan.go
+++ b/plan.go
@@ -12,6 +12,7 @@ import (
 )
 
 type PlanOptions struct {
+	FilterOptions
 	Files      []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQLFile string   `type:"path" help:"Path to a SQL file to execute before applying changes."`
 }
@@ -48,19 +49,19 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	enumDiff, err := diff.DiffEnums(client.filterEnums(currentEnums), client.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
 	if err != nil {
 		return "", err
 	}
 	stmts := enumDiff.Stmts
 
-	tableStmts, err := diff.DiffTables(client.filterTables(currentTables), client.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	if err != nil {
 		return "", fmt.Errorf("failed to diff tables: %w", err)
 	}
 	stmts = append(stmts, tableStmts...)
 
-	viewStmts, err := diff.DiffViews(client.filterViews(currentViews), client.filterViews(client.reverseRemapViewSchemas(desired.Views)))
+	viewStmts, err := diff.DiffViews(options.filterViews(currentViews), options.filterViews(client.reverseRemapViewSchemas(desired.Views)))
 	if err != nil {
 		return "", fmt.Errorf("failed to diff views: %w", err)
 	}


### PR DESCRIPTION
Include/Exclude filters are now per-subcommand (dump, plan, apply) via FilterOptions, instead of global flags. This prevents fmt from implicitly filtering objects and makes the CLI behavior more predictable.