### PR TITLE
Reorder view statements

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -92,7 +92,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}
 
-	// View drops first (views may depend on columns being dropped)
+	// Drop views before table/column changes (views may depend on columns being dropped)
 	stmts = append(stmts, viewDiff.DropStmts...)
 
 	// FK drops before table/column changes

--- a/apply.go
+++ b/apply.go
@@ -87,15 +87,22 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
-	stmts = append(stmts, tableDiff.FKDropStmts...)
-	stmts = append(stmts, tableDiff.Stmts...)
-
-	viewStmts, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
+	viewDiff, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}
-	stmts = append(stmts, viewStmts...)
 
+	// View drops first (views may depend on columns being dropped)
+	stmts = append(stmts, viewDiff.DropStmts...)
+
+	// FK drops before table/column changes
+	stmts = append(stmts, tableDiff.FKDropStmts...)
+	stmts = append(stmts, tableDiff.Stmts...)
+
+	// View creates after table changes
+	stmts = append(stmts, viewDiff.CreateStmts...)
+
+	// Table drops
 	stmts = append(stmts, tableDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
 	stmts = append(stmts, enumDiff.DropStmts...)

--- a/apply.go
+++ b/apply.go
@@ -99,15 +99,15 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	stmts = append(stmts, tableDiff.FKDropStmts...)
 	stmts = append(stmts, tableDiff.Stmts...)
 
-	// View creates after table changes
-	stmts = append(stmts, viewDiff.CreateStmts...)
-
 	// Table drops
 	stmts = append(stmts, tableDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
 	stmts = append(stmts, enumDiff.DropStmts...)
 
 	stmts = append(stmts, tableDiff.FKAddStmts...)
+
+	// View creates last (views may depend on tables/columns created above)
+	stmts = append(stmts, viewDiff.CreateStmts...)
 
 	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
 	if err != nil {

--- a/diff/views.go
+++ b/diff/views.go
@@ -37,7 +37,7 @@ func equalViewDef(a, b string) bool {
 // Drops should run before table changes, creates after.
 type ViewDiffResult struct {
 	DropStmts   []string // DROP VIEW (should run before table changes)
-	CreateStmts []string // CREATE OR REPLACE VIEW, comments (should run after table changes)
+	CreateStmts []string // ALTER VIEW RENAME, CREATE OR REPLACE VIEW, comments (should run after table changes)
 }
 
 func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker) (*ViewDiffResult, error) {

--- a/diff/views.go
+++ b/diff/views.go
@@ -33,22 +33,29 @@ func equalViewDef(a, b string) bool {
 	return normA == normB
 }
 
-func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker) ([]string, error) {
+// ViewDiffResult separates view DROP and CREATE/MODIFY statements.
+// Drops should run before table changes, creates after.
+type ViewDiffResult struct {
+	DropStmts   []string // DROP VIEW (should run before table changes)
+	CreateStmts []string // CREATE OR REPLACE VIEW, comments (should run after table changes)
+}
+
+func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker) (*ViewDiffResult, error) {
 	dc = NormalizeDropChecker(dc)
-	var stmts []string
+	result := &ViewDiffResult{}
 
 	// Detect renames
 	renameStmts, current, err := detectViewRenames(current, desired)
 	if err != nil {
 		return nil, err
 	}
-	stmts = append(stmts, renameStmts...)
+	result.CreateStmts = append(result.CreateStmts, renameStmts...)
 
 	// New or modified views (CREATE OR REPLACE)
 	for k, desiredView := range desired.All() {
 		currentView, ok := current.GetOk(k)
 		if !ok || !equalViewDef(currentView.Definition, desiredView.Definition) {
-			stmts = append(stmts, desiredView.SQL())
+			result.CreateStmts = append(result.CreateStmts, desiredView.SQL())
 		}
 	}
 
@@ -56,7 +63,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 	if dc.IsDropAllowed("view") {
 		for k := range current.Keys() {
 			if _, ok := desired.GetOk(k); !ok {
-				stmts = append(stmts, "DROP VIEW "+k+";")
+				result.DropStmts = append(result.DropStmts, "DROP VIEW "+k+";")
 			}
 		}
 	}
@@ -70,12 +77,12 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 		}
 		if !equalPtr(currentComment, desiredView.Comment) {
 			if desiredView.Comment != nil {
-				stmts = append(stmts, "COMMENT ON VIEW "+k+" IS "+model.QuoteLiteral(*desiredView.Comment)+";")
+				result.CreateStmts = append(result.CreateStmts, "COMMENT ON VIEW "+k+" IS "+model.QuoteLiteral(*desiredView.Comment)+";")
 			} else {
-				stmts = append(stmts, "COMMENT ON VIEW "+k+" IS NULL;")
+				result.CreateStmts = append(result.CreateStmts, "COMMENT ON VIEW "+k+" IS NULL;")
 			}
 		}
 	}
 
-	return stmts, nil
+	return result, nil
 }

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -14,10 +14,10 @@ func TestDiffViews_newView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 1)
-	assert.Contains(t, stmts[0], "CREATE OR REPLACE VIEW public.v1")
+	assert.Len(t, result.CreateStmts, 1)
+	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v1")
 }
 
 func TestDiffViews_dropView(t *testing.T) {
@@ -25,9 +25,9 @@ func TestDiffViews_dropView(t *testing.T) {
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 	desired := orderedmap.New[string, *model.View]()
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"DROP VIEW public.v1;"}, stmts)
+	assert.Equal(t, []string{"DROP VIEW public.v1;"}, result.DropStmts)
 }
 
 func TestDiffViews_dropView_denied(t *testing.T) {
@@ -35,9 +35,9 @@ func TestDiffViews_dropView_denied(t *testing.T) {
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 	desired := orderedmap.New[string, *model.View]()
 
-	stmts, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, DenyAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.CreateStmts)
 }
 
 func TestDiffViews_modifyView(t *testing.T) {
@@ -46,10 +46,10 @@ func TestDiffViews_modifyView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 2"})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 1)
-	assert.Contains(t, stmts[0], "CREATE OR REPLACE VIEW public.v1")
+	assert.Len(t, result.CreateStmts, 1)
+	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v1")
 }
 
 func TestDiffViews_noChange(t *testing.T) {
@@ -58,9 +58,9 @@ func TestDiffViews_noChange(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.CreateStmts)
 }
 
 func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
@@ -69,9 +69,9 @@ func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.CreateStmts)
 }
 
 func TestDiffViews_commentAdd(t *testing.T) {
@@ -80,10 +80,10 @@ func TestDiffViews_commentAdd(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", Comment: ptr("my view")})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 1)
-	assert.Equal(t, "COMMENT ON VIEW public.v1 IS 'my view';", stmts[0])
+	assert.Len(t, result.CreateStmts, 1)
+	assert.Equal(t, "COMMENT ON VIEW public.v1 IS 'my view';", result.CreateStmts[0])
 }
 
 func TestDiffViews_commentDrop(t *testing.T) {
@@ -92,10 +92,10 @@ func TestDiffViews_commentDrop(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 1)
-	assert.Equal(t, "COMMENT ON VIEW public.v1 IS NULL;", stmts[0])
+	assert.Len(t, result.CreateStmts, 1)
+	assert.Equal(t, "COMMENT ON VIEW public.v1 IS NULL;", result.CreateStmts[0])
 }
 
 func TestDiffViews_rename(t *testing.T) {
@@ -106,9 +106,9 @@ func TestDiffViews_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"ALTER VIEW public.v1 RENAME TO v2;"}, stmts)
+	assert.Equal(t, []string{"ALTER VIEW public.v1 RENAME TO v2;"}, result.CreateStmts)
 }
 
 func TestDiffViews_rename_selfRename_skipped(t *testing.T) {
@@ -119,9 +119,9 @@ func TestDiffViews_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.CreateStmts)
 }
 
 func TestDiffViews_rename_alreadyApplied(t *testing.T) {
@@ -132,9 +132,9 @@ func TestDiffViews_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	stmts, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, result.CreateStmts)
 }
 
 func TestDiffViews_rename_destinationExists_error(t *testing.T) {

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -38,6 +38,7 @@ func TestDiffViews_dropView_denied(t *testing.T) {
 	result, err := DiffViews(current, desired, DenyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
+	assert.Empty(t, result.DropStmts)
 }
 
 func TestDiffViews_modifyView(t *testing.T) {
@@ -61,6 +62,7 @@ func TestDiffViews_noChange(t *testing.T) {
 	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
+	assert.Empty(t, result.DropStmts)
 }
 
 func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
@@ -72,6 +74,7 @@ func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
 	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
+	assert.Empty(t, result.DropStmts)
 }
 
 func TestDiffViews_commentAdd(t *testing.T) {
@@ -122,6 +125,7 @@ func TestDiffViews_rename_selfRename_skipped(t *testing.T) {
 	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
+	assert.Empty(t, result.DropStmts)
 }
 
 func TestDiffViews_rename_alreadyApplied(t *testing.T) {
@@ -135,6 +139,7 @@ func TestDiffViews_rename_alreadyApplied(t *testing.T) {
 	result, err := DiffViews(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
+	assert.Empty(t, result.DropStmts)
 }
 
 func TestDiffViews_rename_destinationExists_error(t *testing.T) {

--- a/plan.go
+++ b/plan.go
@@ -136,16 +136,16 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	stmts = append(stmts, tableDiff.FKDropStmts...)
 	stmts = append(stmts, tableDiff.Stmts...)
 
-	// View creates after table changes (views may reference new tables/columns)
-	stmts = append(stmts, viewDiff.CreateStmts...)
-
-	// Table drops
+	// Drops: tables before domains/enums (dependency order)
 	stmts = append(stmts, tableDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
 	stmts = append(stmts, enumDiff.DropStmts...)
 
-	// FK adds last (after all tables exist)
+	// FK adds after all tables exist
 	stmts = append(stmts, tableDiff.FKAddStmts...)
+
+	// View creates last (views may reference new tables/columns/FKs)
+	stmts = append(stmts, viewDiff.CreateStmts...)
 
 	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
 	if err != nil {

--- a/plan.go
+++ b/plan.go
@@ -124,17 +124,22 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
-	// FK drops first (before any table/column changes)
-	stmts = append(stmts, tableDiff.FKDropStmts...)
-	stmts = append(stmts, tableDiff.Stmts...)
-
-	viewStmts, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
+	viewDiff, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}
-	stmts = append(stmts, viewStmts...)
 
-	// Drops: tables before domains/enums (dependency order)
+	// View drops first (views may depend on columns being dropped)
+	stmts = append(stmts, viewDiff.DropStmts...)
+
+	// FK drops before table/column changes
+	stmts = append(stmts, tableDiff.FKDropStmts...)
+	stmts = append(stmts, tableDiff.Stmts...)
+
+	// View creates after table changes (views may reference new tables/columns)
+	stmts = append(stmts, viewDiff.CreateStmts...)
+
+	// Table drops
 	stmts = append(stmts, tableDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
 	stmts = append(stmts, enumDiff.DropStmts...)

--- a/plan.go
+++ b/plan.go
@@ -129,7 +129,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}
 
-	// View drops first (views may depend on columns being dropped)
+	// Drop views before table/column changes (views may depend on columns being dropped)
 	stmts = append(stmts, viewDiff.DropStmts...)
 
 	// FK drops before table/column changes

--- a/testdata/apply/create_view_after_table.yml
+++ b/testdata/apply/create_view_after_table.yml
@@ -1,0 +1,21 @@
+init: ""
+desired: |
+  CREATE VIEW public.user_view AS SELECT id, name FROM public.users;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_view
+  CREATE OR REPLACE VIEW public.user_view AS
+  SELECT users.id,
+      users.name
+     FROM users;

--- a/testdata/apply/drop_view_before_column.yml
+++ b/testdata/apply/drop_view_before_column.yml
@@ -1,0 +1,21 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.user_emails AS SELECT id, email FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/rename_view.yml
+++ b/testdata/apply/rename_view.yml
@@ -1,0 +1,28 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:renamed-from public.active_users
+  CREATE VIEW public.user_list AS SELECT id, name FROM public.users;
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_list
+  CREATE OR REPLACE VIEW public.user_list AS
+  SELECT users.id,
+      users.name
+     FROM users;

--- a/testdata/plan/create_view_after_table.yml
+++ b/testdata/plan/create_view_after_table.yml
@@ -1,0 +1,16 @@
+init: ""
+desired: |
+  CREATE VIEW public.user_view AS SELECT id, name FROM public.users;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE OR REPLACE VIEW public.user_view AS
+  SELECT id, name FROM public.users;

--- a/testdata/plan/drop_view_before_column.yml
+++ b/testdata/plan/drop_view_before_column.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.user_emails AS SELECT id, email FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  DROP VIEW public.user_emails;
+  ALTER TABLE public.users DROP COLUMN email;

--- a/testdata/plan/rename_view.yml
+++ b/testdata/plan/rename_view.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:renamed-from public.active_users
+  CREATE VIEW public.user_list AS SELECT id, name FROM public.users;
+plan: |
+  ALTER VIEW public.active_users RENAME TO user_list;
+  CREATE OR REPLACE VIEW public.user_list AS
+  SELECT id, name FROM public.users;


### PR DESCRIPTION
This pull request refactors the handling of view-related DDL statements during schema diff and apply/plan operations, improving the correctness of migration ordering and making the code more maintainable. The main change is to separate view DROP and CREATE statements, ensuring that views are dropped before dependent tables/columns are altered and created only after all dependencies are in place. This prevents dependency errors during migrations. The refactor also updates tests and introduces new test cases to verify the correct ordering.

Ordering and correctness improvements:

* Refactored `DiffViews` to return a `ViewDiffResult` struct with separate `DropStmts` and `CreateStmts` slices, instead of a flat list of statements. This allows more precise control over when view drops and creates occur in the migration process. [[1]](diffhunk://#diff-9d9c472cb90ddd57607ee4149155d2510868a42c9429f2200bc3713aff0c12dcL36-R66) [[2]](diffhunk://#diff-9d9c472cb90ddd57607ee4149155d2510868a42c9429f2200bc3713aff0c12dcL73-R87)
* Updated `Apply` and `Plan` methods to use the new `ViewDiffResult`, ensuring that view drops are executed before table/column changes, and view creates are executed after all dependencies are established. [[1]](diffhunk://#diff-86ae12b12a6a3e85fd29fb29e6745818c470d89b611f10125ad5761a707e5a76L90-R111) [[2]](diffhunk://#diff-11ffedf6a81044546aa19c8009998208f5a7afec3cdff04ca4281117b5ec0da7L127-R149)

Testing improvements:

* Updated all relevant tests in `diff/views_test.go` to use the new `ViewDiffResult` struct, checking `DropStmts` and `CreateStmts` separately. [[1]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L17-R40) [[2]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L49-R52) [[3]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L61-R63) [[4]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L72-R74) [[5]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L83-R86) [[6]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L95-R98) [[7]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L109-R111) [[8]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L122-R124) [[9]](diffhunk://#diff-cfedb6b8eb135df8f13872b64ad09146a106eb8390e87d3eb18c6086cb765356L135-R137)
* Added new integration test cases to verify that views are created after their dependent tables and dropped before columns are removed, preventing dependency errors. [[1]](diffhunk://#diff-278679a7a3465f1d29db144dbd2bae33a017728f4d5b5b2acaba621f92871dc2R1-R21) [[2]](diffhunk://#diff-92628fda5accc4f7a8552be46e7b2cc649ce40c87cbe204b0ae89d709a44bd3eR1-R21)