### PR TITLE
Normalize desired view definitions through PostgreSQL to prevent drift

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -87,7 +87,9 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
-	viewDiff, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
+	desiredViews := options.filterViews(client.reverseRemapViewSchemas(desired.Views))
+	normalizeDesiredViewDefs(ctx, conn, filteredViews, desiredViews)
+	viewDiff, err := diff.DiffViews(filteredViews, desiredViews, &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}

--- a/export_test.go
+++ b/export_test.go
@@ -1,3 +1,4 @@
 package pistachio
 
 var ResolvePreSQL = resolvePreSQL
+var NormalizeDesiredViewDefs = normalizeDesiredViewDefs

--- a/export_test.go
+++ b/export_test.go
@@ -1,4 +1,6 @@
 package pistachio
 
-var ResolvePreSQL = resolvePreSQL
-var NormalizeDesiredViewDefs = normalizeDesiredViewDefs
+var (
+	ResolvePreSQL            = resolvePreSQL
+	NormalizeDesiredViewDefs = normalizeDesiredViewDefs
+)

--- a/normalize.go
+++ b/normalize.go
@@ -30,16 +30,34 @@ func normalizeDesiredViewDefs(ctx context.Context, conn *pgx.Conn, current, desi
 			continue
 		}
 
-		sql := "CREATE OR REPLACE VIEW " + v.FQVN() + " AS " + v.Definition
-		if _, err := tx.Exec(ctx, sql); err != nil {
-			continue
+		if def, err := normalizeOneViewDef(ctx, tx, v); err == nil {
+			v.Definition = def
 		}
-
-		var def string
-		if err := tx.QueryRow(ctx, "SELECT pg_catalog.pg_get_viewdef($1::regclass, true)", v.FQVN()).Scan(&def); err != nil {
-			continue
-		}
-
-		v.Definition = def
 	}
+}
+
+// normalizeOneViewDef normalizes a single view definition using a savepoint
+// so that a failure does not abort the outer transaction and block subsequent views.
+func normalizeOneViewDef(ctx context.Context, tx pgx.Tx, v *model.View) (string, error) {
+	sp, err := tx.Begin(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer sp.Rollback(ctx) //nolint:errcheck
+
+	sql := "CREATE OR REPLACE VIEW " + v.FQVN() + " AS " + v.Definition
+	if _, err := sp.Exec(ctx, sql); err != nil {
+		return "", err
+	}
+
+	var def string
+	if err := sp.QueryRow(ctx, "SELECT pg_catalog.pg_get_viewdef($1::regclass, true)", v.FQVN()).Scan(&def); err != nil {
+		return "", err
+	}
+
+	if err := sp.Commit(ctx); err != nil {
+		return "", err
+	}
+
+	return def, nil
 }

--- a/normalize.go
+++ b/normalize.go
@@ -1,0 +1,45 @@
+package pistachio
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// normalizeDesiredViewDefs normalizes desired view definitions by creating
+// each view inside a transaction and reading it back via pg_get_viewdef.
+// This ensures the desired definition goes through the same PostgreSQL
+// normalization as the current definition from the catalog, preventing
+// false diffs caused by implicit casts (e.g. 'active'::text) or
+// table-qualified column names that pg_get_viewdef adds.
+// Only views that already exist in current are normalized, so that new
+// views preserve the user's original SQL in plan/apply output.
+// The transaction is always rolled back so no changes are persisted.
+// Views that cannot be created (e.g. missing tables) are silently skipped.
+func normalizeDesiredViewDefs(ctx context.Context, conn *pgx.Conn, current, desired *orderedmap.Map[string, *model.View]) {
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	for k, v := range desired.All() {
+		if _, ok := current.GetOk(k); !ok {
+			continue
+		}
+
+		sql := "CREATE OR REPLACE VIEW " + v.FQVN() + " AS " + v.Definition
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			continue
+		}
+
+		var def string
+		if err := tx.QueryRow(ctx, "SELECT pg_catalog.pg_get_viewdef($1::regclass, true)", v.FQVN()).Scan(&def); err != nil {
+			continue
+		}
+
+		v.Definition = def
+	}
+}

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,0 +1,70 @@
+package pistachio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio"
+	"github.com/winebarrel/pistachio/internal/testutil"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestNormalizeDesiredViewDefs_ClosedConn(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	conn.Close(ctx)
+
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+
+	// Should not panic; silently returns on conn.Begin failure
+	pistachio.NormalizeDesiredViewDefs(ctx, conn, current, desired)
+
+	v, _ := desired.GetOk("public.v1")
+	assert.Equal(t, "SELECT 1", v.Definition)
+}
+
+func TestNormalizeDesiredViewDefs_QueryRowError(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.items (
+    id integer NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_items AS SELECT id FROM items;
+`)
+
+	current := orderedmap.New[string, *model.View]()
+	// FQVN "nonexistent.active_items" exists in current so normalization is attempted,
+	// but CREATE VIEW succeeds under public while pg_get_viewdef('nonexistent.active_items'::regclass) fails.
+	current.Set("nonexistent.active_items", &model.View{Schema: "nonexistent", Name: "active_items", Definition: "SELECT id FROM items"})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("nonexistent.active_items", &model.View{Schema: "nonexistent", Name: "active_items", Definition: "SELECT id FROM items"})
+
+	pistachio.NormalizeDesiredViewDefs(ctx, conn, current, desired)
+
+	// tx.Exec fails (nonexistent schema), definition unchanged
+	v, _ := desired.GetOk("nonexistent.active_items")
+	assert.Equal(t, "SELECT id FROM items", v.Definition)
+}
+
+func TestNormalizeDesiredViewDefs_SkipsNewViews(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	current := orderedmap.New[string, *model.View]()
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+
+	pistachio.NormalizeDesiredViewDefs(ctx, conn, current, desired)
+
+	// New view not in current — definition should remain unchanged
+	v, _ := desired.GetOk("public.v1")
+	assert.Equal(t, "SELECT 1", v.Definition)
+}

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -53,6 +53,39 @@ CREATE VIEW public.active_items AS SELECT id FROM items;
 	assert.Equal(t, "SELECT id FROM items", v.Definition)
 }
 
+func TestNormalizeDesiredViewDefs_SavepointIsolation(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.items (
+    id integer NOT NULL,
+    label text NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.good_view AS SELECT id, label FROM items WHERE label = 'active';
+`)
+
+	current := orderedmap.New[string, *model.View]()
+	// First view: will fail (references nonexistent column)
+	current.Set("public.bad_view", &model.View{Schema: "public", Name: "bad_view", Definition: "SELECT missing_col FROM items"})
+	// Second view: should still succeed despite first failure
+	current.Set("public.good_view", &model.View{Schema: "public", Name: "good_view", Definition: "SELECT id, label FROM items WHERE label = 'active'"})
+
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.bad_view", &model.View{Schema: "public", Name: "bad_view", Definition: "SELECT missing_col FROM items"})
+	desired.Set("public.good_view", &model.View{Schema: "public", Name: "good_view", Definition: "SELECT id, label FROM items WHERE label = 'active'"})
+
+	pistachio.NormalizeDesiredViewDefs(ctx, conn, current, desired)
+
+	// bad_view: definition unchanged (CREATE VIEW failed)
+	bad, _ := desired.GetOk("public.bad_view")
+	assert.Equal(t, "SELECT missing_col FROM items", bad.Definition)
+
+	// good_view: definition normalized despite bad_view failing first
+	good, _ := desired.GetOk("public.good_view")
+	assert.Contains(t, good.Definition, "'active'::text")
+}
+
 func TestNormalizeDesiredViewDefs_SkipsNewViews(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/plan.go
+++ b/plan.go
@@ -124,7 +124,9 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
-	viewDiff, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
+	desiredViews := options.filterViews(client.reverseRemapViewSchemas(desired.Views))
+	normalizeDesiredViewDefs(ctx, conn, filteredViews, desiredViews)
+	viewDiff, err := diff.DiffViews(filteredViews, desiredViews, &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}

--- a/remap_test.go
+++ b/remap_test.go
@@ -521,6 +521,39 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;
 	assert.Contains(t, got.SQL, "CREATE OR REPLACE VIEW myschema.active_users")
 }
 
+func TestPlan_WithSchemaMap_View_NoDiff(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    label text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW myschema.active_users AS SELECT id, label FROM myschema.users WHERE label = 'active';
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    label text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id, label FROM public.users WHERE label = 'active';
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	assert.Empty(t, got.SQL)
+}
+
 func TestApply_WithSchemaMap(t *testing.T) {
 	ctx := context.Background()
 

--- a/testdata/apply/no_diff_view_with_casts.yml
+++ b/testdata/apply/no_diff_view_with_casts.yml
@@ -1,0 +1,30 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT id, label FROM items WHERE label = 'active';
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT id, label FROM items WHERE label = 'active';
+applied: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_items
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT items.id,
+      items.label
+     FROM items
+    WHERE items.label = 'active'::text;

--- a/testdata/plan/no_diff_view_with_casts.yml
+++ b/testdata/plan/no_diff_view_with_casts.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT id, label FROM items WHERE label = 'active';
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT id, label FROM items WHERE label = 'active';
+plan: ""

--- a/testdata/plan/view_normalize_fallback.yml
+++ b/testdata/plan/view_normalize_fallback.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT id, label FROM items WHERE label = 'active';
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT id FROM items;
+plan: |
+  ALTER TABLE public.items DROP COLUMN label;
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT id FROM items;


### PR DESCRIPTION
pg_get_viewdef adds implicit casts (e.g. 'active'::text) and table-qualified column names that pg_query parse/deparse does not, causing views to be recreated on every apply. Fix by normalizing desired view definitions through PostgreSQL (CREATE OR REPLACE VIEW in a rolled-back transaction + pg_get_viewdef) so both sides go through the same normalization.