### PR TITLE
Support stdin

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -37,6 +37,9 @@ func ReadSQLFile(path string) (string, error) {
 	}
 
 	if err != nil {
+		if path == "-" {
+			return "", fmt.Errorf("failed to read SQL from stdin: %w", err)
+		}
 		return "", fmt.Errorf("failed to read SQL file: %w", err)
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -26,7 +27,15 @@ func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error
 }
 
 func ReadSQLFile(path string) (string, error) {
-	data, err := os.ReadFile(path)
+	var data []byte
+	var err error
+
+	if path == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+
 	if err != nil {
 		return "", fmt.Errorf("failed to read SQL file: %w", err)
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -99,6 +99,26 @@ func TestReadSQLFile(t *testing.T) {
 	assert.Equal(t, sql, got)
 }
 
+func TestReadSQLFile_Stdin(t *testing.T) {
+	// Create a pipe to simulate stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	sql := "SELECT 1;"
+	go func() {
+		w.WriteString(sql)
+		w.Close()
+	}()
+
+	got, err := parser.ReadSQLFile("-")
+	require.NoError(t, err)
+	assert.Equal(t, sql, got)
+}
+
 func TestParseSQLFile_NotFound(t *testing.T) {
 	_, err := parser.ParseSQLFile("/nonexistent/file.sql")
 	require.Error(t, err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -122,6 +122,24 @@ func TestReadSQLFile_Stdin(t *testing.T) {
 	assert.Equal(t, sql, got)
 }
 
+func TestReadSQLFile_Stdin_ReadAll(t *testing.T) {
+	// Verify that stdin reads empty content from a closed pipe without error
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = origStdin
+		r.Close()
+	}()
+
+	got, err := parser.ReadSQLFile("-")
+	require.NoError(t, err)
+	assert.Equal(t, "", got)
+}
+
 func TestParseSQLFile_NotFound(t *testing.T) {
 	_, err := parser.ParseSQLFile("/nonexistent/file.sql")
 	require.Error(t, err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -106,7 +106,10 @@ func TestReadSQLFile_Stdin(t *testing.T) {
 
 	origStdin := os.Stdin
 	os.Stdin = r
-	defer func() { os.Stdin = origStdin }()
+	defer func() {
+		os.Stdin = origStdin
+		r.Close()
+	}()
 
 	sql := "SELECT 1;"
 	go func() {


### PR DESCRIPTION
This pull request enhances the flexibility of the `ReadSQLFile` function in the parser package by allowing it to read SQL input from standard input (`stdin`) when the path is specified as `"-"`. It also adds a corresponding test to ensure this new behavior works as expected.

**Enhancements to SQL file reading:**

* Updated the `ReadSQLFile` function in `parser.go` to support reading from `stdin` when the path argument is `"-"`, using `io.ReadAll(os.Stdin)`. [[1]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R5) [[2]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L29-R38)

**Testing improvements:**

* Added a new test `TestReadSQLFile_Stdin` in `parser/parser_test.go` to verify that `ReadSQLFile("-")` correctly reads from standard input.