### PR TITLE
Show command in output

### DIFF
--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -20,7 +20,7 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 		return err
 	}
 
-	fmt.Fprintf(w, "-- Target: %s\n", count) //nolint:errcheck
+	fmt.Fprintf(w, "-- Apply: %s\n", count) //nolint:errcheck
 
 	if buf.Len() == 0 {
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -20,7 +20,7 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 		return err
 	}
 
-	fmt.Fprintf(w, "-- Apply to schema %s (%s)\n", count.SchemaNames(), count.Summary()) //nolint:errcheck
+	fmt.Fprintf(w, "-- Apply to %s (%s)\n", count.SchemaLabel(), count.Summary()) //nolint:errcheck
 
 	if buf.Len() == 0 {
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -20,7 +20,7 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 		return err
 	}
 
-	fmt.Fprintf(w, "-- Apply: %s\n", count) //nolint:errcheck
+	fmt.Fprintf(w, "-- Apply to schema %s (%s)\n", count.SchemaNames(), count.Summary()) //nolint:errcheck
 
 	if buf.Len() == 0 {
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -282,7 +282,7 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- Plan: schema: public, 1 table,")
+	assert.Contains(t, buf.String(), "-- Plan for schema public (")
 	assert.Contains(t, buf.String(), "-- No changes")
 }
 
@@ -309,7 +309,7 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- Apply: schema: public, 1 table,")
+	assert.Contains(t, buf.String(), "-- Apply to schema public (")
 	assert.Contains(t, buf.String(), "-- No changes")
 }
 

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -282,7 +282,7 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- Target: schema: public, 1 table,")
+	assert.Contains(t, buf.String(), "-- Plan: schema: public, 1 table,")
 	assert.Contains(t, buf.String(), "-- No changes")
 }
 
@@ -309,7 +309,7 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- Target: schema: public, 1 table,")
+	assert.Contains(t, buf.String(), "-- Apply: schema: public, 1 table,")
 	assert.Contains(t, buf.String(), "-- No changes")
 }
 

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -18,7 +18,7 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return err
 	}
 
-	fmt.Fprintf(w, "-- Plan: %s\n", result.Count) //nolint:errcheck
+	fmt.Fprintf(w, "-- Plan for schema %s (%s)\n", result.Count.SchemaNames(), result.Count.Summary()) //nolint:errcheck
 
 	if result.SQL == "" {
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -18,7 +18,7 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return err
 	}
 
-	fmt.Fprintf(w, "-- Plan for schema %s (%s)\n", result.Count.SchemaNames(), result.Count.Summary()) //nolint:errcheck
+	fmt.Fprintf(w, "-- Plan for %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 
 	if result.SQL == "" {
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -18,7 +18,7 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return err
 	}
 
-	fmt.Fprintf(w, "-- Target: %s\n", result.Count) //nolint:errcheck
+	fmt.Fprintf(w, "-- Plan: %s\n", result.Count) //nolint:errcheck
 
 	if result.SQL == "" {
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck

--- a/getting-started.md
+++ b/getting-started.md
@@ -77,7 +77,7 @@ pist plan schema.sql
 Output:
 
 ```sql
--- Target: schema: public, 1 table, 0 views, 0 enums, 0 domains
+-- Plan: schema: public, 1 table, 0 views, 0 enums, 0 domains
 ALTER TABLE public.users ADD COLUMN email text;
 ```
 
@@ -93,7 +93,7 @@ Verify by running plan again:
 
 ```bash
 pist plan schema.sql
-# => -- Target: schema: public, 1 table, 0 views, 0 enums, 0 domains
+# => -- Plan: schema: public, 1 table, 0 views, 0 enums, 0 domains
 # => -- No changes
 ```
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -77,7 +77,7 @@ pist plan schema.sql
 Output:
 
 ```sql
--- Plan: schema: public, 1 table, 0 views, 0 enums, 0 domains
+-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
 ALTER TABLE public.users ADD COLUMN email text;
 ```
 
@@ -93,7 +93,7 @@ Verify by running plan again:
 
 ```bash
 pist plan schema.sql
-# => -- Plan: schema: public, 1 table, 0 views, 0 enums, 0 domains
+# => -- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
 # => -- No changes
 ```
 

--- a/plan.go
+++ b/plan.go
@@ -27,9 +27,12 @@ type ObjectCount struct {
 	Domains int
 }
 
-func (c ObjectCount) String() string {
-	return fmt.Sprintf("schema: %s, %s, %s, %s, %s",
-		strings.Join(c.Schemas, ", "),
+func (c ObjectCount) SchemaNames() string {
+	return strings.Join(c.Schemas, ", ")
+}
+
+func (c ObjectCount) Summary() string {
+	return fmt.Sprintf("%s, %s, %s, %s",
 		pluralize(c.Tables, "table"),
 		pluralize(c.Views, "view"),
 		pluralize(c.Enums, "enum"),

--- a/plan.go
+++ b/plan.go
@@ -27,8 +27,11 @@ type ObjectCount struct {
 	Domains int
 }
 
-func (c ObjectCount) SchemaNames() string {
-	return strings.Join(c.Schemas, ", ")
+func (c ObjectCount) SchemaLabel() string {
+	if len(c.Schemas) == 1 {
+		return "schema " + c.Schemas[0]
+	}
+	return "schemas " + strings.Join(c.Schemas, ", ")
 }
 
 func (c ObjectCount) Summary() string {

--- a/schema_filter_test.go
+++ b/schema_filter_test.go
@@ -86,17 +86,20 @@ CREATE TABLE other.stuff (
 	assert.Equal(t, 1, count.Tables)
 }
 
-func TestObjectCount_String(t *testing.T) {
-	c := pistachio.ObjectCount{Schemas: []string{"public"}, Tables: 3, Views: 1, Enums: 2, Domains: 0}
-	assert.Equal(t, "schema: public, 3 tables, 1 view, 2 enums, 0 domains", c.String())
+func TestObjectCount_SchemaNames(t *testing.T) {
+	c := pistachio.ObjectCount{Schemas: []string{"public"}}
+	assert.Equal(t, "public", c.SchemaNames())
+
+	c2 := pistachio.ObjectCount{Schemas: []string{"public", "myschema"}}
+	assert.Equal(t, "public, myschema", c2.SchemaNames())
 }
 
-func TestObjectCount_String_Singular(t *testing.T) {
-	c := pistachio.ObjectCount{Schemas: []string{"myschema"}, Tables: 1, Views: 1, Enums: 1, Domains: 1}
-	assert.Equal(t, "schema: myschema, 1 table, 1 view, 1 enum, 1 domain", c.String())
+func TestObjectCount_Summary(t *testing.T) {
+	c := pistachio.ObjectCount{Tables: 3, Views: 1, Enums: 2, Domains: 0}
+	assert.Equal(t, "3 tables, 1 view, 2 enums, 0 domains", c.Summary())
 }
 
-func TestObjectCount_String_MultipleSchemas(t *testing.T) {
-	c := pistachio.ObjectCount{Schemas: []string{"public", "myschema"}, Tables: 5, Views: 2, Enums: 1, Domains: 0}
-	assert.Equal(t, "schema: public, myschema, 5 tables, 2 views, 1 enum, 0 domains", c.String())
+func TestObjectCount_Summary_Singular(t *testing.T) {
+	c := pistachio.ObjectCount{Tables: 1, Views: 1, Enums: 1, Domains: 1}
+	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain", c.Summary())
 }

--- a/schema_filter_test.go
+++ b/schema_filter_test.go
@@ -86,12 +86,12 @@ CREATE TABLE other.stuff (
 	assert.Equal(t, 1, count.Tables)
 }
 
-func TestObjectCount_SchemaNames(t *testing.T) {
+func TestObjectCount_SchemaLabel(t *testing.T) {
 	c := pistachio.ObjectCount{Schemas: []string{"public"}}
-	assert.Equal(t, "public", c.SchemaNames())
+	assert.Equal(t, "schema public", c.SchemaLabel())
 
 	c2 := pistachio.ObjectCount{Schemas: []string{"public", "myschema"}}
-	assert.Equal(t, "public, myschema", c2.SchemaNames())
+	assert.Equal(t, "schemas public, myschema", c2.SchemaLabel())
 }
 
 func TestObjectCount_Summary(t *testing.T) {


### PR DESCRIPTION
This pull request updates how schema summaries are displayed and tested in the CLI output and documentation. It replaces the old `ObjectCount.String()` method with two clearer methods: `SchemaNames()` and `Summary()`. The output format shown to users is now more readable and consistent across commands, tests, and documentation.

**User-facing output improvements:**
- Changed the output format for schema operations in the `plan` and `apply` commands to a more descriptive form, e.g., "`-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)`" instead of the previous "`-- Target: schema: public, 1 table, ...`". [[1]](diffhunk://#diff-92b4b561c88ccc00657cf1e8f706348821ccdc3e2728cfb2bd741252015e477fL21-R21) [[2]](diffhunk://#diff-d5747f2387e3182f5df03f76bddcc659bdc424e69dfc95d5974c88bffbcc6739L23-R23)

**API and code refactoring:**
- Replaced the `ObjectCount.String()` method with two new methods: `SchemaNames()` (returns a comma-separated list of schema names) and `Summary()` (returns a summary of object counts). Updated all usages to use these new methods for better clarity and separation of concerns.

**Testing updates:**
- Updated and expanded tests to cover the new `SchemaNames()` and `Summary()` methods, ensuring both singular and plural forms are handled correctly. Removed tests for the old `String()` method.
- Updated CLI command tests to match the new output format for both `plan` and `apply` commands. [[1]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L285-R285) [[2]](diffhunk://#diff-0d525203ae22fa43bf4a57137ce679d98aceb2d0cc388ab00e61b04665f18a82L312-R312)

**Documentation updates:**
- Updated `getting-started.md` to reflect the new schema summary output format in code examples and explanations. [[1]](diffhunk://#diff-f007f6cb65740b71d33ebd4511fa8727d48a472d135ffd1bbef978237f9e6fa7L80-R80) [[2]](diffhunk://#diff-f007f6cb65740b71d33ebd4511fa8727d48a472d135ffd1bbef978237f9e6fa7L96-R96)