### PR TITLE
Rename --only to --enable and add --disable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ pist -n staging -m staging=public apply schema.sql
 
 Use `-I` / `--include` to include only matching objects by name, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names).
 
-Use `--only` to restrict operations to specific object types (`table`, `view`, `enum`, `domain`). Can be repeated to include multiple types. Also available as `$PIST_ONLY` environment variable.
+Use `--enable` to restrict operations to specific object types, or `--disable` to exclude specific types. Valid types: `table`, `view`, `enum`, `domain`. Can be repeated. Also available as `$PIST_ENABLE` / `$PIST_DISABLE` environment variables.
 
 These flags are available on the `dump`, `plan`, and `apply` subcommands.
 
@@ -151,20 +151,24 @@ pist plan -E 'tmp_*' schema.sql
 pist apply -I 'user*' -E 'user_tmp' schema.sql
 
 # Dump only enums
-pist dump --only enum
+pist dump --enable enum
 
 # Dump only tables and views
-pist dump --only table --only view
+pist dump --enable table --enable view
+
+# Dump everything except views
+pist dump --disable view
 
 # Plan changes for enums only
-pist plan --only enum schema.sql
+pist plan --enable enum schema.sql
 
-# Using environment variable
-PIST_ONLY=enum pist dump
+# Using environment variables
+PIST_ENABLE=enum pist dump
+PIST_DISABLE=view pist dump
 ```
 
 > [!NOTE]
-> `--only` excludes dependent objects. For example, `--only table` omits enums/domains that table columns may reference, so the generated SQL may not apply cleanly on its own. Use `--only` primarily for inspection (`dump`, `plan`) rather than `apply`.
+> `--enable` takes precedence over `--disable`. When `--enable` is set, only the specified types are included regardless of `--disable`. These flags may exclude dependent objects (e.g. `--enable table` omits enums/domains that table columns may reference), so use them primarily for inspection (`dump`, `plan`) rather than `apply`.
 
 ### Omit schema
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -105,6 +105,92 @@ func TestMatchName(t *testing.T) {
 	})
 }
 
+func TestIsTypeEnabled_Disable(t *testing.T) {
+	t.Run("disable table", func(t *testing.T) {
+		f := &pistachio.FilterOptions{Disable: []string{"table"}}
+		assert.False(t, f.IsTypeEnabled("table"))
+		assert.True(t, f.IsTypeEnabled("view"))
+		assert.True(t, f.IsTypeEnabled("enum"))
+		assert.True(t, f.IsTypeEnabled("domain"))
+	})
+
+	t.Run("disable multiple", func(t *testing.T) {
+		f := &pistachio.FilterOptions{Disable: []string{"table", "view"}}
+		assert.False(t, f.IsTypeEnabled("table"))
+		assert.False(t, f.IsTypeEnabled("view"))
+		assert.True(t, f.IsTypeEnabled("enum"))
+		assert.True(t, f.IsTypeEnabled("domain"))
+	})
+
+	t.Run("enable takes precedence over disable", func(t *testing.T) {
+		f := &pistachio.FilterOptions{Enable: []string{"enum"}, Disable: []string{"table"}}
+		assert.True(t, f.IsTypeEnabled("enum"))
+		assert.False(t, f.IsTypeEnabled("table"))
+		assert.False(t, f.IsTypeEnabled("view"))
+	})
+}
+
+func TestDump_Disable_Table(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{
+		FilterOptions: pistachio.FilterOptions{Disable: []string{"table"}},
+	})
+	require.NoError(t, err)
+	output := got.String()
+	assert.Contains(t, output, "CREATE TYPE public.status")
+	assert.NotContains(t, output, "CREATE TABLE")
+}
+
+func TestPlan_Disable_Table(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TYPE public.status AS ENUM ('active', 'inactive', 'pending');
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		FilterOptions: pistachio.FilterOptions{Disable: []string{"table"}},
+		Files:         []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got, "ALTER TYPE")
+	assert.NotContains(t, got, "ALTER TABLE")
+}
+
 func TestDump_Include(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
@@ -434,7 +520,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 	assert.NotContains(t, output, "'guest'")
 }
 
-func TestIsTypeEnabled(t *testing.T) {
+func TestIsTypeEnabled_Enable(t *testing.T) {
 	t.Run("empty (all enabled)", func(t *testing.T) {
 		f := &pistachio.FilterOptions{}
 		assert.True(t, f.IsTypeEnabled("table"))
@@ -444,7 +530,7 @@ func TestIsTypeEnabled(t *testing.T) {
 	})
 
 	t.Run("only table", func(t *testing.T) {
-		f := &pistachio.FilterOptions{Only: []string{"table"}}
+		f := &pistachio.FilterOptions{Enable: []string{"table"}}
 		assert.True(t, f.IsTypeEnabled("table"))
 		assert.False(t, f.IsTypeEnabled("view"))
 		assert.False(t, f.IsTypeEnabled("enum"))
@@ -452,7 +538,7 @@ func TestIsTypeEnabled(t *testing.T) {
 	})
 
 	t.Run("multiple types", func(t *testing.T) {
-		f := &pistachio.FilterOptions{Only: []string{"table", "enum"}}
+		f := &pistachio.FilterOptions{Enable: []string{"table", "enum"}}
 		assert.True(t, f.IsTypeEnabled("table"))
 		assert.False(t, f.IsTypeEnabled("view"))
 		assert.True(t, f.IsTypeEnabled("enum"))
@@ -460,7 +546,7 @@ func TestIsTypeEnabled(t *testing.T) {
 	})
 }
 
-func TestDump_Only_Enum(t *testing.T) {
+func TestDump_Enable_Enum(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
@@ -478,7 +564,7 @@ CREATE TABLE public.users (
 	})
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{
-		FilterOptions: pistachio.FilterOptions{Only: []string{"enum"}},
+		FilterOptions: pistachio.FilterOptions{Enable: []string{"enum"}},
 	})
 	require.NoError(t, err)
 	output := got.String()
@@ -486,7 +572,7 @@ CREATE TABLE public.users (
 	assert.NotContains(t, output, "CREATE TABLE")
 }
 
-func TestDump_Only_Table(t *testing.T) {
+func TestDump_Enable_Table(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
@@ -504,7 +590,7 @@ CREATE TABLE public.users (
 	})
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{
-		FilterOptions: pistachio.FilterOptions{Only: []string{"table"}},
+		FilterOptions: pistachio.FilterOptions{Enable: []string{"table"}},
 	})
 	require.NoError(t, err)
 	output := got.String()
@@ -512,7 +598,7 @@ CREATE TABLE public.users (
 	assert.NotContains(t, output, "CREATE TYPE")
 }
 
-func TestDump_Only_View(t *testing.T) {
+func TestDump_Enable_View(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
@@ -530,7 +616,7 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
 	})
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{
-		FilterOptions: pistachio.FilterOptions{Only: []string{"view"}},
+		FilterOptions: pistachio.FilterOptions{Enable: []string{"view"}},
 	})
 	require.NoError(t, err)
 	output := got.String()
@@ -538,7 +624,7 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
 	assert.NotContains(t, output, "CREATE TABLE")
 }
 
-func TestDump_Only_Domain(t *testing.T) {
+func TestDump_Enable_Domain(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
@@ -556,7 +642,7 @@ CREATE TABLE public.users (
 	})
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{
-		FilterOptions: pistachio.FilterOptions{Only: []string{"domain"}},
+		FilterOptions: pistachio.FilterOptions{Enable: []string{"domain"}},
 	})
 	require.NoError(t, err)
 	output := got.String()
@@ -564,7 +650,7 @@ CREATE TABLE public.users (
 	assert.NotContains(t, output, "CREATE TABLE")
 }
 
-func TestPlan_Only_Enum(t *testing.T) {
+func TestPlan_Enable_Enum(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
@@ -591,7 +677,7 @@ CREATE TABLE public.users (
 	})
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{
-		FilterOptions: pistachio.FilterOptions{Only: []string{"enum"}},
+		FilterOptions: pistachio.FilterOptions{Enable: []string{"enum"}},
 		Files:         []string{desiredFile},
 	})
 	require.NoError(t, err)
@@ -599,7 +685,7 @@ CREATE TABLE public.users (
 	assert.NotContains(t, got, "ALTER TABLE")
 }
 
-func TestApply_Only_Table(t *testing.T) {
+func TestApply_Enable_Table(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
@@ -627,7 +713,7 @@ CREATE TABLE public.users (
 
 	var buf bytes.Buffer
 	err := client.Apply(ctx, &pistachio.ApplyOptions{
-		FilterOptions: pistachio.FilterOptions{Only: []string{"table"}},
+		FilterOptions: pistachio.FilterOptions{Enable: []string{"table"}},
 		Files:         []string{desiredFile},
 	}, &buf)
 	require.NoError(t, err)

--- a/options.go
+++ b/options.go
@@ -15,21 +15,29 @@ type Options struct {
 type FilterOptions struct {
 	Include []string `short:"I" help:"Include only tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
 	Exclude []string `short:"E" help:"Exclude tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
-	Only    []string `enum:"table,view,enum,domain" env:"PIST_ONLY" help:"Include only specified object types (can be repeated)."`
+	Enable  []string `enum:"table,view,enum,domain" env:"PIST_ENABLE" help:"Enable only specified object types (can be repeated)."`
+	Disable []string `enum:"table,view,enum,domain" env:"PIST_DISABLE" help:"Disable specified object types (can be repeated)."`
 }
 
 // IsTypeEnabled returns true if the given object type should be included.
-// If Only is empty, all types are enabled.
+// Enable takes precedence: if set, only listed types are enabled.
+// Disable excludes listed types (ignored when Enable is set).
+// If neither is set, all types are enabled.
 func (f *FilterOptions) IsTypeEnabled(typeName string) bool {
-	if len(f.Only) == 0 {
-		return true
+	if len(f.Enable) > 0 {
+		for _, t := range f.Enable {
+			if t == typeName {
+				return true
+			}
+		}
+		return false
 	}
-	for _, t := range f.Only {
+	for _, t := range f.Disable {
 		if t == typeName {
-			return true
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func (f *FilterOptions) MatchName(name string) bool {


### PR DESCRIPTION
--enable restricts to specified object types (table, view, enum, domain). --disable excludes specified object types. --enable takes precedence. Also available as $PIST_ENABLE / $PIST_DISABLE environment variables.