### PR TITLE
Add missing test cases for parser, plan, apply, and dump

### DIFF
--- a/testdata/apply/add_domain_constraint.yml
+++ b/testdata/apply/add_domain_constraint.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+desired: |
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (VALUE > 0)
+      CONSTRAINT max_check CHECK (VALUE < 1000);
+applied: |
+  -- public.pos_int
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT max_check CHECK ((VALUE < 1000))
+      CONSTRAINT pos_check CHECK ((VALUE > 0));

--- a/testdata/apply/drop_domain_constraint.yml
+++ b/testdata/apply/drop_domain_constraint.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (VALUE > 0)
+      CONSTRAINT max_check CHECK (VALUE < 1000);
+desired: |
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (VALUE > 0);
+applied: |
+  -- public.pos_int
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK ((VALUE > 0));

--- a/testdata/apply/rename_constraint.yml
+++ b/testdata/apply/rename_constraint.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_code_key UNIQUE (code)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      -- pist:renamed-from users_code_key
+      CONSTRAINT users_code_unique UNIQUE (code)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_code_unique UNIQUE (code)
+  );

--- a/testdata/apply/rename_fk.yml
+++ b/testdata/apply/rename_fk.yml
@@ -1,0 +1,38 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  -- pist:renamed-from fk_user
+  ALTER TABLE public.orders ADD CONSTRAINT fk_buyer FOREIGN KEY (user_id) REFERENCES public.users(id);
+applied: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_buyer FOREIGN KEY (user_id) REFERENCES users(id);
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/rename_index.yml
+++ b/testdata/apply/rename_index.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:renamed-from idx_users_name
+  CREATE INDEX idx_users_display_name ON public.users (name);
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_display_name ON public.users USING btree (name);

--- a/testdata/apply/validate_check_constraint.yml
+++ b/testdata/apply/validate_check_constraint.yml
@@ -1,0 +1,22 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0)
+  );

--- a/testdata/apply/validate_fk_constraint.yml
+++ b/testdata/apply/validate_fk_constraint.yml
@@ -1,0 +1,37 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);
+applied: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id);
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/dump/column_collation.yml
+++ b/testdata/dump/column_collation.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "C" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "C" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/dump/deferrable_constraint.yml
+++ b/testdata/dump/deferrable_constraint.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_code_key UNIQUE (code) DEFERRABLE INITIALLY DEFERRED
+  );
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_code_key UNIQUE (code) DEFERRABLE INITIALLY DEFERRED
+  );

--- a/testdata/dump/domain_multiple_constraints.yml
+++ b/testdata/dump/domain_multiple_constraints.yml
@@ -1,0 +1,9 @@
+init: |
+  CREATE DOMAIN public.bounded_int AS integer
+      CONSTRAINT min_check CHECK (VALUE > 0)
+      CONSTRAINT max_check CHECK (VALUE < 1000);
+dump: |
+  -- public.bounded_int
+  CREATE DOMAIN public.bounded_int AS integer
+      CONSTRAINT max_check CHECK ((VALUE < 1000))
+      CONSTRAINT min_check CHECK ((VALUE > 0));

--- a/testdata/dump/exclusion_constraint.yml
+++ b/testdata/dump/exclusion_constraint.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE EXTENSION IF NOT EXISTS btree_gist;
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, during WITH &&)
+  );
+dump: |
+  -- public.reservations
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, during WITH &&)
+  );

--- a/testdata/parser/brin_index.yml
+++ b/testdata/parser/brin_index.yml
@@ -1,0 +1,15 @@
+input: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp without time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX events_created_at_idx ON public.events USING brin (created_at);
+expected: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp without time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX events_created_at_idx ON public.events USING brin (created_at);

--- a/testdata/parser/domain_column.yml
+++ b/testdata/parser/domain_column.yml
@@ -1,0 +1,14 @@
+input: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      quantity public.pos_int NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+expected: |
+  -- public.products
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      quantity public.pos_int NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );

--- a/testdata/parser/gin_index.yml
+++ b/testdata/parser/gin_index.yml
@@ -1,0 +1,15 @@
+input: |
+  CREATE TABLE public.documents (
+      id integer NOT NULL,
+      tags jsonb NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX documents_tags_idx ON public.documents USING gin (tags);
+expected: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id integer NOT NULL,
+      tags jsonb NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX documents_tags_idx ON public.documents USING gin (tags);

--- a/testdata/parser/hash_index.yml
+++ b/testdata/parser/hash_index.yml
@@ -1,0 +1,15 @@
+input: |
+  CREATE TABLE public.lookups (
+      id integer NOT NULL,
+      key text NOT NULL,
+      CONSTRAINT lookups_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX lookups_key_idx ON public.lookups USING hash (key);
+expected: |
+  -- public.lookups
+  CREATE TABLE public.lookups (
+      id integer NOT NULL,
+      key text NOT NULL,
+      CONSTRAINT lookups_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX lookups_key_idx ON public.lookups USING hash (key);

--- a/testdata/plan/rename_multiple_columns.yml
+++ b/testdata/plan/rename_multiple_columns.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      first_name text NOT NULL,
+      last_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from first_name
+      given_name text NOT NULL,
+      -- pist:renamed-from last_name
+      family_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users RENAME COLUMN first_name TO given_name;
+  ALTER TABLE public.users RENAME COLUMN last_name TO family_name;

--- a/testdata/plan/validate_check_constraint.yml
+++ b/testdata/plan/validate_check_constraint.yml
@@ -1,0 +1,16 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0)
+  );
+plan: |
+  ALTER TABLE public.users VALIDATE CONSTRAINT chk_age;

--- a/testdata/plan/validate_fk_constraint.yml
+++ b/testdata/plan/validate_fk_constraint.yml
@@ -1,0 +1,24 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);
+plan: |
+  ALTER TABLE public.orders VALIDATE CONSTRAINT fk_user;


### PR DESCRIPTION
## Summary
- **parser**: hash/gin/brin インデックスタイプ、ドメイン型カラムのパーステスト追加
- **plan**: NOT VALID → VALIDATE CONSTRAINT 遷移（CHECK & FK）、同一テーブル内の複数カラムリネーム
- **apply**: 単独の制約/インデックス/FK リネーム、NOT VALID → VALID 適用、ドメイン制約の追加/削除
- **dump**: DEFERRABLE 制約、EXCLUDE 制約、カラム COLLATION、複数制約ドメイン

## Test plan
- [x] `make test` 全テスト通過
- [x] `make lint` クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)