### PR TITLE
Rename pgschemas env

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Flags:
                               https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
                               ($PIST_CONN_STR)
       --password=STRING       PostgreSQL password ($PIST_PASSWORD).
-  -n, --schemas=public,...    Schemas to inspect and modify ($PGSCHEMAS).
+  -n, --schemas=public,...    Schemas to inspect and modify ($PIST_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
       --version

--- a/getting-started.md
+++ b/getting-started.md
@@ -123,11 +123,15 @@ After applying, you can leave the directive in place (it will be silently skippe
 
 ### Working with specific schemas
 
-By default, pistachio targets the `public` schema. Use `-n` to specify a different schema:
+By default, pistachio targets the `public` schema. Use `-n` or `$PIST_SCHEMAS` to specify a different schema:
 
 ```bash
 # Dump the "myschema" schema
 pist -n myschema dump
+
+# Or use environment variable
+export PIST_SCHEMAS=myschema
+pist dump
 
 # Plan/apply against "myschema"
 pist -n myschema plan schema.sql

--- a/options.go
+++ b/options.go
@@ -8,7 +8,7 @@ import (
 type Options struct {
 	ConnString string            `short:"c" env:"PIST_CONN_STR" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
 	Password   string            `env:"PIST_PASSWORD" help:"PostgreSQL password."`
-	Schemas    []string          `short:"n" env:"PGSCHEMAS" default:"public" help:"Schemas to inspect and modify."`
+	Schemas    []string          `short:"n" env:"PIST_SCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
 }
 


### PR DESCRIPTION
This pull request updates the way schemas are specified for inspection and modification in the project, standardizing the environment variable name across documentation, code, and help text. The main change is the replacement of the old `PGSCHEMAS` environment variable with the new `PIST_SCHEMAS` variable, improving consistency and clarity for users.

**Schema environment variable standardization:**

* Changed the environment variable for specifying schemas from `PGSCHEMAS` to `PIST_SCHEMAS` in the `Options` struct in `options.go`, ensuring the code uses the new standard variable.
* Updated the help text in `README.md` to reference `$PIST_SCHEMAS` instead of `$PGSCHEMAS` for the `--schemas` option, aligning documentation with the code change.
* Improved the `getting-started.md` documentation to mention both the `-n` flag and the `$PIST_SCHEMAS` environment variable for specifying schemas, and added an example of using the environment variable.