### PR TITLE
Fix double NOT VALID in constraint definitions

### DIFF
--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/winebarrel/pistachio/model"
@@ -80,6 +81,11 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 		if err != nil {
 			return nil, nil, fmt.Errorf("catalog: failed to scan constraint info: %w", err)
 		}
+
+		// pg_get_constraintdef includes "NOT VALID" in the definition string
+		// for unvalidated constraints. Strip it so Definition only contains
+		// the constraint body; validation state is tracked via Validated.
+		con.Definition = strings.TrimSuffix(con.Definition, " NOT VALID")
 
 		if con.Type.IsForeignKeyConstraint() {
 			fk := model.ForeignKey{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1141,6 +1141,12 @@ func deparseExpr(node *pg_query.Node) (string, error) {
 }
 
 func deparseConstraintDef(con *pg_query.Constraint) (string, error) {
+	// Temporarily clear SkipValidation so "NOT VALID" is not included in the
+	// definition string (it is tracked separately via the Validated field).
+	origSkipValidation := con.SkipValidation
+	con.SkipValidation = false
+	defer func() { con.SkipValidation = origSkipValidation }()
+
 	alterCmd := &pg_query.AlterTableCmd{
 		Subtype: pg_query.AlterTableType_AT_AddConstraint,
 		Def:     &pg_query.Node{Node: &pg_query.Node_Constraint{Constraint: con}},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -299,6 +299,7 @@ ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCE
 	fk, ok := tbl.ForeignKeys.GetOk("fk_user")
 	require.True(t, ok)
 	assert.False(t, fk.Validated)
+	assert.NotContains(t, fk.Definition, "NOT VALID")
 	assert.Equal(t, "public", *fk.RefSchema)
 	assert.Equal(t, "users", *fk.RefTable)
 	assert.Equal(t, []string{"user_id"}, fk.Columns)
@@ -412,6 +413,7 @@ ALTER TABLE public.items ADD CONSTRAINT items_id_check CHECK (id > 0) NOT VALID;
 	con, ok := tbl.Constraints.GetOk("items_id_check")
 	require.True(t, ok)
 	assert.Contains(t, con.Definition, "CHECK")
+	assert.NotContains(t, con.Definition, "NOT VALID")
 	assert.False(t, con.Validated)
 }
 


### PR DESCRIPTION
## Summary
- `deparseConstraintDef` included `NOT VALID` in the `Definition` string when `SkipValidation` was true
- `ForeignKey.SQL()` and `diffConstraints` then appended `NOT VALID` again based on the `Validated` field
- This resulted in `NOT VALID NOT VALID` in generated DDL
- Fix by temporarily clearing `SkipValidation` during deparse

## How found
Running `pist plan` against sample schemas (`make schema`) with a `NOT VALID` FK produced `NOT VALID NOT VALID`.

## Test plan
- [x] All existing tests pass (`make test`)
- [x] `make lint` passes (0 issues)
- [x] Verified with `make schema` + `pist plan` that `NOT VALID` appears exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)