### PR TITLE
Support domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,15 @@ pist apply ./schema/*.sql         # apply it
 
 ## Supported Objects
 
+- Domain types (`CREATE DOMAIN`, `ALTER DOMAIN SET/DROP DEFAULT`, `SET/DROP NOT NULL`, `ADD/DROP CONSTRAINT`)
 - Enum types (`CREATE TYPE ... AS ENUM`, `ALTER TYPE ... ADD VALUE`)
 - Tables (including unlogged and partitioned tables)
 - Views
 - Columns (serial/bigserial/smallserial, identity, generated)
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
-- Comments (on tables, columns, views, types)
-- Renaming (tables, views, enums, columns, constraints, foreign keys, indexes via `-- pist:rename-from` directive)
+- Comments (on tables, columns, views, types, domains)
+- Renaming (tables, views, enums, domains, columns, constraints, foreign keys, indexes via `-- pist:rename-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 

--- a/apply.go
+++ b/apply.go
@@ -45,16 +45,27 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to fetch enums: %w", err)
 	}
 
+	currentDomains, err := cat.Domains(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch domains: %w", err)
+	}
+
 	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
+	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)))
+	if err != nil {
+		return fmt.Errorf("failed to diff domains: %w", err)
+	}
+	stmts := domainDiff.Stmts
+
 	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
 	if err != nil {
 		return err
 	}
-	stmts := enumDiff.Stmts
+	stmts = append(stmts, enumDiff.Stmts...)
 
 	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	if err != nil {
@@ -69,6 +80,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	stmts = append(stmts, viewStmts...)
 
 	stmts = append(stmts, enumDiff.DropStmts...)
+	stmts = append(stmts, domainDiff.DropStmts...)
 
 	var preSQL string
 	if options.PreSQLFile != "" {

--- a/apply.go
+++ b/apply.go
@@ -55,17 +55,17 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)))
-	if err != nil {
-		return fmt.Errorf("failed to diff domains: %w", err)
-	}
-	stmts := domainDiff.Stmts
-
 	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
 	if err != nil {
 		return err
 	}
-	stmts = append(stmts, enumDiff.Stmts...)
+	stmts := enumDiff.Stmts
+
+	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)))
+	if err != nil {
+		return fmt.Errorf("failed to diff domains: %w", err)
+	}
+	stmts = append(stmts, domainDiff.Stmts...)
 
 	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	if err != nil {
@@ -79,8 +79,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	}
 	stmts = append(stmts, viewStmts...)
 
-	stmts = append(stmts, enumDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
+	stmts = append(stmts, enumDiff.DropStmts...)
 
 	var preSQL string
 	if options.PreSQLFile != "" {

--- a/catalog/domains.go
+++ b/catalog/domains.go
@@ -1,0 +1,146 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func (c *Catalog) Domains(ctx context.Context) (*orderedmap.Map[string, *model.Domain], error) {
+	domains, err := c.ListDomains(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	domainByKey := orderedmap.New[string, *model.Domain]()
+	for _, d := range domains {
+		domainByKey.Set(d.FQDN(), d)
+	}
+
+	return domainByKey, nil
+}
+
+func (c *Catalog) ListDomains(ctx context.Context) ([]*model.Domain, error) {
+	q := `
+		WITH
+			dependency_extension AS (
+				SELECT DISTINCT
+					d.objid
+				FROM
+					pg_catalog.pg_depend d
+				WHERE
+					d.deptype = 'e'
+			)
+		SELECT
+			t.oid,
+			n.nspname,
+			t.typname,
+			pg_catalog.format_type(t.typbasetype, t.typtypmod) AS base_type,
+			t.typnotnull,
+			pg_catalog.pg_get_expr(t.typdefaultbin, 0) AS default_value,
+			(SELECT c.collname FROM pg_catalog.pg_collation c WHERE c.oid = t.typcollation AND t.typcollation <> 0) AS collation,
+			d.description
+		FROM
+			pg_catalog.pg_type t
+			JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+			LEFT JOIN pg_catalog.pg_description d ON d.objoid = t.oid
+			AND d.classoid = 'pg_type'::regclass
+			AND d.objsubid = 0
+			LEFT JOIN dependency_extension de ON de.objid = t.oid
+		WHERE
+			t.typtype = 'd'
+			AND n.nspname = ANY(@schemas)
+			AND de.objid IS NULL
+		ORDER BY
+			n.nspname,
+			t.typname
+	`
+
+	args := pgx.NamedArgs{
+		"schemas": c.schemas,
+	}
+
+	rows, err := c.conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get domain info: %w", err)
+	}
+	defer rows.Close()
+
+	var domains []*model.Domain
+	for rows.Next() {
+		var d model.Domain
+		err := rows.Scan(
+			&d.OID,
+			&d.Schema,
+			&d.Name,
+			&d.BaseType,
+			&d.NotNull,
+			&d.Default,
+			&d.Collation,
+			&d.Comment,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("catalog: failed to scan domain info: %w", err)
+		}
+		domains = append(domains, &d)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: failed to scan domain info rows: %w", err)
+	}
+
+	// Fetch constraints for each domain
+	for _, d := range domains {
+		constraints, err := c.listDomainConstraints(ctx, d.OID)
+		if err != nil {
+			return nil, err
+		}
+		d.Constraints = constraints
+	}
+
+	return domains, nil
+}
+
+func (c *Catalog) listDomainConstraints(ctx context.Context, domainOID uint32) ([]*model.DomainConstraint, error) {
+	q := `
+		SELECT
+			con.conname,
+			pg_catalog.pg_get_constraintdef(con.oid) AS definition
+		FROM
+			pg_catalog.pg_constraint con
+		WHERE
+			con.contypid = @oid
+			AND con.contype = 'c'
+		ORDER BY
+			con.conname
+	`
+
+	args := pgx.NamedArgs{
+		"oid": domainOID,
+	}
+
+	rows, err := c.conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get domain constraints: %w", err)
+	}
+	defer rows.Close()
+
+	var constraints []*model.DomainConstraint
+	for rows.Next() {
+		var dc model.DomainConstraint
+		err := rows.Scan(&dc.Name, &dc.Definition)
+		if err != nil {
+			return nil, fmt.Errorf("catalog: failed to scan domain constraint: %w", err)
+		}
+		constraints = append(constraints, &dc)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: failed to scan domain constraint rows: %w", err)
+	}
+
+	return constraints, nil
+}

--- a/catalog/domains.go
+++ b/catalog/domains.go
@@ -41,7 +41,7 @@ func (c *Catalog) ListDomains(ctx context.Context) ([]*model.Domain, error) {
 			pg_catalog.format_type(t.typbasetype, t.typtypmod) AS base_type,
 			t.typnotnull,
 			pg_catalog.pg_get_expr(t.typdefaultbin, 0) AS default_value,
-			(SELECT cn.nspname || '.' || c.collname FROM pg_catalog.pg_collation c JOIN pg_catalog.pg_namespace cn ON cn.oid = c.collnamespace WHERE c.oid = t.typcollation AND t.typcollation <> 0) AS collation,
+			(SELECT cn.nspname || '.' || c.collname FROM pg_catalog.pg_collation c JOIN pg_catalog.pg_namespace cn ON cn.oid = c.collnamespace WHERE c.oid = t.typcollation AND t.typcollation <> 0 AND c.collname <> 'default') AS collation,
 			d.description
 		FROM
 			pg_catalog.pg_type t

--- a/catalog/domains.go
+++ b/catalog/domains.go
@@ -41,7 +41,7 @@ func (c *Catalog) ListDomains(ctx context.Context) ([]*model.Domain, error) {
 			pg_catalog.format_type(t.typbasetype, t.typtypmod) AS base_type,
 			t.typnotnull,
 			pg_catalog.pg_get_expr(t.typdefaultbin, 0) AS default_value,
-			(SELECT c.collname FROM pg_catalog.pg_collation c WHERE c.oid = t.typcollation AND t.typcollation <> 0) AS collation,
+			(SELECT cn.nspname || '.' || c.collname FROM pg_catalog.pg_collation c JOIN pg_catalog.pg_namespace cn ON cn.oid = c.collnamespace WHERE c.oid = t.typcollation AND t.typcollation <> 0) AS collation,
 			d.description
 		FROM
 			pg_catalog.pg_type t

--- a/catalog/domains_test.go
+++ b/catalog/domains_test.go
@@ -1,0 +1,76 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/catalog"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+func TestDomains(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	t.Run("empty", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, "")
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		domains, err := cat.Domains(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, domains.Len())
+	})
+
+	t.Run("simple domain", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		domains, err := cat.Domains(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 1, domains.Len())
+
+		d, ok := domains.GetOk("public.pos_int")
+		require.True(t, ok)
+		assert.Equal(t, "pos_int", d.Name)
+		assert.Equal(t, "public", d.Schema)
+		assert.Equal(t, "integer", d.BaseType)
+		assert.Len(t, d.Constraints, 1)
+		assert.Equal(t, "pos_check", d.Constraints[0].Name)
+	})
+
+	t.Run("domain with default and not null", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE DOMAIN public.email AS varchar(255) NOT NULL DEFAULT ''::varchar;
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		domains, err := cat.Domains(ctx)
+		require.NoError(t, err)
+
+		d := domains.Get("public.email")
+		require.NotNil(t, d)
+		assert.True(t, d.NotNull)
+		require.NotNil(t, d.Default)
+	})
+
+	t.Run("domain with comment", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE DOMAIN public.pos_int AS integer;
+			COMMENT ON DOMAIN public.pos_int IS 'Positive integer';
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		domains, err := cat.Domains(ctx)
+		require.NoError(t, err)
+
+		d := domains.Get("public.pos_int")
+		require.NotNil(t, d)
+		require.NotNil(t, d.Comment)
+		assert.Equal(t, "Positive integer", *d.Comment)
+	})
+}

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -65,6 +65,11 @@ func diffDomain(fqdn string, current, desired *model.Domain) ([]string, error) {
 		return nil, fmt.Errorf("cannot change base type of domain %s from %s to %s: PostgreSQL does not support this", fqdn, current.BaseType, desired.BaseType)
 	}
 
+	// Collation change is not supported by PostgreSQL ALTER DOMAIN
+	if !equalPtr(current.Collation, desired.Collation) {
+		return nil, fmt.Errorf("cannot change collation of domain %s: PostgreSQL does not support this", fqdn)
+	}
+
 	// Default change (use AST comparison to handle type alias differences)
 	if !equalDefault(current.Default, desired.Default) {
 		if desired.Default != nil {
@@ -168,7 +173,6 @@ func detectDomainRenames(current, desired *orderedmap.Map[string, *model.Domain]
 		adjusted.Delete(oldKey)
 		renamed := *oldDomain
 		renamed.Name = desiredDomain.Name
-		// Deep copy constraints
 		renamed.Constraints = slices.Clone(oldDomain.Constraints)
 		adjusted.Set(newKey, &renamed)
 	}

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -1,0 +1,177 @@
+package diff
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+type DomainDiffResult struct {
+	Stmts     []string
+	DropStmts []string
+}
+
+func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain]) (*DomainDiffResult, error) {
+	result := &DomainDiffResult{}
+
+	// Detect renames
+	renameStmts, current, err := detectDomainRenames(current, desired)
+	if err != nil {
+		return nil, err
+	}
+	result.Stmts = append(result.Stmts, renameStmts...)
+
+	// New domains
+	for k, desiredDomain := range desired.All() {
+		if _, ok := current.GetOk(k); !ok {
+			result.Stmts = append(result.Stmts, desiredDomain.SQL())
+			if commentSQL := desiredDomain.CommentSQL(); commentSQL != "" {
+				result.Stmts = append(result.Stmts, commentSQL)
+			}
+		}
+	}
+
+	// Modified domains
+	for k, desiredDomain := range desired.All() {
+		currentDomain, ok := current.GetOk(k)
+		if !ok {
+			continue
+		}
+
+		stmts, err := diffDomain(k, currentDomain, desiredDomain)
+		if err != nil {
+			return nil, err
+		}
+		result.Stmts = append(result.Stmts, stmts...)
+	}
+
+	// Dropped domains
+	for k := range current.Keys() {
+		if _, ok := desired.GetOk(k); !ok {
+			result.DropStmts = append(result.DropStmts, "DROP DOMAIN "+k+";")
+		}
+	}
+
+	return result, nil
+}
+
+func diffDomain(fqdn string, current, desired *model.Domain) ([]string, error) {
+	var stmts []string
+
+	// Base type change is not supported by PostgreSQL ALTER DOMAIN
+	if current.BaseType != desired.BaseType {
+		return nil, fmt.Errorf("cannot change base type of domain %s from %s to %s: PostgreSQL does not support this", fqdn, current.BaseType, desired.BaseType)
+	}
+
+	// Default change (use AST comparison to handle type alias differences)
+	if !equalDefault(current.Default, desired.Default) {
+		if desired.Default != nil {
+			stmts = append(stmts, "ALTER DOMAIN "+fqdn+" SET DEFAULT "+*desired.Default+";")
+		} else {
+			stmts = append(stmts, "ALTER DOMAIN "+fqdn+" DROP DEFAULT;")
+		}
+	}
+
+	// NOT NULL change
+	if current.NotNull != desired.NotNull {
+		if desired.NotNull {
+			stmts = append(stmts, "ALTER DOMAIN "+fqdn+" SET NOT NULL;")
+		} else {
+			stmts = append(stmts, "ALTER DOMAIN "+fqdn+" DROP NOT NULL;")
+		}
+	}
+
+	// Constraint changes
+	stmts = append(stmts, diffDomainConstraints(fqdn, current.Constraints, desired.Constraints)...)
+
+	// Comment change
+	if !equalPtr(current.Comment, desired.Comment) {
+		if desired.Comment != nil {
+			stmts = append(stmts, "COMMENT ON DOMAIN "+fqdn+" IS "+model.QuoteLiteral(*desired.Comment)+";")
+		} else {
+			stmts = append(stmts, "COMMENT ON DOMAIN "+fqdn+" IS NULL;")
+		}
+	}
+
+	return stmts, nil
+}
+
+func diffDomainConstraints(fqdn string, current, desired []*model.DomainConstraint) []string {
+	var stmts []string
+
+	currentByName := make(map[string]string)
+	for _, c := range current {
+		currentByName[c.Name] = c.Definition
+	}
+
+	desiredByName := make(map[string]string)
+	for _, c := range desired {
+		desiredByName[c.Name] = c.Definition
+	}
+
+	// Drop removed or changed constraints
+	for _, c := range current {
+		desiredDef, ok := desiredByName[c.Name]
+		if !ok || !equalConstraintDef(c.Definition, desiredDef) {
+			stmts = append(stmts, "ALTER DOMAIN "+fqdn+" DROP CONSTRAINT "+model.Ident(c.Name)+";")
+		}
+	}
+
+	// Add new or changed constraints
+	for _, c := range desired {
+		currentDef, ok := currentByName[c.Name]
+		if !ok || !equalConstraintDef(currentDef, c.Definition) {
+			stmts = append(stmts, "ALTER DOMAIN "+fqdn+" ADD CONSTRAINT "+model.Ident(c.Name)+" "+c.Definition+";")
+		}
+	}
+
+	return stmts
+}
+
+// detectDomainRenames finds desired domains with RenameFrom that match a current domain.
+func detectDomainRenames(current, desired *orderedmap.Map[string, *model.Domain]) ([]string, *orderedmap.Map[string, *model.Domain], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newKey, desiredDomain := range desired.All() {
+		if desiredDomain.RenameFrom == nil {
+			continue
+		}
+		oldKey := *desiredDomain.RenameFrom
+
+		if oldKey == newKey {
+			continue
+		}
+
+		oldDomain, ok := adjusted.GetOk(oldKey)
+		if !ok {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+		}
+
+		if oldKey != newKey {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				return nil, nil, fmt.Errorf("cannot rename %s to %s: destination already exists", oldKey, newKey)
+			}
+		}
+
+		if oldDomain.Schema != desiredDomain.Schema {
+			return nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
+		}
+
+		stmts = append(stmts, "ALTER DOMAIN "+oldKey+" RENAME TO "+model.Ident(desiredDomain.Name)+";")
+
+		adjusted.Delete(oldKey)
+		renamed := *oldDomain
+		renamed.Name = desiredDomain.Name
+		// Deep copy constraints
+		renamed.Constraints = slices.Clone(oldDomain.Constraints)
+		adjusted.Set(newKey, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -122,6 +122,16 @@ func TestDiffDomains_DropConstraint(t *testing.T) {
 	assert.Contains(t, result.Stmts[0], "DROP CONSTRAINT pos_check")
 }
 
+func TestDiffDomains_CollationChange_Error(t *testing.T) {
+	colA := "pg_catalog.C"
+	colB := "pg_catalog.POSIX"
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "name", BaseType: "text", Collation: &colA})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "name", BaseType: "text", Collation: &colB})
+	_, err := diff.DiffDomains(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot change collation")
+}
+
 func TestDiffDomains_BaseTypeChange_Error(t *testing.T) {
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "bigint"})

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -1,0 +1,197 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/diff"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func newDomainMap(domains ...*model.Domain) *orderedmap.Map[string, *model.Domain] {
+	m := orderedmap.New[string, *model.Domain]()
+	for _, d := range domains {
+		m.Set(d.FQDN(), d)
+	}
+	return m
+}
+
+func TestDiffDomains_CreateNew(t *testing.T) {
+	current := newDomainMap()
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Len(t, result.Stmts, 1)
+	assert.Contains(t, result.Stmts[0], "CREATE DOMAIN public.pos_int AS integer")
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffDomains_CreateWithComment(t *testing.T) {
+	comment := "Positive int"
+	current := newDomainMap()
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Comment: &comment})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Len(t, result.Stmts, 2)
+	assert.Contains(t, result.Stmts[1], "COMMENT ON DOMAIN")
+}
+
+func TestDiffDomains_Drop(t *testing.T) {
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap()
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Equal(t, []string{"DROP DOMAIN public.pos_int;"}, result.DropStmts)
+}
+
+func TestDiffDomains_NoDiff(t *testing.T) {
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffDomains_SetDefault(t *testing.T) {
+	def := "0"
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Default: &def})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int SET DEFAULT 0;"}, result.Stmts)
+}
+
+func TestDiffDomains_DropDefault(t *testing.T) {
+	def := "0"
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Default: &def})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int DROP DEFAULT;"}, result.Stmts)
+}
+
+func TestDiffDomains_SetNotNull(t *testing.T) {
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", NotNull: true})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int SET NOT NULL;"}, result.Stmts)
+}
+
+func TestDiffDomains_DropNotNull(t *testing.T) {
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", NotNull: true})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int DROP NOT NULL;"}, result.Stmts)
+}
+
+func TestDiffDomains_AddConstraint(t *testing.T) {
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{
+		Schema:   "public",
+		Name:     "pos_int",
+		BaseType: "integer",
+		Constraints: []*model.DomainConstraint{
+			{Name: "pos_check", Definition: "CHECK (VALUE > 0)"},
+		},
+	})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Len(t, result.Stmts, 1)
+	assert.Contains(t, result.Stmts[0], "ADD CONSTRAINT pos_check")
+}
+
+func TestDiffDomains_DropConstraint(t *testing.T) {
+	current := newDomainMap(&model.Domain{
+		Schema:   "public",
+		Name:     "pos_int",
+		BaseType: "integer",
+		Constraints: []*model.DomainConstraint{
+			{Name: "pos_check", Definition: "CHECK (VALUE > 0)"},
+		},
+	})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Len(t, result.Stmts, 1)
+	assert.Contains(t, result.Stmts[0], "DROP CONSTRAINT pos_check")
+}
+
+func TestDiffDomains_BaseTypeChange_Error(t *testing.T) {
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "bigint"})
+	_, err := diff.DiffDomains(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot change base type")
+}
+
+func TestDiffDomains_AddComment(t *testing.T) {
+	comment := "Positive int"
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Comment: &comment})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"COMMENT ON DOMAIN public.pos_int IS 'Positive int';"}, result.Stmts)
+}
+
+func TestDiffDomains_DropComment(t *testing.T) {
+	comment := "Positive int"
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Comment: &comment})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"COMMENT ON DOMAIN public.pos_int IS NULL;"}, result.Stmts)
+}
+
+func TestDiffDomains_Rename(t *testing.T) {
+	oldName := "public.pos_int"
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "positive_int", RenameFrom: &oldName, BaseType: "integer"})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int RENAME TO positive_int;"}, result.Stmts)
+}
+
+func TestDiffDomains_Rename_AlreadyApplied(t *testing.T) {
+	oldName := "public.old"
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "positive_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "positive_int", RenameFrom: &oldName, BaseType: "integer"})
+	result, err := diff.DiffDomains(current, desired)
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+}
+
+func TestDiffDomains_Rename_SourceNotFound(t *testing.T) {
+	oldName := "public.nonexistent"
+	current := newDomainMap()
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", RenameFrom: &oldName, BaseType: "integer"})
+	_, err := diff.DiffDomains(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source")
+}
+
+func TestDiffDomains_Rename_CrossSchema_Error(t *testing.T) {
+	oldName := "other.pos_int"
+	current := newDomainMap(&model.Domain{Schema: "other", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", RenameFrom: &oldName, BaseType: "integer"})
+	_, err := diff.DiffDomains(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-schema rename")
+}
+
+func TestDiffDomains_Rename_DestinationExists_Error(t *testing.T) {
+	oldName := "public.pos_int"
+	current := newDomainMap(
+		&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"},
+		&model.Domain{Schema: "public", Name: "positive_int", BaseType: "integer"},
+	)
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "positive_int", RenameFrom: &oldName, BaseType: "integer"})
+	_, err := diff.DiffDomains(current, desired)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}

--- a/dump.go
+++ b/dump.go
@@ -20,6 +20,7 @@ type DumpResult struct {
 	Tables     *orderedmap.Map[string, *model.Table]
 	Views      *orderedmap.Map[string, *model.View]
 	Enums      *orderedmap.Map[string, *model.Enum]
+	Domains    *orderedmap.Map[string, *model.Domain]
 	OmitSchema bool
 }
 
@@ -86,8 +87,24 @@ func (r *DumpResult) enums() *orderedmap.Map[string, *model.Enum] {
 	return enums
 }
 
+func (r *DumpResult) domains() *orderedmap.Map[string, *model.Domain] {
+	if r.Domains == nil {
+		return orderedmap.New[string, *model.Domain]()
+	}
+	if !r.OmitSchema {
+		return r.Domains
+	}
+	domains := orderedmap.New[string, *model.Domain]()
+	for _, d := range r.Domains.CollectValues() {
+		copied := *d
+		copied.Schema = ""
+		domains.Set(d.FQDN(), &copied)
+	}
+	return domains
+}
+
 func (r *DumpResult) String() string {
-	return formatSchemaSQL(r.enums(), r.tables(), r.views())
+	return formatSchemaSQL(r.domains(), r.enums(), r.tables(), r.views())
 }
 
 func (r *DumpResult) Files() map[string]string {
@@ -96,6 +113,11 @@ func (r *DumpResult) Files() map[string]string {
 	for _, e := range r.enums().CollectValues() {
 		name := uniqueFileName(seen, toFileName(e.Schema, e.Name))
 		files[name] = model.EnumToSQL(e) + "\n"
+		seen[strings.ToLower(name)] = true
+	}
+	for _, d := range r.domains().CollectValues() {
+		name := uniqueFileName(seen, toFileName(d.Schema, d.Name))
+		files[name] = model.DomainToSQL(d) + "\n"
 		seen[strings.ToLower(name)] = true
 	}
 	for _, t := range r.tables().CollectValues() {
@@ -169,10 +191,16 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 		return nil, fmt.Errorf("failed to fetch enums: %w", err)
 	}
 
+	domains, err := catalog.Domains(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch domains: %w", err)
+	}
+
 	return &DumpResult{
 		Tables:     options.filterTables(client.remapTableSchemas(tables)),
 		Views:      options.filterViews(client.remapViewSchemas(views)),
 		Enums:      options.filterEnums(client.remapEnumSchemas(enums)),
+		Domains:    options.filterDomains(client.remapDomainSchemas(domains)),
 		OmitSchema: options.OmitSchema,
 	}, nil
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -313,6 +313,26 @@ COMMENT ON TYPE public.status IS 'User status';`)
 	assert.Contains(t, s, "COMMENT ON TYPE status")
 }
 
+func TestDumpResult_OmitSchema_Domain(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "CREATE DOMAIN pos_int AS integer")
+	assert.NotContains(t, s, "public.pos_int")
+}
+
 func TestDumpResult_OmitSchema_Enum_Files(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/dump_test.go
+++ b/dump_test.go
@@ -2,6 +2,7 @@ package pistachio_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -331,6 +332,58 @@ CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);`
 	s := got.String()
 	assert.Contains(t, s, "CREATE DOMAIN pos_int AS integer")
 	assert.NotContains(t, s, "public.pos_int")
+}
+
+func TestDump_Domain_DefaultCollationExcluded(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE DOMAIN public.email AS varchar(255) NOT NULL DEFAULT ''::varchar;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	s := got.String()
+	assert.Contains(t, s, "CREATE DOMAIN public.email")
+	assert.NotContains(t, s, "COLLATE")
+	assert.NotContains(t, s, "default")
+}
+
+func TestDump_Domain_OmitSchema_PlanNoDiff(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+CREATE DOMAIN public.email AS varchar(255) NOT NULL DEFAULT ''::varchar;
+CREATE TABLE public.users (
+    id pos_int NOT NULL,
+    email email NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// Dump with omit-schema, then plan should have no diff
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+
+	tmpFile := filepath.Join(t.TempDir(), "schema.sql")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(got.String()), 0o644))
+
+	plan, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{tmpFile}})
+	require.NoError(t, err)
+	assert.Empty(t, plan)
 }
 
 func TestDumpResult_OmitSchema_Enum_Files(t *testing.T) {

--- a/filter.go
+++ b/filter.go
@@ -46,3 +46,17 @@ func (f *FilterOptions) filterEnums(enums *orderedmap.Map[string, *model.Enum]) 
 	}
 	return filtered
 }
+
+func (f *FilterOptions) filterDomains(domains *orderedmap.Map[string, *model.Domain]) *orderedmap.Map[string, *model.Domain] {
+	if len(f.Include) == 0 && len(f.Exclude) == 0 {
+		return domains
+	}
+
+	filtered := orderedmap.New[string, *model.Domain]()
+	for k, d := range domains.All() {
+		if f.MatchName(d.Name) {
+			filtered.Set(k, d)
+		}
+	}
+	return filtered
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -433,6 +433,29 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 	assert.NotContains(t, output, "'guest'")
 }
 
+func TestDump_IncludeDomain(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+CREATE DOMAIN public.email AS varchar(255);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{
+		FilterOptions: pistachio.FilterOptions{Include: []string{"pos_int"}},
+	})
+	require.NoError(t, err)
+	output := got.String()
+	assert.Contains(t, output, "public.pos_int")
+	assert.NotContains(t, output, "public.email")
+}
+
 func TestApply_Include(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/fmt.go
+++ b/fmt.go
@@ -35,8 +35,9 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 	return results, nil
 }
 
-// formatSchemaSQL formats enums, tables, and views into canonical SQL output.
+// formatSchemaSQL formats domains, enums, tables, and views into canonical SQL output.
 // This is the shared formatting logic used by both dump and fmt.
+// Order: enums → domains → tables → views (enums first since domains may depend on them).
 func formatSchemaSQL(
 	domains *orderedmap.Map[string, *model.Domain],
 	enums *orderedmap.Map[string, *model.Enum],
@@ -44,11 +45,11 @@ func formatSchemaSQL(
 	views *orderedmap.Map[string, *model.View],
 ) string {
 	var parts []string
-	if domains != nil && domains.Len() > 0 {
-		parts = append(parts, model.DomainsToSQL(domains))
-	}
 	if enums != nil && enums.Len() > 0 {
 		parts = append(parts, model.EnumsToSQL(enums))
+	}
+	if domains != nil && domains.Len() > 0 {
+		parts = append(parts, model.DomainsToSQL(domains))
 	}
 	if tables != nil && tables.Len() > 0 {
 		parts = append(parts, model.TablesToSQL(tables))

--- a/fmt.go
+++ b/fmt.go
@@ -29,7 +29,7 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse SQL file %q: %w", path, err)
 		}
-		results[path] = formatSchemaSQL(result.Enums, result.Tables, result.Views)
+		results[path] = formatSchemaSQL(result.Domains, result.Enums, result.Tables, result.Views)
 	}
 
 	return results, nil
@@ -38,11 +38,15 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 // formatSchemaSQL formats enums, tables, and views into canonical SQL output.
 // This is the shared formatting logic used by both dump and fmt.
 func formatSchemaSQL(
+	domains *orderedmap.Map[string, *model.Domain],
 	enums *orderedmap.Map[string, *model.Enum],
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
 ) string {
 	var parts []string
+	if domains != nil && domains.Len() > 0 {
+		parts = append(parts, model.DomainsToSQL(domains))
+	}
 	if enums != nil && enums.Len() > 0 {
 		parts = append(parts, model.EnumsToSQL(enums))
 	}

--- a/model/domain.go
+++ b/model/domain.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"strings"
+
+	"github.com/winebarrel/orderedmap"
+)
+
+type DomainConstraint struct {
+	Name       string
+	Definition string
+}
+
+type Domain struct {
+	OID         uint32
+	Schema      string
+	Name        string
+	RenameFrom  *string
+	BaseType    string
+	NotNull     bool
+	Default     *string
+	Collation   *string
+	Constraints []*DomainConstraint
+	Comment     *string
+}
+
+func (d Domain) FQDN() string {
+	return Ident(d.Schema, d.Name)
+}
+
+func (d Domain) SQL() string {
+	sql := "CREATE DOMAIN " + Ident(d.Schema, d.Name) + " AS " + d.BaseType
+
+	if d.Collation != nil {
+		sql += " COLLATE " + Ident(*d.Collation)
+	}
+
+	if d.Default != nil {
+		sql += " DEFAULT " + *d.Default
+	}
+
+	if d.NotNull {
+		sql += " NOT NULL"
+	}
+
+	for _, c := range d.Constraints {
+		sql += "\n    CONSTRAINT " + Ident(c.Name) + " " + c.Definition
+	}
+
+	return sql + ";"
+}
+
+func (d Domain) CommentSQL() string {
+	if d.Comment != nil {
+		return "COMMENT ON DOMAIN " + Ident(d.Schema, d.Name) + " IS " + QuoteLiteral(*d.Comment) + ";"
+	}
+	return ""
+}
+
+func DomainToSQL(d *Domain) string {
+	parts := []string{"-- " + d.FQDN(), d.SQL()}
+	if s := d.CommentSQL(); s != "" {
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func DomainsToSQL(domains *orderedmap.Map[string, *Domain]) string {
+	return strings.Join(
+		orderedmap.TransformSlice(domains, func(_ string, d *Domain) string {
+			return DomainToSQL(d)
+		}),
+		"\n\n",
+	)
+}

--- a/model/domain.go
+++ b/model/domain.go
@@ -32,7 +32,13 @@ func (d Domain) SQL() string {
 	sql := "CREATE DOMAIN " + Ident(d.Schema, d.Name) + " AS " + d.BaseType
 
 	if d.Collation != nil {
-		sql += " COLLATE " + Ident(*d.Collation)
+		// Collation may be schema-qualified (e.g. "pg_catalog.default")
+		parts := strings.Split(*d.Collation, ".")
+		quotedParts := make([]string, len(parts))
+		for i, p := range parts {
+			quotedParts[i] = Ident(p)
+		}
+		sql += " COLLATE " + strings.Join(quotedParts, ".")
 	}
 
 	if d.Default != nil {

--- a/model/domain_test.go
+++ b/model/domain_test.go
@@ -1,0 +1,83 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestDomain_FQDN(t *testing.T) {
+	d := &model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"}
+	assert.Equal(t, "public.pos_int", d.FQDN())
+}
+
+func TestDomain_SQL_Simple(t *testing.T) {
+	d := &model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"}
+	assert.Equal(t, "CREATE DOMAIN public.pos_int AS integer;", d.SQL())
+}
+
+func TestDomain_SQL_WithDefault(t *testing.T) {
+	def := "0"
+	d := &model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Default: &def}
+	assert.Contains(t, d.SQL(), "DEFAULT 0")
+}
+
+func TestDomain_SQL_WithNotNull(t *testing.T) {
+	d := &model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", NotNull: true}
+	assert.Contains(t, d.SQL(), "NOT NULL")
+}
+
+func TestDomain_SQL_WithCollation(t *testing.T) {
+	col := "en_US"
+	d := &model.Domain{Schema: "public", Name: "name", BaseType: "text", Collation: &col}
+	assert.Contains(t, d.SQL(), `COLLATE "en_US"`)
+}
+
+func TestDomain_SQL_WithConstraint(t *testing.T) {
+	d := &model.Domain{
+		Schema:   "public",
+		Name:     "pos_int",
+		BaseType: "integer",
+		Constraints: []*model.DomainConstraint{
+			{Name: "pos_check", Definition: "CHECK (VALUE > 0)"},
+		},
+	}
+	sql := d.SQL()
+	assert.Contains(t, sql, "CONSTRAINT pos_check CHECK (VALUE > 0)")
+}
+
+func TestDomain_CommentSQL(t *testing.T) {
+	comment := "Positive integer"
+	d := &model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Comment: &comment}
+	assert.Equal(t, "COMMENT ON DOMAIN public.pos_int IS 'Positive integer';", d.CommentSQL())
+}
+
+func TestDomain_CommentSQL_NoComment(t *testing.T) {
+	d := &model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"}
+	assert.Equal(t, "", d.CommentSQL())
+}
+
+func TestDomainToSQL(t *testing.T) {
+	comment := "Positive integer"
+	d := &model.Domain{
+		Schema:   "public",
+		Name:     "pos_int",
+		BaseType: "integer",
+		Comment:  &comment,
+	}
+	sql := model.DomainToSQL(d)
+	assert.Contains(t, sql, "-- public.pos_int")
+	assert.Contains(t, sql, "CREATE DOMAIN public.pos_int AS integer;")
+	assert.Contains(t, sql, "COMMENT ON DOMAIN")
+}
+
+func TestDomainsToSQL(t *testing.T) {
+	domains := orderedmap.New[string, *model.Domain]()
+	domains.Set("public.pos_int", &model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	domains.Set("public.email", &model.Domain{Schema: "public", Name: "email", BaseType: "text"})
+	sql := model.DomainsToSQL(domains)
+	assert.Contains(t, sql, "public.pos_int")
+	assert.Contains(t, sql, "public.email")
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11,9 +11,10 @@ import (
 )
 
 type ParseResult struct {
-	Tables *orderedmap.Map[string, *model.Table]
-	Views  *orderedmap.Map[string, *model.View]
-	Enums  *orderedmap.Map[string, *model.Enum]
+	Tables  *orderedmap.Map[string, *model.Table]
+	Views   *orderedmap.Map[string, *model.View]
+	Enums   *orderedmap.Map[string, *model.Enum]
+	Domains *orderedmap.Map[string, *model.Domain]
 }
 
 func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error {
@@ -76,6 +77,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	tables := orderedmap.New[string, *model.Table]()
 	views := orderedmap.New[string, *model.View]()
 	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
 
 	stmtDirectives := ExtractStmtDirectives(sql, result.Stmts)
 
@@ -94,6 +96,19 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				enum.RenameFrom = &qualified
 			}
 			if err := setUnique(enums, enum.FQEN(), "enum", enum); err != nil {
+				return nil, err
+			}
+
+		case node.GetCreateDomainStmt() != nil:
+			domain, err := parseCreateDomainStmt(node.GetCreateDomainStmt(), rawStmt, defaultSchema)
+			if err != nil {
+				return nil, err
+			}
+			if renameFrom != "" {
+				qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+				domain.RenameFrom = &qualified
+			}
+			if err := setUnique(domains, domain.FQDN(), "domain", domain); err != nil {
 				return nil, err
 			}
 
@@ -199,11 +214,11 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 
 		case node.GetCommentStmt() != nil:
 			cs := node.GetCommentStmt()
-			parseCommentStmt(cs, defaultSchema, tables, views, enums)
+			parseCommentStmt(cs, defaultSchema, tables, views, enums, domains)
 		}
 	}
 
-	return &ParseResult{Tables: tables, Views: views, Enums: enums}, nil
+	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains}, nil
 }
 
 func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Table, error) {
@@ -514,6 +529,160 @@ func parseViewStmt(vs *pg_query.ViewStmt, defaultSchema string) (*model.View, er
 	}, nil
 }
 
+func parseCreateDomainStmt(ds *pg_query.CreateDomainStmt, rawStmt *pg_query.RawStmt, defaultSchema string) (*model.Domain, error) {
+	schema := defaultSchema
+	name := ""
+
+	for i, n := range ds.Domainname {
+		if s := n.GetString_(); s != nil {
+			if i == len(ds.Domainname)-1 {
+				name = s.Sval
+			} else {
+				schema = s.Sval
+			}
+		}
+	}
+
+	// Deparse the full statement and extract the domain definition
+	result := &pg_query.ParseResult{
+		Stmts: []*pg_query.RawStmt{{Stmt: rawStmt.Stmt}},
+	}
+	deparsed, err := pg_query.Deparse(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deparse domain %s: %w", name, err)
+	}
+
+	// Parse the base type
+	baseType := ""
+	if ds.TypeName != nil {
+		bt, err := deparseTypeName(ds.TypeName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to deparse base type for domain %s: %w", name, err)
+		}
+		baseType = bt
+	}
+
+	domain := &model.Domain{
+		Schema:   schema,
+		Name:     name,
+		BaseType: baseType,
+	}
+
+	// Extract collation
+	if ds.CollClause != nil && len(ds.CollClause.Collname) > 0 {
+		var parts []string
+		for _, n := range ds.CollClause.Collname {
+			if s := n.GetString_(); s != nil {
+				parts = append(parts, s.Sval)
+			}
+		}
+		if len(parts) > 0 {
+			collation := strings.Join(parts, ".")
+			domain.Collation = &collation
+		}
+	}
+
+	// Extract constraints from deparsed SQL
+	// Parse the deparsed statement to get normalized constraints
+	for _, conNode := range ds.Constraints {
+		con := conNode.GetConstraint()
+		if con == nil {
+			continue
+		}
+		switch con.Contype {
+		case pg_query.ConstrType_CONSTR_NOTNULL:
+			domain.NotNull = true
+		case pg_query.ConstrType_CONSTR_DEFAULT:
+			if con.RawExpr != nil {
+				def, err := deparseExpr(con.RawExpr)
+				if err != nil {
+					return nil, fmt.Errorf("failed to deparse default for domain %s: %w", name, err)
+				}
+				domain.Default = &def
+			}
+		case pg_query.ConstrType_CONSTR_CHECK:
+			if con.Conname == "" {
+				return nil, fmt.Errorf("unnamed constraint on domain %q is not supported", name)
+			}
+			// Extract CHECK definition from the deparsed SQL
+			def := extractCheckDefFromDeparsed(deparsed, con.Conname)
+			if def == "" {
+				// Fallback: deparse the raw expression
+				if con.RawExpr != nil {
+					expr, err := deparseExpr(con.RawExpr)
+					if err != nil {
+						return nil, fmt.Errorf("failed to deparse constraint %s for domain %s: %w", con.Conname, name, err)
+					}
+					def = "CHECK (" + expr + ")"
+				}
+			}
+			domain.Constraints = append(domain.Constraints, &model.DomainConstraint{
+				Name:       con.Conname,
+				Definition: def,
+			})
+		}
+	}
+
+	return domain, nil
+}
+
+// extractCheckDefFromDeparsed extracts a CHECK constraint definition from a deparsed
+// CREATE DOMAIN statement by finding the CONSTRAINT name ... portion.
+func extractCheckDefFromDeparsed(deparsed, conName string) string {
+	marker := "CONSTRAINT " + model.Ident(conName) + " "
+	idx := strings.Index(deparsed, marker)
+	if idx == -1 {
+		return ""
+	}
+	rest := deparsed[idx+len(marker):]
+	// The CHECK definition is everything from "CHECK" to the end of the constraint
+	// which ends at the next CONSTRAINT keyword or end of statement
+	checkIdx := strings.Index(rest, "CHECK")
+	if checkIdx == -1 {
+		return ""
+	}
+	def := rest[checkIdx:]
+	// Find the end: next CONSTRAINT or end of statement
+	nextCon := strings.Index(def[1:], " CONSTRAINT ")
+	if nextCon >= 0 {
+		def = strings.TrimSpace(def[:nextCon+1])
+	} else {
+		def = strings.TrimSpace(def)
+	}
+	return def
+}
+
+func parseCommentOnDomain(cs *pg_query.CommentStmt, defaultSchema string, domains *orderedmap.Map[string, *model.Domain]) {
+	tn := cs.Object.GetTypeName()
+	if tn == nil {
+		return
+	}
+	var names []string
+	for _, n := range tn.Names {
+		if s := n.GetString_(); s != nil {
+			names = append(names, s.Sval)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	schema := defaultSchema
+	domainName := names[0]
+	if len(names) >= 2 {
+		schema = names[0]
+		domainName = names[1]
+	}
+	fqdn := model.Ident(schema, domainName)
+	if d, ok := domains.GetOk(fqdn); ok {
+		if cs.Comment != "" {
+			c := cs.Comment
+			d.Comment = &c
+		} else {
+			d.Comment = nil
+		}
+	}
+}
+
 func parseCreateEnumStmt(es *pg_query.CreateEnumStmt, defaultSchema string) (*model.Enum, error) {
 	schema := defaultSchema
 	name := ""
@@ -542,10 +711,14 @@ func parseCreateEnumStmt(es *pg_query.CreateEnumStmt, defaultSchema string) (*mo
 	}, nil
 }
 
-func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View], enums *orderedmap.Map[string, *model.Enum]) {
-	// COMMENT ON TYPE uses TypeName, not a list
+func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View], enums *orderedmap.Map[string, *model.Enum], domains *orderedmap.Map[string, *model.Domain]) {
+	// COMMENT ON TYPE/DOMAIN uses TypeName, not a list
 	if cs.Objtype == pg_query.ObjectType_OBJECT_TYPE {
 		parseCommentOnType(cs, defaultSchema, enums)
+		return
+	}
+	if cs.Objtype == pg_query.ObjectType_OBJECT_DOMAIN {
+		parseCommentOnDomain(cs, defaultSchema, domains)
 		return
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -577,8 +577,12 @@ func parseCreateDomainStmt(ds *pg_query.CreateDomainStmt, rawStmt *pg_query.RawS
 			}
 		}
 		if len(parts) > 0 {
-			collation := strings.Join(parts, ".")
-			domain.Collation = &collation
+			// Skip "default" collation (implicit for text types, excluded by catalog)
+			lastPart := parts[len(parts)-1]
+			if lastPart != "default" {
+				collation := strings.Join(parts, ".")
+				domain.Collation = &collation
+			}
 		}
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1338,6 +1338,17 @@ func TestParseSQL_DomainWithCollation(t *testing.T) {
 	assert.Equal(t, "en_US", *d.Collation)
 }
 
+func TestParseSQL_DomainDefaultCollationExcluded(t *testing.T) {
+	sql := `CREATE DOMAIN public.name AS text COLLATE "default";`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	d := result.Domains.Get("public.name")
+	require.NotNil(t, d)
+	assert.Nil(t, d.Collation)
+}
+
 func TestParseSQL_DomainCommentRemove(t *testing.T) {
 	sql := `CREATE DOMAIN public.pos_int AS integer;
 COMMENT ON DOMAIN public.pos_int IS 'Positive integer';

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1326,6 +1326,57 @@ func TestParseSQLWithSchema_Domain(t *testing.T) {
 	assert.Equal(t, "myschema", d.Schema)
 }
 
+func TestParseSQL_DomainWithCollation(t *testing.T) {
+	sql := `CREATE DOMAIN public.name AS text COLLATE "en_US";`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	d := result.Domains.Get("public.name")
+	require.NotNil(t, d)
+	require.NotNil(t, d.Collation)
+	assert.Equal(t, "en_US", *d.Collation)
+}
+
+func TestParseSQL_DomainCommentRemove(t *testing.T) {
+	sql := `CREATE DOMAIN public.pos_int AS integer;
+COMMENT ON DOMAIN public.pos_int IS 'Positive integer';
+COMMENT ON DOMAIN public.pos_int IS '';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	d := result.Domains.Get("public.pos_int")
+	require.NotNil(t, d)
+	assert.Nil(t, d.Comment)
+}
+
+func TestParseSQL_DomainMultipleConstraints(t *testing.T) {
+	sql := `CREATE DOMAIN public.bounded_int AS integer
+    CONSTRAINT min_check CHECK (VALUE >= 0)
+    CONSTRAINT max_check CHECK (VALUE <= 100);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	d := result.Domains.Get("public.bounded_int")
+	require.NotNil(t, d)
+	assert.Len(t, d.Constraints, 2)
+}
+
+func TestParseSQL_DomainRenameDirective(t *testing.T) {
+	sql := `-- pist:rename-from public.old_domain
+CREATE DOMAIN public.new_domain AS integer;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	d := result.Domains.Get("public.new_domain")
+	require.NotNil(t, d)
+	require.NotNil(t, d.RenameFrom)
+	assert.Equal(t, "public.old_domain", *d.RenameFrom)
+}
+
 func TestParseSQL_DomainUnnamedConstraint_Error(t *testing.T) {
 	sql := `CREATE DOMAIN public.pos_int AS integer CHECK (VALUE > 0);`
 	_, err := parser.ParseSQL(sql)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1273,6 +1273,74 @@ CREATE VIEW new_view AS SELECT 1;`
 	assert.Equal(t, "myschema.old_view", *v.RenameFrom)
 }
 
+func TestParseSQL_Domain(t *testing.T) {
+	sql := `CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Domains.Len())
+
+	d, ok := result.Domains.GetOk("public.pos_int")
+	require.True(t, ok)
+	assert.Equal(t, "pos_int", d.Name)
+	assert.Equal(t, "public", d.Schema)
+	assert.Equal(t, "integer", d.BaseType)
+	assert.Len(t, d.Constraints, 1)
+	assert.Equal(t, "pos_check", d.Constraints[0].Name)
+}
+
+func TestParseSQL_DomainWithDefault(t *testing.T) {
+	sql := `CREATE DOMAIN public.pos_int AS integer NOT NULL DEFAULT 1;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	d := result.Domains.Get("public.pos_int")
+	require.NotNil(t, d)
+	assert.True(t, d.NotNull)
+	require.NotNil(t, d.Default)
+	assert.Equal(t, "1", *d.Default)
+}
+
+func TestParseSQL_DomainWithComment(t *testing.T) {
+	sql := `CREATE DOMAIN public.pos_int AS integer;
+COMMENT ON DOMAIN public.pos_int IS 'Positive integer';`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	d := result.Domains.Get("public.pos_int")
+	require.NotNil(t, d)
+	require.NotNil(t, d.Comment)
+	assert.Equal(t, "Positive integer", *d.Comment)
+}
+
+func TestParseSQLWithSchema_Domain(t *testing.T) {
+	sql := `CREATE DOMAIN pos_int AS integer;`
+
+	result, err := parser.ParseSQLWithSchema(sql, "myschema")
+	require.NoError(t, err)
+
+	d, ok := result.Domains.GetOk("myschema.pos_int")
+	require.True(t, ok)
+	assert.Equal(t, "myschema", d.Schema)
+}
+
+func TestParseSQL_DomainUnnamedConstraint_Error(t *testing.T) {
+	sql := `CREATE DOMAIN public.pos_int AS integer CHECK (VALUE > 0);`
+	_, err := parser.ParseSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unnamed constraint")
+}
+
+func TestParseSQL_DuplicateDomain(t *testing.T) {
+	sql := `CREATE DOMAIN public.pos_int AS integer;
+CREATE DOMAIN public.pos_int AS bigint;`
+	_, err := parser.ParseSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate domain")
+}
+
 func TestParseSQL_NoRenameDirective(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,

--- a/plan.go
+++ b/plan.go
@@ -44,16 +44,27 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to fetch enums: %w", err)
 	}
 
+	currentDomains, err := cat.Domains(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch domains: %w", err)
+	}
+
 	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
+	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)))
+	if err != nil {
+		return "", fmt.Errorf("failed to diff domains: %w", err)
+	}
+	stmts := domainDiff.Stmts
+
 	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
 	if err != nil {
 		return "", err
 	}
-	stmts := enumDiff.Stmts
+	stmts = append(stmts, enumDiff.Stmts...)
 
 	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	if err != nil {
@@ -68,6 +79,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 	stmts = append(stmts, viewStmts...)
 
 	stmts = append(stmts, enumDiff.DropStmts...)
+	stmts = append(stmts, domainDiff.DropStmts...)
 
 	if options.PreSQLFile != "" && len(stmts) > 0 {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)

--- a/plan.go
+++ b/plan.go
@@ -54,17 +54,17 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)))
-	if err != nil {
-		return "", fmt.Errorf("failed to diff domains: %w", err)
-	}
-	stmts := domainDiff.Stmts
-
 	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
 	if err != nil {
 		return "", err
 	}
-	stmts = append(stmts, enumDiff.Stmts...)
+	stmts := enumDiff.Stmts
+
+	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)))
+	if err != nil {
+		return "", fmt.Errorf("failed to diff domains: %w", err)
+	}
+	stmts = append(stmts, domainDiff.Stmts...)
 
 	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
 	if err != nil {
@@ -78,8 +78,8 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 	}
 	stmts = append(stmts, viewStmts...)
 
-	stmts = append(stmts, enumDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
+	stmts = append(stmts, enumDiff.DropStmts...)
 
 	if options.PreSQLFile != "" && len(stmts) > 0 {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)

--- a/remap.go
+++ b/remap.go
@@ -158,3 +158,33 @@ func (client *Client) reverseRemapEnumSchemas(enums *orderedmap.Map[string, *mod
 
 	return remapped
 }
+
+func (client *Client) remapDomainSchemas(domains *orderedmap.Map[string, *model.Domain]) *orderedmap.Map[string, *model.Domain] {
+	if len(client.SchemaMap) == 0 {
+		return domains
+	}
+
+	remapped := orderedmap.New[string, *model.Domain]()
+
+	for _, d := range domains.CollectValues() {
+		d.Schema = client.RemapSchema(d.Schema)
+		remapped.Set(d.FQDN(), d)
+	}
+
+	return remapped
+}
+
+func (client *Client) reverseRemapDomainSchemas(domains *orderedmap.Map[string, *model.Domain]) *orderedmap.Map[string, *model.Domain] {
+	if len(client.SchemaMap) == 0 {
+		return domains
+	}
+
+	remapped := orderedmap.New[string, *model.Domain]()
+
+	for _, d := range domains.CollectValues() {
+		d.Schema = client.ReverseRemapSchema(d.Schema)
+		remapped.Set(d.FQDN(), d)
+	}
+
+	return remapped
+}

--- a/remap.go
+++ b/remap.go
@@ -164,10 +164,12 @@ func (client *Client) remapDomainSchemas(domains *orderedmap.Map[string, *model.
 		return domains
 	}
 
+	replacer := buildDefReplacer(client.SchemaMap)
 	remapped := orderedmap.New[string, *model.Domain]()
 
 	for _, d := range domains.CollectValues() {
 		d.Schema = client.RemapSchema(d.Schema)
+		d.BaseType = replacer.Replace(d.BaseType)
 		remapped.Set(d.FQDN(), d)
 	}
 
@@ -179,10 +181,12 @@ func (client *Client) reverseRemapDomainSchemas(domains *orderedmap.Map[string, 
 		return domains
 	}
 
+	replacer := buildReverseDefReplacer(client.SchemaMap)
 	remapped := orderedmap.New[string, *model.Domain]()
 
 	for _, d := range domains.CollectValues() {
 		d.Schema = client.ReverseRemapSchema(d.Schema)
+		d.BaseType = replacer.Replace(d.BaseType)
 		remapped.Set(d.FQDN(), d)
 	}
 

--- a/remap_test.go
+++ b/remap_test.go
@@ -618,6 +618,48 @@ CREATE TABLE myschema.users (
 	assert.Empty(t, got)
 }
 
+func TestDump_WithSchemaMap_Domain(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE DOMAIN myschema.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	assert.Contains(t, output, "CREATE DOMAIN public.pos_int")
+	assert.NotContains(t, output, "myschema.pos_int")
+}
+
+func TestPlan_WithSchemaMap_Domain(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE DOMAIN myschema.pos_int AS integer;
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE DOMAIN public.pos_int AS integer NOT NULL;`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Contains(t, got, "ALTER DOMAIN myschema.pos_int SET NOT NULL;")
+}
+
 func TestDump_WithSchemaMap_Enum(t *testing.T) {
 	ctx := context.Background()
 

--- a/testdata/apply/create_domain.yml
+++ b/testdata/apply/create_domain.yml
@@ -1,0 +1,7 @@
+init: ""
+desired: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+applied: |
+  -- public.pos_int
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK ((VALUE > 0));

--- a/testdata/apply/create_domain_with_enum.yml
+++ b/testdata/apply/create_domain_with_enum.yml
@@ -1,0 +1,13 @@
+init: ""
+desired: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+  CREATE DOMAIN public.user_status AS status;
+applied: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+
+  -- public.user_status
+  CREATE DOMAIN public.user_status AS status;

--- a/testdata/dump/domain.yml
+++ b/testdata/dump/domain.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+dump: |
+  -- public.pos_int
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK ((VALUE > 0));

--- a/testdata/plan/create_domain.yml
+++ b/testdata/plan/create_domain.yml
@@ -1,0 +1,6 @@
+init: ""
+desired: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+plan: |
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (value > 0);

--- a/testdata/plan/create_domain_with_enum.yml
+++ b/testdata/plan/create_domain_with_enum.yml
@@ -1,0 +1,11 @@
+init: ""
+desired: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+  CREATE DOMAIN public.user_status AS status CONSTRAINT status_check CHECK (VALUE <> 'inactive'::status);
+plan: |
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+  CREATE DOMAIN public.user_status AS status
+      CONSTRAINT status_check CHECK (value <> 'inactive'::status);

--- a/testdata/plan/drop_domain.yml
+++ b/testdata/plan/drop_domain.yml
@@ -1,0 +1,5 @@
+init: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+desired: ""
+plan: |
+  DROP DOMAIN public.pos_int;

--- a/testdata/plan/drop_domain_and_enum.yml
+++ b/testdata/plan/drop_domain_and_enum.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+  CREATE DOMAIN public.user_status AS status;
+desired: ""
+plan: |
+  DROP DOMAIN public.user_status;
+  DROP TYPE public.status;

--- a/testdata/plan/no_diff_domain.yml
+++ b/testdata/plan/no_diff_domain.yml
@@ -1,0 +1,5 @@
+init: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+desired: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+plan: ""


### PR DESCRIPTION
This pull request adds comprehensive support for PostgreSQL domains to the codebase, including their extraction from the database, diffing, and integration into schema dumps and the apply workflow. The changes include new catalog and diff logic for domains, updates to the dump and apply pipelines, and thorough test coverage.

**Domain support in catalog and diff:**

- Added domain extraction to the catalog, including constraints and comments, via new methods `Domains`, `ListDomains`, and `listDomainConstraints` in `catalog/domains.go`.
- Implemented domain diffing logic in `diff/domains.go`, supporting detection of new, modified, dropped, and renamed domains, as well as constraint and comment changes.

**Integration into apply and dump workflows:**

- Updated the `Apply` method in `apply.go` to fetch, diff, and apply domain changes, including handling of drop statements. [[1]](diffhunk://#diff-86ae12b12a6a3e85fd29fb29e6745818c470d89b611f10125ad5761a707e5a76R48-R68) [[2]](diffhunk://#diff-86ae12b12a6a3e85fd29fb29e6745818c470d89b611f10125ad5761a707e5a76R83)
- Modified `DumpResult` in `dump.go` to include domains in schema dumps and file outputs, ensuring domains are handled alongside tables, views, and enums. [[1]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR23) [[2]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR90-R107) [[3]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR118-R122) [[4]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdR194-R203)
- Added domain filtering support to `FilterOptions` for selective inclusion/exclusion.

**Testing:**

- Introduced comprehensive tests for domain extraction and diffing, covering creation, modification, renaming, constraints, comments, and error scenarios. [[1]](diffhunk://#diff-443737b51e0a7db9708dac8b0e4ab5c5ba4354b4aa3a6324d5fe6e3f90385398R1-R76) [[2]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7R1-R197)