### PR TITLE
Rename directive from pist:rename-from to pist:renamed-from

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,21 +191,21 @@ pist -n staging apply schema.sql
 
 ### Renaming objects
 
-Use `-- pist:rename-from <old_name>` directives to rename objects instead of dropping and recreating them.
+Use `-- pist:renamed-from <old_name>` directives to rename objects instead of dropping and recreating them.
 
 **Tables, views, enums:**
 
 ```sql
--- pist:rename-from public.old_status
+-- pist:renamed-from public.old_status
 CREATE TYPE public.new_status AS ENUM ('active', 'inactive');
 
--- pist:rename-from public.old_users
+-- pist:renamed-from public.old_users
 CREATE TABLE public.users (
     id integer NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );
 
--- pist:rename-from public.old_view
+-- pist:renamed-from public.old_view
 CREATE VIEW public.new_view AS SELECT 1;
 ```
 
@@ -214,17 +214,17 @@ CREATE VIEW public.new_view AS SELECT 1;
 ```sql
 CREATE TABLE public.users (
     id integer NOT NULL,
-    -- pist:rename-from name
+    -- pist:renamed-from name
     display_name text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id),
-    -- pist:rename-from users_name_key
+    -- pist:renamed-from users_name_key
     CONSTRAINT users_display_name_key UNIQUE (display_name)
 );
 
--- pist:rename-from idx_users_name
+-- pist:renamed-from idx_users_name
 CREATE INDEX idx_users_display_name ON public.users (display_name);
 
--- pist:rename-from fk_old_name
+-- pist:renamed-from fk_old_name
 ALTER TABLE public.orders ADD CONSTRAINT fk_new_name FOREIGN KEY (user_id) REFERENCES public.users(id);
 ```
 
@@ -296,7 +296,7 @@ pist apply ./schema/*.sql         # apply it
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
 - Comments (on tables, columns, views, types, domains)
-- Renaming (tables, views, enums, domains, columns, constraints, foreign keys, indexes via `-- pist:rename-from` directive)
+- Renaming (tables, views, enums, domains, columns, constraints, foreign keys, indexes via `-- pist:renamed-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -103,12 +103,12 @@ Repeat steps 4-6 as your schema evolves. Your schema file is always the source o
 
 ### Renaming objects
 
-Use the `-- pist:rename-from` directive to rename objects without dropping and recreating them:
+Use the `-- pist:renamed-from` directive to rename objects without dropping and recreating them:
 
 ```sql
 CREATE TABLE public.users (
     id integer NOT NULL,
-    -- pist:rename-from name
+    -- pist:renamed-from name
     display_name text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -8,9 +8,9 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-var renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:rename-from[ \t]+(.+?)[ \t]*$`)
+var renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:renamed-from[ \t]+(.+?)[ \t]*$`)
 
-// QualifyRenameFrom qualifies a rename-from value with the default schema
+// QualifyRenameFrom qualifies a renamed-from value with the default schema
 // if it does not already contain a schema. Quoted identifiers containing
 // dots (e.g. `"a.b"`) are treated as a single identifier.
 func QualifyRenameFrom(value, defaultSchema string) string {
@@ -35,7 +35,7 @@ func unquoteIdent(s string) string {
 	return strings.ToLower(s)
 }
 
-// normalizeDirectiveValue normalizes a rename-from directive value by
+// normalizeDirectiveValue normalizes a renamed-from directive value by
 // unquoting each part and re-quoting via model.Ident to match the
 // canonical identifier format used by the parser and diff layer.
 // Used for schema-qualified names (tables, views, enums).
@@ -47,7 +47,7 @@ func normalizeDirectiveValue(s string) string {
 	return model.Ident(parts...)
 }
 
-// normalizeUnqualifiedDirective normalizes a rename-from directive value
+// normalizeUnqualifiedDirective normalizes a renamed-from directive value
 // for unqualified names (columns, constraints, indexes, foreign keys)
 // by unquoting the identifier. If a schema-qualified name is provided
 // (e.g. "public.old_idx"), only the last part is used.
@@ -91,7 +91,7 @@ func splitQualifiedName(s string) []string {
 	return parts
 }
 
-// ExtractStmtDirectives scans raw SQL for `-- pist:rename-from <name>` comments
+// ExtractStmtDirectives scans raw SQL for `-- pist:renamed-from <name>` comments
 // that appear in each statement's raw text region (including leading comments).
 // pg_query includes leading comments in StmtLocation/StmtLen, so we scan the
 // raw text of each statement for the directive.
@@ -152,7 +152,7 @@ type InlineDirectives struct {
 }
 
 // ExtractInlineDirectives scans the raw text of a CREATE TABLE statement for
-// `-- pist:rename-from <old_name>` directives that appear on lines immediately
+// `-- pist:renamed-from <old_name>` directives that appear on lines immediately
 // before column or constraint definitions.
 func ExtractInlineDirectives(rawCreateTableSQL string) *InlineDirectives {
 	result := &InlineDirectives{

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestExtractStmtDirectives(t *testing.T) {
 	t.Run("single directive", func(t *testing.T) {
-		sql := `-- pist:rename-from public.old_status
+		sql := `-- pist:renamed-from public.old_status
 CREATE TYPE public.new_status AS ENUM ('active', 'inactive');`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
@@ -20,9 +20,9 @@ CREATE TYPE public.new_status AS ENUM ('active', 'inactive');`
 	})
 
 	t.Run("multiple directives", func(t *testing.T) {
-		sql := `-- pist:rename-from public.old_status
+		sql := `-- pist:renamed-from public.old_status
 CREATE TYPE public.new_status AS ENUM ('active');
--- pist:rename-from public.old_users
+-- pist:renamed-from public.old_users
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
@@ -42,7 +42,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 
 	t.Run("directive only on second statement", func(t *testing.T) {
 		sql := `CREATE TABLE public.users (id integer NOT NULL);
--- pist:rename-from public.old_posts
+-- pist:renamed-from public.old_posts
 CREATE TABLE public.posts (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
@@ -52,7 +52,7 @@ CREATE TABLE public.posts (id integer NOT NULL);`
 	})
 
 	t.Run("directive with extra whitespace", func(t *testing.T) {
-		sql := `  -- pist:rename-from  public.old_name
+		sql := `  -- pist:renamed-from  public.old_name
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
@@ -61,7 +61,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 	})
 
 	t.Run("unqualified name", func(t *testing.T) {
-		sql := `-- pist:rename-from old_name
+		sql := `-- pist:renamed-from old_name
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
@@ -70,7 +70,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 	})
 
 	t.Run("whitespace-only directive ignored", func(t *testing.T) {
-		sql := `-- pist:rename-from
+		sql := `-- pist:renamed-from
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestExtractColumnDirectives(t *testing.T) {
 	t.Run("single column directive", func(t *testing.T) {
 		sql := `CREATE TABLE public.users (
     id integer NOT NULL,
-    -- pist:rename-from name
+    -- pist:renamed-from name
     display_name text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );`
@@ -103,9 +103,9 @@ func TestExtractColumnDirectives(t *testing.T) {
 
 	t.Run("multiple column directives", func(t *testing.T) {
 		sql := `CREATE TABLE public.users (
-    -- pist:rename-from uid
+    -- pist:renamed-from uid
     id integer NOT NULL,
-    -- pist:rename-from name
+    -- pist:renamed-from name
     display_name text NOT NULL
 );`
 		dirs := ExtractColumnDirectives(sql)
@@ -125,7 +125,7 @@ func TestExtractColumnDirectives(t *testing.T) {
 
 	t.Run("quoted column name", func(t *testing.T) {
 		sql := `CREATE TABLE public.users (
-    -- pist:rename-from "Old Name"
+    -- pist:renamed-from "Old Name"
     "New Name" text NOT NULL
 );`
 		dirs := ExtractColumnDirectives(sql)
@@ -135,7 +135,7 @@ func TestExtractColumnDirectives(t *testing.T) {
 	t.Run("constraint line skipped", func(t *testing.T) {
 		sql := `CREATE TABLE public.users (
     id integer NOT NULL,
-    -- pist:rename-from old_col
+    -- pist:renamed-from old_col
     new_col text,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );`
@@ -150,7 +150,7 @@ func TestExtractInlineDirectives_Constraint(t *testing.T) {
     id integer NOT NULL,
     code text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id),
-    -- pist:rename-from users_code_key
+    -- pist:renamed-from users_code_key
     CONSTRAINT users_code_unique UNIQUE (code)
 );`
 	dirs := ExtractInlineDirectives(sql)
@@ -162,10 +162,10 @@ func TestExtractInlineDirectives_Constraint(t *testing.T) {
 func TestExtractInlineDirectives_Mixed(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,
-    -- pist:rename-from name
+    -- pist:renamed-from name
     display_name text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id),
-    -- pist:rename-from old_unique
+    -- pist:renamed-from old_unique
     CONSTRAINT new_unique UNIQUE (display_name)
 );`
 	dirs := ExtractInlineDirectives(sql)
@@ -219,7 +219,7 @@ func TestQualifyRenameFrom(t *testing.T) {
 }
 
 func TestExtractStmtDirectives_QuotedName(t *testing.T) {
-	sql := `-- pist:rename-from "My Schema"."Old Name"
+	sql := `-- pist:renamed-from "My Schema"."Old Name"
 CREATE TABLE public.users (id integer NOT NULL);`
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1100,7 +1100,7 @@ func TestParseSQL_CommentOnUnknownEnum(t *testing.T) {
 }
 
 func TestParseSQL_RenameDirective_Enum(t *testing.T) {
-	sql := `-- pist:rename-from public.old_status
+	sql := `-- pist:renamed-from public.old_status
 CREATE TYPE public.new_status AS ENUM ('active', 'inactive');`
 
 	result, err := parser.ParseSQL(sql)
@@ -1113,7 +1113,7 @@ CREATE TYPE public.new_status AS ENUM ('active', 'inactive');`
 }
 
 func TestParseSQL_RenameDirective_Table(t *testing.T) {
-	sql := `-- pist:rename-from public.old_users
+	sql := `-- pist:renamed-from public.old_users
 CREATE TABLE public.users (
     id integer NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
@@ -1129,7 +1129,7 @@ CREATE TABLE public.users (
 }
 
 func TestParseSQL_RenameDirective_View(t *testing.T) {
-	sql := `-- pist:rename-from public.old_view
+	sql := `-- pist:renamed-from public.old_view
 CREATE VIEW public.new_view AS SELECT 1;`
 
 	result, err := parser.ParseSQL(sql)
@@ -1144,7 +1144,7 @@ CREATE VIEW public.new_view AS SELECT 1;`
 func TestParseSQL_RenameDirective_Column(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,
-    -- pist:rename-from name
+    -- pist:renamed-from name
     display_name text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );`
@@ -1166,7 +1166,7 @@ func TestParseSQL_RenameDirective_Index(t *testing.T) {
     name text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );
--- pist:rename-from idx_old
+-- pist:renamed-from idx_old
 CREATE INDEX idx_new ON public.users (name);`
 
 	result, err := parser.ParseSQL(sql)
@@ -1185,7 +1185,7 @@ func TestParseSQL_RenameDirective_Constraint(t *testing.T) {
     id integer NOT NULL,
     code text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id),
-    -- pist:rename-from old_unique
+    -- pist:renamed-from old_unique
     CONSTRAINT new_unique UNIQUE (code)
 );`
 
@@ -1210,7 +1210,7 @@ CREATE TABLE public.orders (
     user_id integer NOT NULL,
     CONSTRAINT orders_pkey PRIMARY KEY (id)
 );
--- pist:rename-from old_fk
+-- pist:renamed-from old_fk
 ALTER TABLE public.orders ADD CONSTRAINT new_fk FOREIGN KEY (user_id) REFERENCES public.users(id);`
 
 	result, err := parser.ParseSQL(sql)
@@ -1229,7 +1229,7 @@ func TestParseSQL_RenameDirective_AlterTableConstraint(t *testing.T) {
     id integer NOT NULL,
     code text NOT NULL
 );
--- pist:rename-from old_unique
+-- pist:renamed-from old_unique
 ALTER TABLE public.users ADD CONSTRAINT new_unique UNIQUE (code);`
 
 	result, err := parser.ParseSQL(sql)
@@ -1244,14 +1244,14 @@ ALTER TABLE public.users ADD CONSTRAINT new_unique UNIQUE (code);`
 }
 
 func TestParseSQLWithSchema_RenameDirective_Qualifies(t *testing.T) {
-	sql := `-- pist:rename-from old_status
+	sql := `-- pist:renamed-from old_status
 CREATE TYPE new_status AS ENUM ('active', 'inactive');
--- pist:rename-from old_users
+-- pist:renamed-from old_users
 CREATE TABLE users (
     id integer NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );
--- pist:rename-from old_view
+-- pist:renamed-from old_view
 CREATE VIEW new_view AS SELECT 1;`
 
 	result, err := parser.ParseSQLWithSchema(sql, "myschema")
@@ -1376,7 +1376,7 @@ func TestParseSQL_DomainMultipleConstraints(t *testing.T) {
 }
 
 func TestParseSQL_DomainRenameDirective(t *testing.T) {
-	sql := `-- pist:rename-from public.old_domain
+	sql := `-- pist:renamed-from public.old_domain
 CREATE DOMAIN public.new_domain AS integer;`
 
 	result, err := parser.ParseSQL(sql)

--- a/testdata/apply/rename_column.yml
+++ b/testdata/apply/rename_column.yml
@@ -7,7 +7,7 @@ init: |
 desired: |
   CREATE TABLE public.users (
       id integer NOT NULL,
-      -- pist:rename-from name
+      -- pist:renamed-from name
       display_name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/apply/rename_enum.yml
+++ b/testdata/apply/rename_enum.yml
@@ -1,7 +1,7 @@
 init: |
   CREATE TYPE public.status AS ENUM ('active', 'inactive');
 desired: |
-  -- pist:rename-from public.status
+  -- pist:renamed-from public.status
   CREATE TYPE public.user_status AS ENUM ('active', 'inactive');
 applied: |
   -- public.user_status

--- a/testdata/apply/rename_table.yml
+++ b/testdata/apply/rename_table.yml
@@ -4,7 +4,7 @@ init: |
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 desired: |
-  -- pist:rename-from public.users
+  -- pist:renamed-from public.users
   CREATE TABLE public.accounts (
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)

--- a/testdata/apply/rename_table_and_column.yml
+++ b/testdata/apply/rename_table_and_column.yml
@@ -5,10 +5,10 @@ init: |
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 desired: |
-  -- pist:rename-from public.users
+  -- pist:renamed-from public.users
   CREATE TABLE public.accounts (
       id integer NOT NULL,
-      -- pist:rename-from name
+      -- pist:renamed-from name
       display_name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/apply/rename_table_and_fk.yml
+++ b/testdata/apply/rename_table_and_fk.yml
@@ -14,13 +14,13 @@ desired: |
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
-  -- pist:rename-from public.orders
+  -- pist:renamed-from public.orders
   CREATE TABLE public.purchases (
       id integer NOT NULL,
       user_id integer NOT NULL,
       CONSTRAINT orders_pkey PRIMARY KEY (id)
   );
-  -- pist:rename-from fk_user
+  -- pist:renamed-from fk_user
   ALTER TABLE public.purchases ADD CONSTRAINT fk_buyer FOREIGN KEY (user_id) REFERENCES public.users(id);
 applied: |
   -- public.purchases

--- a/testdata/apply/rename_table_and_index.yml
+++ b/testdata/apply/rename_table_and_index.yml
@@ -6,13 +6,13 @@ init: |
   );
   CREATE INDEX idx_users_name ON public.users (name);
 desired: |
-  -- pist:rename-from public.users
+  -- pist:renamed-from public.users
   CREATE TABLE public.accounts (
       id integer NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
-  -- pist:rename-from idx_users_name
+  -- pist:renamed-from idx_users_name
   CREATE INDEX idx_accounts_name ON public.accounts (name);
 applied: |
   -- public.accounts

--- a/testdata/plan/rename_column.yml
+++ b/testdata/plan/rename_column.yml
@@ -7,7 +7,7 @@ init: |
 desired: |
   CREATE TABLE public.users (
       id integer NOT NULL,
-      -- pist:rename-from name
+      -- pist:renamed-from name
       display_name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/plan/rename_constraint.yml
+++ b/testdata/plan/rename_constraint.yml
@@ -10,7 +10,7 @@ desired: |
       id integer NOT NULL,
       code text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id),
-      -- pist:rename-from users_code_key
+      -- pist:renamed-from users_code_key
       CONSTRAINT users_code_unique UNIQUE (code)
   );
 plan: |

--- a/testdata/plan/rename_enum.yml
+++ b/testdata/plan/rename_enum.yml
@@ -1,7 +1,7 @@
 init: |
   CREATE TYPE public.status AS ENUM ('active', 'inactive');
 desired: |
-  -- pist:rename-from public.status
+  -- pist:renamed-from public.status
   CREATE TYPE public.user_status AS ENUM ('active', 'inactive');
 plan: |
   ALTER TYPE public.status RENAME TO user_status;

--- a/testdata/plan/rename_index.yml
+++ b/testdata/plan/rename_index.yml
@@ -11,7 +11,7 @@ desired: |
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
-  -- pist:rename-from idx_users_name
+  -- pist:renamed-from idx_users_name
   CREATE INDEX idx_users_display_name ON public.users (name);
 plan: |
   ALTER INDEX public.idx_users_name RENAME TO idx_users_display_name;

--- a/testdata/plan/rename_table.yml
+++ b/testdata/plan/rename_table.yml
@@ -4,7 +4,7 @@ init: |
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 desired: |
-  -- pist:rename-from public.users
+  -- pist:renamed-from public.users
   CREATE TABLE public.accounts (
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)

--- a/testdata/plan/rename_table_and_column.yml
+++ b/testdata/plan/rename_table_and_column.yml
@@ -5,10 +5,10 @@ init: |
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 desired: |
-  -- pist:rename-from public.users
+  -- pist:renamed-from public.users
   CREATE TABLE public.accounts (
       id integer NOT NULL,
-      -- pist:rename-from name
+      -- pist:renamed-from name
       display_name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/plan/rename_table_and_fk.yml
+++ b/testdata/plan/rename_table_and_fk.yml
@@ -14,13 +14,13 @@ desired: |
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
-  -- pist:rename-from public.orders
+  -- pist:renamed-from public.orders
   CREATE TABLE public.purchases (
       id integer NOT NULL,
       user_id integer NOT NULL,
       CONSTRAINT orders_pkey PRIMARY KEY (id)
   );
-  -- pist:rename-from fk_user
+  -- pist:renamed-from fk_user
   ALTER TABLE public.purchases ADD CONSTRAINT fk_buyer FOREIGN KEY (user_id) REFERENCES public.users(id);
 plan: |
   ALTER TABLE public.orders RENAME TO purchases;

--- a/testdata/plan/rename_table_and_index.yml
+++ b/testdata/plan/rename_table_and_index.yml
@@ -6,13 +6,13 @@ init: |
   );
   CREATE INDEX idx_users_name ON public.users (name);
 desired: |
-  -- pist:rename-from public.users
+  -- pist:renamed-from public.users
   CREATE TABLE public.accounts (
       id integer NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
-  -- pist:rename-from idx_users_name
+  -- pist:renamed-from idx_users_name
   CREATE INDEX idx_accounts_name ON public.accounts (name);
 plan: |
   ALTER TABLE public.users RENAME TO accounts;


### PR DESCRIPTION
This pull request standardizes the directive used for renaming database objects by replacing all instances of `-- pist:rename-from` with `-- pist:renamed-from` across the codebase, documentation, and tests. This change ensures consistency in how rename operations are specified and parsed.

**Directive Standardization:**

* Updated the rename directive throughout the codebase, replacing `-- pist:rename-from` with `-- pist:renamed-from` in all documentation (`README.md`, `getting-started.md`), code comments, and user-facing examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L194-R208) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L217-R227) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L299-R299) [[4]](diffhunk://#diff-f007f6cb65740b71d33ebd4511fa8727d48a472d135ffd1bbef978237f9e6fa7L106-R111)
* Modified the regular expression and related logic in `parser/directive.go` to recognize the new `-- pist:renamed-from` directive, and updated all relevant function and comment references to match. [[1]](diffhunk://#diff-0795503a3dc0adaf21f5eb098f52cba53ec37a27b097f1dd8c8b650239ee7633L11-R13) [[2]](diffhunk://#diff-0795503a3dc0adaf21f5eb098f52cba53ec37a27b097f1dd8c8b650239ee7633L38-R38) [[3]](diffhunk://#diff-0795503a3dc0adaf21f5eb098f52cba53ec37a27b097f1dd8c8b650239ee7633L50-R50) [[4]](diffhunk://#diff-0795503a3dc0adaf21f5eb098f52cba53ec37a27b097f1dd8c8b650239ee7633L94-R94) [[5]](diffhunk://#diff-0795503a3dc0adaf21f5eb098f52cba53ec37a27b097f1dd8c8b650239ee7633L155-R155)

**Test Suite Updates:**

* Updated all tests in `parser/directive_test.go` and `parser/parser_test.go` to use the new directive, ensuring that parsing and extraction logic is validated against the updated syntax. [[1]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L13-R13) [[2]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L23-R25) [[3]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L45-R45) [[4]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L55-R55) [[5]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L64-R64) [[6]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L73-R73) [[7]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L95-R95) [[8]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L106-R108) [[9]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L128-R128) [[10]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L138-R138) [[11]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L153-R153) [[12]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L165-R168) [[13]](diffhunk://#diff-853de31e800809c668bb848100d2ea62bb213cb4210828cbc2bb1f2deece84a8L222-R222) [[14]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1103-R1103) [[15]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1116-R1116) [[16]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1132-R1132) [[17]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1147-R1147) [[18]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1169-R1169) [[19]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1188-R1188) [[20]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1213-R1213) [[21]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1232-R1232) [[22]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1247-R1254) [[23]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faL1379-R1379)

**Test Data and Example Updates:**

* Updated test data files and YAML fixtures to use the new directive for consistency in integration and end-to-end tests. [[1]](diffhunk://#diff-46965638ced8e721e07c7471db84077f5a9285e98818b894491f4d2ee187c008L10-R10) [[2]](diffhunk://#diff-979b172e99d88a93a3d847857c9cd32d9ec48d54d897ed94a7d23b39bd604b61L4-R4)