### PR TITLE
Drop FKs on tables being dropped to avoid dependency errors

### DIFF
--- a/diff/tables.go
+++ b/diff/tables.go
@@ -53,10 +53,13 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 		}
 	}
 
-	// Dropped tables
+	// Dropped tables: drop FKs on dropped tables first to avoid dependency errors
 	if dc.IsDropAllowed("table") {
-		for k := range current.Keys() {
+		for k, tbl := range current.All() {
 			if _, ok := desired.GetOk(k); !ok {
+				for name := range tbl.ForeignKeys.Keys() {
+					result.FKDropStmts = append(result.FKDropStmts, "ALTER TABLE "+k+" DROP CONSTRAINT "+model.Ident(name)+";")
+				}
 				result.DropStmts = append(result.DropStmts, "DROP TABLE "+k+";")
 			}
 		}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -68,6 +68,48 @@ func TestDiffTables_dropTable(t *testing.T) {
 	assert.Equal(t, []string{"DROP TABLE public.users;"}, result.DropStmts)
 }
 
+func TestDiffTables_dropTable_withFK(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	users := newTable("public", "users")
+	current.Set("public.users", users)
+
+	posts := newTable("public", "posts")
+	posts.ForeignKeys.Set("posts_user_id_fkey", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "posts_user_id_fkey", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)"},
+		Schema:     "public",
+		Table:      "posts",
+	})
+	current.Set("public.posts", posts)
+
+	result, err := DiffTables(current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.posts DROP CONSTRAINT posts_user_id_fkey;"}, result.FKDropStmts)
+	assert.Equal(t, []string{"DROP TABLE public.users;", "DROP TABLE public.posts;"}, result.DropStmts)
+}
+
+func TestDiffTables_dropTable_withFK_denied(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	users := newTable("public", "users")
+	current.Set("public.users", users)
+
+	posts := newTable("public", "posts")
+	posts.ForeignKeys.Set("posts_user_id_fkey", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "posts_user_id_fkey", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)"},
+		Schema:     "public",
+		Table:      "posts",
+	})
+	current.Set("public.posts", posts)
+
+	result, err := DiffTables(current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.FKDropStmts)
+	assert.Empty(t, result.DropStmts)
+}
+
 func TestNormalizeDropChecker_nil(t *testing.T) {
 	dc := NormalizeDropChecker(nil)
 	assert.False(t, dc.IsDropAllowed("table"))

--- a/testdata/apply/drop_tables_with_fk.yml
+++ b/testdata/apply/drop_tables_with_fk.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
+desired: ""
+applied: ""

--- a/testdata/plan/drop_tables_with_fk.yml
+++ b/testdata/plan/drop_tables_with_fk.yml
@@ -1,0 +1,16 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
+desired: ""
+plan: |
+  ALTER TABLE public.posts DROP CONSTRAINT posts_user_id_fkey;
+  DROP TABLE public.posts;
+  DROP TABLE public.users;


### PR DESCRIPTION
When dropping tables that reference each other via foreign keys, the FK constraints must be dropped first. Otherwise the DROP TABLE order may cause dependency errors.