### PR TITLE
Extract common diff logic from Plan and Apply into diffAll

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	"github.com/winebarrel/pistachio/catalog"
-	"github.com/winebarrel/pistachio/diff"
-	"github.com/winebarrel/pistachio/parser"
 )
 
 type ApplyOptions struct {
@@ -26,95 +22,20 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	}
 	defer conn.Close(ctx) //nolint:errcheck
 
-	cat, err := catalog.NewCatalog(conn, client.Schemas)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create catalog: %w", err)
-	}
-
-	currentTables, err := cat.Tables(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch tables: %w", err)
-	}
-
-	currentViews, err := cat.Views(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch views: %w", err)
-	}
-
-	currentEnums, err := cat.Enums(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch enums: %w", err)
-	}
-
-	currentDomains, err := cat.Domains(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch domains: %w", err)
-	}
-
-	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse SQL file: %w", err)
-	}
-
-	filterDesiredBySchemas(desired, client.Schemas, client.SchemaMap)
-
-	filteredTables := options.filterTables(currentTables)
-	filteredViews := options.filterViews(currentViews)
-	filteredEnums := options.filterEnums(currentEnums)
-	filteredDomains := options.filterDomains(currentDomains)
-
-	count := &ObjectCount{
-		Schemas: client.Schemas,
-		Tables:  filteredTables.Len(),
-		Views:   filteredViews.Len(),
-		Enums:   filteredEnums.Len(),
-		Domains: filteredDomains.Len(),
-	}
-
-	enumDiff, err := diff.DiffEnums(filteredEnums, options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
-	if err != nil {
-		return nil, err
-	}
-	stmts := enumDiff.Stmts
-
-	domainDiff, err := diff.DiffDomains(filteredDomains, options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff domains: %w", err)
-	}
-	stmts = append(stmts, domainDiff.Stmts...)
-
-	tableDiff, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff tables: %w", err)
-	}
-	viewDiff, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff views: %w", err)
-	}
-
-	// Drop views before table/column changes (views may depend on columns being dropped)
-	stmts = append(stmts, viewDiff.DropStmts...)
-
-	// FK drops before table/column changes
-	stmts = append(stmts, tableDiff.FKDropStmts...)
-	stmts = append(stmts, tableDiff.Stmts...)
-
-	// Table drops
-	stmts = append(stmts, tableDiff.DropStmts...)
-	stmts = append(stmts, domainDiff.DropStmts...)
-	stmts = append(stmts, enumDiff.DropStmts...)
-
-	stmts = append(stmts, tableDiff.FKAddStmts...)
-
-	// View creates last (views may depend on tables/columns created above)
-	stmts = append(stmts, viewDiff.CreateStmts...)
-
-	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
+	result, err := client.diffAll(ctx, conn, &diffAllOptions{
+		FilterOptions: options.FilterOptions,
+		DropPolicy:    options.DropPolicy,
+		Files:         options.Files,
+		PreSQL:        options.PreSQL,
+		PreSQLFile:    options.PreSQLFile,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	if len(stmts) == 0 {
+	count := &result.Count
+
+	if len(result.Stmts) == 0 {
 		return count, nil
 	}
 
@@ -131,14 +52,14 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		commit = tx.Commit
 	}
 
-	if preSQL != "" {
-		fmt.Fprintln(w, preSQL) //nolint:errcheck
-		if _, err := exec(ctx, preSQL); err != nil {
+	if result.PreSQL != "" {
+		fmt.Fprintln(w, result.PreSQL) //nolint:errcheck
+		if _, err := exec(ctx, result.PreSQL); err != nil {
 			return nil, fmt.Errorf("failed to execute pre-SQL: %w", err)
 		}
 	}
 
-	for _, stmt := range stmts {
+	for _, stmt := range result.Stmts {
 		fmt.Fprintln(w, stmt) //nolint:errcheck
 		if _, err := exec(ctx, stmt); err != nil {
 			return nil, fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)

--- a/diff_all.go
+++ b/diff_all.go
@@ -1,0 +1,126 @@
+package pistachio
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/pistachio/catalog"
+	"github.com/winebarrel/pistachio/diff"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+// diffAllOptions holds the common options for diffAll.
+type diffAllOptions struct {
+	FilterOptions
+	DropPolicy
+	Files      []string
+	PreSQL     string
+	PreSQLFile string
+}
+
+// diffAllResult holds the result of diffAll.
+type diffAllResult struct {
+	Stmts  []string
+	PreSQL string
+	Count  ObjectCount
+}
+
+// diffAll performs the common catalog fetch, parse, diff, and statement
+// ordering logic shared by Plan and Apply.
+func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diffAllOptions) (*diffAllResult, error) {
+	cat, err := catalog.NewCatalog(conn, client.Schemas)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create catalog: %w", err)
+	}
+
+	currentTables, err := cat.Tables(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch tables: %w", err)
+	}
+
+	currentViews, err := cat.Views(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch views: %w", err)
+	}
+
+	currentEnums, err := cat.Enums(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch enums: %w", err)
+	}
+
+	currentDomains, err := cat.Domains(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch domains: %w", err)
+	}
+
+	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SQL file: %w", err)
+	}
+
+	filterDesiredBySchemas(desired, client.Schemas, client.SchemaMap)
+
+	filteredTables := options.filterTables(currentTables)
+	filteredViews := options.filterViews(currentViews)
+	filteredEnums := options.filterEnums(currentEnums)
+	filteredDomains := options.filterDomains(currentDomains)
+
+	count := ObjectCount{
+		Schemas: client.Schemas,
+		Tables:  filteredTables.Len(),
+		Views:   filteredViews.Len(),
+		Enums:   filteredEnums.Len(),
+		Domains: filteredDomains.Len(),
+	}
+
+	enumDiff, err := diff.DiffEnums(filteredEnums, options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
+	if err != nil {
+		return nil, err
+	}
+	stmts := enumDiff.Stmts
+
+	domainDiff, err := diff.DiffDomains(filteredDomains, options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff domains: %w", err)
+	}
+	stmts = append(stmts, domainDiff.Stmts...)
+
+	tableDiff, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff tables: %w", err)
+	}
+	viewDiff, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff views: %w", err)
+	}
+
+	// Drop views before table/column changes (views may depend on columns being dropped)
+	stmts = append(stmts, viewDiff.DropStmts...)
+
+	// FK drops before table/column changes
+	stmts = append(stmts, tableDiff.FKDropStmts...)
+	stmts = append(stmts, tableDiff.Stmts...)
+
+	// Drops: tables before domains/enums (dependency order)
+	stmts = append(stmts, tableDiff.DropStmts...)
+	stmts = append(stmts, domainDiff.DropStmts...)
+	stmts = append(stmts, enumDiff.DropStmts...)
+
+	// FK adds after all tables exist
+	stmts = append(stmts, tableDiff.FKAddStmts...)
+
+	// View creates last (views may reference new tables/columns/FKs)
+	stmts = append(stmts, viewDiff.CreateStmts...)
+
+	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &diffAllResult{
+		Stmts:  stmts,
+		PreSQL: preSQL,
+		Count:  count,
+	}, nil
+}

--- a/diff_all.go
+++ b/diff_all.go
@@ -76,7 +76,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 
 	enumDiff, err := diff.DiffEnums(filteredEnums, options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to diff enums: %w", err)
 	}
 	stmts := enumDiff.Stmts
 

--- a/plan.go
+++ b/plan.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	"github.com/winebarrel/pistachio/catalog"
-	"github.com/winebarrel/pistachio/diff"
-	"github.com/winebarrel/pistachio/parser"
 )
 
 type PlanOptions struct {
@@ -63,100 +59,24 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	}
 	defer conn.Close(ctx) //nolint:errcheck
 
-	cat, err := catalog.NewCatalog(conn, client.Schemas)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create catalog: %w", err)
-	}
-
-	currentTables, err := cat.Tables(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch tables: %w", err)
-	}
-
-	currentViews, err := cat.Views(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch views: %w", err)
-	}
-
-	currentEnums, err := cat.Enums(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch enums: %w", err)
-	}
-
-	currentDomains, err := cat.Domains(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch domains: %w", err)
-	}
-
-	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse SQL file: %w", err)
-	}
-
-	filterDesiredBySchemas(desired, client.Schemas, client.SchemaMap)
-
-	filteredTables := options.filterTables(currentTables)
-	filteredViews := options.filterViews(currentViews)
-	filteredEnums := options.filterEnums(currentEnums)
-	filteredDomains := options.filterDomains(currentDomains)
-
-	count := ObjectCount{
-		Schemas: client.Schemas,
-		Tables:  filteredTables.Len(),
-		Views:   filteredViews.Len(),
-		Enums:   filteredEnums.Len(),
-		Domains: filteredDomains.Len(),
-	}
-
-	enumDiff, err := diff.DiffEnums(filteredEnums, options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
+	result, err := client.diffAll(ctx, conn, &diffAllOptions{
+		FilterOptions: options.FilterOptions,
+		DropPolicy:    options.DropPolicy,
+		Files:         options.Files,
+		PreSQL:        options.PreSQL,
+		PreSQLFile:    options.PreSQLFile,
+	})
 	if err != nil {
 		return nil, err
 	}
-	stmts := enumDiff.Stmts
 
-	domainDiff, err := diff.DiffDomains(filteredDomains, options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff domains: %w", err)
-	}
-	stmts = append(stmts, domainDiff.Stmts...)
-
-	tableDiff, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff tables: %w", err)
-	}
-	viewDiff, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff views: %w", err)
-	}
-
-	// Drop views before table/column changes (views may depend on columns being dropped)
-	stmts = append(stmts, viewDiff.DropStmts...)
-
-	// FK drops before table/column changes
-	stmts = append(stmts, tableDiff.FKDropStmts...)
-	stmts = append(stmts, tableDiff.Stmts...)
-
-	// Drops: tables before domains/enums (dependency order)
-	stmts = append(stmts, tableDiff.DropStmts...)
-	stmts = append(stmts, domainDiff.DropStmts...)
-	stmts = append(stmts, enumDiff.DropStmts...)
-
-	// FK adds after all tables exist
-	stmts = append(stmts, tableDiff.FKAddStmts...)
-
-	// View creates last (views may reference new tables/columns/FKs)
-	stmts = append(stmts, viewDiff.CreateStmts...)
-
-	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
-	if err != nil {
-		return nil, err
-	}
-	if preSQL != "" && len(stmts) > 0 {
-		stmts = append([]string{preSQL}, stmts...)
+	stmts := result.Stmts
+	if result.PreSQL != "" && len(stmts) > 0 {
+		stmts = append([]string{result.PreSQL}, stmts...)
 	}
 
 	return &PlanResult{
 		SQL:   strings.Join(stmts, "\n"),
-		Count: count,
+		Count: result.Count,
 	}, nil
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -17,6 +17,7 @@ type planTestCase struct {
 	Init    string `yaml:"init"`
 	Desired string `yaml:"desired"`
 	Plan    string `yaml:"plan"`
+	Error   string `yaml:"error"`
 }
 
 func TestPlan_InvalidConnString(t *testing.T) {
@@ -293,6 +294,11 @@ func TestPlan(t *testing.T) {
 			})
 
 			got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+			if tc.Error != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.Error)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.Plan), strings.TrimSpace(got.SQL))
 		})

--- a/testdata/plan/error_domain_rename_source_not_found.yml
+++ b/testdata/plan/error_domain_rename_source_not_found.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE DOMAIN public.positive_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+desired: |
+  -- pist:renamed-from public.nonexistent
+  CREATE DOMAIN public.new_positive_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+error: "rename source"

--- a/testdata/plan/error_enum_rename_source_not_found.yml
+++ b/testdata/plan/error_enum_rename_source_not_found.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: |
+  -- pist:renamed-from public.nonexistent
+  CREATE TYPE public.new_status AS ENUM ('active', 'inactive');
+error: "rename source"

--- a/testdata/plan/error_table_rename_source_not_found.yml
+++ b/testdata/plan/error_table_rename_source_not_found.yml
@@ -1,0 +1,12 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pist:renamed-from public.nonexistent
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+error: "rename source"

--- a/testdata/plan/error_view_rename_source_not_found.yml
+++ b/testdata/plan/error_view_rename_source_not_found.yml
@@ -1,0 +1,14 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.user_view AS SELECT id FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:renamed-from public.nonexistent
+  CREATE VIEW public.new_view AS SELECT id FROM public.users;
+error: "rename source"


### PR DESCRIPTION
The catalog fetch, parse, diff, and statement ordering logic was duplicated between Plan() and Apply(). Extract it into a shared diffAll() method to eliminate the duplication.