### PR TITLE
Add NormalizeDropChecker and nil DropChecker tests

### DIFF
--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -68,6 +68,28 @@ func TestDiffTables_dropTable(t *testing.T) {
 	assert.Equal(t, []string{"DROP TABLE public.users;"}, stmts)
 }
 
+func TestNormalizeDropChecker_nil(t *testing.T) {
+	dc := NormalizeDropChecker(nil)
+	assert.False(t, dc.IsDropAllowed("table"))
+}
+
+func TestNormalizeDropChecker_nonNil(t *testing.T) {
+	dc := NormalizeDropChecker(AllowAllDrops{})
+	assert.True(t, dc.IsDropAllowed("table"))
+}
+
+func TestDiffTables_nilDropChecker(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	current.Set("public.users", newTable("public", "users"))
+
+	// nil DropChecker should not panic, drops should be denied
+	stmts, err := DiffTables(current, desired, nil)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
 func TestDiffTables_dropTable_denied(t *testing.T) {
 	current := orderedmap.New[string, *model.Table]()
 	desired := orderedmap.New[string, *model.Table]()


### PR DESCRIPTION
This pull request adds new tests to improve coverage and robustness related to drop table operations and the `DropChecker` interface. The main focus is ensuring that the `NormalizeDropChecker` function behaves correctly with both `nil` and non-`nil` arguments, and that the `DiffTables` function handles a `nil` `DropChecker` safely.

### Test coverage improvements

* Added `TestNormalizeDropChecker_nil` to verify that passing `nil` to `NormalizeDropChecker` results in a drop checker that does not allow drops.
* Added `TestNormalizeDropChecker_nonNil` to verify that passing a permissive drop checker to `NormalizeDropChecker` allows drops as expected.
* Added `TestDiffTables_nilDropChecker` to ensure that passing a `nil` `DropChecker` to `DiffTables` does not panic and correctly denies all drop operations.