### PR TITLE
Auto-name unnamed constraints following PostgreSQL's convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ pist apply ./schema/*.sql         # apply it
 ```
 
 > [!NOTE]
-> Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are not tracked by pistachio because PostgreSQL auto-generates their names at creation time, making them unpredictable from the SQL file alone. Use explicit `CONSTRAINT <name>` clauses to ensure constraints are managed correctly.
+> Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are auto-named by pistachio following PostgreSQL's naming convention (`{table}_pkey`, `{table}_{col}_key`, `{table}_{col}_check`, `{table}_{col}_fkey`, `{table}_{col}_excl`). However, when multiple constraints would generate the same name, PostgreSQL appends a numeric suffix (e.g. `_1`) that pistachio cannot predict. **It is strongly recommended to use explicit `CONSTRAINT <name>` clauses** to avoid name collisions.
 
 ## Supported Objects
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,11 @@ pist apply ./schema/*.sql         # apply it
 ```
 
 > [!NOTE]
-> Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are auto-named by pistachio following PostgreSQL's naming convention (`{table}_pkey`, `{table}_{col}_key`, `{table}_{col}_check`, `{table}_{col}_fkey`, `{table}_{col}_excl`). However, when multiple constraints would generate the same name, PostgreSQL appends a numeric suffix (e.g. `_1`) that pistachio cannot predict. **It is strongly recommended to use explicit `CONSTRAINT <name>` clauses** to avoid name collisions.
+> Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are auto-named by pistachio following PostgreSQL's naming convention (`{table}_pkey`, `{table}_{col}_key`, `{table}_{col}_check`, `{table}_{col}_fkey`, `{table}_{col}_excl`). However, pistachio's auto-naming has the following limitations:
+> - When multiple constraints would generate the same name, PostgreSQL appends a numeric suffix (e.g. `_1`) that pistachio cannot predict.
+> - PostgreSQL truncates identifier names to 63 bytes (NAMEDATALEN - 1). pistachio does not apply this truncation, so very long table/column names may produce mismatched constraint names.
+>
+> **It is strongly recommended to use explicit `CONSTRAINT <name>` clauses** to avoid these issues.
 
 ## Supported Objects
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -245,6 +245,6 @@ pist plan schema.sql | grep -q "No changes"
 
 ## Tips
 
-- Unnamed constraints are auto-named following PostgreSQL's convention, but duplicate names and 63-byte identifier truncation cannot be predicted. **Use explicit `CONSTRAINT <name>` clauses** to avoid ambiguity.
+- Unnamed constraints are auto-named following PostgreSQL's convention, but pistachio does not currently emulate PostgreSQL's identifier truncation (63 bytes) or collision suffixing, so generated names may differ. **Use explicit `CONSTRAINT <name>` clauses** to avoid ambiguity.
 - Run `pist plan` before `pist apply` to review changes.
 - Keep your schema file(s) in version control alongside your application code.

--- a/getting-started.md
+++ b/getting-started.md
@@ -245,6 +245,6 @@ pist plan schema.sql | grep -q "No changes"
 
 ## Tips
 
-- Always use explicit `CONSTRAINT <name>` clauses. Unnamed constraints are not tracked by pistachio.
+- Unnamed constraints are auto-named following PostgreSQL's convention, but duplicate names cannot be predicted. **Use explicit `CONSTRAINT <name>` clauses** to avoid ambiguity.
 - Run `pist plan` before `pist apply` to review changes.
 - Keep your schema file(s) in version control alongside your application code.

--- a/getting-started.md
+++ b/getting-started.md
@@ -245,6 +245,6 @@ pist plan schema.sql | grep -q "No changes"
 
 ## Tips
 
-- Unnamed constraints are auto-named following PostgreSQL's convention, but duplicate names cannot be predicted. **Use explicit `CONSTRAINT <name>` clauses** to avoid ambiguity.
+- Unnamed constraints are auto-named following PostgreSQL's convention, but duplicate names and 63-byte identifier truncation cannot be predicted. **Use explicit `CONSTRAINT <name>` clauses** to avoid ambiguity.
 - Run `pist plan` before `pist apply` to review changes.
 - Keep your schema file(s) in version control alongside your application code.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -409,17 +409,21 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 // Duplicate name resolution is NOT handled; users should use explicit CONSTRAINT
 // names to avoid ambiguity.
 func autoNameConstraint(tableName, colName string, contype pg_query.ConstrType) string {
+	base := tableName
+	if colName != "" {
+		base += "_" + colName
+	}
 	switch contype {
 	case pg_query.ConstrType_CONSTR_PRIMARY:
 		return tableName + "_pkey"
 	case pg_query.ConstrType_CONSTR_UNIQUE:
-		return tableName + "_" + colName + "_key"
+		return base + "_key"
 	case pg_query.ConstrType_CONSTR_CHECK:
-		return tableName + "_" + colName + "_check"
+		return base + "_check"
 	case pg_query.ConstrType_CONSTR_EXCLUSION:
-		return tableName + "_" + colName + "_excl"
+		return base + "_excl"
 	case pg_query.ConstrType_CONSTR_FOREIGN:
-		return tableName + "_" + colName + "_fkey"
+		return base + "_fkey"
 	default:
 		return ""
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -395,11 +395,41 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 	return col, nil
 }
 
+// autoNameConstraint generates a PostgreSQL-style constraint name for unnamed
+// constraints, following the naming convention from PostgreSQL's
+// ChooseConstraintName (src/backend/catalog/pg_constraint.c):
+//
+//	PRIMARY KEY → {table}_pkey
+//	UNIQUE      → {table}_{col}_key
+//	CHECK       → {table}_{col}_check
+//	EXCLUSION   → {table}_{col}_excl
+//	FOREIGN KEY → {table}_{col}_fkey
+//
+// colName is the first column involved; it is empty for table-level PRIMARY KEY.
+// Duplicate name resolution is NOT handled; users should use explicit CONSTRAINT
+// names to avoid ambiguity.
+func autoNameConstraint(tableName, colName string, contype pg_query.ConstrType) string {
+	switch contype {
+	case pg_query.ConstrType_CONSTR_PRIMARY:
+		return tableName + "_pkey"
+	case pg_query.ConstrType_CONSTR_UNIQUE:
+		return tableName + "_" + colName + "_key"
+	case pg_query.ConstrType_CONSTR_CHECK:
+		return tableName + "_" + colName + "_check"
+	case pg_query.ConstrType_CONSTR_EXCLUSION:
+		return tableName + "_" + colName + "_excl"
+	case pg_query.ConstrType_CONSTR_FOREIGN:
+		return tableName + "_" + colName + "_fkey"
+	default:
+		return ""
+	}
+}
+
 // extractColumnConstraints extracts named constraints from a column definition
 // (e.g. PRIMARY KEY, UNIQUE, CHECK, EXCLUSION, FOREIGN KEY) and adds them to
 // the table. Column-attribute constraints (NOT NULL, DEFAULT, IDENTITY,
 // GENERATED) are skipped as they are handled by parseColumnDef.
-// Unnamed non-attribute constraints return an error.
+// Unnamed constraints are auto-named following PostgreSQL's naming convention.
 func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema, defaultSchema string) error {
 	for _, conNode := range cd.Constraints {
 		con := conNode.GetConstraint()
@@ -413,7 +443,22 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 			continue
 		}
 		if con.Conname == "" {
-			return fmt.Errorf("unnamed constraint on column %q in table %q is not supported (type: %s)", cd.Colname, table.Name, con.Contype)
+			con.Conname = autoNameConstraint(table.Name, cd.Colname, con.Contype)
+		}
+		// Column-level PK/UNIQUE/CHECK/EXCLUSION have no Keys; fill in the column name.
+		switch con.Contype {
+		case pg_query.ConstrType_CONSTR_PRIMARY:
+			if len(con.Keys) == 0 {
+				con.Keys = []*pg_query.Node{pg_query.MakeStrNode(cd.Colname)}
+			}
+			// PK implies NOT NULL
+			if col, ok := table.Columns.GetOk(cd.Colname); ok {
+				col.NotNull = true
+			}
+		case pg_query.ConstrType_CONSTR_UNIQUE, pg_query.ConstrType_CONSTR_EXCLUSION:
+			if len(con.Keys) == 0 {
+				con.Keys = []*pg_query.Node{pg_query.MakeStrNode(cd.Colname)}
+			}
 		}
 		switch con.Contype {
 		case pg_query.ConstrType_CONSTR_FOREIGN:
@@ -448,7 +493,13 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 
 func parseTableConstraint(con *pg_query.Constraint, tableName string) (*model.Constraint, error) {
 	if con.Conname == "" {
-		return nil, fmt.Errorf("unnamed constraint on table %q is not supported (type: %s)", tableName, con.Contype)
+		var firstCol string
+		if len(con.Keys) > 0 {
+			if s := con.Keys[0].GetString_(); s != nil {
+				firstCol = s.Sval
+			}
+		}
+		con.Conname = autoNameConstraint(tableName, firstCol, con.Contype)
 	}
 
 	var conType model.ConstraintType
@@ -618,7 +669,7 @@ func parseCreateDomainStmt(ds *pg_query.CreateDomainStmt, rawStmt *pg_query.RawS
 			}
 		case pg_query.ConstrType_CONSTR_CHECK:
 			if con.Conname == "" {
-				return nil, fmt.Errorf("unnamed constraint on domain %q is not supported", name)
+				con.Conname = name + "_check"
 			}
 			// Extract CHECK definition from the deparsed SQL
 			def := extractCheckDefFromDeparsed(deparsed, con.Conname)
@@ -915,7 +966,13 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 // constraint inside a CREATE TABLE statement.
 func parseInlineForeignKey(con *pg_query.Constraint, schema, table, defaultSchema string) (*model.ForeignKey, error) {
 	if con.Conname == "" {
-		return nil, fmt.Errorf("unnamed FOREIGN KEY constraint on table %q is not supported", table)
+		var firstCol string
+		if len(con.FkAttrs) > 0 {
+			if s := con.FkAttrs[0].GetString_(); s != nil {
+				firstCol = s.Sval
+			}
+		}
+		con.Conname = autoNameConstraint(table, firstCol, con.Contype)
 	}
 
 	def, err := deparseConstraintDef(con)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -498,6 +498,13 @@ func parseTableConstraint(con *pg_query.Constraint, tableName string) (*model.Co
 			if s := con.Keys[0].GetString_(); s != nil {
 				firstCol = s.Sval
 			}
+		} else if len(con.Exclusions) > 0 {
+			// EXCLUSION constraints store columns in Exclusions, not Keys
+			if elem := con.Exclusions[0].GetList(); elem != nil && len(elem.Items) > 0 {
+				if ie := elem.Items[0].GetIndexElem(); ie != nil {
+					firstCol = ie.Name
+				}
+			}
 		}
 		con.Conname = autoNameConstraint(tableName, firstCol, con.Contype)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -321,6 +321,14 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 					if err := setUnique(table.Constraints, constraint.Name, "constraint", constraint); err != nil {
 						return nil, err
 					}
+					// PK implies NOT NULL on all key columns
+					if constraint.Type.IsPrimaryKeyConstraint() {
+						for _, colName := range constraint.Columns {
+							if col, ok := table.Columns.GetOk(colName); ok {
+								col.NotNull = true
+							}
+						}
+					}
 				}
 			}
 		}
@@ -400,12 +408,13 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 // ChooseConstraintName (src/backend/catalog/pg_constraint.c):
 //
 //	PRIMARY KEY → {table}_pkey
-//	UNIQUE      → {table}_{col}_key
-//	CHECK       → {table}_{col}_check
-//	EXCLUSION   → {table}_{col}_excl
-//	FOREIGN KEY → {table}_{col}_fkey
+//	UNIQUE      → {table}_{col}_key  (or {table}_key if colName is empty)
+//	CHECK       → {table}_{col}_check (or {table}_check if colName is empty)
+//	EXCLUSION   → {table}_{col}_excl  (or {table}_excl if colName is empty)
+//	FOREIGN KEY → {table}_{col}_fkey  (or {table}_fkey if colName is empty)
 //
-// colName is the first column involved; it is empty for table-level PRIMARY KEY.
+// colName is the first column involved when one is derivable; it may be empty
+// for table-level constraints where no single column name is available.
 // Duplicate name resolution is NOT handled; users should use explicit CONSTRAINT
 // names to avoid ambiguity.
 func autoNameConstraint(tableName, colName string, contype pg_query.ConstrType) string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -458,7 +458,8 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 		if con.Conname == "" {
 			con.Conname = autoNameConstraint(table.Name, cd.Colname, con.Contype)
 		}
-		// Column-level PK/UNIQUE/CHECK/EXCLUSION have no Keys; fill in the column name.
+		// Column-level PK/UNIQUE/EXCLUSION have no Keys; fill in the column name.
+		// CHECK constraints do not use Keys (they reference columns via the expression).
 		switch con.Contype {
 		case pg_query.ConstrType_CONSTR_PRIMARY:
 			if len(con.Keys) == 0 {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -539,6 +539,22 @@ func TestParseSQL_ColumnLevelUnnamedConstraintsAutoNamed(t *testing.T) {
 	}
 }
 
+func TestParseSQL_TableLevelUnnamedExclusionAutoNamed(t *testing.T) {
+	sql := `CREATE TABLE public.reservations (
+    id integer NOT NULL,
+    room integer NOT NULL,
+    during tsrange NOT NULL,
+    CONSTRAINT reservations_pkey PRIMARY KEY (id),
+    EXCLUDE USING gist (room WITH =, during WITH &&)
+);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	tbl := result.Tables.Get("public.reservations")
+	require.NotNil(t, tbl)
+	_, ok := tbl.Constraints.GetOk("reservations_room_excl")
+	assert.True(t, ok)
+}
+
 func TestParseSQL_TablespaceOnCreate(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -359,7 +359,7 @@ CREATE TABLE myapp.items (
 }
 
 func TestParseSQL_InlineForeignKeyUnnamed(t *testing.T) {
-	// Unnamed table-level FK constraints should return an error
+	// Unnamed table-level FK constraints should be auto-named
 	sql := `CREATE TABLE public.groups (
     id integer NOT NULL,
     CONSTRAINT groups_pkey PRIMARY KEY (id)
@@ -371,9 +371,11 @@ CREATE TABLE public.members (
     FOREIGN KEY (group_id) REFERENCES public.groups(id)
 );`
 
-	_, err := parser.ParseSQL(sql)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unnamed FOREIGN KEY constraint on table \"members\" is not supported")
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	tbl := result.Tables.Get("public.members")
+	_, ok := tbl.ForeignKeys.GetOk("members_group_id_fkey")
+	assert.True(t, ok)
 }
 
 func TestParseSQL_ColumnLevelNamedCheck(t *testing.T) {
@@ -485,35 +487,54 @@ CREATE TABLE public.items (
 	assert.Equal(t, []string{"group_id"}, fk.Columns)
 }
 
-func TestParseSQL_ColumnLevelUnnamedConstraintsError(t *testing.T) {
+func TestParseSQL_ColumnLevelUnnamedConstraintsAutoNamed(t *testing.T) {
 	tests := []struct {
-		name string
-		sql  string
+		name         string
+		sql          string
+		table        string
+		conName      string
+		isForeignKey bool
 	}{
 		{
-			name: "PRIMARY KEY",
-			sql:  `CREATE TABLE public.items (id integer PRIMARY KEY);`,
+			name:    "PRIMARY KEY",
+			sql:     `CREATE TABLE public.items (id integer PRIMARY KEY);`,
+			table:   "public.items",
+			conName: "items_pkey",
 		},
 		{
-			name: "UNIQUE",
-			sql:  `CREATE TABLE public.items (id integer NOT NULL, code text UNIQUE);`,
+			name:    "UNIQUE",
+			sql:     `CREATE TABLE public.items (id integer NOT NULL, code text UNIQUE, CONSTRAINT items_pkey PRIMARY KEY (id));`,
+			table:   "public.items",
+			conName: "items_code_key",
 		},
 		{
-			name: "CHECK",
-			sql:  `CREATE TABLE public.items (id integer NOT NULL, val integer CHECK (val > 0));`,
+			name:    "CHECK",
+			sql:     `CREATE TABLE public.items (id integer NOT NULL, val integer CHECK (val > 0), CONSTRAINT items_pkey PRIMARY KEY (id));`,
+			table:   "public.items",
+			conName: "items_val_check",
 		},
 		{
-			name: "FOREIGN KEY",
-			sql: `CREATE TABLE public.groups (id integer NOT NULL, CONSTRAINT groups_pkey PRIMARY KEY (id));
-CREATE TABLE public.items (id integer NOT NULL, group_id integer REFERENCES public.groups(id));`,
+			name:         "FOREIGN KEY",
+			sql:          "CREATE TABLE public.groups (id integer NOT NULL, CONSTRAINT groups_pkey PRIMARY KEY (id));\nCREATE TABLE public.items (id integer NOT NULL, group_id integer REFERENCES public.groups(id), CONSTRAINT items_pkey PRIMARY KEY (id));",
+			table:        "public.items",
+			conName:      "items_group_id_fkey",
+			isForeignKey: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := parser.ParseSQL(tt.sql)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "unnamed constraint")
+			result, err := parser.ParseSQL(tt.sql)
+			require.NoError(t, err)
+			tbl := result.Tables.Get(tt.table)
+			require.NotNil(t, tbl)
+			if tt.isForeignKey {
+				_, ok := tbl.ForeignKeys.GetOk(tt.conName)
+				assert.True(t, ok, "expected FK %s", tt.conName)
+			} else {
+				_, ok := tbl.Constraints.GetOk(tt.conName)
+				assert.True(t, ok, "expected constraint %s", tt.conName)
+			}
 		})
 	}
 }
@@ -627,16 +648,18 @@ CREATE VIEW public.v2 AS SELECT name FROM users;`
 	assert.Equal(t, 2, result.Views.Len())
 }
 
-func TestParseSQL_UnnamedConstraintError(t *testing.T) {
-	// An unnamed table constraint should return an error
+func TestParseSQL_UnnamedTableConstraintAutoNamed(t *testing.T) {
+	// An unnamed table constraint should be auto-named
 	sql := `CREATE TABLE public.items (
     id integer NOT NULL,
     name text,
     PRIMARY KEY (id)
 );`
-	_, err := parser.ParseSQL(sql)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unnamed constraint on table \"items\" is not supported")
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	tbl := result.Tables.Get("public.items")
+	_, ok := tbl.Constraints.GetOk("items_pkey")
+	assert.True(t, ok)
 }
 
 func TestParseSQL_CommentRemove(t *testing.T) {
@@ -1429,11 +1452,14 @@ CREATE DOMAIN public.new_domain AS integer;`
 	assert.Equal(t, "public.old_domain", *d.RenameFrom)
 }
 
-func TestParseSQL_DomainUnnamedConstraint_Error(t *testing.T) {
+func TestParseSQL_DomainUnnamedConstraintAutoNamed(t *testing.T) {
 	sql := `CREATE DOMAIN public.pos_int AS integer CHECK (VALUE > 0);`
-	_, err := parser.ParseSQL(sql)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unnamed constraint")
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	d := result.Domains.Get("public.pos_int")
+	require.NotNil(t, d)
+	require.Len(t, d.Constraints, 1)
+	assert.Equal(t, "pos_int_check", d.Constraints[0].Name)
 }
 
 func TestParseSQL_DuplicateDomain(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -374,6 +374,7 @@ CREATE TABLE public.members (
 	result, err := parser.ParseSQL(sql)
 	require.NoError(t, err)
 	tbl := result.Tables.Get("public.members")
+	require.NotNil(t, tbl)
 	_, ok := tbl.ForeignKeys.GetOk("members_group_id_fkey")
 	assert.True(t, ok)
 }
@@ -674,6 +675,7 @@ func TestParseSQL_UnnamedTableConstraintAutoNamed(t *testing.T) {
 	result, err := parser.ParseSQL(sql)
 	require.NoError(t, err)
 	tbl := result.Tables.Get("public.items")
+	require.NotNil(t, tbl)
 	_, ok := tbl.Constraints.GetOk("items_pkey")
 	assert.True(t, ok)
 }

--- a/testdata/apply/unnamed_primary_key.yml
+++ b/testdata/apply/unnamed_primary_key.yml
@@ -1,0 +1,11 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer PRIMARY KEY
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/named_table_level_pk_implies_not_null.yml
+++ b/testdata/plan/named_table_level_pk_implies_not_null.yml
@@ -1,0 +1,11 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/table_level_pk_implies_not_null.yml
+++ b/testdata/plan/table_level_pk_implies_not_null.yml
@@ -1,0 +1,11 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer,
+      PRIMARY KEY (id)
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/unnamed_check.yml
+++ b/testdata/plan/unnamed_check.yml
@@ -1,0 +1,14 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer CHECK (age > 0),
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer,
+      CONSTRAINT users_age_check CHECK (age > 0),
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/unnamed_domain_check.yml
+++ b/testdata/plan/unnamed_domain_check.yml
@@ -1,0 +1,6 @@
+init: ""
+desired: |
+  CREATE DOMAIN public.positive_int AS integer CHECK (VALUE > 0);
+plan: |
+  CREATE DOMAIN public.positive_int AS integer
+      CONSTRAINT positive_int_check CHECK (value > 0);

--- a/testdata/plan/unnamed_exclusion.yml
+++ b/testdata/plan/unnamed_exclusion.yml
@@ -1,0 +1,17 @@
+init: ""
+desired: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      EXCLUDE USING gist (room WITH =, during WITH &&)
+  );
+plan: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT reservations_room_excl EXCLUDE USING gist (room WITH =, during WITH &&)
+  );

--- a/testdata/plan/unnamed_foreign_key.yml
+++ b/testdata/plan/unnamed_foreign_key.yml
@@ -1,0 +1,22 @@
+init: |
+  CREATE TABLE public.groups (
+      id integer NOT NULL,
+      CONSTRAINT groups_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.groups (
+      id integer NOT NULL,
+      CONSTRAINT groups_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.members (
+      id integer NOT NULL,
+      group_id integer REFERENCES public.groups(id),
+      CONSTRAINT members_pkey PRIMARY KEY (id)
+  );
+plan: |
+  CREATE TABLE public.members (
+      id integer NOT NULL,
+      group_id integer,
+      CONSTRAINT members_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.members ADD CONSTRAINT members_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups (id);

--- a/testdata/plan/unnamed_primary_key.yml
+++ b/testdata/plan/unnamed_primary_key.yml
@@ -1,0 +1,10 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer PRIMARY KEY
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/unnamed_table_level_check.yml
+++ b/testdata/plan/unnamed_table_level_check.yml
@@ -1,0 +1,17 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      start_date date,
+      end_date date,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CHECK (start_date < end_date)
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      start_date date,
+      end_date date,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_check CHECK (start_date < end_date)
+  );

--- a/testdata/plan/unnamed_table_level_fk.yml
+++ b/testdata/plan/unnamed_table_level_fk.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.groups (
+      id integer NOT NULL,
+      CONSTRAINT groups_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.groups (
+      id integer NOT NULL,
+      CONSTRAINT groups_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.members (
+      id integer NOT NULL,
+      group_id integer,
+      CONSTRAINT members_pkey PRIMARY KEY (id),
+      FOREIGN KEY (group_id) REFERENCES public.groups(id)
+  );
+plan: |
+  CREATE TABLE public.members (
+      id integer NOT NULL,
+      group_id integer,
+      CONSTRAINT members_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.members ADD CONSTRAINT members_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups (id);

--- a/testdata/plan/unnamed_table_level_pk.yml
+++ b/testdata/plan/unnamed_table_level_pk.yml
@@ -1,0 +1,11 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      PRIMARY KEY (id)
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/unnamed_table_level_unique.yml
+++ b/testdata/plan/unnamed_table_level_unique.yml
@@ -1,0 +1,15 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      UNIQUE (email)
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );

--- a/testdata/plan/unnamed_unique.yml
+++ b/testdata/plan/unnamed_unique.yml
@@ -1,0 +1,14 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text UNIQUE,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      CONSTRAINT users_email_key UNIQUE (email),
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );


### PR DESCRIPTION
Instead of rejecting unnamed constraints with an error, generate names following PostgreSQL's ChooseConstraintName convention:
  PRIMARY KEY → {table}_pkey
  UNIQUE      → {table}_{col}_key
  CHECK       → {table}_{col}_check
  FOREIGN KEY → {table}_{col}_fkey
  EXCLUSION   → {table}_{col}_excl

Column-level PRIMARY KEY also sets NotNull on the column. Duplicate name resolution is not handled; docs recommend explicit CONSTRAINT names to avoid collisions.