### PR TITLE
Improve test coverage for diff and root packages

### DIFF
--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1876,3 +1876,86 @@ func TestDiffColumns_renameColumn_sourceNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source column")
 }
+
+func TestUpdateIndexName_parseError(t *testing.T) {
+	_, err := updateIndexName("NOT VALID SQL", "new_idx")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse index definition")
+}
+
+func TestUpdateIndexName_notIndexStmt(t *testing.T) {
+	_, err := updateIndexName("SELECT 1", "new_idx")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected IndexStmt")
+}
+
+func TestUpdateIndexName_success(t *testing.T) {
+	got, err := updateIndexName("CREATE INDEX old_idx ON t (id)", "new_idx")
+	require.NoError(t, err)
+	assert.Contains(t, got, "new_idx")
+	assert.NotContains(t, got, "old_idx")
+}
+
+func TestUpdateIndexTableName_parseError(t *testing.T) {
+	_, err := updateIndexTableName("NOT VALID SQL", "new_table")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse index definition")
+}
+
+func TestUpdateIndexTableName_notIndexStmt(t *testing.T) {
+	_, err := updateIndexTableName("SELECT 1", "new_table")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected IndexStmt with relation")
+}
+
+func TestUpdateIndexTableName_success(t *testing.T) {
+	got, err := updateIndexTableName("CREATE INDEX idx ON old_table (id)", "new_table")
+	require.NoError(t, err)
+	assert.Contains(t, got, "new_table")
+	assert.NotContains(t, got, "old_table")
+}
+
+func TestParseFKDef_parseError(t *testing.T) {
+	_, err := parseFKDef("NOT VALID SQL")
+	require.Error(t, err)
+}
+
+func TestParseFKDef_success(t *testing.T) {
+	con, err := parseFKDef("FOREIGN KEY (user_id) REFERENCES users(id)")
+	require.NoError(t, err)
+	require.NotNil(t, con)
+}
+
+func TestParseDefault_parseError(t *testing.T) {
+	_, err := parseDefault(")))INVALID(((")
+	require.Error(t, err)
+}
+
+func TestParseDefault_success(t *testing.T) {
+	node, err := parseDefault("42")
+	require.NoError(t, err)
+	require.NotNil(t, node)
+}
+
+func TestParseDefault_stripTypeCast(t *testing.T) {
+	node, err := parseDefault("'hello'::text")
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	// The type cast should be stripped, leaving just the string constant
+	assert.Nil(t, node.GetTypeCast())
+}
+
+func TestIsTextLikeTypeName_nil(t *testing.T) {
+	assert.False(t, isTextLikeTypeName(nil))
+}
+
+func TestNormalizeIndexDef_parseError(t *testing.T) {
+	_, err := normalizeIndexDef("NOT VALID SQL")
+	require.Error(t, err)
+}
+
+func TestNormalizeIndexDef_notIndexStmt(t *testing.T) {
+	_, err := normalizeIndexDef("SELECT 1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected parse result")
+}

--- a/dump_test.go
+++ b/dump_test.go
@@ -168,6 +168,46 @@ func TestDumpResult_Files_Empty(t *testing.T) {
 	assert.Empty(t, files)
 }
 
+func TestDumpResult_Files_Enums(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Contains(t, files, "public.status.sql")
+	assert.Contains(t, files["public.status.sql"], "CREATE TYPE public.status AS ENUM")
+}
+
+func TestDumpResult_Files_Domains(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Contains(t, files, "public.pos_int.sql")
+	assert.Contains(t, files["public.pos_int.sql"], "CREATE DOMAIN public.pos_int")
+}
+
 func TestDumpResult_Files_SpecialCharacters(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)


### PR DESCRIPTION
## Summary
- **diff**: `updateIndexName`, `updateIndexTableName`, `parseFKDef`, `parseDefault`, `isTextLikeTypeName`, `normalizeIndexDef` のエラーパスをカバーするユニットテスト追加 (97.7% → 98.3%)
- **root**: `DumpResult.Files()` の enum/domain 出力パスをカバーするテスト追加 (97.3% → 98.0%)
- 全体カバレッジ: 93.6% → 93.9%

残りの未カバー行は以下のカテゴリであり、自然なテストが困難なため対象外としています:
- catalog: DB クエリエラーハンドリング (`rows.Err()`, `Query()` 失敗)
- parser: `deparseConstraintDef` 等の pg_query deparse エラー (到達困難な防御コード)
- root: `Apply`/`diffAll` 内の DB エラーハンドリング

## Test plan
- [x] `make test` 全テスト通過
- [x] `make lint` クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)