### PR TITLE
Add only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ pist -n staging -m staging=public apply schema.sql
 
 Use `-I` / `--include` to include only matching objects by name, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names).
 
-Use `--only` to restrict operations to specific object types (`table`, `view`, `enum`, `domain`). Can be repeated to include multiple types.
+Use `--only` to restrict operations to specific object types (`table`, `view`, `enum`, `domain`). Can be repeated to include multiple types. Also available as `$PIST_ONLY` environment variable.
 
 These flags are available on the `dump`, `plan`, and `apply` subcommands.
 
@@ -158,6 +158,9 @@ pist dump --only table --only view
 
 # Plan changes for enums only
 pist plan --only enum schema.sql
+
+# Using environment variable
+PIST_ONLY=enum pist dump
 ```
 
 ### Omit schema

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ pist plan --only enum schema.sql
 PIST_ONLY=enum pist dump
 ```
 
+> [!NOTE]
+> `--only` excludes dependent objects. For example, `--only table` omits enums/domains that table columns may reference, so the generated SQL may not apply cleanly on its own. Use `--only` primarily for inspection (`dump`, `plan`) rather than `apply`.
+
 ### Omit schema
 
 Use `--omit-schema` to omit schema names from the dump output.

--- a/README.md
+++ b/README.md
@@ -132,9 +132,13 @@ pist -n staging -m staging=public plan schema.sql
 pist -n staging -m staging=public apply schema.sql
 ```
 
-### Filtering tables/views/enums
+### Filtering objects
 
-Use `-I` / `--include` to include only matching tables/views/enums, or `-E` / `--exclude` to exclude them. These flags are available on the `dump`, `plan`, and `apply` subcommands. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names).
+Use `-I` / `--include` to include only matching objects by name, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names).
+
+Use `--only` to restrict operations to specific object types (`table`, `view`, `enum`, `domain`). Can be repeated to include multiple types.
+
+These flags are available on the `dump`, `plan`, and `apply` subcommands.
 
 ```bash
 # Dump only objects matching "user*"
@@ -145,6 +149,15 @@ pist plan -E 'tmp_*' schema.sql
 
 # Combine include and exclude
 pist apply -I 'user*' -E 'user_tmp' schema.sql
+
+# Dump only enums
+pist dump --only enum
+
+# Dump only tables and views
+pist dump --only table --only view
+
+# Plan changes for enums only
+pist plan --only enum schema.sql
 ```
 
 ### Omit schema

--- a/filter.go
+++ b/filter.go
@@ -6,6 +6,9 @@ import (
 )
 
 func (f *FilterOptions) filterTables(tables *orderedmap.Map[string, *model.Table]) *orderedmap.Map[string, *model.Table] {
+	if !f.IsTypeEnabled("table") {
+		return orderedmap.New[string, *model.Table]()
+	}
 	if len(f.Include) == 0 && len(f.Exclude) == 0 {
 		return tables
 	}
@@ -20,6 +23,9 @@ func (f *FilterOptions) filterTables(tables *orderedmap.Map[string, *model.Table
 }
 
 func (f *FilterOptions) filterViews(views *orderedmap.Map[string, *model.View]) *orderedmap.Map[string, *model.View] {
+	if !f.IsTypeEnabled("view") {
+		return orderedmap.New[string, *model.View]()
+	}
 	if len(f.Include) == 0 && len(f.Exclude) == 0 {
 		return views
 	}
@@ -34,6 +40,9 @@ func (f *FilterOptions) filterViews(views *orderedmap.Map[string, *model.View]) 
 }
 
 func (f *FilterOptions) filterEnums(enums *orderedmap.Map[string, *model.Enum]) *orderedmap.Map[string, *model.Enum] {
+	if !f.IsTypeEnabled("enum") {
+		return orderedmap.New[string, *model.Enum]()
+	}
 	if len(f.Include) == 0 && len(f.Exclude) == 0 {
 		return enums
 	}
@@ -48,6 +57,9 @@ func (f *FilterOptions) filterEnums(enums *orderedmap.Map[string, *model.Enum]) 
 }
 
 func (f *FilterOptions) filterDomains(domains *orderedmap.Map[string, *model.Domain]) *orderedmap.Map[string, *model.Domain] {
+	if !f.IsTypeEnabled("domain") {
+		return orderedmap.New[string, *model.Domain]()
+	}
 	if len(f.Include) == 0 && len(f.Exclude) == 0 {
 		return domains
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -433,6 +433,84 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 	assert.NotContains(t, output, "'guest'")
 }
 
+func TestIsTypeEnabled(t *testing.T) {
+	t.Run("empty (all enabled)", func(t *testing.T) {
+		f := &pistachio.FilterOptions{}
+		assert.True(t, f.IsTypeEnabled("table"))
+		assert.True(t, f.IsTypeEnabled("view"))
+		assert.True(t, f.IsTypeEnabled("enum"))
+		assert.True(t, f.IsTypeEnabled("domain"))
+	})
+
+	t.Run("only table", func(t *testing.T) {
+		f := &pistachio.FilterOptions{Only: []string{"table"}}
+		assert.True(t, f.IsTypeEnabled("table"))
+		assert.False(t, f.IsTypeEnabled("view"))
+		assert.False(t, f.IsTypeEnabled("enum"))
+		assert.False(t, f.IsTypeEnabled("domain"))
+	})
+
+	t.Run("multiple types", func(t *testing.T) {
+		f := &pistachio.FilterOptions{Only: []string{"table", "enum"}}
+		assert.True(t, f.IsTypeEnabled("table"))
+		assert.False(t, f.IsTypeEnabled("view"))
+		assert.True(t, f.IsTypeEnabled("enum"))
+		assert.False(t, f.IsTypeEnabled("domain"))
+	})
+}
+
+func TestDump_Only_Enum(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{
+		FilterOptions: pistachio.FilterOptions{Only: []string{"enum"}},
+	})
+	require.NoError(t, err)
+	output := got.String()
+	assert.Contains(t, output, "CREATE TYPE public.status")
+	assert.NotContains(t, output, "CREATE TABLE")
+}
+
+func TestDump_Only_Table(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{
+		FilterOptions: pistachio.FilterOptions{Only: []string{"table"}},
+	})
+	require.NoError(t, err)
+	output := got.String()
+	assert.Contains(t, output, "CREATE TABLE public.users")
+	assert.NotContains(t, output, "CREATE TYPE")
+}
+
 func TestDump_IncludeDomain(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,6 +1,7 @@
 package pistachio_test
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -509,6 +510,130 @@ CREATE TABLE public.users (
 	output := got.String()
 	assert.Contains(t, output, "CREATE TABLE public.users")
 	assert.NotContains(t, output, "CREATE TYPE")
+}
+
+func TestDump_Only_View(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{
+		FilterOptions: pistachio.FilterOptions{Only: []string{"view"}},
+	})
+	require.NoError(t, err)
+	output := got.String()
+	assert.Contains(t, output, "CREATE OR REPLACE VIEW")
+	assert.NotContains(t, output, "CREATE TABLE")
+}
+
+func TestDump_Only_Domain(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{
+		FilterOptions: pistachio.FilterOptions{Only: []string{"domain"}},
+	})
+	require.NoError(t, err)
+	output := got.String()
+	assert.Contains(t, output, "CREATE DOMAIN")
+	assert.NotContains(t, output, "CREATE TABLE")
+}
+
+func TestPlan_Only_Enum(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		FilterOptions: pistachio.FilterOptions{Only: []string{"enum"}},
+		Files:         []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got, "ALTER TYPE")
+	assert.NotContains(t, got, "ALTER TABLE")
+}
+
+func TestApply_Only_Table(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	err := client.Apply(ctx, &pistachio.ApplyOptions{
+		FilterOptions: pistachio.FilterOptions{Only: []string{"table"}},
+		Files:         []string{desiredFile},
+	}, &buf)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "ALTER TABLE")
+	assert.NotContains(t, output, "ALTER TYPE")
 }
 
 func TestDump_IncludeDomain(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -15,7 +15,7 @@ type Options struct {
 type FilterOptions struct {
 	Include []string `short:"I" help:"Include only tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
 	Exclude []string `short:"E" help:"Exclude tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
-	Only    []string `enum:"table,view,enum,domain" help:"Include only specified object types (can be repeated)."`
+	Only    []string `enum:"table,view,enum,domain" env:"PIST_ONLY" help:"Include only specified object types (can be repeated)."`
 }
 
 // IsTypeEnabled returns true if the given object type should be included.

--- a/options.go
+++ b/options.go
@@ -13,8 +13,23 @@ type Options struct {
 }
 
 type FilterOptions struct {
-	Include []string `short:"I" help:"Include only tables/views/enums matching the pattern (wildcard: *, ?)."`
-	Exclude []string `short:"E" help:"Exclude tables/views/enums matching the pattern (wildcard: *, ?)."`
+	Include []string `short:"I" help:"Include only tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
+	Exclude []string `short:"E" help:"Exclude tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
+	Only    []string `enum:"table,view,enum,domain" help:"Include only specified object types (can be repeated)."`
+}
+
+// IsTypeEnabled returns true if the given object type should be included.
+// If Only is empty, all types are enabled.
+func (f *FilterOptions) IsTypeEnabled(typeName string) bool {
+	if len(f.Only) == 0 {
+		return true
+	}
+	for _, t := range f.Only {
+		if t == typeName {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *FilterOptions) MatchName(name string) bool {


### PR DESCRIPTION
This pull request adds support for filtering database objects by type (table, view, enum, domain) using a new `--only` flag and corresponding environment variable, in addition to the existing include/exclude name pattern filters. The documentation and tests have been updated to reflect and verify these enhancements.

**Feature: Object Type Filtering**

* Added a new `Only` field to `FilterOptions`, supporting the `--only` flag and `PIST_ONLY` environment variable to restrict operations to specific object types (`table`, `view`, `enum`, `domain`). Includes implementation of the `IsTypeEnabled` method to determine if a type should be included.
* Updated filter methods (`filterTables`, `filterViews`, `filterEnums`, `filterDomains`) to respect the new object type filtering by returning an empty result if the type is not enabled. [[1]](diffhunk://#diff-8a6290ede135299ac187338deaf28c9f658a4e45634d78c9e2ef113bbbd7ef67R9-R11) [[2]](diffhunk://#diff-8a6290ede135299ac187338deaf28c9f658a4e45634d78c9e2ef113bbbd7ef67R26-R28) [[3]](diffhunk://#diff-8a6290ede135299ac187338deaf28c9f658a4e45634d78c9e2ef113bbbd7ef67R43-R45) [[4]](diffhunk://#diff-8a6290ede135299ac187338deaf28c9f658a4e45634d78c9e2ef113bbbd7ef67R60-R62)

**Documentation Updates**

* Revised the `README.md` to document the new `--only` flag, its usage, and the `PIST_ONLY` environment variable, including usage examples for dumping or planning with specific object types. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L135-R141) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R152-R163)

**Testing**

* Added unit tests for the `IsTypeEnabled` method and for the new filtering logic to ensure only the specified object types are included in dumps.