### PR TITLE
Add fmt test coverage for domain, idempotency, and CLI scenarios

### DIFF
--- a/test/scenario/fmt.test.sh
+++ b/test/scenario/fmt.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Scenario test: pist fmt (formatting SQL files)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/fmt"
+
+# --- Step 1: stdout output matches expected ---
+step "01 fmt stdout output"
+actual=$("$PIST" fmt "$DATA/unformatted.sql" 2>&1)
+expected=$(cat "$DATA/formatted.sql")
+if [ "$actual" = "$expected" ]; then
+  pass
+else
+  fail "stdout output mismatch"
+  diff <(echo "$actual") <(echo "$expected") >&2 || true
+fi
+
+# --- Step 2: --check detects unformatted file ---
+step "02 --check detects unformatted"
+if "$PIST" fmt --check "$DATA/unformatted.sql" >/dev/null 2>&1; then
+  fail "expected non-zero exit for unformatted file"
+else
+  pass
+fi
+
+# --- Step 3: --check passes for formatted file ---
+step "03 --check passes for formatted"
+if "$PIST" fmt --check "$DATA/formatted.sql" 2>&1; then
+  pass
+else
+  fail "expected zero exit for formatted file"
+fi
+
+# --- Step 4: -w writes formatted output to file ---
+step "04 -w writes formatted file"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+cp "$DATA/unformatted.sql" "$tmp_dir/input.sql"
+"$PIST" fmt -w "$tmp_dir/input.sql" 2>&1
+actual=$(cat "$tmp_dir/input.sql")
+expected=$(cat "$DATA/formatted.sql")
+if [ "$actual" = "$expected" ]; then
+  pass
+else
+  fail "written file mismatch"
+  diff <(echo "$actual") <(echo "$expected") >&2 || true
+fi
+
+# --- Step 5: -w then --check is idempotent ---
+step "05 -w then --check idempotent"
+if "$PIST" fmt --check "$tmp_dir/input.sql" 2>&1; then
+  pass
+else
+  fail "formatted file should pass --check"
+fi
+
+# --- Step 6: fmt multiple files ---
+step "06 fmt multiple files"
+cp "$DATA/unformatted.sql" "$tmp_dir/a.sql"
+cp "$DATA/unformatted2.sql" "$tmp_dir/b.sql"
+"$PIST" fmt -w "$tmp_dir/a.sql" "$tmp_dir/b.sql" 2>&1
+if "$PIST" fmt --check "$tmp_dir/a.sql" "$tmp_dir/b.sql" 2>&1; then
+  pass
+else
+  fail "multiple files should pass --check after -w"
+fi
+
+# --- Step 7: --check lists unformatted files ---
+step "07 --check lists unformatted files"
+cp "$DATA/unformatted.sql" "$tmp_dir/c.sql"
+check_output=$("$PIST" fmt --check "$tmp_dir/a.sql" "$tmp_dir/c.sql" 2>&1 || true)
+if echo "$check_output" | grep -qF "$tmp_dir/c.sql"; then
+  pass
+else
+  fail "expected unformatted file path in --check output"
+  echo "    actual: $check_output" >&2
+fi
+
+summary

--- a/test/scenario/testdata/fmt/formatted.sql
+++ b/test/scenario/testdata/fmt/formatted.sql
@@ -1,0 +1,24 @@
+-- public.status
+CREATE TYPE public.status AS ENUM (
+    'active',
+    'inactive',
+    'pending'
+);
+
+-- public.pos_int
+CREATE DOMAIN public.pos_int AS integer
+    CONSTRAINT pos_check CHECK (value > 0);
+
+-- public.users
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    status public.status,
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    CONSTRAINT users_name_key UNIQUE (name)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);
+
+-- public.active_users
+CREATE OR REPLACE VIEW public.active_users AS
+SELECT id, name FROM public.users WHERE status = 'active'::public.status;

--- a/test/scenario/testdata/fmt/unformatted.sql
+++ b/test/scenario/testdata/fmt/unformatted.sql
@@ -1,0 +1,6 @@
+CREATE TYPE public.status AS ENUM ('active','inactive','pending');
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+CREATE TABLE public.users (id integer NOT NULL, name text NOT NULL, status public.status, CONSTRAINT users_pkey PRIMARY KEY (id));
+CREATE INDEX idx_users_name ON public.users (name);
+ALTER TABLE public.users ADD CONSTRAINT users_name_key UNIQUE (name);
+CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE status = 'active'::public.status;

--- a/test/scenario/testdata/fmt/unformatted2.sql
+++ b/test/scenario/testdata/fmt/unformatted2.sql
@@ -1,0 +1,1 @@
+CREATE TABLE public.products (id integer NOT NULL, name text NOT NULL, CONSTRAINT products_pkey PRIMARY KEY (id));

--- a/testdata/fmt/domain.yml
+++ b/testdata/fmt/domain.yml
@@ -1,0 +1,6 @@
+input: |
+  CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+expected: |
+  -- public.pos_int
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (value > 0);

--- a/testdata/fmt/domain_with_enum.yml
+++ b/testdata/fmt/domain_with_enum.yml
@@ -1,0 +1,13 @@
+input: |
+  CREATE DOMAIN public.user_status AS public.status CONSTRAINT status_check CHECK (VALUE <> 'inactive'::status);
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+expected: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+
+  -- public.user_status
+  CREATE DOMAIN public.user_status AS public.status
+      CONSTRAINT status_check CHECK (value <> 'inactive'::status);

--- a/testdata/fmt/idempotent.yml
+++ b/testdata/fmt/idempotent.yml
@@ -1,0 +1,34 @@
+input: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id, name FROM public.users WHERE name IS NOT NULL;
+expected: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id, name FROM public.users WHERE name IS NOT NULL;

--- a/testdata/fmt/multiple_enums.yml
+++ b/testdata/fmt/multiple_enums.yml
@@ -1,0 +1,16 @@
+input: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+  CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');
+expected: |
+  -- public.status
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+
+  -- public.role
+  CREATE TYPE public.role AS ENUM (
+      'admin',
+      'user',
+      'guest'
+  );

--- a/testdata/fmt/multiple_views.yml
+++ b/testdata/fmt/multiple_views.yml
@@ -1,0 +1,19 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, name text NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE name IS NOT NULL;
+  CREATE VIEW public.user_ids AS SELECT id FROM public.users;
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id, name FROM public.users WHERE name IS NOT NULL;
+
+  -- public.user_ids
+  CREATE OR REPLACE VIEW public.user_ids AS
+  SELECT id FROM public.users;

--- a/testdata/fmt/table_check_unique_default.yml
+++ b/testdata/fmt/table_check_unique_default.yml
@@ -1,0 +1,12 @@
+input: |
+  CREATE TABLE public.products (id integer NOT NULL, name text NOT NULL DEFAULT 'unnamed', price integer NOT NULL, CONSTRAINT products_pkey PRIMARY KEY (id), CONSTRAINT products_name_key UNIQUE (name), CONSTRAINT products_price_check CHECK (price > 0));
+expected: |
+  -- public.products
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      name text DEFAULT 'unnamed' NOT NULL,
+      price integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_name_key UNIQUE (name),
+      CONSTRAINT products_price_check CHECK (price > 0)
+  );


### PR DESCRIPTION
## Summary
- Add 6 unit test fixtures for `pist fmt`: domain, domain+enum ordering, multiple enums, multiple views, table CHECK/UNIQUE/DEFAULT constraints, and idempotency
- Add CLI scenario test (`fmt.test.sh`) covering stdout output, `--check` mode, `-w` write mode, idempotency after write, multiple file handling, and unformatted file listing

## Test plan
- [x] `make test` passes (all new fmt fixtures pass)
- [x] `make test-scenario` passes (all scenarios including new fmt scenario pass)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)