### PR TITLE
Strip implicit ::text casts when comparing view definitions

### DIFF
--- a/diff/views.go
+++ b/diff/views.go
@@ -4,17 +4,82 @@ import (
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // normalizeViewDef normalizes a view definition by parsing and deparsing it
 // through pg_query, so that formatting differences are eliminated.
+// It also strips implicit ::text casts on string literals that pg_get_viewdef adds.
 func normalizeViewDef(def string) (string, error) {
 	sql := "CREATE VIEW _v AS " + def
 	result, err := pg_query.Parse(sql)
 	if err != nil {
 		return "", err
 	}
+	for _, stmt := range result.Stmts {
+		stripImplicitTextCastsFromNode(stmt.Stmt)
+	}
 	return pg_query.Deparse(result)
+}
+
+// isImplicitTextCast returns true if the TypeCast is a ::text cast on a string literal.
+// pg_get_viewdef adds these casts implicitly; they are semantically redundant.
+func isImplicitTextCast(tc *pg_query.TypeCast) bool {
+	if tc == nil || tc.Arg == nil || tc.TypeName == nil {
+		return false
+	}
+	if c := tc.Arg.GetAConst(); c == nil || c.GetSval() == nil {
+		return false
+	}
+	for _, n := range tc.TypeName.Names {
+		if s := n.GetString_(); s != nil && s.Sval == "text" {
+			return true
+		}
+	}
+	return false
+}
+
+var nodeFullName = (&pg_query.Node{}).ProtoReflect().Descriptor().FullName()
+
+// stripImplicitTextCastsFromNode unwraps ::text casts on string literals in the given node.
+func stripImplicitTextCastsFromNode(node *pg_query.Node) {
+	if node == nil {
+		return
+	}
+	if tc := node.GetTypeCast(); isImplicitTextCast(tc) {
+		node.Node = tc.Arg.Node
+		stripImplicitTextCastsFromNode(node)
+		return
+	}
+	walkNodeChildren(node.ProtoReflect())
+}
+
+// walkNodeChildren recursively visits all child Node fields via protobuf reflection.
+func walkNodeChildren(msg protoreflect.Message) {
+	msg.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		if fd.Kind() != protoreflect.MessageKind {
+			return true
+		}
+		if fd.IsList() {
+			list := v.List()
+			for i := 0; i < list.Len(); i++ {
+				m := list.Get(i).Message()
+				if m.Descriptor().FullName() == nodeFullName {
+					stripImplicitTextCastsFromNode(m.Interface().(*pg_query.Node))
+				} else {
+					walkNodeChildren(m)
+				}
+			}
+		} else {
+			m := v.Message()
+			if m.Descriptor().FullName() == nodeFullName {
+				stripImplicitTextCastsFromNode(m.Interface().(*pg_query.Node))
+			} else {
+				walkNodeChildren(m)
+			}
+		}
+		return true
+	})
 }
 
 // equalViewDef compares two view definitions by normalizing them through

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -198,3 +198,48 @@ func TestEqualViewDef_formattingDifference(t *testing.T) {
 func TestEqualViewDef_different(t *testing.T) {
 	assert.False(t, equalViewDef("SELECT 1", "SELECT 2"))
 }
+
+func TestEqualViewDef_implicitTextCast(t *testing.T) {
+	// pg_get_viewdef adds ::text to string literals; this should be ignored
+	assert.True(t, equalViewDef(
+		"SELECT id FROM items WHERE label = 'active'::text",
+		"SELECT id FROM items WHERE label = 'active'",
+	))
+}
+
+func TestEqualViewDef_implicitTextCastMultiple(t *testing.T) {
+	assert.True(t, equalViewDef(
+		"SELECT id FROM items WHERE label = 'active'::text AND status = 'enabled'::text",
+		"SELECT id FROM items WHERE label = 'active' AND status = 'enabled'",
+	))
+}
+
+func TestEqualViewDef_nonTextCastPreserved(t *testing.T) {
+	// ::integer cast is meaningful and should NOT be stripped
+	assert.False(t, equalViewDef(
+		"SELECT id FROM items WHERE id = '123'::integer",
+		"SELECT id FROM items WHERE id = '123'",
+	))
+}
+
+func TestEqualViewDef_textCastOnNonStringPreserved(t *testing.T) {
+	// ::text on a non-string-literal (column ref) is meaningful
+	assert.False(t, equalViewDef(
+		"SELECT id::text FROM items",
+		"SELECT id FROM items",
+	))
+}
+
+func TestEqualViewDef_implicitTextCastInSubquery(t *testing.T) {
+	assert.True(t, equalViewDef(
+		"SELECT id FROM items WHERE label IN (SELECT name FROM categories WHERE name = 'food'::text)",
+		"SELECT id FROM items WHERE label IN (SELECT name FROM categories WHERE name = 'food')",
+	))
+}
+
+func TestEqualViewDef_implicitTextCastInCaseExpr(t *testing.T) {
+	assert.True(t, equalViewDef(
+		"SELECT CASE WHEN label = 'active'::text THEN 'yes'::text ELSE 'no'::text END FROM items",
+		"SELECT CASE WHEN label = 'active' THEN 'yes' ELSE 'no' END FROM items",
+	))
+}

--- a/testdata/apply/no_diff_view_with_text_cast.yml
+++ b/testdata/apply/no_diff_view_with_text_cast.yml
@@ -1,0 +1,30 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT id, label FROM items WHERE label = 'active';
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT items.id, items.label FROM items WHERE items.label = 'active';
+applied: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_items
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT items.id,
+      items.label
+     FROM items
+    WHERE items.label = 'active'::text;

--- a/testdata/plan/no_diff_view_with_text_cast.yml
+++ b/testdata/plan/no_diff_view_with_text_cast.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT id, label FROM items WHERE label = 'active';
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      label text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS
+  SELECT items.id, items.label FROM items WHERE items.label = 'active';
+plan: ""


### PR DESCRIPTION
pg_get_viewdef adds ::text casts to string literals, causing false diffs when the user writes the same query without them. Walk the pg_query AST via protobuf reflection and unwrap TypeCast nodes where the argument is a string constant and the target type is text.