### PR TITLE
Add allow drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ By default, `plan` and `apply` do not generate DROP statements. Use `--allow-dro
 pist plan --allow-drop all schema.sql
 
 # Allow only column and table drops
-pist apply --allow-drop column --allow-drop table schema.sql
+pist apply --allow-drop column,table schema.sql
 ```
 
 ### dump

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ pist apply -I 'user*' -E 'user_tmp' schema.sql
 pist dump --enable enum
 
 # Dump only tables and views
-pist dump --enable table --enable view
+pist dump --enable table,view
 
 # Dump everything except views
 pist dump --disable view

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Use `--pre-sql-file` to run SQL before applying changes. Use `--with-tx` to wrap
 pist apply schema.sql --pre-sql-file pre.sql --with-tx
 ```
 
-By default, `plan` and `apply` do not generate DROP statements. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `index`). Also available as `$PIST_ALLOW_DROP`.
+By default, `plan` and `apply` do not generate DROP statements. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
 
 ```bash
 # Allow all drops

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ Use `--pre-sql-file` to run SQL before applying changes. Use `--with-tx` to wrap
 pist apply schema.sql --pre-sql-file pre.sql --with-tx
 ```
 
+By default, `plan` and `apply` do not generate DROP statements. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `index`). Also available as `$PIST_ALLOW_DROP`.
+
+```bash
+# Allow all drops
+pist plan --allow-drop all schema.sql
+
+# Allow only column and table drops
+pist apply --allow-drop column --allow-drop table schema.sql
+```
+
 ### dump
 
 Dump the current database schema as SQL. Output can be used directly as a schema file.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ pist plan --allow-drop all schema.sql
 pist apply --allow-drop column,table schema.sql
 ```
 
+> [!NOTE]
+> Constraints and indexes are always dropped when their definitions change or they are removed from the desired schema, regardless of `--allow-drop`. This is because PostgreSQL does not support `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes — the only way to update them is DROP + ADD.
+
 ### dump
 
 Dump the current database schema as SQL. Output can be used directly as a schema file.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Use `--pre-sql-file` to run SQL before applying changes. Use `--with-tx` to wrap
 pist apply schema.sql --pre-sql-file pre.sql --with-tx
 ```
 
-By default, `plan` and `apply` do not generate DROP statements. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
+By default, `plan` and `apply` do not drop tables, views, enums, domains, or columns. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
 
 ```bash
 # Allow all drops

--- a/apply.go
+++ b/apply.go
@@ -13,6 +13,7 @@ import (
 
 type ApplyOptions struct {
 	FilterOptions
+	DropPolicy
 	Files      []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQLFile string   `type:"path" help:"Path to a SQL file to execute before applying changes."`
 	WithTx     bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
@@ -55,25 +56,25 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
 	if err != nil {
 		return err
 	}
 	stmts := enumDiff.Stmts
 
-	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)))
+	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to diff domains: %w", err)
 	}
 	stmts = append(stmts, domainDiff.Stmts...)
 
-	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to diff tables: %w", err)
 	}
 	stmts = append(stmts, tableStmts...)
 
-	viewStmts, err := diff.DiffViews(options.filterViews(currentViews), options.filterViews(client.reverseRemapViewSchemas(desired.Views)))
+	viewStmts, err := diff.DiffViews(options.filterViews(currentViews), options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to diff views: %w", err)
 	}

--- a/apply_test.go
+++ b/apply_test.go
@@ -43,7 +43,7 @@ func TestApply(t *testing.T) {
 				ConnString: conn.Config().ConnString(),
 				Schemas:    []string{"public"},
 			})
-			err = client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+			err = client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
 			require.NoError(t, err)
 
 			// Verify

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -33,7 +33,7 @@ func TestPlan_Run(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
@@ -241,7 +241,7 @@ func TestPlan_Run_Error(t *testing.T) {
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 }
@@ -279,7 +279,7 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "-- No changes\n", buf.String())
@@ -305,7 +305,7 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "-- No changes\n", buf.String())
@@ -322,7 +322,7 @@ func TestApply_Run_Error(t *testing.T) {
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 }
@@ -346,7 +346,7 @@ func TestApply_Run(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -13,7 +13,7 @@ type DomainDiffResult struct {
 	DropStmts []string
 }
 
-func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain]) (*DomainDiffResult, error) {
+func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain], dc DropChecker) (*DomainDiffResult, error) {
 	result := &DomainDiffResult{}
 
 	// Detect renames
@@ -48,9 +48,11 @@ func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain]) (*Doma
 	}
 
 	// Dropped domains
-	for k := range current.Keys() {
-		if _, ok := desired.GetOk(k); !ok {
-			result.DropStmts = append(result.DropStmts, "DROP DOMAIN "+k+";")
+	if dc.IsDropAllowed("domain") {
+		for k := range current.Keys() {
+			if _, ok := desired.GetOk(k); !ok {
+				result.DropStmts = append(result.DropStmts, "DROP DOMAIN "+k+";")
+			}
 		}
 	}
 

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -14,6 +14,7 @@ type DomainDiffResult struct {
 }
 
 func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain], dc DropChecker) (*DomainDiffResult, error) {
+	dc = NormalizeDropChecker(dc)
 	result := &DomainDiffResult{}
 
 	// Detect renames

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -21,7 +21,7 @@ func newDomainMap(domains ...*model.Domain) *orderedmap.Map[string, *model.Domai
 func TestDiffDomains_CreateNew(t *testing.T) {
 	current := newDomainMap()
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "CREATE DOMAIN public.pos_int AS integer")
@@ -32,7 +32,7 @@ func TestDiffDomains_CreateWithComment(t *testing.T) {
 	comment := "Positive int"
 	current := newDomainMap()
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Comment: &comment})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 2)
 	assert.Contains(t, result.Stmts[1], "COMMENT ON DOMAIN")
@@ -41,7 +41,7 @@ func TestDiffDomains_CreateWithComment(t *testing.T) {
 func TestDiffDomains_Drop(t *testing.T) {
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap()
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Equal(t, []string{"DROP DOMAIN public.pos_int;"}, result.DropStmts)
@@ -50,7 +50,7 @@ func TestDiffDomains_Drop(t *testing.T) {
 func TestDiffDomains_NoDiff(t *testing.T) {
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
@@ -60,7 +60,7 @@ func TestDiffDomains_SetDefault(t *testing.T) {
 	def := "0"
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Default: &def})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int SET DEFAULT 0;"}, result.Stmts)
 }
@@ -69,7 +69,7 @@ func TestDiffDomains_DropDefault(t *testing.T) {
 	def := "0"
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Default: &def})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int DROP DEFAULT;"}, result.Stmts)
 }
@@ -77,7 +77,7 @@ func TestDiffDomains_DropDefault(t *testing.T) {
 func TestDiffDomains_SetNotNull(t *testing.T) {
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", NotNull: true})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int SET NOT NULL;"}, result.Stmts)
 }
@@ -85,7 +85,7 @@ func TestDiffDomains_SetNotNull(t *testing.T) {
 func TestDiffDomains_DropNotNull(t *testing.T) {
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", NotNull: true})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int DROP NOT NULL;"}, result.Stmts)
 }
@@ -100,7 +100,7 @@ func TestDiffDomains_AddConstraint(t *testing.T) {
 			{Name: "pos_check", Definition: "CHECK (VALUE > 0)"},
 		},
 	})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "ADD CONSTRAINT pos_check")
@@ -116,7 +116,7 @@ func TestDiffDomains_DropConstraint(t *testing.T) {
 		},
 	})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "DROP CONSTRAINT pos_check")
@@ -127,7 +127,7 @@ func TestDiffDomains_CollationChange_Error(t *testing.T) {
 	colB := "pg_catalog.POSIX"
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "name", BaseType: "text", Collation: &colA})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "name", BaseType: "text", Collation: &colB})
-	_, err := diff.DiffDomains(current, desired)
+	_, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot change collation")
 }
@@ -135,7 +135,7 @@ func TestDiffDomains_CollationChange_Error(t *testing.T) {
 func TestDiffDomains_BaseTypeChange_Error(t *testing.T) {
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "bigint"})
-	_, err := diff.DiffDomains(current, desired)
+	_, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot change base type")
 }
@@ -144,7 +144,7 @@ func TestDiffDomains_AddComment(t *testing.T) {
 	comment := "Positive int"
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Comment: &comment})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"COMMENT ON DOMAIN public.pos_int IS 'Positive int';"}, result.Stmts)
 }
@@ -153,7 +153,7 @@ func TestDiffDomains_DropComment(t *testing.T) {
 	comment := "Positive int"
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer", Comment: &comment})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"COMMENT ON DOMAIN public.pos_int IS NULL;"}, result.Stmts)
 }
@@ -162,7 +162,7 @@ func TestDiffDomains_Rename(t *testing.T) {
 	oldName := "public.pos_int"
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "positive_int", RenameFrom: &oldName, BaseType: "integer"})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int RENAME TO positive_int;"}, result.Stmts)
 }
@@ -171,7 +171,7 @@ func TestDiffDomains_Rename_AlreadyApplied(t *testing.T) {
 	oldName := "public.old"
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "positive_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "positive_int", RenameFrom: &oldName, BaseType: "integer"})
-	result, err := diff.DiffDomains(current, desired)
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -180,7 +180,7 @@ func TestDiffDomains_Rename_SourceNotFound(t *testing.T) {
 	oldName := "public.nonexistent"
 	current := newDomainMap()
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", RenameFrom: &oldName, BaseType: "integer"})
-	_, err := diff.DiffDomains(current, desired)
+	_, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }
@@ -189,7 +189,7 @@ func TestDiffDomains_Rename_CrossSchema_Error(t *testing.T) {
 	oldName := "other.pos_int"
 	current := newDomainMap(&model.Domain{Schema: "other", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", RenameFrom: &oldName, BaseType: "integer"})
-	_, err := diff.DiffDomains(current, desired)
+	_, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
@@ -201,7 +201,7 @@ func TestDiffDomains_Rename_DestinationExists_Error(t *testing.T) {
 		&model.Domain{Schema: "public", Name: "positive_int", BaseType: "integer"},
 	)
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "positive_int", RenameFrom: &oldName, BaseType: "integer"})
-	_, err := diff.DiffDomains(current, desired)
+	_, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -47,6 +47,15 @@ func TestDiffDomains_Drop(t *testing.T) {
 	assert.Equal(t, []string{"DROP DOMAIN public.pos_int;"}, result.DropStmts)
 }
 
+func TestDiffDomains_Drop_Denied(t *testing.T) {
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
+	desired := newDomainMap()
+	result, err := diff.DiffDomains(current, desired, diff.DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+}
+
 func TestDiffDomains_NoDiff(t *testing.T) {
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})

--- a/diff/drop_policy.go
+++ b/diff/drop_policy.go
@@ -9,3 +9,16 @@ type DropChecker interface {
 type AllowAllDrops struct{}
 
 func (AllowAllDrops) IsDropAllowed(string) bool { return true }
+
+// DenyAllDrops is a DropChecker that denies all drops.
+type DenyAllDrops struct{}
+
+func (DenyAllDrops) IsDropAllowed(string) bool { return false }
+
+// NormalizeDropChecker returns dc if non-nil, otherwise returns DenyAllDrops.
+func NormalizeDropChecker(dc DropChecker) DropChecker {
+	if dc == nil {
+		return DenyAllDrops{}
+	}
+	return dc
+}

--- a/diff/drop_policy.go
+++ b/diff/drop_policy.go
@@ -1,0 +1,11 @@
+package diff
+
+// DropChecker checks whether dropping a specific object type is allowed.
+type DropChecker interface {
+	IsDropAllowed(objectType string) bool
+}
+
+// AllowAllDrops is a DropChecker that allows all drops.
+type AllowAllDrops struct{}
+
+func (AllowAllDrops) IsDropAllowed(string) bool { return true }

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -14,6 +14,7 @@ type EnumDiffResult struct {
 }
 
 func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum], dc DropChecker) (*EnumDiffResult, error) {
+	dc = NormalizeDropChecker(dc)
 	result := &EnumDiffResult{}
 
 	// Detect renames

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -13,7 +13,7 @@ type EnumDiffResult struct {
 	DropStmts []string
 }
 
-func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) (*EnumDiffResult, error) {
+func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum], dc DropChecker) (*EnumDiffResult, error) {
 	result := &EnumDiffResult{}
 
 	// Detect renames
@@ -57,9 +57,11 @@ func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum]) (*EnumDiff
 	}
 
 	// Dropped enums
-	for k := range current.Keys() {
-		if _, ok := desired.GetOk(k); !ok {
-			result.DropStmts = append(result.DropStmts, "DROP TYPE "+k+";")
+	if dc.IsDropAllowed("enum") {
+		for k := range current.Keys() {
+			if _, ok := desired.GetOk(k); !ok {
+				result.DropStmts = append(result.DropStmts, "DROP TYPE "+k+";")
+			}
 		}
 	}
 

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -45,6 +45,19 @@ func TestDiffEnums_DropExisting(t *testing.T) {
 	assert.Equal(t, []string{"DROP TYPE public.status;"}, result.DropStmts)
 }
 
+func TestDiffEnums_DropExisting_Denied(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	desired := newEnumMap()
+	result, err := diff.DiffEnums(current, desired, diff.DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+}
+
 func TestDiffEnums_AddValue(t *testing.T) {
 	current := newEnumMap(&model.Enum{
 		Schema: "public",

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -25,7 +25,7 @@ func TestDiffEnums_CreateNew(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "CREATE TYPE public.status AS ENUM")
@@ -39,7 +39,7 @@ func TestDiffEnums_DropExisting(t *testing.T) {
 		Values: []string{"active", "inactive"},
 	})
 	desired := newEnumMap()
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Equal(t, []string{"DROP TYPE public.status;"}, result.DropStmts)
@@ -56,7 +56,7 @@ func TestDiffEnums_AddValue(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive", "pending"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';"}, result.Stmts)
 }
@@ -72,7 +72,7 @@ func TestDiffEnums_AddValueMiddle(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "pending", "closed"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'pending' AFTER 'active';"}, result.Stmts)
 }
@@ -88,7 +88,7 @@ func TestDiffEnums_AddValueBeginning(t *testing.T) {
 		Name:   "status",
 		Values: []string{"new", "active", "inactive"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TYPE public.status ADD VALUE 'new' BEFORE 'active';"}, result.Stmts)
 }
@@ -104,7 +104,7 @@ func TestDiffEnums_AddMultipleValues(t *testing.T) {
 		Name:   "status",
 		Values: []string{"a", "b", "c", "d"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TYPE public.status ADD VALUE 'c' AFTER 'b';",
@@ -123,7 +123,7 @@ func TestDiffEnums_AddMultipleValuesMiddle(t *testing.T) {
 		Name:   "status",
 		Values: []string{"a", "b", "c", "d"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TYPE public.status ADD VALUE 'b' AFTER 'a';",
@@ -142,7 +142,7 @@ func TestDiffEnums_NoDiff(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
@@ -161,7 +161,7 @@ func TestDiffEnums_AddComment(t *testing.T) {
 		Values:  []string{"active"},
 		Comment: &comment,
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS 'User status';"}, result.Stmts)
 }
@@ -179,7 +179,7 @@ func TestDiffEnums_DropComment(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"COMMENT ON TYPE public.status IS NULL;"}, result.Stmts)
 }
@@ -193,7 +193,7 @@ func TestDiffEnums_CreateWithComment(t *testing.T) {
 		Values:  []string{"active"},
 		Comment: &comment,
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 2)
 	assert.Contains(t, result.Stmts[0], "CREATE TYPE public.status AS ENUM")
@@ -211,7 +211,7 @@ func TestDiffEnums_RemoveValue_Error(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active", "inactive"},
 	})
-	_, err := diff.DiffEnums(current, desired)
+	_, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot remove enum value")
 	assert.Contains(t, err.Error(), "public.status")
@@ -228,7 +228,7 @@ func TestDiffEnums_Reorder_Error(t *testing.T) {
 		Name:   "status",
 		Values: []string{"inactive", "active", "pending"},
 	})
-	_, err := diff.DiffEnums(current, desired)
+	_, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot reorder enum values")
 	assert.Contains(t, err.Error(), "public.status")
@@ -247,7 +247,7 @@ func TestDiffEnums_Rename(t *testing.T) {
 		RenameFrom: &oldName,
 		Values:     []string{"active", "inactive"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TYPE public.status RENAME TO user_status;"}, result.Stmts)
 	assert.Empty(t, result.DropStmts)
@@ -266,7 +266,7 @@ func TestDiffEnums_RenameAndAddValue(t *testing.T) {
 		RenameFrom: &oldName,
 		Values:     []string{"active", "inactive", "pending"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 2)
 	assert.Equal(t, "ALTER TYPE public.status RENAME TO user_status;", result.Stmts[0])
@@ -286,7 +286,7 @@ func TestDiffEnums_RenameSelfRename_Skipped(t *testing.T) {
 		RenameFrom: &oldName,
 		Values:     []string{"active"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -304,7 +304,7 @@ func TestDiffEnums_RenameAlreadyApplied(t *testing.T) {
 		RenameFrom: &oldName,
 		Values:     []string{"active", "inactive"},
 	})
-	result, err := diff.DiffEnums(current, desired)
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
@@ -323,7 +323,7 @@ func TestDiffEnums_RenameCrossSchema_Error(t *testing.T) {
 		RenameFrom: &oldName,
 		Values:     []string{"active"},
 	})
-	_, err := diff.DiffEnums(current, desired)
+	_, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
@@ -340,7 +340,7 @@ func TestDiffEnums_RenameDestinationExists_Error(t *testing.T) {
 		RenameFrom: &oldName,
 		Values:     []string{"active"},
 	})
-	_, err := diff.DiffEnums(current, desired)
+	_, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -354,7 +354,7 @@ func TestDiffEnums_RenameSourceNotFound(t *testing.T) {
 		RenameFrom: &oldName,
 		Values:     []string{"active"},
 	})
-	_, err := diff.DiffEnums(current, desired)
+	_, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -11,6 +11,7 @@ import (
 )
 
 func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) ([]string, error) {
+	dc = NormalizeDropChecker(dc)
 	var stmts []string
 
 	// Detect renames
@@ -66,6 +67,7 @@ func newTableExtras(t *model.Table) []string {
 }
 
 func diffTable(current, desired *model.Table, dc DropChecker) ([]string, error) {
+	dc = NormalizeDropChecker(dc)
 	var stmts []string
 	fqtn := desired.FQTN()
 
@@ -115,6 +117,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) ([]string, error) 
 }
 
 func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column], dc DropChecker) ([]string, error) {
+	dc = NormalizeDropChecker(dc)
 	var stmts []string
 
 	// Detect renames

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func DiffTables(current, desired *orderedmap.Map[string, *model.Table]) ([]string, error) {
+func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) ([]string, error) {
 	var stmts []string
 
 	// Detect renames
@@ -31,7 +31,7 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table]) ([]strin
 	// Modified tables
 	for k, desiredTable := range desired.All() {
 		if currentTable, ok := current.GetOk(k); ok {
-			tableStmts, err := diffTable(currentTable, desiredTable)
+			tableStmts, err := diffTable(currentTable, desiredTable, dc)
 			if err != nil {
 				return nil, err
 			}
@@ -40,9 +40,11 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table]) ([]strin
 	}
 
 	// Dropped tables
-	for k := range current.Keys() {
-		if _, ok := desired.GetOk(k); !ok {
-			stmts = append(stmts, "DROP TABLE "+k+";")
+	if dc.IsDropAllowed("table") {
+		for k := range current.Keys() {
+			if _, ok := desired.GetOk(k); !ok {
+				stmts = append(stmts, "DROP TABLE "+k+";")
+			}
 		}
 	}
 
@@ -63,7 +65,7 @@ func newTableExtras(t *model.Table) []string {
 	return stmts
 }
 
-func diffTable(current, desired *model.Table) ([]string, error) {
+func diffTable(current, desired *model.Table, dc DropChecker) ([]string, error) {
 	var stmts []string
 	fqtn := desired.FQTN()
 
@@ -83,7 +85,7 @@ func diffTable(current, desired *model.Table) ([]string, error) {
 		return stmts, nil
 	}
 
-	colStmts, err := diffColumns(fqtn, current.Columns, desired.Columns)
+	colStmts, err := diffColumns(fqtn, current.Columns, desired.Columns, dc)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +114,7 @@ func diffTable(current, desired *model.Table) ([]string, error) {
 	return stmts, nil
 }
 
-func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column]) ([]string, error) {
+func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column], dc DropChecker) ([]string, error) {
 	var stmts []string
 
 	// Detect renames
@@ -137,9 +139,11 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 	}
 
 	// Drop removed columns
-	for name := range current.Keys() {
-		if _, ok := desired.GetOk(name); !ok {
-			stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
+	if dc.IsDropAllowed("column") {
+		for name := range current.Keys() {
+			if _, ok := desired.GetOk(name); !ok {
+				stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
+			}
 		}
 	}
 

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -68,6 +68,30 @@ func TestDiffTables_dropTable(t *testing.T) {
 	assert.Equal(t, []string{"DROP TABLE public.users;"}, stmts)
 }
 
+func TestDiffTables_dropTable_denied(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	current.Set("public.users", newTable("public", "users"))
+
+	stmts, err := DiffTables(current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffColumns_dropColumn_denied(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	current.Set("name", &model.Column{Name: "name", TypeName: "text"})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+
+	stmts, err := diffColumns("public.users", current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
 func TestDiffTables_noChange(t *testing.T) {
 	current := orderedmap.New[string, *model.Table]()
 	desired := orderedmap.New[string, *model.Table]()

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -33,7 +33,7 @@ func TestDiffTables_newTable(t *testing.T) {
 	tbl.Constraints.Set("users_pkey", &model.Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
 	desired.Set("public.users", tbl)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE TABLE public.users")
@@ -49,7 +49,7 @@ func TestDiffTables_newTable_withExtras(t *testing.T) {
 	tbl.Comment = ptr("Users table")
 	desired.Set("public.users", tbl)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 3)
 	assert.Contains(t, stmts[0], "CREATE TABLE")
@@ -63,7 +63,7 @@ func TestDiffTables_dropTable(t *testing.T) {
 
 	current.Set("public.users", newTable("public", "users"))
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP TABLE public.users;"}, stmts)
 }
@@ -80,7 +80,7 @@ func TestDiffTables_noChange(t *testing.T) {
 	tbl2.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 	desired.Set("public.users", tbl2)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -93,7 +93,7 @@ func TestDiffColumns_addColumn(t *testing.T) {
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ADD COLUMN name text NOT NULL;", stmts[0])
@@ -107,7 +107,7 @@ func TestDiffColumns_dropColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users DROP COLUMN name;", stmts[0])
@@ -120,7 +120,7 @@ func TestDiffColumns_alterType(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;", stmts[0])
@@ -133,7 +133,7 @@ func TestDiffColumns_alterType_withCollation(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], `COLLATE "en_US"`)
@@ -146,7 +146,7 @@ func TestDiffColumns_alterDefault_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer", Default: ptr("0")})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age SET DEFAULT 0;", stmts[0])
@@ -159,7 +159,7 @@ func TestDiffColumns_alterDefault_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer"})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age DROP DEFAULT;", stmts[0])
@@ -172,7 +172,7 @@ func TestDiffColumns_alterNotNull_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;", stmts[0])
@@ -185,7 +185,7 @@ func TestDiffColumns_alterNotNull_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;", stmts[0])
@@ -198,7 +198,7 @@ func TestDiffColumns_identitySkipsNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", Identity: model.ColumnIdentity('a')})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -433,7 +433,7 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 	})
 	desired.Set("public.orders", tbl)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Contains(t, stmts[0], "CREATE TABLE")
@@ -510,7 +510,7 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	desired.PartitionBound = &bound
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
 
-	stmts, err := diffTable(current, desired)
+	stmts, err := diffTable(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE INDEX idx_new")
@@ -530,7 +530,7 @@ func TestDiffTable_partitionChild_indexRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", RenameFrom: &oldName, Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
 
-	_, err := diffTable(current, desired)
+	_, err := diffTable(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -553,7 +553,7 @@ func TestDiffTable_partitionChild_fkRenameError(t *testing.T) {
 		Table:      "events_2024",
 	})
 
-	_, err := diffTable(current, desired)
+	_, err := diffTable(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -567,7 +567,7 @@ func TestDiffTable_constraintRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Constraints.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (id)"})
 
-	_, err := diffTable(current, desired)
+	_, err := diffTable(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source constraint")
 }
@@ -581,7 +581,7 @@ func TestDiffTable_indexRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", RenameFrom: &oldName, Definition: "CREATE INDEX idx_new ON public.users (id)"})
 
-	_, err := diffTable(current, desired)
+	_, err := diffTable(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -599,7 +599,7 @@ func TestDiffTable_fkRenameError(t *testing.T) {
 		Table:      "users",
 	})
 
-	_, err := diffTable(current, desired)
+	_, err := diffTable(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -868,7 +868,7 @@ func TestDiffTables_indexWhereClauseSchemaInsensitive(t *testing.T) {
 	})
 	desired.Set("public.products", dt)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -952,7 +952,7 @@ func TestDiffTables_indexSchemaInsensitive(t *testing.T) {
 	dt.Indexes.Set("idx", &model.Index{Schema: "", Name: "idx", Table: "users", Definition: "CREATE INDEX idx ON users USING btree (id)"})
 	desired.Set("public.users", dt)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -971,7 +971,7 @@ func TestDiffTables_renameTable(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, stmts)
 }
@@ -990,7 +990,7 @@ func TestDiffTables_renameTable_selfRename_skipped(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.users", dt)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1003,7 +1003,7 @@ func TestDiffColumns_renameColumn_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1069,7 +1069,7 @@ func TestDiffTables_renameTable_alreadyApplied(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1092,7 +1092,7 @@ func TestDiffTables_renameTable_withIndex(t *testing.T) {
 	dt.Indexes.Set("idx_users_name", &model.Index{Schema: "public", Name: "idx_users_name", Table: "accounts", Definition: "CREATE INDEX idx_users_name ON public.accounts USING btree (name)"})
 	desired.Set("public.accounts", dt)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	// Should only rename the table, no DROP/CREATE index
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, stmts)
@@ -1124,7 +1124,7 @@ func TestDiffTables_renameTable_withFK(t *testing.T) {
 	})
 	desired.Set("public.purchases", dt)
 
-	stmts, err := DiffTables(current, desired)
+	stmts, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME TO purchases;"}, stmts)
 }
@@ -1147,7 +1147,7 @@ func TestDiffTables_renameTable_destinationExists_error(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	_, err := DiffTables(current, desired)
+	_, err := DiffTables(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -1161,7 +1161,7 @@ func TestDiffColumns_renameColumn_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	_, err := diffColumns("public.users", current, desired)
+	_, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -1180,7 +1180,7 @@ func TestDiffTables_renameTable_crossSchema_error(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("other.users", dt)
 
-	_, err := DiffTables(current, desired)
+	_, err := DiffTables(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
@@ -1193,7 +1193,7 @@ func TestDiffColumns_renameColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME COLUMN name TO display_name;"}, stmts)
 }
@@ -1206,7 +1206,7 @@ func TestDiffColumns_renameColumn_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired)
+	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1409,7 +1409,7 @@ func TestDiffTables_renameTable_sourceNotFound(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	_, err := DiffTables(current, desired)
+	_, err := DiffTables(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }
@@ -1428,7 +1428,7 @@ func TestDiffTables_renameColumn_error_propagates(t *testing.T) {
 	dt.Columns.Set("new_col", &model.Column{Name: "new_col", RenameFrom: &oldName, TypeName: "text"})
 	desired.Set("public.users", dt)
 
-	_, err := DiffTables(current, desired)
+	_, err := DiffTables(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source column")
 }
@@ -1440,7 +1440,7 @@ func TestDiffColumns_renameColumn_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	_, err := diffColumns("public.users", current, desired)
+	_, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source column")
 }

--- a/diff/views.go
+++ b/diff/views.go
@@ -34,6 +34,7 @@ func equalViewDef(a, b string) bool {
 }
 
 func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker) ([]string, error) {
+	dc = NormalizeDropChecker(dc)
 	var stmts []string
 
 	// Detect renames

--- a/diff/views.go
+++ b/diff/views.go
@@ -33,7 +33,7 @@ func equalViewDef(a, b string) bool {
 	return normA == normB
 }
 
-func DiffViews(current, desired *orderedmap.Map[string, *model.View]) ([]string, error) {
+func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker) ([]string, error) {
 	var stmts []string
 
 	// Detect renames
@@ -52,9 +52,11 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View]) ([]string,
 	}
 
 	// Dropped views
-	for k := range current.Keys() {
-		if _, ok := desired.GetOk(k); !ok {
-			stmts = append(stmts, "DROP VIEW "+k+";")
+	if dc.IsDropAllowed("view") {
+		for k := range current.Keys() {
+			if _, ok := desired.GetOk(k); !ok {
+				stmts = append(stmts, "DROP VIEW "+k+";")
+			}
 		}
 	}
 

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -14,7 +14,7 @@ func TestDiffViews_newView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE OR REPLACE VIEW public.v1")
@@ -25,7 +25,7 @@ func TestDiffViews_dropView(t *testing.T) {
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 	desired := orderedmap.New[string, *model.View]()
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP VIEW public.v1;"}, stmts)
 }
@@ -36,7 +36,7 @@ func TestDiffViews_modifyView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 2"})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], "CREATE OR REPLACE VIEW public.v1")
@@ -48,7 +48,7 @@ func TestDiffViews_noChange(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -59,7 +59,7 @@ func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -70,7 +70,7 @@ func TestDiffViews_commentAdd(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", Comment: ptr("my view")})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS 'my view';", stmts[0])
@@ -82,7 +82,7 @@ func TestDiffViews_commentDrop(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS NULL;", stmts[0])
@@ -96,7 +96,7 @@ func TestDiffViews_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER VIEW public.v1 RENAME TO v2;"}, stmts)
 }
@@ -109,7 +109,7 @@ func TestDiffViews_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -122,7 +122,7 @@ func TestDiffViews_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired)
+	stmts, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -136,7 +136,7 @@ func TestDiffViews_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired)
+	_, err := DiffViews(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -149,7 +149,7 @@ func TestDiffViews_rename_crossSchema_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("other.v2", &model.View{Schema: "other", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired)
+	_, err := DiffViews(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
@@ -161,7 +161,7 @@ func TestDiffViews_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired)
+	_, err := DiffViews(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -30,6 +30,16 @@ func TestDiffViews_dropView(t *testing.T) {
 	assert.Equal(t, []string{"DROP VIEW public.v1;"}, stmts)
 }
 
+func TestDiffViews_dropView_denied(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+	desired := orderedmap.New[string, *model.View]()
+
+	stmts, err := DiffViews(current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
 func TestDiffViews_modifyView(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -1,0 +1,18 @@
+package pistachio
+
+import "slices"
+
+// DropPolicy controls which object types are allowed to be dropped.
+// If AllowDrop is empty, no drops are allowed (safe default).
+// If AllowDrop contains "all", all drops are allowed.
+// Otherwise, only the listed object types are allowed to be dropped.
+type DropPolicy struct {
+	AllowDrop []string `enum:"all,table,view,enum,domain,column,constraint,index" env:"PIST_ALLOW_DROP" help:"Allow dropping specified object types (can be repeated). Use 'all' to allow all drops."`
+}
+
+func (p *DropPolicy) IsDropAllowed(objectType string) bool {
+	if len(p.AllowDrop) == 0 {
+		return false
+	}
+	return slices.Contains(p.AllowDrop, "all") || slices.Contains(p.AllowDrop, objectType)
+}

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -11,7 +11,7 @@ type DropPolicy struct {
 }
 
 func (p *DropPolicy) IsDropAllowed(objectType string) bool {
-	if len(p.AllowDrop) == 0 {
+	if p == nil || len(p.AllowDrop) == 0 {
 		return false
 	}
 	return slices.Contains(p.AllowDrop, "all") || slices.Contains(p.AllowDrop, objectType)

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -7,7 +7,7 @@ import "slices"
 // If AllowDrop contains "all", all drops are allowed.
 // Otherwise, only the listed object types are allowed to be dropped.
 type DropPolicy struct {
-	AllowDrop []string `enum:"all,table,view,enum,domain,column,constraint,index" env:"PIST_ALLOW_DROP" help:"Allow dropping specified object types (can be repeated). Use 'all' to allow all drops."`
+	AllowDrop []string `enum:"all,table,view,enum,domain,column" env:"PIST_ALLOW_DROP" help:"Allow dropping specified object types (can be repeated). Use 'all' to allow all drops."`
 }
 
 func (p *DropPolicy) IsDropAllowed(objectType string) bool {

--- a/drop_policy_test.go
+++ b/drop_policy_test.go
@@ -1,0 +1,36 @@
+package pistachio_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/pistachio"
+)
+
+func TestDropPolicy_IsDropAllowed(t *testing.T) {
+	t.Run("empty (no drops)", func(t *testing.T) {
+		p := &pistachio.DropPolicy{}
+		assert.False(t, p.IsDropAllowed("table"))
+		assert.False(t, p.IsDropAllowed("view"))
+		assert.False(t, p.IsDropAllowed("enum"))
+		assert.False(t, p.IsDropAllowed("domain"))
+		assert.False(t, p.IsDropAllowed("column"))
+	})
+
+	t.Run("all", func(t *testing.T) {
+		p := &pistachio.DropPolicy{AllowDrop: []string{"all"}}
+		assert.True(t, p.IsDropAllowed("table"))
+		assert.True(t, p.IsDropAllowed("view"))
+		assert.True(t, p.IsDropAllowed("enum"))
+		assert.True(t, p.IsDropAllowed("domain"))
+		assert.True(t, p.IsDropAllowed("column"))
+	})
+
+	t.Run("specific types", func(t *testing.T) {
+		p := &pistachio.DropPolicy{AllowDrop: []string{"table", "column"}}
+		assert.True(t, p.IsDropAllowed("table"))
+		assert.True(t, p.IsDropAllowed("column"))
+		assert.False(t, p.IsDropAllowed("view"))
+		assert.False(t, p.IsDropAllowed("enum"))
+	})
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -217,7 +217,7 @@ CREATE TABLE public.users (
 	assert.Empty(t, got)
 }
 
-func TestPlan_AllowDrop_Table(t *testing.T) {
+func TestPlan_AllowDrop_Column(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)

--- a/filter_test.go
+++ b/filter_test.go
@@ -191,6 +191,66 @@ CREATE TABLE public.users (
 	assert.NotContains(t, got, "ALTER TABLE")
 }
 
+func TestPlan_AllowDrop_None(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(``), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// No --allow-drop: DROP TABLE should be suppressed
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestPlan_AllowDrop_Table(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// --allow-drop column: DROP COLUMN allowed but DROP TABLE not
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"column"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got, "DROP COLUMN email")
+}
+
 func TestDump_Include(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
@@ -370,7 +430,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
@@ -409,7 +469,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Exclude: []string{"posts"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Exclude: []string{"posts"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
@@ -478,7 +538,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';")
@@ -503,7 +563,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: only status should have the new value
@@ -777,7 +837,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: only users should have the new column

--- a/filter_test.go
+++ b/filter_test.go
@@ -251,6 +251,38 @@ CREATE TABLE public.users (
 	assert.Contains(t, got, "DROP COLUMN email")
 }
 
+func TestApply_DefaultNoDrops(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	// Desired is empty — without --allow-drop, table should NOT be dropped
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(``), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+
+	// Verify table still exists
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	assert.Contains(t, got.String(), "CREATE TABLE public.users")
+}
+
 func TestDump_Include(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/getting-started.md
+++ b/getting-started.md
@@ -207,7 +207,7 @@ pist apply --allow-drop column,table schema.sql
 PIST_ALLOW_DROP=all pist plan schema.sql
 ```
 
-Valid types: `all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `index`.
+Valid types: `all`, `table`, `view`, `enum`, `domain`, `column`.
 
 ### Using transactions
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -200,8 +200,8 @@ By default, `plan` and `apply` do **not** generate DROP statements to prevent ac
 pist plan --allow-drop all schema.sql
 pist apply --allow-drop all schema.sql
 
-# Allow only specific drop types
-pist apply --allow-drop column --allow-drop table schema.sql
+# Allow only specific drop types (comma-separated or repeated)
+pist apply --allow-drop column,table schema.sql
 
 # Using environment variable
 PIST_ALLOW_DROP=all pist plan schema.sql

--- a/getting-started.md
+++ b/getting-started.md
@@ -210,7 +210,7 @@ PIST_ALLOW_DROP=all pist plan schema.sql
 Valid types: `all`, `table`, `view`, `enum`, `domain`, `column`.
 
 > [!NOTE]
-> Constraints and indexes are always dropped regardless of `--allow-drop` (PostgreSQL requires DROP + ADD to change their definitions).
+> Constraints and indexes are dropped when their definitions change or they are removed from the desired schema, regardless of `--allow-drop`. PostgreSQL does not support altering their definitions in place — the only way to update them is DROP + ADD.
 
 ### Using transactions
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -193,7 +193,7 @@ pist dump --enable table,enum        # dump tables and enums only
 
 ### Controlling drops
 
-By default, `plan` and `apply` do **not** generate DROP statements to prevent accidental data loss. Use `--allow-drop` to opt in:
+By default, `plan` and `apply` do **not** drop tables, views, enums, domains, or columns. Use `--allow-drop` to opt in:
 
 ```bash
 # Allow all drops

--- a/getting-started.md
+++ b/getting-started.md
@@ -186,9 +186,9 @@ pist plan -E 'tmp_*' schema.sql  # ignore temporary tables
 Use `--enable` / `--disable` to filter by object type:
 
 ```bash
-pist dump --enable enum            # dump only enums
-pist dump --disable view           # dump everything except views
-pist dump --enable table --enable enum  # dump tables and enums only
+pist dump --enable enum              # dump only enums
+pist dump --disable view             # dump everything except views
+pist dump --enable table,enum        # dump tables and enums only
 ```
 
 ### Controlling drops

--- a/getting-started.md
+++ b/getting-started.md
@@ -191,6 +191,24 @@ pist dump --disable view           # dump everything except views
 pist dump --enable table --enable enum  # dump tables and enums only
 ```
 
+### Controlling drops
+
+By default, `plan` and `apply` do **not** generate DROP statements to prevent accidental data loss. Use `--allow-drop` to opt in:
+
+```bash
+# Allow all drops
+pist plan --allow-drop all schema.sql
+pist apply --allow-drop all schema.sql
+
+# Allow only specific drop types
+pist apply --allow-drop column --allow-drop table schema.sql
+
+# Using environment variable
+PIST_ALLOW_DROP=all pist plan schema.sql
+```
+
+Valid types: `all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `index`.
+
 ### Using transactions
 
 Wrap apply in a transaction so all changes succeed or fail together:

--- a/getting-started.md
+++ b/getting-started.md
@@ -209,6 +209,9 @@ PIST_ALLOW_DROP=all pist plan schema.sql
 
 Valid types: `all`, `table`, `view`, `enum`, `domain`, `column`.
 
+> [!NOTE]
+> Constraints and indexes are always dropped regardless of `--allow-drop` (PostgreSQL requires DROP + ADD to change their definitions).
+
 ### Using transactions
 
 Wrap apply in a transaction so all changes succeed or fail together:

--- a/plan.go
+++ b/plan.go
@@ -13,6 +13,7 @@ import (
 
 type PlanOptions struct {
 	FilterOptions
+	DropPolicy
 	Files      []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQLFile string   `type:"path" help:"Path to a SQL file to execute before applying changes."`
 }
@@ -54,25 +55,25 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 		return "", fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)))
+	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
 	if err != nil {
 		return "", err
 	}
 	stmts := enumDiff.Stmts
 
-	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)))
+	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
 	if err != nil {
 		return "", fmt.Errorf("failed to diff domains: %w", err)
 	}
 	stmts = append(stmts, domainDiff.Stmts...)
 
-	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)))
+	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
 	if err != nil {
 		return "", fmt.Errorf("failed to diff tables: %w", err)
 	}
 	stmts = append(stmts, tableStmts...)
 
-	viewStmts, err := diff.DiffViews(options.filterViews(currentViews), options.filterViews(client.reverseRemapViewSchemas(desired.Views)))
+	viewStmts, err := diff.DiffViews(options.filterViews(currentViews), options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
 	if err != nil {
 		return "", fmt.Errorf("failed to diff views: %w", err)
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -52,7 +52,7 @@ func TestPlan_WithPassword(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Contains(t, got, "CREATE TABLE public.users")
 }
@@ -206,7 +206,7 @@ CREATE TABLE public.users (
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
 }
@@ -233,7 +233,7 @@ CREATE TABLE public.users (
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -261,7 +261,7 @@ func TestPlan(t *testing.T) {
 				Schemas:    []string{"public"},
 			})
 
-			got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+			got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.Plan), strings.TrimSpace(got))
 		})

--- a/remap_test.go
+++ b/remap_test.go
@@ -213,7 +213,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -243,7 +243,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	// No diff expected since schemas are remapped
@@ -293,7 +293,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -406,7 +406,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	// "other" schema is not reverse-mapped, so it won't match myschema
@@ -450,7 +450,7 @@ ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (use
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -483,7 +483,7 @@ CREATE INDEX users_name_idx ON public.users (name);
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -514,7 +514,7 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -545,7 +545,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: dump without schema map should show myschema with new column
@@ -585,7 +585,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -613,7 +613,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -655,7 +655,7 @@ CREATE DOMAIN myschema.pos_int AS integer;
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Contains(t, got, "ALTER DOMAIN myschema.pos_int SET NOT NULL;")
 }
@@ -697,7 +697,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got, "ALTER TYPE myschema.status ADD VALUE 'pending' AFTER 'inactive';")
@@ -719,7 +719,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -740,7 +740,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	verifyClient := pistachio.NewClient(&pistachio.Options{
@@ -775,7 +775,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{})


### PR DESCRIPTION
This pull request introduces a configurable drop policy for schema changes, allowing users to control which object types can be dropped during `plan` and `apply` operations. The changes add support for the `--allow-drop` flag and its corresponding code logic, update documentation and tests, and refactor the diffing logic for domains to respect the drop policy.

**Drop Policy and CLI Enhancements:**
- Added the `--allow-drop` flag (and `$PIST_ALLOW_DROP` environment variable) to `plan` and `apply` commands, enabling users to specify which object types (e.g., `table`, `view`, `domain`, etc.) can be dropped. This is now reflected in the `README.md` documentation with usage examples.
- Updated `ApplyOptions` and `PlanOptions` structs to include a `DropPolicy`, wiring this policy through to all relevant diffing functions.
- Modified the invocation of diffing functions for enums, domains, tables, and views to pass the drop policy, ensuring that drop statements are only generated if allowed.

**Domain Diff Logic Refactor:**
- Refactored `DiffDomains` to accept a drop checker and only generate drop statements for domains if dropping is permitted by the policy. [[1]](diffhunk://#diff-52d50f0e02b7cf6b819e766355a54d37d387f601a14b246ce20516076066b658L16-R16) [[2]](diffhunk://#diff-52d50f0e02b7cf6b819e766355a54d37d387f601a14b246ce20516076066b658R51-R57)

**Testing Updates:**
- Updated all domain diff tests to pass an explicit drop policy, ensuring tests reflect the new drop behavior. [[1]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L24-R24) [[2]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L35-R35) [[3]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L44-R44) [[4]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L53-R53) [[5]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L63-R63) [[6]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L72-R88) [[7]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L103-R103) [[8]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L119-R119) [[9]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L130-R138) [[10]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L147-R147) [[11]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L156-R156) [[12]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L165-R165) [[13]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L174-R174) [[14]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L183-R183) [[15]](diffhunk://#diff-ec1fafa73e86295f6e0e811a58d1136ec89c669126e481e75e973a889373d6c7L192-R192)
- Updated integration and command tests to use the new drop policy in `ApplyOptions` and `PlanOptions`. [[1]](diffhunk://#diff-8e3345a8a7d74bb86f72848f08ec03aa8856e6d7afeb77621cd16f0077b5f939L46-R46) [[2]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L36-R36) [[3]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L244-R244) [[4]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L282-R282) [[5]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L308-R308) [[6]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L325-R325) [[7]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L349-R349)

**Documentation Improvements:**
- Improved documentation for `dump` command to clarify usage of `--enable` with comma-separated values.

These changes make drop operations safer and more controllable, improving both the developer experience and the reliability of schema migrations.