### PR TITLE
Add world and usda sample schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,16 @@ schema: clean-schema
 	$(MAKE) sample-db SQL_FILE=pagila.sql
 	$(MAKE) sample-db SQL_FILE=periodic_table.sql
 	$(MAKE) sample-db SQL_FILE=titanic.sql
+	$(MAKE) sample-db-tar TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/world/world-1.0/world-1.0.tar.gz TAR_SQL_PATH=dbsamples-0.1/world/world.sql
+	$(MAKE) sample-db-tar TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/usda/usda-r18-1.0/usda-r18-1.0.tar.gz TAR_SQL_PATH=usda-r18-1.0/usda.sql
 
 .PHONY: sample-db
 sample-db:
 	curl -sSf https://raw.githubusercontent.com/neondatabase/postgres-sample-dbs/refs/heads/main/$(SQL_FILE) | psql
+
+.PHONY: sample-db-tar
+sample-db-tar:
+	curl -sSfL $(TAR_URL) | tar xzO $(TAR_SQL_PATH) | psql
 
 .PHONY: clean-schema
 clean-schema:


### PR DESCRIPTION
## Summary
- pgFoundry の world / usda データベースをサンプルスキーマに追加
- tar.gz 形式の SQL ファイル取得用に `sample-db-tar` ターゲットを共通化

## 動作確認
全 9 サンプルスキーマ (既存 7 + world + usda) で以下を確認済み:
- `pist dump` → `pist plan` で No changes (dump の冪等性)
- world / usda は `dump` → clean DB → `apply` → `plan` で No changes (apply の往復テスト)
- world スキーマで 12 種類の段階的変更 (カラム追加/型変更/インデックス/制約/ビュー/FK/ENUM/リネーム/削除) の plan → apply → drift-free を確認

## Test plan
- [x] `make sample-db-tar` で world / usda がロードできること
- [x] 全サンプルスキーマで dump → plan が No changes
- [x] apply 後に plan が No changes (ドリフトなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)