### PR TITLE
Filter desired SQL by target schemas and show object counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,9 @@ ALTER TABLE ONLY public.posts
 Preview and apply:
 
 ```bash
-pist plan schema.sql   # review the diff
-pist apply schema.sql  # apply it
+pist plan schema.sql                  # review the diff (drops suppressed by default)
+pist plan --allow-drop all schema.sql # review the diff (with drops)
+pist apply schema.sql                 # apply it
 ```
 
 Or split schema into multiple files and use them together:

--- a/apply.go
+++ b/apply.go
@@ -64,6 +64,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	filteredDomains := options.filterDomains(currentDomains)
 
 	count := &ObjectCount{
+		Schemas: client.Schemas,
 		Tables:  filteredTables.Len(),
 		Views:   filteredViews.Len(),
 		Enums:   filteredEnums.Len(),

--- a/apply.go
+++ b/apply.go
@@ -19,64 +19,78 @@ type ApplyOptions struct {
 	WithTx     bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
 }
 
-func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) error {
+func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (*ObjectCount, error) {
 	conn, err := client.connect()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer conn.Close(ctx) //nolint:errcheck
 
 	cat, err := catalog.NewCatalog(conn, client.Schemas)
 	if err != nil {
-		return fmt.Errorf("failed to create catalog: %w", err)
+		return nil, fmt.Errorf("failed to create catalog: %w", err)
 	}
 
 	currentTables, err := cat.Tables(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to fetch tables: %w", err)
+		return nil, fmt.Errorf("failed to fetch tables: %w", err)
 	}
 
 	currentViews, err := cat.Views(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to fetch views: %w", err)
+		return nil, fmt.Errorf("failed to fetch views: %w", err)
 	}
 
 	currentEnums, err := cat.Enums(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to fetch enums: %w", err)
+		return nil, fmt.Errorf("failed to fetch enums: %w", err)
 	}
 
 	currentDomains, err := cat.Domains(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to fetch domains: %w", err)
+		return nil, fmt.Errorf("failed to fetch domains: %w", err)
 	}
 
 	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse SQL file: %w", err)
+		return nil, fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
+	filterDesiredBySchemas(desired, client.Schemas, client.SchemaMap)
+
+	filteredTables := options.filterTables(currentTables)
+	filteredViews := options.filterViews(currentViews)
+	filteredEnums := options.filterEnums(currentEnums)
+	filteredDomains := options.filterDomains(currentDomains)
+
+	count := &ObjectCount{
+		Tables:  filteredTables.Len(),
+		Views:   filteredViews.Len(),
+		Enums:   filteredEnums.Len(),
+		Domains: filteredDomains.Len(),
+	}
+
+	enumDiff, err := diff.DiffEnums(filteredEnums, options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	stmts := enumDiff.Stmts
 
-	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
+	domainDiff, err := diff.DiffDomains(filteredDomains, options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
 	if err != nil {
-		return fmt.Errorf("failed to diff domains: %w", err)
+		return nil, fmt.Errorf("failed to diff domains: %w", err)
 	}
 	stmts = append(stmts, domainDiff.Stmts...)
 
-	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
+	tableStmts, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
 	if err != nil {
-		return fmt.Errorf("failed to diff tables: %w", err)
+		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
 	stmts = append(stmts, tableStmts...)
 
-	viewStmts, err := diff.DiffViews(options.filterViews(currentViews), options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
+	viewStmts, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
 	if err != nil {
-		return fmt.Errorf("failed to diff views: %w", err)
+		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}
 	stmts = append(stmts, viewStmts...)
 
@@ -87,13 +101,13 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if options.PreSQLFile != "" {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)
 		if err != nil {
-			return fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
+			return nil, fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
 		}
 		preSQL = string(rawPreSQL)
 	}
 
 	if len(stmts) == 0 {
-		return nil
+		return count, nil
 	}
 
 	exec := conn.Exec
@@ -102,7 +116,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if options.WithTx {
 		tx, err := conn.Begin(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to begin transaction: %w", err)
+			return nil, fmt.Errorf("failed to begin transaction: %w", err)
 		}
 		defer tx.Rollback(ctx) //nolint:errcheck
 		exec = tx.Exec
@@ -112,20 +126,20 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if preSQL != "" {
 		fmt.Fprintln(w, preSQL) //nolint:errcheck
 		if _, err := exec(ctx, preSQL); err != nil {
-			return fmt.Errorf("failed to execute pre-SQL: %w", err)
+			return nil, fmt.Errorf("failed to execute pre-SQL: %w", err)
 		}
 	}
 
 	for _, stmt := range stmts {
 		fmt.Fprintln(w, stmt) //nolint:errcheck
 		if _, err := exec(ctx, stmt); err != nil {
-			return fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)
+			return nil, fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)
 		}
 	}
 
 	if err := commit(ctx); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	return nil
+	return count, nil
 }

--- a/apply_test.go
+++ b/apply_test.go
@@ -43,7 +43,7 @@ func TestApply(t *testing.T) {
 				ConnString: conn.Config().ConnString(),
 				Schemas:    []string{"public"},
 			})
-			err = client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
+			_, err = client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
 			require.NoError(t, err)
 
 			// Verify
@@ -79,7 +79,7 @@ func TestApply_WithPreSQLFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	applyErr := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, applyErr := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 	}, io.Discard)
@@ -117,7 +117,7 @@ func TestApply_WithPreSQLFile_Output(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	err := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 	}, &buf)
@@ -158,7 +158,7 @@ SELECT * FROM public.missing_table;`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
@@ -193,7 +193,7 @@ func TestApply_WithTx_Success(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
@@ -224,7 +224,7 @@ func TestApply_NoDiff(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 }
 
@@ -251,7 +251,7 @@ CREATE TABLE public.users (
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
@@ -282,7 +282,7 @@ func TestApply_ExecError(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -299,7 +299,7 @@ func TestApply_EmptySchemas(t *testing.T) {
 		Schemas:    []string{},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -313,7 +313,7 @@ func TestApply_InvalidConnString(t *testing.T) {
 	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -329,7 +329,7 @@ func TestApply_InvalidDesiredFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{"/nonexistent/file.sql"}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{"/nonexistent/file.sql"}}, io.Discard)
 	require.Error(t, err)
 }
 
@@ -351,7 +351,7 @@ func TestApply_InvalidPreSQLFile(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:      []string{desiredFile},
 		PreSQLFile: "/nonexistent/pre.sql",
 	}, io.Discard)

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -20,8 +20,10 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 		return err
 	}
 
+	fmt.Fprintf(w, "-- Target: %s\n", count) //nolint:errcheck
+
 	if buf.Len() == 0 {
-		fmt.Fprintf(w, "-- No changes (%s)\n", count) //nolint:errcheck
+		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {
 		w.Write(buf.Bytes()) //nolint:errcheck
 	}

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -15,13 +15,13 @@ type Apply struct {
 
 func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer) error {
 	var buf bytes.Buffer
-	err := client.Apply(ctx, &cmd.ApplyOptions, &buf)
+	count, err := client.Apply(ctx, &cmd.ApplyOptions, &buf)
 	if err != nil {
 		return err
 	}
 
 	if buf.Len() == 0 {
-		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
+		fmt.Fprintf(w, "-- No changes (%s)\n", count) //nolint:errcheck
 	} else {
 		w.Write(buf.Bytes()) //nolint:errcheck
 	}

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -282,7 +282,7 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Equal(t, "-- No changes\n", buf.String())
+	assert.Contains(t, buf.String(), "-- No changes", buf.String())
 }
 
 func TestApply_Run_NoChanges(t *testing.T) {
@@ -308,7 +308,7 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Equal(t, "-- No changes\n", buf.String())
+	assert.Contains(t, buf.String(), "-- No changes", buf.String())
 }
 
 func TestApply_Run_Error(t *testing.T) {

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -282,7 +282,8 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Equal(t, "-- No changes (1 table, 0 views, 0 enums, 0 domains)\n", buf.String())
+	assert.Contains(t, buf.String(), "-- Target: schema: public, 1 table,")
+	assert.Contains(t, buf.String(), "-- No changes")
 }
 
 func TestApply_Run_NoChanges(t *testing.T) {
@@ -308,7 +309,8 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Equal(t, "-- No changes (1 table, 0 views, 0 enums, 0 domains)\n", buf.String())
+	assert.Contains(t, buf.String(), "-- Target: schema: public, 1 table,")
+	assert.Contains(t, buf.String(), "-- No changes")
 }
 
 func TestApply_Run_Error(t *testing.T) {

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -282,7 +282,7 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- No changes", buf.String())
+	assert.Equal(t, "-- No changes (1 table, 0 views, 0 enums, 0 domains)\n", buf.String())
 }
 
 func TestApply_Run_NoChanges(t *testing.T) {
@@ -308,7 +308,7 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- No changes", buf.String())
+	assert.Equal(t, "-- No changes (1 table, 0 views, 0 enums, 0 domains)\n", buf.String())
 }
 
 func TestApply_Run_Error(t *testing.T) {

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -13,15 +13,15 @@ type Plan struct {
 }
 
 func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer) error {
-	plan, err := client.Plan(ctx, &cmd.PlanOptions)
+	result, err := client.Plan(ctx, &cmd.PlanOptions)
 	if err != nil {
 		return err
 	}
 
-	if plan == "" {
-		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
+	if result.SQL == "" {
+		fmt.Fprintf(w, "-- No changes (%s)\n", result.Count) //nolint:errcheck
 	} else {
-		fmt.Fprintln(w, plan) //nolint:errcheck
+		fmt.Fprintln(w, result.SQL) //nolint:errcheck
 	}
 
 	return nil

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -18,8 +18,10 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return err
 	}
 
+	fmt.Fprintf(w, "-- Target: %s\n", result.Count) //nolint:errcheck
+
 	if result.SQL == "" {
-		fmt.Fprintf(w, "-- No changes (%s)\n", result.Count) //nolint:errcheck
+		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {
 		fmt.Fprintln(w, result.SQL) //nolint:errcheck
 	}

--- a/dump_test.go
+++ b/dump_test.go
@@ -383,7 +383,7 @@ CREATE TABLE public.users (
 
 	plan, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{tmpFile}})
 	require.NoError(t, err)
-	assert.Empty(t, plan)
+	assert.Empty(t, plan.SQL)
 }
 
 func TestDumpResult_OmitSchema_Enum_Files(t *testing.T) {

--- a/filter_test.go
+++ b/filter_test.go
@@ -187,8 +187,8 @@ CREATE TABLE public.users (
 		Files:         []string{desiredFile},
 	})
 	require.NoError(t, err)
-	assert.Contains(t, got, "ALTER TYPE")
-	assert.NotContains(t, got, "ALTER TABLE")
+	assert.Contains(t, got.SQL, "ALTER TYPE")
+	assert.NotContains(t, got.SQL, "ALTER TABLE")
 }
 
 func TestPlan_AllowDrop_None(t *testing.T) {
@@ -214,7 +214,7 @@ CREATE TABLE public.users (
 	// No --allow-drop: DROP TABLE should be suppressed
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 	require.NoError(t, err)
-	assert.Empty(t, got)
+	assert.Empty(t, got.SQL)
 }
 
 func TestPlan_AllowDrop_Column(t *testing.T) {
@@ -248,7 +248,7 @@ CREATE TABLE public.users (
 		Files:      []string{desiredFile},
 	})
 	require.NoError(t, err)
-	assert.Contains(t, got, "DROP COLUMN email")
+	assert.Contains(t, got.SQL, "DROP COLUMN email")
 }
 
 func TestApply_DefaultNoDrops(t *testing.T) {
@@ -273,7 +273,7 @@ CREATE TABLE public.users (
 	})
 
 	var buf bytes.Buffer
-	err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 
@@ -465,8 +465,8 @@ CREATE TABLE public.posts (
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
-	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
-	assert.NotContains(t, got, "posts")
+	assert.Contains(t, got.SQL, "ALTER TABLE public.users ADD COLUMN name text;")
+	assert.NotContains(t, got.SQL, "posts")
 }
 
 func TestPlan_Exclude(t *testing.T) {
@@ -504,8 +504,8 @@ CREATE TABLE public.posts (
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Exclude: []string{"posts"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
-	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
-	assert.NotContains(t, got, "posts")
+	assert.Contains(t, got.SQL, "ALTER TABLE public.users ADD COLUMN name text;")
+	assert.NotContains(t, got.SQL, "posts")
 }
 
 func TestDump_IncludeEnum(t *testing.T) {
@@ -573,8 +573,8 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
-	assert.Contains(t, got, "ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';")
-	assert.NotContains(t, got, "role")
+	assert.Contains(t, got.SQL, "ALTER TYPE public.status ADD VALUE 'pending' AFTER 'inactive';")
+	assert.NotContains(t, got.SQL, "role")
 }
 
 func TestApply_IncludeEnum(t *testing.T) {
@@ -595,7 +595,7 @@ CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"status"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: only status should have the new value
@@ -773,8 +773,8 @@ CREATE TABLE public.users (
 		Files:         []string{desiredFile},
 	})
 	require.NoError(t, err)
-	assert.Contains(t, got, "ALTER TYPE")
-	assert.NotContains(t, got, "ALTER TABLE")
+	assert.Contains(t, got.SQL, "ALTER TYPE")
+	assert.NotContains(t, got.SQL, "ALTER TABLE")
 }
 
 func TestApply_Enable_Table(t *testing.T) {
@@ -804,7 +804,7 @@ CREATE TABLE public.users (
 	})
 
 	var buf bytes.Buffer
-	err := client.Apply(ctx, &pistachio.ApplyOptions{
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		FilterOptions: pistachio.FilterOptions{Enable: []string{"table"}},
 		Files:         []string{desiredFile},
 	}, &buf)
@@ -869,7 +869,7 @@ CREATE TABLE public.posts (
 		Schemas:    []string{"public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, FilterOptions: pistachio.FilterOptions{Include: []string{"users"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: only users should have the new column

--- a/getting-started.md
+++ b/getting-started.md
@@ -77,6 +77,7 @@ pist plan schema.sql
 Output:
 
 ```sql
+-- Target: schema: public, 1 table, 0 views, 0 enums, 0 domains
 ALTER TABLE public.users ADD COLUMN email text;
 ```
 
@@ -92,6 +93,7 @@ Verify by running plan again:
 
 ```bash
 pist plan schema.sql
+# => -- Target: schema: public, 1 table, 0 views, 0 enums, 0 domains
 # => -- No changes
 ```
 

--- a/plan.go
+++ b/plan.go
@@ -20,6 +20,7 @@ type PlanOptions struct {
 
 // ObjectCount holds the number of objects inspected by type.
 type ObjectCount struct {
+	Schemas []string
 	Tables  int
 	Views   int
 	Enums   int
@@ -27,7 +28,8 @@ type ObjectCount struct {
 }
 
 func (c ObjectCount) String() string {
-	return fmt.Sprintf("%s, %s, %s, %s",
+	return fmt.Sprintf("schema: %s, %s, %s, %s, %s",
+		strings.Join(c.Schemas, ", "),
 		pluralize(c.Tables, "table"),
 		pluralize(c.Views, "view"),
 		pluralize(c.Enums, "enum"),
@@ -93,6 +95,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	filteredDomains := options.filterDomains(currentDomains)
 
 	count := ObjectCount{
+		Schemas: client.Schemas,
 		Tables:  filteredTables.Len(),
 		Views:   filteredViews.Len(),
 		Enums:   filteredEnums.Len(),

--- a/plan.go
+++ b/plan.go
@@ -18,64 +18,96 @@ type PlanOptions struct {
 	PreSQLFile string   `type:"path" help:"Path to a SQL file to execute before applying changes."`
 }
 
-func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, error) {
+// ObjectCount holds the number of objects inspected by type.
+type ObjectCount struct {
+	Tables  int
+	Views   int
+	Enums   int
+	Domains int
+}
+
+func (c ObjectCount) String() string {
+	return fmt.Sprintf("%d tables, %d views, %d enums, %d domains", c.Tables, c.Views, c.Enums, c.Domains)
+}
+
+// PlanResult holds the result of a Plan operation.
+type PlanResult struct {
+	SQL   string
+	Count ObjectCount
+}
+
+func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResult, error) {
 	conn, err := client.connect()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer conn.Close(ctx) //nolint:errcheck
 
 	cat, err := catalog.NewCatalog(conn, client.Schemas)
 	if err != nil {
-		return "", fmt.Errorf("failed to create catalog: %w", err)
+		return nil, fmt.Errorf("failed to create catalog: %w", err)
 	}
 
 	currentTables, err := cat.Tables(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch tables: %w", err)
+		return nil, fmt.Errorf("failed to fetch tables: %w", err)
 	}
 
 	currentViews, err := cat.Views(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch views: %w", err)
+		return nil, fmt.Errorf("failed to fetch views: %w", err)
 	}
 
 	currentEnums, err := cat.Enums(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch enums: %w", err)
+		return nil, fmt.Errorf("failed to fetch enums: %w", err)
 	}
 
 	currentDomains, err := cat.Domains(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch domains: %w", err)
+		return nil, fmt.Errorf("failed to fetch domains: %w", err)
 	}
 
 	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
-		return "", fmt.Errorf("failed to parse SQL file: %w", err)
+		return nil, fmt.Errorf("failed to parse SQL file: %w", err)
 	}
 
-	enumDiff, err := diff.DiffEnums(options.filterEnums(currentEnums), options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
+	filterDesiredBySchemas(desired, client.Schemas, client.SchemaMap)
+
+	filteredTables := options.filterTables(currentTables)
+	filteredViews := options.filterViews(currentViews)
+	filteredEnums := options.filterEnums(currentEnums)
+	filteredDomains := options.filterDomains(currentDomains)
+
+	count := ObjectCount{
+		Tables:  filteredTables.Len(),
+		Views:   filteredViews.Len(),
+		Enums:   filteredEnums.Len(),
+		Domains: filteredDomains.Len(),
+	}
+
+	enumDiff, err := diff.DiffEnums(filteredEnums, options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	stmts := enumDiff.Stmts
 
-	domainDiff, err := diff.DiffDomains(options.filterDomains(currentDomains), options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
+	domainDiff, err := diff.DiffDomains(filteredDomains, options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
 	if err != nil {
-		return "", fmt.Errorf("failed to diff domains: %w", err)
+		return nil, fmt.Errorf("failed to diff domains: %w", err)
 	}
 	stmts = append(stmts, domainDiff.Stmts...)
 
-	tableStmts, err := diff.DiffTables(options.filterTables(currentTables), options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
+	tableStmts, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
 	if err != nil {
-		return "", fmt.Errorf("failed to diff tables: %w", err)
+		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
 	stmts = append(stmts, tableStmts...)
 
-	viewStmts, err := diff.DiffViews(options.filterViews(currentViews), options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
+	viewStmts, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
 	if err != nil {
-		return "", fmt.Errorf("failed to diff views: %w", err)
+		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}
 	stmts = append(stmts, viewStmts...)
 
@@ -85,10 +117,13 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (string, e
 	if options.PreSQLFile != "" && len(stmts) > 0 {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)
 		if err != nil {
-			return "", fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
+			return nil, fmt.Errorf("failed to read pre-SQL file: %s: %w", options.PreSQLFile, err)
 		}
 		stmts = append([]string{string(rawPreSQL)}, stmts...)
 	}
 
-	return strings.Join(stmts, "\n"), nil
+	return &PlanResult{
+		SQL:   strings.Join(stmts, "\n"),
+		Count: count,
+	}, nil
 }

--- a/plan.go
+++ b/plan.go
@@ -27,7 +27,19 @@ type ObjectCount struct {
 }
 
 func (c ObjectCount) String() string {
-	return fmt.Sprintf("%d tables, %d views, %d enums, %d domains", c.Tables, c.Views, c.Enums, c.Domains)
+	return fmt.Sprintf("%s, %s, %s, %s",
+		pluralize(c.Tables, "table"),
+		pluralize(c.Views, "view"),
+		pluralize(c.Enums, "enum"),
+		pluralize(c.Domains, "domain"),
+	)
+}
+
+func pluralize(n int, singular string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %ss", n, singular)
 }
 
 // PlanResult holds the result of a Plan operation.

--- a/plan_test.go
+++ b/plan_test.go
@@ -54,7 +54,7 @@ func TestPlan_WithPassword(t *testing.T) {
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
-	assert.Contains(t, got, "CREATE TABLE public.users")
+	assert.Contains(t, got.SQL, "CREATE TABLE public.users")
 }
 
 func TestPlan_InvalidDesiredFile(t *testing.T) {
@@ -115,12 +115,12 @@ func TestPlan_WithPreSQLFile(t *testing.T) {
 		PreSQLFile: preSQLFile,
 	})
 	require.NoError(t, err)
-	assert.Contains(t, got, "SELECT 1;")
-	assert.Contains(t, got, "CREATE TABLE public.users")
+	assert.Contains(t, got.SQL, "SELECT 1;")
+	assert.Contains(t, got.SQL, "CREATE TABLE public.users")
 
 	// pre-SQL should appear before diff statements
-	preSQLPos := strings.Index(got, "SELECT 1;")
-	diffPos := strings.Index(got, "CREATE TABLE public.users")
+	preSQLPos := strings.Index(got.SQL, "SELECT 1;")
+	diffPos := strings.Index(got.SQL, "CREATE TABLE public.users")
 	assert.Less(t, preSQLPos, diffPos)
 }
 
@@ -179,7 +179,7 @@ func TestPlan_WithPreSQLFile_NoDiff(t *testing.T) {
 		PreSQLFile: preSQLFile,
 	})
 	require.NoError(t, err)
-	assert.Empty(t, got)
+	assert.Empty(t, got.SQL)
 }
 
 func TestPlan_SchemalessDesired(t *testing.T) {
@@ -208,7 +208,7 @@ CREATE TABLE public.users (
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
-	assert.Contains(t, got, "ALTER TABLE public.users ADD COLUMN name text;")
+	assert.Contains(t, got.SQL, "ALTER TABLE public.users ADD COLUMN name text;")
 }
 
 func TestPlan_SchemalessDesired_NoDiff(t *testing.T) {
@@ -235,7 +235,7 @@ CREATE TABLE public.users (
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
-	assert.Empty(t, got)
+	assert.Empty(t, got.SQL)
 }
 
 func TestPlan(t *testing.T) {
@@ -263,7 +263,7 @@ func TestPlan(t *testing.T) {
 
 			got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 			require.NoError(t, err)
-			assert.Equal(t, strings.TrimSpace(tc.Plan), strings.TrimSpace(got))
+			assert.Equal(t, strings.TrimSpace(tc.Plan), strings.TrimSpace(got.SQL))
 		})
 	}
 }

--- a/remap_test.go
+++ b/remap_test.go
@@ -218,7 +218,7 @@ CREATE TABLE myschema.users (
 	t.Log(got)
 
 	// Should detect the diff and produce ALTER TABLE with the real DB schema
-	assert.Contains(t, got, "ALTER TABLE myschema.users ADD COLUMN name text;")
+	assert.Contains(t, got.SQL, "ALTER TABLE myschema.users ADD COLUMN name text;")
 }
 
 func TestPlan_WithSchemaMap_NoDiff(t *testing.T) {
@@ -247,7 +247,7 @@ CREATE TABLE myschema.users (
 	require.NoError(t, err)
 
 	// No diff expected since schemas are remapped
-	assert.Empty(t, got)
+	assert.Empty(t, got.SQL)
 }
 
 func TestDump_WithoutSchemaMap(t *testing.T) {
@@ -295,7 +295,7 @@ CREATE TABLE myschema.users (
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
-	assert.Empty(t, got)
+	assert.Empty(t, got.SQL)
 }
 
 func TestDump_WithSchemaMap_ForeignKey(t *testing.T) {
@@ -411,7 +411,7 @@ CREATE TABLE myschema.users (
 
 	// "other" schema is not reverse-mapped, so it won't match myschema
 	// This results in creating the "other" table and dropping "myschema" table
-	assert.Contains(t, got, "DROP TABLE myschema.users;")
+	assert.Contains(t, got.SQL, "DROP TABLE myschema.users;")
 }
 
 func TestPlan_WithSchemaMap_ForeignKey(t *testing.T) {
@@ -454,7 +454,7 @@ ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (use
 	require.NoError(t, err)
 	t.Log(got)
 
-	assert.Contains(t, got, "ALTER TABLE myschema.posts ADD COLUMN title text;")
+	assert.Contains(t, got.SQL, "ALTER TABLE myschema.posts ADD COLUMN title text;")
 }
 
 func TestPlan_WithSchemaMap_Index(t *testing.T) {
@@ -487,7 +487,7 @@ CREATE INDEX users_name_idx ON public.users (name);
 	require.NoError(t, err)
 	t.Log(got)
 
-	assert.Contains(t, got, "users_name_idx")
+	assert.Contains(t, got.SQL, "users_name_idx")
 }
 
 func TestPlan_WithSchemaMap_View(t *testing.T) {
@@ -518,7 +518,7 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;
 	require.NoError(t, err)
 	t.Log(got)
 
-	assert.Contains(t, got, "CREATE OR REPLACE VIEW myschema.active_users")
+	assert.Contains(t, got.SQL, "CREATE OR REPLACE VIEW myschema.active_users")
 }
 
 func TestApply_WithSchemaMap(t *testing.T) {
@@ -545,7 +545,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: dump without schema map should show myschema with new column
@@ -589,7 +589,7 @@ CREATE TABLE myschema.users (
 	require.NoError(t, err)
 	t.Log(got)
 
-	assert.Contains(t, got, "ALTER TABLE myschema.users ADD COLUMN name text;")
+	assert.Contains(t, got.SQL, "ALTER TABLE myschema.users ADD COLUMN name text;")
 }
 
 func TestPlan_SchemalessDesired_CustomSchema_NoDiff(t *testing.T) {
@@ -615,7 +615,7 @@ CREATE TABLE myschema.users (
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
-	assert.Empty(t, got)
+	assert.Empty(t, got.SQL)
 }
 
 func TestDump_WithSchemaMap_Domain(t *testing.T) {
@@ -657,7 +657,7 @@ CREATE DOMAIN myschema.pos_int AS integer;
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
-	assert.Contains(t, got, "ALTER DOMAIN myschema.pos_int SET NOT NULL;")
+	assert.Contains(t, got.SQL, "ALTER DOMAIN myschema.pos_int SET NOT NULL;")
 }
 
 func TestDump_WithSchemaMap_Enum(t *testing.T) {
@@ -700,7 +700,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
-	assert.Contains(t, got, "ALTER TYPE myschema.status ADD VALUE 'pending' AFTER 'inactive';")
+	assert.Contains(t, got.SQL, "ALTER TYPE myschema.status ADD VALUE 'pending' AFTER 'inactive';")
 }
 
 func TestPlan_WithSchemaMap_Enum_NoDiff(t *testing.T) {
@@ -721,7 +721,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
 	require.NoError(t, err)
-	assert.Empty(t, got)
+	assert.Empty(t, got.SQL)
 }
 
 func TestApply_WithSchemaMap_Enum(t *testing.T) {
@@ -740,7 +740,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	verifyClient := pistachio.NewClient(&pistachio.Options{
@@ -775,7 +775,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{})

--- a/schema_filter.go
+++ b/schema_filter.go
@@ -1,0 +1,36 @@
+package pistachio
+
+import (
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+// filterDesiredBySchemas removes objects from the parse result whose schema
+// is not in the target schemas list. This prevents objects from unrelated
+// schemas in the SQL file from being treated as desired state.
+func filterDesiredBySchemas(result *parser.ParseResult, schemas []string, schemaMap map[string]string) {
+	schemaSet := make(map[string]bool, len(schemas))
+	for _, s := range schemas {
+		schemaSet[s] = true
+	}
+	// Also include schema-map destinations (desired SQL may use mapped names)
+	for _, v := range schemaMap {
+		schemaSet[v] = true
+	}
+
+	result.Tables = filterMapBySchema(result.Tables, schemaSet, func(t *model.Table) string { return t.Schema })
+	result.Views = filterMapBySchema(result.Views, schemaSet, func(v *model.View) string { return v.Schema })
+	result.Enums = filterMapBySchema(result.Enums, schemaSet, func(e *model.Enum) string { return e.Schema })
+	result.Domains = filterMapBySchema(result.Domains, schemaSet, func(d *model.Domain) string { return d.Schema })
+}
+
+func filterMapBySchema[V any](m *orderedmap.Map[string, V], schemas map[string]bool, getSchema func(V) string) *orderedmap.Map[string, V] {
+	filtered := orderedmap.New[string, V]()
+	for k, v := range m.All() {
+		if schemas[getSchema(v)] {
+			filtered.Set(k, v)
+		}
+	}
+	return filtered
+}

--- a/schema_filter_test.go
+++ b/schema_filter_test.go
@@ -87,16 +87,16 @@ CREATE TABLE other.stuff (
 }
 
 func TestObjectCount_String(t *testing.T) {
-	c := pistachio.ObjectCount{Tables: 3, Views: 1, Enums: 2, Domains: 0}
-	assert.Equal(t, "3 tables, 1 view, 2 enums, 0 domains", c.String())
+	c := pistachio.ObjectCount{Schemas: []string{"public"}, Tables: 3, Views: 1, Enums: 2, Domains: 0}
+	assert.Equal(t, "schema: public, 3 tables, 1 view, 2 enums, 0 domains", c.String())
 }
 
 func TestObjectCount_String_Singular(t *testing.T) {
-	c := pistachio.ObjectCount{Tables: 1, Views: 1, Enums: 1, Domains: 1}
-	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain", c.String())
+	c := pistachio.ObjectCount{Schemas: []string{"myschema"}, Tables: 1, Views: 1, Enums: 1, Domains: 1}
+	assert.Equal(t, "schema: myschema, 1 table, 1 view, 1 enum, 1 domain", c.String())
 }
 
-func TestObjectCount_String_Zero(t *testing.T) {
-	c := pistachio.ObjectCount{}
-	assert.Equal(t, "0 tables, 0 views, 0 enums, 0 domains", c.String())
+func TestObjectCount_String_MultipleSchemas(t *testing.T) {
+	c := pistachio.ObjectCount{Schemas: []string{"public", "myschema"}, Tables: 5, Views: 2, Enums: 1, Domains: 0}
+	assert.Equal(t, "schema: public, myschema, 5 tables, 2 views, 1 enum, 0 domains", c.String())
 }

--- a/schema_filter_test.go
+++ b/schema_filter_test.go
@@ -88,5 +88,15 @@ CREATE TABLE other.stuff (
 
 func TestObjectCount_String(t *testing.T) {
 	c := pistachio.ObjectCount{Tables: 3, Views: 1, Enums: 2, Domains: 0}
-	assert.Equal(t, "3 tables, 1 views, 2 enums, 0 domains", c.String())
+	assert.Equal(t, "3 tables, 1 view, 2 enums, 0 domains", c.String())
+}
+
+func TestObjectCount_String_Singular(t *testing.T) {
+	c := pistachio.ObjectCount{Tables: 1, Views: 1, Enums: 1, Domains: 1}
+	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain", c.String())
+}
+
+func TestObjectCount_String_Zero(t *testing.T) {
+	c := pistachio.ObjectCount{}
+	assert.Equal(t, "0 tables, 0 views, 0 enums, 0 domains", c.String())
 }

--- a/schema_filter_test.go
+++ b/schema_filter_test.go
@@ -1,0 +1,92 @@
+package pistachio_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+func TestPlan_DesiredSchemaFiltered(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE other.stuff (
+    id integer NOT NULL
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	// other.stuff should be ignored
+	assert.Empty(t, got.SQL)
+	assert.Equal(t, 1, got.Count.Tables)
+}
+
+func TestApply_DesiredSchemaFiltered(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE other.stuff (
+    id integer NOT NULL
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	count, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
+		Files:      []string{desiredFile},
+	}, &buf)
+	require.NoError(t, err)
+	// No changes (other.stuff ignored)
+	assert.Empty(t, buf.String())
+	assert.Equal(t, 1, count.Tables)
+}
+
+func TestObjectCount_String(t *testing.T) {
+	c := pistachio.ObjectCount{Tables: 3, Views: 1, Enums: 2, Domains: 0}
+	assert.Equal(t, "3 tables, 1 views, 2 enums, 0 domains", c.String())
+}


### PR DESCRIPTION
- filterDesiredBySchemas removes objects whose schema is not in -n list (or schema-map destinations), preventing unrelated schemas in SQL files from being treated as desired state
- Plan/Apply return ObjectCount with per-type counts
- "No changes" output includes object counts: -- No changes (3 tables, 1 views, 1 enums, 0 domains)