### PR TITLE
Add docker ghcr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 env:
   GOLANG_CROSS_VERSION: v1.26.0
@@ -18,6 +19,25 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v3
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            PIST_VERSION=${{ github.ref_name }}
       - name: Run GoReleaser
         run: |
           docker run -q \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,18 +19,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository }}
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.26 AS build
+
+WORKDIR /src
+COPY go.* /src/
+RUN go mod download
+
+COPY . /src/
+ARG PIST_VERSION
+RUN CGO_ENABLED=1 go build -o pist -ldflags "-X main.version=${PIST_VERSION#v}" ./cmd/pist
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/pist /usr/local/bin/
+
+ENTRYPOINT ["pist"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.26 AS build
+FROM golang:1.26-alpine AS build
+
+RUN apk add --no-cache gcc musl-dev
 
 WORKDIR /src
 COPY go.* /src/
@@ -8,9 +10,9 @@ COPY . /src/
 ARG PIST_VERSION
 RUN CGO_ENABLED=1 go build -o pist -ldflags "-X main.version=${PIST_VERSION#v}" ./cmd/pist
 
-FROM debian:bookworm-slim
+FROM alpine:3
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates
 
 COPY --from=build /src/pist /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,7 @@ WORKDIR /src
 COPY go.* /src/
 RUN go mod download
 
-COPY *.go /src/
-COPY catalog/ /src/catalog/
-COPY cmd/ /src/cmd/
-COPY diff/ /src/diff/
-COPY internal/ /src/internal/
-COPY model/ /src/model/
-COPY parser/ /src/parser/
+COPY . /src/
 ARG PIST_VERSION
 RUN CGO_ENABLED=1 go build -o pist -ldflags "-X main.version=${PIST_VERSION#v}" ./cmd/pist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,13 @@ WORKDIR /src
 COPY go.* /src/
 RUN go mod download
 
-COPY . /src/
+COPY *.go /src/
+COPY catalog/ /src/catalog/
+COPY cmd/ /src/cmd/
+COPY diff/ /src/diff/
+COPY internal/ /src/internal/
+COPY model/ /src/model/
+COPY parser/ /src/parser/
 ARG PIST_VERSION
 RUN CGO_ENABLED=1 go build -o pist -ldflags "-X main.version=${PIST_VERSION#v}" ./cmd/pist
 


### PR DESCRIPTION
This pull request introduces Docker support for building and publishing the project as a multi-platform container image, and updates the release workflow to automate Docker image creation and publishing to GitHub Container Registry (GHCR). The main changes include adding a `Dockerfile` for building the application, updating the GitHub Actions workflow to build and push Docker images, and setting the necessary permissions.

**Docker support and release automation:**

* Added a new `Dockerfile` that builds the Go application in a multi-stage process and creates a minimal runtime image using `debian:bookworm-slim`.
* Updated `.github/workflows/release.yml` to include steps for setting up Docker Buildx and QEMU, generating image metadata, logging into GHCR, and building/pushing multi-platform Docker images (`linux/amd64`, `linux/arm64`).
* Set the required `packages: write` permission in the GitHub Actions workflow to allow publishing images to GHCR.