### PR TITLE
Stop normalizing serial/bigserial/smallserial to base integer types

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1014,9 +1014,6 @@ var typeAliases = map[string]string{
 	"varbit":      "bit varying",
 	"decimal":     "numeric",
 	"float":       "double precision",
-	"serial":      "integer",
-	"bigserial":   "bigint",
-	"smallserial": "smallint",
 }
 
 func normalizeTypeName(name string) string {

--- a/testdata/apply/add_column_bigserial.yml
+++ b/testdata/apply/add_column_bigserial.yml
@@ -1,14 +1,17 @@
-init: ""
+init: |
+  CREATE TABLE public.users (
+      name text NOT NULL
+  );
 desired: |
   CREATE TABLE public.users (
-      id serial NOT NULL,
+      id bigserial NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 applied: |
   -- public.users
   CREATE TABLE public.users (
-      id serial NOT NULL,
       name text NOT NULL,
+      id bigserial NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/apply/create_table_with_bigserial.yml
+++ b/testdata/apply/create_table_with_bigserial.yml
@@ -8,7 +8,7 @@ desired: |
 applied: |
   -- public.users
   CREATE TABLE public.users (
-      id bigint NOT NULL,
+      id bigserial NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/apply/create_table_with_smallserial.yml
+++ b/testdata/apply/create_table_with_smallserial.yml
@@ -8,7 +8,7 @@ desired: |
 applied: |
   -- public.users
   CREATE TABLE public.users (
-      id smallint NOT NULL,
+      id smallserial NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/apply/no_diff_bigserial_vs_bigint.yml
+++ b/testdata/apply/no_diff_bigserial_vs_bigint.yml
@@ -1,14 +1,19 @@
-init: ""
+init: |
+  CREATE TABLE public.users (
+      id bigserial NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
 desired: |
   CREATE TABLE public.users (
-      id serial NOT NULL,
+      id bigint NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 applied: |
   -- public.users
   CREATE TABLE public.users (
-      id serial NOT NULL,
+      id bigserial NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/apply/no_diff_serial_vs_integer.yml
+++ b/testdata/apply/no_diff_serial_vs_integer.yml
@@ -1,7 +1,12 @@
-init: ""
-desired: |
+init: |
   CREATE TABLE public.users (
       id serial NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/parser/bigserial.yml
+++ b/testdata/parser/bigserial.yml
@@ -6,6 +6,6 @@ input: |
 expected: |
   -- public.users
   CREATE TABLE public.users (
-      id bigint NOT NULL,
+      id bigserial NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/parser/serial.yml
+++ b/testdata/parser/serial.yml
@@ -6,6 +6,6 @@ input: |
 expected: |
   -- public.users
   CREATE TABLE public.users (
-      id integer NOT NULL,
+      id serial NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/parser/smallserial.yml
+++ b/testdata/parser/smallserial.yml
@@ -6,6 +6,6 @@ input: |
 expected: |
   -- public.users
   CREATE TABLE public.users (
-      id smallint NOT NULL,
+      id smallserial NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/plan/add_column_bigserial.yml
+++ b/testdata/plan/add_column_bigserial.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TABLE public.users (
+      name text NOT NULL
+  );
+desired: |
+  CREATE TABLE public.users (
+      id bigserial NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users ADD COLUMN id bigserial NOT NULL;
+  ALTER TABLE public.users ADD CONSTRAINT users_pkey PRIMARY KEY (id);

--- a/testdata/plan/create_table_with_bigserial.yml
+++ b/testdata/plan/create_table_with_bigserial.yml
@@ -7,7 +7,7 @@ desired: |
   );
 plan: |
   CREATE TABLE public.users (
-      id bigint NOT NULL,
+      id bigserial NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/plan/create_table_with_serial.yml
+++ b/testdata/plan/create_table_with_serial.yml
@@ -7,7 +7,7 @@ desired: |
   );
 plan: |
   CREATE TABLE public.users (
-      id integer NOT NULL,
+      id serial NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/plan/create_table_with_smallserial.yml
+++ b/testdata/plan/create_table_with_smallserial.yml
@@ -7,7 +7,7 @@ desired: |
   );
 plan: |
   CREATE TABLE public.users (
-      id smallint NOT NULL,
+      id smallserial NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/plan/no_diff_bigserial_vs_bigint.yml
+++ b/testdata/plan/no_diff_bigserial_vs_bigint.yml
@@ -1,14 +1,13 @@
-init: ""
+init: |
+  CREATE TABLE public.users (
+      id bigserial NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
 desired: |
   CREATE TABLE public.users (
-      id serial NOT NULL,
+      id bigint NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
-applied: |
-  -- public.users
-  CREATE TABLE public.users (
-      id serial NOT NULL,
-      name text NOT NULL,
-      CONSTRAINT users_pkey PRIMARY KEY (id)
-  );
+plan: ""

--- a/testdata/plan/no_diff_serial_vs_integer.yml
+++ b/testdata/plan/no_diff_serial_vs_integer.yml
@@ -1,14 +1,13 @@
-init: ""
+init: |
+  CREATE TABLE public.users (
+      id serial NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
 desired: |
   CREATE TABLE public.users (
-      id serial NOT NULL,
+      id integer NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
-applied: |
-  -- public.users
-  CREATE TABLE public.users (
-      id serial NOT NULL,
-      name text NOT NULL,
-      CONSTRAINT users_pkey PRIMARY KEY (id)
-  );
+plan: ""


### PR DESCRIPTION
The parser was converting serial→integer, bigserial→bigint, and smallserial→smallint via typeAliases, which caused CREATE TABLE DDL to use base types instead of serial types. This prevented PostgreSQL from auto-creating sequences, breaking auto-increment behavior.