### PR TITLE
Reorder FK statements: drops first, adds last

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -83,11 +83,12 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	}
 	stmts = append(stmts, domainDiff.Stmts...)
 
-	tableStmts, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
+	tableDiff, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
-	stmts = append(stmts, tableStmts...)
+	stmts = append(stmts, tableDiff.FKDropStmts...)
+	stmts = append(stmts, tableDiff.Stmts...)
 
 	viewStmts, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
 	if err != nil {
@@ -95,8 +96,11 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	}
 	stmts = append(stmts, viewStmts...)
 
+	stmts = append(stmts, tableDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
 	stmts = append(stmts, enumDiff.DropStmts...)
+
+	stmts = append(stmts, tableDiff.FKAddStmts...)
 
 	var preSQL string
 	if options.PreSQLFile != "" {

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -10,33 +10,46 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) ([]string, error) {
+// TableDiffResult separates FK operations from other statements to allow
+// correct ordering: FK drops first, then schema changes, then FK adds last.
+type TableDiffResult struct {
+	FKDropStmts  []string // FK drops (should run first)
+	Stmts        []string // CREATE/ALTER/DROP TABLE, columns, constraints, indexes, comments
+	FKAddStmts   []string // FK adds (should run last)
+	DropStmts    []string // DROP TABLE (should run after FK drops)
+}
+
+func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) (*TableDiffResult, error) {
 	dc = NormalizeDropChecker(dc)
-	var stmts []string
+	result := &TableDiffResult{}
 
 	// Detect renames
 	renameStmts, current, err := detectTableRenames(current, desired)
 	if err != nil {
 		return nil, err
 	}
-	stmts = append(stmts, renameStmts...)
+	result.Stmts = append(result.Stmts, renameStmts...)
 
 	// New tables
 	for k, v := range desired.All() {
 		if _, ok := current.GetOk(k); !ok {
-			stmts = append(stmts, v.SQL())
-			stmts = append(stmts, newTableExtras(v)...)
+			result.Stmts = append(result.Stmts, v.SQL())
+			stmts, fkStmts := newTableExtras(v)
+			result.Stmts = append(result.Stmts, stmts...)
+			result.FKAddStmts = append(result.FKAddStmts, fkStmts...)
 		}
 	}
 
 	// Modified tables
 	for k, desiredTable := range desired.All() {
 		if currentTable, ok := current.GetOk(k); ok {
-			tableStmts, err := diffTable(currentTable, desiredTable, dc)
+			tableResult, err := diffTable(currentTable, desiredTable, dc)
 			if err != nil {
 				return nil, err
 			}
-			stmts = append(stmts, tableStmts...)
+			result.FKDropStmts = append(result.FKDropStmts, tableResult.FKDropStmts...)
+			result.Stmts = append(result.Stmts, tableResult.Stmts...)
+			result.FKAddStmts = append(result.FKAddStmts, tableResult.FKAddStmts...)
 		}
 	}
 
@@ -44,31 +57,37 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 	if dc.IsDropAllowed("table") {
 		for k := range current.Keys() {
 			if _, ok := desired.GetOk(k); !ok {
-				stmts = append(stmts, "DROP TABLE "+k+";")
+				result.DropStmts = append(result.DropStmts, "DROP TABLE "+k+";")
 			}
 		}
 	}
 
-	return stmts, nil
+	return result, nil
 }
 
-func newTableExtras(t *model.Table) []string {
-	var stmts []string
+// newTableExtras returns non-FK extras and FK statements separately.
+func newTableExtras(t *model.Table) (stmts []string, fkStmts []string) {
 	for _, idx := range t.Indexes.CollectValues() {
 		stmts = append(stmts, idx.SQL())
 	}
 	for _, fk := range t.ForeignKeys.CollectValues() {
-		stmts = append(stmts, fk.SQL())
+		fkStmts = append(fkStmts, fk.SQL())
 	}
 	if commentSQL := t.CommentSQL(); commentSQL != "" {
 		stmts = append(stmts, strings.Split(commentSQL, "\n")...)
 	}
-	return stmts
+	return
 }
 
-func diffTable(current, desired *model.Table, dc DropChecker) ([]string, error) {
+type tableDiffResult struct {
+	FKDropStmts []string
+	Stmts       []string
+	FKAddStmts  []string
+}
+
+func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult, error) {
 	dc = NormalizeDropChecker(dc)
-	var stmts []string
+	result := &tableDiffResult{}
 	fqtn := desired.FQTN()
 
 	// Partition children inherit columns and constraints from the parent,
@@ -78,42 +97,44 @@ func diffTable(current, desired *model.Table, dc DropChecker) ([]string, error) 
 		if err != nil {
 			return nil, err
 		}
-		stmts = append(stmts, idxStmts...)
-		fkStmts, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
+		result.Stmts = append(result.Stmts, idxStmts...)
+		fkDrops, fkAdds, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
 		if err != nil {
 			return nil, err
 		}
-		stmts = append(stmts, fkStmts...)
-		return stmts, nil
+		result.FKDropStmts = append(result.FKDropStmts, fkDrops...)
+		result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
+		return result, nil
 	}
 
 	colStmts, err := diffColumns(fqtn, current.Columns, desired.Columns, dc)
 	if err != nil {
 		return nil, err
 	}
-	stmts = append(stmts, colStmts...)
+	result.Stmts = append(result.Stmts, colStmts...)
 
 	conStmts, err := diffConstraints(fqtn, current.Constraints, desired.Constraints)
 	if err != nil {
 		return nil, err
 	}
-	stmts = append(stmts, conStmts...)
+	result.Stmts = append(result.Stmts, conStmts...)
 
 	idxStmts, err := diffIndexes(current.Indexes, desired.Indexes)
 	if err != nil {
 		return nil, err
 	}
-	stmts = append(stmts, idxStmts...)
+	result.Stmts = append(result.Stmts, idxStmts...)
 
-	fkStmts, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
+	fkDrops, fkAdds, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
 	if err != nil {
 		return nil, err
 	}
-	stmts = append(stmts, fkStmts...)
+	result.FKDropStmts = append(result.FKDropStmts, fkDrops...)
+	result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
 
-	stmts = append(stmts, diffComments(current, desired)...)
+	result.Stmts = append(result.Stmts, diffComments(current, desired)...)
 
-	return stmts, nil
+	return result, nil
 }
 
 func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column], dc DropChecker) ([]string, error) {
@@ -394,22 +415,24 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) ([]stri
 	return stmts, nil
 }
 
-func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[string, *model.ForeignKey]) ([]string, error) {
-	var stmts []string
+// diffForeignKeys returns (dropStmts, addStmts, error).
+// Rename statements are included in addStmts (they depend on table renames being done first).
+func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[string, *model.ForeignKey]) ([]string, []string, error) {
+	var dropStmts, addStmts []string
 
-	// Detect renames
+	// Detect renames (renames go into addStmts since they may depend on table renames)
 	renameStmts, current, err := detectForeignKeyRenames(fqtn, current, desired)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	stmts = append(stmts, renameStmts...)
+	addStmts = append(addStmts, renameStmts...)
 
 	// Drop removed or changed FKs
 	for name := range current.All() {
 		desiredFk, ok := desired.GetOk(name)
 		currentFk := current.Get(name)
 		if !ok || !equalFKDef(currentFk.Definition, desiredFk.Definition, schema) {
-			stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP CONSTRAINT "+model.Ident(name)+";")
+			dropStmts = append(dropStmts, "ALTER TABLE "+fqtn+" DROP CONSTRAINT "+model.Ident(name)+";")
 		}
 	}
 
@@ -417,11 +440,11 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 	for name, desiredFk := range desired.All() {
 		currentFk, ok := current.GetOk(name)
 		if !ok || !equalFKDef(currentFk.Definition, desiredFk.Definition, schema) {
-			stmts = append(stmts, desiredFk.SQL())
+			addStmts = append(addStmts, desiredFk.SQL())
 		}
 	}
 
-	return stmts, nil
+	return dropStmts, addStmts, nil
 }
 
 func diffComments(current, desired *model.Table) []string {

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -13,10 +13,10 @@ import (
 // TableDiffResult separates FK operations from other statements to allow
 // correct ordering: FK drops first, then schema changes, then FK adds last.
 type TableDiffResult struct {
-	FKDropStmts  []string // FK drops (should run first)
-	Stmts        []string // CREATE/ALTER/DROP TABLE, columns, constraints, indexes, comments
-	FKAddStmts   []string // FK adds (should run last)
-	DropStmts    []string // DROP TABLE (should run after FK drops)
+	FKDropStmts []string // FK drops (should run first)
+	Stmts       []string // CREATE/ALTER/DROP TABLE, columns, constraints, indexes, comments
+	FKAddStmts  []string // FK adds (should run last)
+	DropStmts   []string // DROP TABLE (should run after FK drops)
 }
 
 func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) (*TableDiffResult, error) {

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -14,9 +14,9 @@ import (
 // correct ordering: FK drops first, then schema changes, then FK adds last.
 type TableDiffResult struct {
 	FKDropStmts []string // FK drops (should run first)
-	Stmts       []string // CREATE/ALTER/DROP TABLE, columns, constraints, indexes, comments
-	FKAddStmts  []string // FK adds (should run last)
-	DropStmts   []string // DROP TABLE (should run after FK drops)
+	Stmts       []string // CREATE/ALTER TABLE, columns, constraints, indexes, comments
+	FKAddStmts  []string // FK adds and renames (should run last)
+	DropStmts   []string // DROP TABLE (separate from Stmts for ordering)
 }
 
 func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) (*TableDiffResult, error) {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -33,10 +33,10 @@ func TestDiffTables_newTable(t *testing.T) {
 	tbl.Constraints.Set("users_pkey", &model.Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
 	desired.Set("public.users", tbl)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 1)
-	assert.Contains(t, stmts[0], "CREATE TABLE public.users")
+	assert.Len(t, result.Stmts, 1)
+	assert.Contains(t, result.Stmts[0], "CREATE TABLE public.users")
 }
 
 func TestDiffTables_newTable_withExtras(t *testing.T) {
@@ -49,12 +49,12 @@ func TestDiffTables_newTable_withExtras(t *testing.T) {
 	tbl.Comment = ptr("Users table")
 	desired.Set("public.users", tbl)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 3)
-	assert.Contains(t, stmts[0], "CREATE TABLE")
-	assert.Contains(t, stmts[1], "CREATE INDEX idx_name")
-	assert.Contains(t, stmts[2], "COMMENT ON TABLE")
+	assert.Len(t, result.Stmts, 3)
+	assert.Contains(t, result.Stmts[0], "CREATE TABLE")
+	assert.Contains(t, result.Stmts[1], "CREATE INDEX idx_name")
+	assert.Contains(t, result.Stmts[2], "COMMENT ON TABLE")
 }
 
 func TestDiffTables_dropTable(t *testing.T) {
@@ -63,9 +63,9 @@ func TestDiffTables_dropTable(t *testing.T) {
 
 	current.Set("public.users", newTable("public", "users"))
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"DROP TABLE public.users;"}, stmts)
+	assert.Equal(t, []string{"DROP TABLE public.users;"}, result.DropStmts)
 }
 
 func TestNormalizeDropChecker_nil(t *testing.T) {
@@ -85,9 +85,9 @@ func TestDiffTables_nilDropChecker(t *testing.T) {
 	current.Set("public.users", newTable("public", "users"))
 
 	// nil DropChecker should not panic, drops should be denied
-	stmts, err := DiffTables(current, desired, nil)
+	result, err := DiffTables(current, desired, nil)
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.Stmts)
 }
 
 func TestDiffTables_dropTable_denied(t *testing.T) {
@@ -96,9 +96,9 @@ func TestDiffTables_dropTable_denied(t *testing.T) {
 
 	current.Set("public.users", newTable("public", "users"))
 
-	stmts, err := DiffTables(current, desired, DenyAllDrops{})
+	result, err := DiffTables(current, desired, DenyAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.Stmts)
 }
 
 func TestDiffColumns_dropColumn_denied(t *testing.T) {
@@ -126,9 +126,9 @@ func TestDiffTables_noChange(t *testing.T) {
 	tbl2.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 	desired.Set("public.users", tbl2)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.Stmts)
 }
 
 func TestDiffColumns_addColumn(t *testing.T) {
@@ -356,10 +356,10 @@ func TestDiffForeignKeys_add(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
 	require.NoError(t, err)
-	assert.Len(t, stmts, 1)
-	assert.Contains(t, stmts[0], "ADD CONSTRAINT fk_user")
+	assert.Len(t, addStmts, 1)
+	assert.Contains(t, addStmts[0], "ADD CONSTRAINT fk_user")
 }
 
 func TestDiffForeignKeys_drop(t *testing.T) {
@@ -371,9 +371,10 @@ func TestDiffForeignKeys_drop(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 
-	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, stmts)
+	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, dropStmts)
+	assert.Empty(t, addStmts)
 }
 
 func TestDiffComments_tableComment_add(t *testing.T) {
@@ -479,11 +480,12 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 	})
 	desired.Set("public.orders", tbl)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 2)
-	assert.Contains(t, stmts[0], "CREATE TABLE")
-	assert.Contains(t, stmts[1], "ADD CONSTRAINT fk_user")
+	assert.Len(t, result.Stmts, 1)
+	assert.Contains(t, result.Stmts[0], "CREATE TABLE")
+	assert.Len(t, result.FKAddStmts, 1)
+	assert.Contains(t, result.FKAddStmts[0], "ADD CONSTRAINT fk_user")
 }
 
 func TestEqualFKDef_implicitPublicSchema(t *testing.T) {
@@ -536,11 +538,11 @@ func TestDiffForeignKeys_change(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
 	require.NoError(t, err)
-	assert.Len(t, stmts, 2)
-	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", stmts[0])
-	assert.Contains(t, stmts[1], "ADD CONSTRAINT fk_user")
+	assert.Len(t, append(dropStmts, addStmts...), 2)
+	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", dropStmts[0])
+	assert.Contains(t, addStmts[0], "ADD CONSTRAINT fk_user")
 }
 
 func TestDiffTable_partitionChild(t *testing.T) {
@@ -556,10 +558,10 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	desired.PartitionBound = &bound
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
 
-	stmts, err := diffTable(current, desired, AllowAllDrops{})
+	tableResult, err := diffTable(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 1)
-	assert.Contains(t, stmts[0], "CREATE INDEX idx_new")
+	assert.Len(t, tableResult.Stmts, 1)
+	assert.Contains(t, tableResult.Stmts[0], "CREATE INDEX idx_new")
 }
 
 func TestDiffTable_partitionChild_indexRenameError(t *testing.T) {
@@ -914,9 +916,9 @@ func TestDiffTables_indexWhereClauseSchemaInsensitive(t *testing.T) {
 	})
 	desired.Set("public.products", dt)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.Stmts)
 }
 
 func TestEqualIndexDef_explicitAscVsDefault(t *testing.T) {
@@ -998,9 +1000,9 @@ func TestDiffTables_indexSchemaInsensitive(t *testing.T) {
 	dt.Indexes.Set("idx", &model.Index{Schema: "", Name: "idx", Table: "users", Definition: "CREATE INDEX idx ON users USING btree (id)"})
 	desired.Set("public.users", dt)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.Stmts)
 }
 
 func TestDiffTables_renameTable(t *testing.T) {
@@ -1017,9 +1019,9 @@ func TestDiffTables_renameTable(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, stmts)
+	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, result.Stmts)
 }
 
 func TestDiffTables_renameTable_selfRename_skipped(t *testing.T) {
@@ -1036,9 +1038,9 @@ func TestDiffTables_renameTable_selfRename_skipped(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.users", dt)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.Stmts)
 }
 
 func TestDiffColumns_renameColumn_selfRename_skipped(t *testing.T) {
@@ -1096,9 +1098,10 @@ func TestDiffForeignKeys_rename_selfRename_skipped(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, dropStmts)
+	assert.Empty(t, addStmts)
 }
 
 func TestDiffTables_renameTable_alreadyApplied(t *testing.T) {
@@ -1115,9 +1118,9 @@ func TestDiffTables_renameTable_alreadyApplied(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.Stmts)
 }
 
 func TestDiffTables_renameTable_withIndex(t *testing.T) {
@@ -1138,10 +1141,10 @@ func TestDiffTables_renameTable_withIndex(t *testing.T) {
 	dt.Indexes.Set("idx_users_name", &model.Index{Schema: "public", Name: "idx_users_name", Table: "accounts", Definition: "CREATE INDEX idx_users_name ON public.accounts USING btree (name)"})
 	desired.Set("public.accounts", dt)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	// Should only rename the table, no DROP/CREATE index
-	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, stmts)
+	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, result.Stmts)
 }
 
 func TestDiffTables_renameTable_withFK(t *testing.T) {
@@ -1170,9 +1173,9 @@ func TestDiffTables_renameTable_withFK(t *testing.T) {
 	})
 	desired.Set("public.purchases", dt)
 
-	stmts, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME TO purchases;"}, stmts)
+	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME TO purchases;"}, result.Stmts)
 }
 
 func TestDiffTables_renameTable_destinationExists_error(t *testing.T) {
@@ -1349,9 +1352,10 @@ func TestDiffForeignKeys_rename(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME CONSTRAINT old_fk TO new_fk;"}, stmts)
+	assert.Empty(t, dropStmts)
+	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME CONSTRAINT old_fk TO new_fk;"}, addStmts)
 }
 
 func TestDiffForeignKeys_rename_alreadyApplied(t *testing.T) {
@@ -1370,9 +1374,8 @@ func TestDiffForeignKeys_rename_alreadyApplied(t *testing.T) {
 		Table:      "orders",
 	})
 
-	stmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, _, err := diffForeignKeys("public.orders", "public", current, desired)
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
 }
 
 func TestDiffForeignKeys_rename_sourceNotFound(t *testing.T) {
@@ -1386,7 +1389,7 @@ func TestDiffForeignKeys_rename_sourceNotFound(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, _, err := diffForeignKeys("public.orders", "public", current, desired)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -1440,7 +1443,7 @@ func TestDiffForeignKeys_rename_destinationExists_error(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, _, err := diffForeignKeys("public.orders", "public", current, desired)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }

--- a/plan.go
+++ b/plan.go
@@ -114,11 +114,13 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	}
 	stmts = append(stmts, domainDiff.Stmts...)
 
-	tableStmts, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
+	tableDiff, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
-	stmts = append(stmts, tableStmts...)
+	// FK drops first (before any table/column changes)
+	stmts = append(stmts, tableDiff.FKDropStmts...)
+	stmts = append(stmts, tableDiff.Stmts...)
 
 	viewStmts, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
 	if err != nil {
@@ -126,8 +128,13 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	}
 	stmts = append(stmts, viewStmts...)
 
+	// Drops: tables before domains/enums (dependency order)
+	stmts = append(stmts, tableDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
 	stmts = append(stmts, enumDiff.DropStmts...)
+
+	// FK adds last (after all tables exist)
+	stmts = append(stmts, tableDiff.FKAddStmts...)
 
 	if options.PreSQLFile != "" && len(stmts) > 0 {
 		rawPreSQL, err := os.ReadFile(options.PreSQLFile)

--- a/testdata/apply/create_tables_with_fk.yml
+++ b/testdata/apply/create_tables_with_fk.yml
@@ -1,0 +1,27 @@
+init: ""
+desired: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id);
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );


### PR DESCRIPTION
Separate FK operations from other table diff statements to prevent dependency errors:

1. FK DROP statements run first (before any table/column changes)
2. Table CREATE/ALTER/DROP run in the middle
3. FK ADD statements run last (after all tables exist)

This fixes "relation does not exist" errors when creating tables with FKs referencing tables that appear later in the SQL file.