### PR TITLE
Replace hardcoded diff ordering with topological sort

### DIFF
--- a/diff_all.go
+++ b/diff_all.go
@@ -167,30 +167,33 @@ func orderStatements(
 		dropPosMap[name] = i
 	}
 
-	// Phase 1: Creates/modifications in topological order
+	// Phase 1: Creates/modifications in topological order.
+	// Statements whose owning object cannot be identified (pos < 0) are placed
+	// after all topo-ordered statements, preserving their original relative order.
 	var createStmts []taggedStmt
 	createStmts = append(createStmts, tagStatements(enumDiff.Stmts, createPosMap)...)
 	createStmts = append(createStmts, tagStatements(domainDiff.Stmts, createPosMap)...)
 	createStmts = append(createStmts, tagStatements(tableDiff.Stmts, createPosMap)...)
 	sort.SliceStable(createStmts, func(i, j int) bool {
-		return createStmts[i].pos < createStmts[j].pos
+		return compareTaggedPos(createStmts[i].pos, createStmts[j].pos, false)
 	})
 
-	// Phase 2: Drops in reverse topological order (dependents dropped first)
+	// Phase 2: Drops in reverse topological order (dependents dropped first).
+	// Unknown statements (pos < 0) are placed first (before known drops).
 	var dropStmts []taggedStmt
 	dropStmts = append(dropStmts, tagStatements(viewDiff.DropStmts, dropPosMap)...)
 	dropStmts = append(dropStmts, tagStatements(tableDiff.DropStmts, dropPosMap)...)
 	dropStmts = append(dropStmts, tagStatements(domainDiff.DropStmts, dropPosMap)...)
 	dropStmts = append(dropStmts, tagStatements(enumDiff.DropStmts, dropPosMap)...)
 	sort.SliceStable(dropStmts, func(i, j int) bool {
-		return dropStmts[i].pos > dropStmts[j].pos // reverse order
+		return compareTaggedPos(dropStmts[i].pos, dropStmts[j].pos, true)
 	})
 
 	// Phase 3: View creates in topological order
 	var viewCreateStmts []taggedStmt
 	viewCreateStmts = append(viewCreateStmts, tagStatements(viewDiff.CreateStmts, createPosMap)...)
 	sort.SliceStable(viewCreateStmts, func(i, j int) bool {
-		return viewCreateStmts[i].pos < viewCreateStmts[j].pos
+		return compareTaggedPos(viewCreateStmts[i].pos, viewCreateStmts[j].pos, false)
 	})
 
 	// Assemble: FK drops → drops → creates → FK adds → view creates
@@ -242,9 +245,33 @@ type taggedStmt struct {
 	pos int
 }
 
+// compareTaggedPos compares two tagged statement positions for sorting.
+// Unknown positions (pos < 0) are placed before all known positions,
+// preserving their original relative order via the stable sort.
+// This ensures RENAME and INDEX statements (which can't be mapped to a
+// posMap entry) execute before dependent creates/modifications.
+func compareTaggedPos(posI, posJ int, reverse bool) bool {
+	iUnknown := posI < 0
+	jUnknown := posJ < 0
+
+	switch {
+	case iUnknown && jUnknown:
+		return false // preserve original order
+	case iUnknown:
+		return true // unknown before known
+	case jUnknown:
+		return false
+	default:
+		if reverse {
+			return posI > posJ
+		}
+		return posI < posJ
+	}
+}
+
 // tagStatements extracts object names from SQL statements and assigns
 // topological positions. Statements whose object can't be identified
-// get position -1 (sorted first) to preserve safety.
+// get position -1.
 func tagStatements(stmts []string, posMap map[string]int) []taggedStmt {
 	tagged := make([]taggedStmt, len(stmts))
 	for i, sql := range stmts {

--- a/diff_all.go
+++ b/diff_all.go
@@ -3,11 +3,16 @@ package pistachio
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/catalog"
 	"github.com/winebarrel/pistachio/diff"
+	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/parser"
+	"github.com/winebarrel/pistachio/toposort"
 )
 
 // diffAllOptions holds the common options for diffAll.
@@ -74,44 +79,35 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		Domains: filteredDomains.Len(),
 	}
 
-	enumDiff, err := diff.DiffEnums(filteredEnums, options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums)), &options.DropPolicy)
+	desiredEnums := options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums))
+	desiredDomains := options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains))
+	desiredTables := options.filterTables(client.reverseRemapTableSchemas(desired.Tables))
+	desiredViews := options.filterViews(client.reverseRemapViewSchemas(desired.Views))
+
+	enumDiff, err := diff.DiffEnums(filteredEnums, desiredEnums, &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff enums: %w", err)
 	}
-	stmts := enumDiff.Stmts
 
-	domainDiff, err := diff.DiffDomains(filteredDomains, options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains)), &options.DropPolicy)
+	domainDiff, err := diff.DiffDomains(filteredDomains, desiredDomains, &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff domains: %w", err)
 	}
-	stmts = append(stmts, domainDiff.Stmts...)
 
-	tableDiff, err := diff.DiffTables(filteredTables, options.filterTables(client.reverseRemapTableSchemas(desired.Tables)), &options.DropPolicy)
+	tableDiff, err := diff.DiffTables(filteredTables, desiredTables, &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
-	viewDiff, err := diff.DiffViews(filteredViews, options.filterViews(client.reverseRemapViewSchemas(desired.Views)), &options.DropPolicy)
+
+	viewDiff, err := diff.DiffViews(filteredViews, desiredViews, &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}
 
-	// Drop views before table/column changes (views may depend on columns being dropped)
-	stmts = append(stmts, viewDiff.DropStmts...)
-
-	// FK drops before table/column changes
-	stmts = append(stmts, tableDiff.FKDropStmts...)
-	stmts = append(stmts, tableDiff.Stmts...)
-
-	// Drops: tables before domains/enums (dependency order)
-	stmts = append(stmts, tableDiff.DropStmts...)
-	stmts = append(stmts, domainDiff.DropStmts...)
-	stmts = append(stmts, enumDiff.DropStmts...)
-
-	// FK adds after all tables exist
-	stmts = append(stmts, tableDiff.FKAddStmts...)
-
-	// View creates last (views may reference new tables/columns/FKs)
-	stmts = append(stmts, viewDiff.CreateStmts...)
+	stmts := orderStatements(
+		desiredEnums, desiredDomains, desiredTables, desiredViews,
+		enumDiff, domainDiff, tableDiff, viewDiff,
+	)
 
 	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
 	if err != nil {
@@ -123,4 +119,232 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		PreSQL: preSQL,
 		Count:  count,
 	}, nil
+}
+
+// orderStatements uses topological sort to determine the correct execution
+// order for diff statements based on object dependencies.
+// Falls back to the default category-based ordering if topological sort fails.
+func orderStatements(
+	desiredEnums *orderedmap.Map[string, *model.Enum],
+	desiredDomains *orderedmap.Map[string, *model.Domain],
+	desiredTables *orderedmap.Map[string, *model.Table],
+	desiredViews *orderedmap.Map[string, *model.View],
+	enumDiff *diff.EnumDiffResult,
+	domainDiff *diff.DomainDiffResult,
+	tableDiff *diff.TableDiffResult,
+	viewDiff *diff.ViewDiffResult,
+) []string {
+	// Build topological order from desired schema
+	order, err := toposort.OrderFromSchema(
+		desiredEnums,
+		desiredDomains,
+		desiredTables,
+		desiredViews,
+	)
+	if err != nil {
+		// Fallback to hardcoded order (e.g., cyclic FK dependencies)
+		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff)
+	}
+
+	posMap := make(map[string]int, len(order))
+	for i, name := range order {
+		posMap[name] = i
+	}
+
+	// Phase 1: Creates/modifications in topological order
+	var createStmts []taggedStmt
+	createStmts = append(createStmts, tagStatements(enumDiff.Stmts, posMap)...)
+	createStmts = append(createStmts, tagStatements(domainDiff.Stmts, posMap)...)
+	createStmts = append(createStmts, tagStatements(tableDiff.Stmts, posMap)...)
+	sort.SliceStable(createStmts, func(i, j int) bool {
+		return createStmts[i].pos < createStmts[j].pos
+	})
+
+	// Phase 2: Drops in reverse topological order (dependents dropped first)
+	var dropStmts []taggedStmt
+	dropStmts = append(dropStmts, tagStatements(viewDiff.DropStmts, posMap)...)
+	dropStmts = append(dropStmts, tagStatements(tableDiff.DropStmts, posMap)...)
+	dropStmts = append(dropStmts, tagStatements(domainDiff.DropStmts, posMap)...)
+	dropStmts = append(dropStmts, tagStatements(enumDiff.DropStmts, posMap)...)
+	sort.SliceStable(dropStmts, func(i, j int) bool {
+		return dropStmts[i].pos > dropStmts[j].pos // reverse order
+	})
+
+	// Phase 3: View creates in topological order
+	var viewCreateStmts []taggedStmt
+	viewCreateStmts = append(viewCreateStmts, tagStatements(viewDiff.CreateStmts, posMap)...)
+	sort.SliceStable(viewCreateStmts, func(i, j int) bool {
+		return viewCreateStmts[i].pos < viewCreateStmts[j].pos
+	})
+
+	// Assemble: FK drops → drops → creates → FK adds → view creates
+	var stmts []string
+	for _, ts := range tagStatements(tableDiff.FKDropStmts, posMap) {
+		stmts = append(stmts, ts.sql)
+	}
+	for _, ts := range dropStmts {
+		stmts = append(stmts, ts.sql)
+	}
+	for _, ts := range createStmts {
+		stmts = append(stmts, ts.sql)
+	}
+	for _, ts := range tagStatements(tableDiff.FKAddStmts, posMap) {
+		stmts = append(stmts, ts.sql)
+	}
+	for _, ts := range viewCreateStmts {
+		stmts = append(stmts, ts.sql)
+	}
+
+	return stmts
+}
+
+// fallbackOrder is the original hardcoded ordering logic used as fallback.
+func fallbackOrder(
+	enumDiff *diff.EnumDiffResult,
+	domainDiff *diff.DomainDiffResult,
+	tableDiff *diff.TableDiffResult,
+	viewDiff *diff.ViewDiffResult,
+) []string {
+	var stmts []string
+	stmts = append(stmts, enumDiff.Stmts...)
+	stmts = append(stmts, domainDiff.Stmts...)
+	stmts = append(stmts, viewDiff.DropStmts...)
+	stmts = append(stmts, tableDiff.FKDropStmts...)
+	stmts = append(stmts, tableDiff.Stmts...)
+	stmts = append(stmts, tableDiff.DropStmts...)
+	stmts = append(stmts, domainDiff.DropStmts...)
+	stmts = append(stmts, enumDiff.DropStmts...)
+	stmts = append(stmts, tableDiff.FKAddStmts...)
+	stmts = append(stmts, viewDiff.CreateStmts...)
+	return stmts
+}
+
+// taggedStmt pairs a SQL statement with a sort position derived from
+// the topological order of the object it affects.
+type taggedStmt struct {
+	sql string
+	pos int
+}
+
+// tagStatements extracts object names from SQL statements and assigns
+// topological positions. Statements whose object can't be identified
+// get position -1 (sorted first) to preserve safety.
+func tagStatements(stmts []string, posMap map[string]int) []taggedStmt {
+	tagged := make([]taggedStmt, len(stmts))
+	for i, sql := range stmts {
+		name := extractObjectName(sql)
+		pos := -1
+		if p, ok := posMap[name]; ok {
+			pos = p
+		}
+		tagged[i] = taggedStmt{sql: sql, pos: pos}
+	}
+	return tagged
+}
+
+// extractObjectName extracts the primary schema-qualified object name from a DDL statement.
+func extractObjectName(sql string) string {
+	sql = strings.TrimSpace(sql)
+
+	// Try common DDL patterns
+	patterns := []struct {
+		prefix string
+	}{
+		{"CREATE TABLE "},
+		{"CREATE UNLOGGED TABLE "},
+		{"CREATE TYPE "},
+		{"CREATE DOMAIN "},
+		{"CREATE OR REPLACE VIEW "},
+		{"CREATE VIEW "},
+		{"CREATE INDEX "}, // special: name is after ON
+		{"ALTER TABLE ONLY "},
+		{"ALTER TABLE "},
+		{"ALTER TYPE "},
+		{"ALTER DOMAIN "},
+		{"ALTER VIEW "},
+		{"DROP TABLE "},
+		{"DROP VIEW "},
+		{"DROP TYPE "},
+		{"DROP DOMAIN "},
+		{"COMMENT ON TABLE "},
+		{"COMMENT ON VIEW "},
+		{"COMMENT ON TYPE "},
+		{"COMMENT ON DOMAIN "},
+		{"COMMENT ON COLUMN "}, // schema.table.column → take schema.table
+	}
+
+	upper := strings.ToUpper(sql)
+	for _, p := range patterns {
+		if !strings.HasPrefix(upper, strings.ToUpper(p.prefix)) {
+			continue
+		}
+
+		if strings.HasPrefix(upper, "CREATE INDEX ") {
+			// CREATE INDEX name ON [ONLY] schema.table ...
+			return extractIndexTable(sql)
+		}
+
+		rest := sql[len(p.prefix):]
+		name := extractFirstIdentifier(rest)
+
+		if strings.HasPrefix(upper, "COMMENT ON COLUMN ") {
+			// schema.table.column → schema.table
+			parts := strings.SplitN(name, ".", 3)
+			if len(parts) >= 2 {
+				return parts[0] + "." + parts[1]
+			}
+		}
+
+		return name
+	}
+
+	return ""
+}
+
+// extractFirstIdentifier extracts a possibly schema-qualified identifier
+// from the beginning of a string.
+func extractFirstIdentifier(s string) string {
+	s = strings.TrimSpace(s)
+	var result strings.Builder
+	inQuote := false
+
+	for _, ch := range s {
+		if ch == '"' {
+			inQuote = !inQuote
+			result.WriteRune(ch)
+			continue
+		}
+		if inQuote {
+			result.WriteRune(ch)
+			continue
+		}
+		if ch == '.' || ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+			result.WriteRune(ch)
+			continue
+		}
+		break
+	}
+
+	name := result.String()
+	// Remove quotes for matching
+	name = strings.ReplaceAll(name, "\"", "")
+	return name
+}
+
+// extractIndexTable extracts the table name from a CREATE INDEX statement.
+func extractIndexTable(sql string) string {
+	upper := strings.ToUpper(sql)
+	idx := strings.Index(upper, " ON ")
+	if idx < 0 {
+		return ""
+	}
+	rest := sql[idx+4:]
+	rest = strings.TrimSpace(rest)
+
+	// Skip optional ONLY keyword
+	if strings.HasPrefix(strings.ToUpper(rest), "ONLY ") {
+		rest = rest[5:]
+	}
+
+	return extractFirstIdentifier(rest)
 }

--- a/diff_all.go
+++ b/diff_all.go
@@ -105,6 +105,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	}
 
 	stmts := orderStatements(
+		filteredEnums, filteredDomains, filteredTables, filteredViews,
 		desiredEnums, desiredDomains, desiredTables, desiredViews,
 		enumDiff, domainDiff, tableDiff, viewDiff,
 	)
@@ -125,6 +126,10 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 // order for diff statements based on object dependencies.
 // Falls back to the default category-based ordering if topological sort fails.
 func orderStatements(
+	currentEnums *orderedmap.Map[string, *model.Enum],
+	currentDomains *orderedmap.Map[string, *model.Domain],
+	currentTables *orderedmap.Map[string, *model.Table],
+	currentViews *orderedmap.Map[string, *model.View],
 	desiredEnums *orderedmap.Map[string, *model.Enum],
 	desiredDomains *orderedmap.Map[string, *model.Domain],
 	desiredTables *orderedmap.Map[string, *model.Table],
@@ -134,52 +139,63 @@ func orderStatements(
 	tableDiff *diff.TableDiffResult,
 	viewDiff *diff.ViewDiffResult,
 ) []string {
-	// Build topological order from desired schema
-	order, err := toposort.OrderFromSchema(
-		desiredEnums,
-		desiredDomains,
-		desiredTables,
-		desiredViews,
+	// Build topological order from desired schema for creates
+	createOrder, err := toposort.OrderFromSchema(
+		desiredEnums, desiredDomains, desiredTables, desiredViews,
 	)
 	if err != nil {
-		// Fallback to hardcoded order (e.g., cyclic FK dependencies)
 		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff)
 	}
 
-	posMap := make(map[string]int, len(order))
-	for i, name := range order {
-		posMap[name] = i
+	createPosMap := make(map[string]int, len(createOrder))
+	for i, name := range createOrder {
+		createPosMap[name] = i
+	}
+
+	// Build topological order from current schema for drops.
+	// Dropped objects are not in the desired schema, so we need the current
+	// schema's dependency graph to determine correct drop order.
+	dropOrder, err := toposort.OrderFromSchema(
+		currentEnums, currentDomains, currentTables, currentViews,
+	)
+	if err != nil {
+		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff)
+	}
+
+	dropPosMap := make(map[string]int, len(dropOrder))
+	for i, name := range dropOrder {
+		dropPosMap[name] = i
 	}
 
 	// Phase 1: Creates/modifications in topological order
 	var createStmts []taggedStmt
-	createStmts = append(createStmts, tagStatements(enumDiff.Stmts, posMap)...)
-	createStmts = append(createStmts, tagStatements(domainDiff.Stmts, posMap)...)
-	createStmts = append(createStmts, tagStatements(tableDiff.Stmts, posMap)...)
+	createStmts = append(createStmts, tagStatements(enumDiff.Stmts, createPosMap)...)
+	createStmts = append(createStmts, tagStatements(domainDiff.Stmts, createPosMap)...)
+	createStmts = append(createStmts, tagStatements(tableDiff.Stmts, createPosMap)...)
 	sort.SliceStable(createStmts, func(i, j int) bool {
 		return createStmts[i].pos < createStmts[j].pos
 	})
 
 	// Phase 2: Drops in reverse topological order (dependents dropped first)
 	var dropStmts []taggedStmt
-	dropStmts = append(dropStmts, tagStatements(viewDiff.DropStmts, posMap)...)
-	dropStmts = append(dropStmts, tagStatements(tableDiff.DropStmts, posMap)...)
-	dropStmts = append(dropStmts, tagStatements(domainDiff.DropStmts, posMap)...)
-	dropStmts = append(dropStmts, tagStatements(enumDiff.DropStmts, posMap)...)
+	dropStmts = append(dropStmts, tagStatements(viewDiff.DropStmts, dropPosMap)...)
+	dropStmts = append(dropStmts, tagStatements(tableDiff.DropStmts, dropPosMap)...)
+	dropStmts = append(dropStmts, tagStatements(domainDiff.DropStmts, dropPosMap)...)
+	dropStmts = append(dropStmts, tagStatements(enumDiff.DropStmts, dropPosMap)...)
 	sort.SliceStable(dropStmts, func(i, j int) bool {
 		return dropStmts[i].pos > dropStmts[j].pos // reverse order
 	})
 
 	// Phase 3: View creates in topological order
 	var viewCreateStmts []taggedStmt
-	viewCreateStmts = append(viewCreateStmts, tagStatements(viewDiff.CreateStmts, posMap)...)
+	viewCreateStmts = append(viewCreateStmts, tagStatements(viewDiff.CreateStmts, createPosMap)...)
 	sort.SliceStable(viewCreateStmts, func(i, j int) bool {
 		return viewCreateStmts[i].pos < viewCreateStmts[j].pos
 	})
 
 	// Assemble: FK drops → drops → creates → FK adds → view creates
 	var stmts []string
-	for _, ts := range tagStatements(tableDiff.FKDropStmts, posMap) {
+	for _, ts := range tagStatements(tableDiff.FKDropStmts, dropPosMap) {
 		stmts = append(stmts, ts.sql)
 	}
 	for _, ts := range dropStmts {
@@ -188,7 +204,7 @@ func orderStatements(
 	for _, ts := range createStmts {
 		stmts = append(stmts, ts.sql)
 	}
-	for _, ts := range tagStatements(tableDiff.FKAddStmts, posMap) {
+	for _, ts := range tagStatements(tableDiff.FKAddStmts, createPosMap) {
 		stmts = append(stmts, ts.sql)
 	}
 	for _, ts := range viewCreateStmts {
@@ -337,7 +353,7 @@ func extractFirstIdentifier(s string) string {
 			result.WriteByte(ch)
 			continue
 		}
-		if ch == '.' || ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+		if ch == '.' || ch == '_' || ch == '$' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
 			result.WriteByte(ch)
 			continue
 		}

--- a/diff_all.go
+++ b/diff_all.go
@@ -243,6 +243,7 @@ func tagStatements(stmts []string, posMap map[string]int) []taggedStmt {
 }
 
 // extractObjectName extracts the primary schema-qualified object name from a DDL statement.
+// The returned name preserves quoting to match the canonical format used by model.Ident.
 func extractObjectName(sql string) string {
 	sql = strings.TrimSpace(sql)
 
@@ -256,7 +257,9 @@ func extractObjectName(sql string) string {
 		{"CREATE DOMAIN "},
 		{"CREATE OR REPLACE VIEW "},
 		{"CREATE VIEW "},
-		{"CREATE INDEX "}, // special: name is after ON
+		{"CREATE INDEX "},
+		{"ALTER INDEX "},
+		{"DROP INDEX "},
 		{"ALTER TABLE ONLY "},
 		{"ALTER TABLE "},
 		{"ALTER TYPE "},
@@ -279,9 +282,17 @@ func extractObjectName(sql string) string {
 			continue
 		}
 
-		if strings.HasPrefix(upper, "CREATE INDEX ") {
-			// CREATE INDEX name ON [ONLY] schema.table ...
+		if strings.HasPrefix(upper, "CREATE INDEX ") ||
+			strings.HasPrefix(upper, "DROP INDEX ") {
+			// CREATE/DROP INDEX name ON [ONLY] schema.table ...
 			return extractIndexTable(sql)
+		}
+
+		if strings.HasPrefix(upper, "ALTER INDEX ") {
+			// ALTER INDEX schema.idx RENAME TO ... → extract table from idx name context
+			// Index statements belong to the table they're on, but ALTER INDEX
+			// doesn't contain the table name directly. Return "" to use pos=-1.
+			return ""
 		}
 
 		rest := sql[len(p.prefix):]
@@ -289,9 +300,9 @@ func extractObjectName(sql string) string {
 
 		if strings.HasPrefix(upper, "COMMENT ON COLUMN ") {
 			// schema.table.column → schema.table
-			parts := strings.SplitN(name, ".", 3)
+			parts := splitIdentifier(name, 3)
 			if len(parts) >= 2 {
-				return parts[0] + "." + parts[1]
+				return joinIdentifierParts(parts[:2])
 			}
 		}
 
@@ -302,36 +313,81 @@ func extractObjectName(sql string) string {
 }
 
 // extractFirstIdentifier extracts a possibly schema-qualified identifier
-// from the beginning of a string.
+// from the beginning of a string, preserving quoting to match the canonical
+// format used by model.Ident.
 func extractFirstIdentifier(s string) string {
 	s = strings.TrimSpace(s)
 	var result strings.Builder
 	inQuote := false
 
-	for _, ch := range s {
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
 		if ch == '"' {
+			result.WriteByte(ch)
+			if inQuote && i+1 < len(s) && s[i+1] == '"' {
+				// Escaped quote inside a quoted identifier
+				result.WriteByte(s[i+1])
+				i++
+				continue
+			}
 			inQuote = !inQuote
-			result.WriteRune(ch)
 			continue
 		}
 		if inQuote {
-			result.WriteRune(ch)
+			result.WriteByte(ch)
 			continue
 		}
 		if ch == '.' || ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
-			result.WriteRune(ch)
+			result.WriteByte(ch)
 			continue
 		}
 		break
 	}
 
-	name := result.String()
-	// Remove quotes for matching
-	name = strings.ReplaceAll(name, "\"", "")
-	return name
+	return result.String()
 }
 
-// extractIndexTable extracts the table name from a CREATE INDEX statement.
+// splitIdentifier splits a possibly-quoted schema-qualified identifier into parts.
+// e.g., `"MySchema"."MyTable".col` → ["\"MySchema\"", "\"MyTable\"", "col"]
+func splitIdentifier(ident string, maxParts int) []string {
+	var parts []string
+	var part strings.Builder
+	inQuote := false
+
+	for i := 0; i < len(ident); i++ {
+		ch := ident[i]
+		if ch == '"' {
+			part.WriteByte(ch)
+			if inQuote && i+1 < len(ident) && ident[i+1] == '"' {
+				part.WriteByte(ident[i+1])
+				i++
+				continue
+			}
+			inQuote = !inQuote
+			continue
+		}
+		if ch == '.' && !inQuote {
+			parts = append(parts, part.String())
+			part.Reset()
+			if len(parts) >= maxParts-1 {
+				// Put the rest into the last part
+				parts = append(parts, ident[i+1:])
+				return parts
+			}
+			continue
+		}
+		part.WriteByte(ch)
+	}
+	parts = append(parts, part.String())
+	return parts
+}
+
+// joinIdentifierParts joins identifier parts back with dots.
+func joinIdentifierParts(parts []string) string {
+	return strings.Join(parts, ".")
+}
+
+// extractIndexTable extracts the table name from a CREATE/DROP INDEX statement.
 func extractIndexTable(sql string) string {
 	upper := strings.ToUpper(sql)
 	idx := strings.Index(upper, " ON ")

--- a/diff_all.go
+++ b/diff_all.go
@@ -169,7 +169,7 @@ func orderStatements(
 
 	// Phase 1: Creates/modifications in topological order.
 	// Statements whose owning object cannot be identified (pos < 0) are placed
-	// after all topo-ordered statements, preserving their original relative order.
+	// before all topo-ordered statements, preserving their original relative order.
 	var createStmts []taggedStmt
 	createStmts = append(createStmts, tagStatements(enumDiff.Stmts, createPosMap)...)
 	createStmts = append(createStmts, tagStatements(domainDiff.Stmts, createPosMap)...)

--- a/diff_all.go
+++ b/diff_all.go
@@ -178,33 +178,47 @@ func orderStatements(
 		return compareTaggedPos(createStmts[i].pos, createStmts[j].pos, false)
 	})
 
-	// Phase 2: Drops in reverse topological order (dependents dropped first).
-	// Unknown statements (pos < 0) are placed first (before known drops).
-	var dropStmts []taggedStmt
-	dropStmts = append(dropStmts, tagStatements(viewDiff.DropStmts, dropPosMap)...)
-	dropStmts = append(dropStmts, tagStatements(tableDiff.DropStmts, dropPosMap)...)
-	dropStmts = append(dropStmts, tagStatements(domainDiff.DropStmts, dropPosMap)...)
-	dropStmts = append(dropStmts, tagStatements(enumDiff.DropStmts, dropPosMap)...)
-	sort.SliceStable(dropStmts, func(i, j int) bool {
-		return compareTaggedPos(dropStmts[i].pos, dropStmts[j].pos, true)
+	// Phase 2: Pre-create drops in reverse topological order.
+	// View drops must happen before table/column changes (views may depend on
+	// columns being dropped).
+	var preDropStmts []taggedStmt
+	preDropStmts = append(preDropStmts, tagStatements(viewDiff.DropStmts, dropPosMap)...)
+	sort.SliceStable(preDropStmts, func(i, j int) bool {
+		return compareTaggedPos(preDropStmts[i].pos, preDropStmts[j].pos, true)
 	})
 
-	// Phase 3: View creates in topological order
+	// Phase 3: Post-create drops in reverse dependency order.
+	// Table drops must come after table creates/alters (column type changes may
+	// remove references to domains/enums). Domain/enum drops come after table
+	// drops (tables must stop referencing them first).
+	var postDropStmts []taggedStmt
+	postDropStmts = append(postDropStmts, tagStatements(tableDiff.DropStmts, dropPosMap)...)
+	postDropStmts = append(postDropStmts, tagStatements(domainDiff.DropStmts, dropPosMap)...)
+	postDropStmts = append(postDropStmts, tagStatements(enumDiff.DropStmts, dropPosMap)...)
+	sort.SliceStable(postDropStmts, func(i, j int) bool {
+		return compareTaggedPos(postDropStmts[i].pos, postDropStmts[j].pos, true)
+	})
+
+	// Phase 4: View creates in topological order
 	var viewCreateStmts []taggedStmt
 	viewCreateStmts = append(viewCreateStmts, tagStatements(viewDiff.CreateStmts, createPosMap)...)
 	sort.SliceStable(viewCreateStmts, func(i, j int) bool {
 		return compareTaggedPos(viewCreateStmts[i].pos, viewCreateStmts[j].pos, false)
 	})
 
-	// Assemble: FK drops → drops → creates → FK adds → view creates
+	// Assemble:
+	// FK drops → view drops → creates/alters → table/domain/enum drops → FK adds → view creates
 	var stmts []string
 	for _, ts := range tagStatements(tableDiff.FKDropStmts, dropPosMap) {
 		stmts = append(stmts, ts.sql)
 	}
-	for _, ts := range dropStmts {
+	for _, ts := range preDropStmts {
 		stmts = append(stmts, ts.sql)
 	}
 	for _, ts := range createStmts {
+		stmts = append(stmts, ts.sql)
+	}
+	for _, ts := range postDropStmts {
 		stmts = append(stmts, ts.sql)
 	}
 	for _, ts := range tagStatements(tableDiff.FKAddStmts, createPosMap) {

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -43,6 +43,7 @@ func TestExtractObjectName(t *testing.T) {
 		{`COMMENT ON COLUMN "S"."T".col IS 'x';`, `"S"."T"`},
 		{`CREATE TABLE public."escaped""quote" (id integer);`, `public."escaped""quote"`},
 		{`CREATE TABLE public.$foo (id integer);`, "public.$foo"},
+		{`COMMENT ON COLUMN "S""x"."T".col IS 'x';`, `"S""x"."T"`},
 	}
 
 	for _, tt := range tests {

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -165,3 +165,55 @@ func TestOrderStatements_DropUsesCurrentSchema(t *testing.T) {
 	assert.Contains(t, result[0], "view_b", "dependent view dropped first")
 	assert.Contains(t, result[1], "view_a", "dependency dropped second")
 }
+
+func TestOrderStatements_DropFallbackOnCurrentCycle(t *testing.T) {
+	// Current schema has cyclic FK → drop ordering should fall back
+	refA := "a"
+	refB := "b"
+	schemaPublic := "public"
+
+	currentEnums := orderedmap.New[string, *model.Enum]()
+	currentDomains := orderedmap.New[string, *model.Domain]()
+	currentViews := orderedmap.New[string, *model.View]()
+	currentTables := orderedmap.New[string, *model.Table]()
+	for _, cfg := range []struct{ name, ref string }{{"a", refB}, {"b", refA}} {
+		tbl := &model.Table{Schema: "public", Name: cfg.name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tbl.ForeignKeys.Set(cfg.name+"_fk", &model.ForeignKey{
+			Constraint: model.Constraint{Name: cfg.name + "_fk"},
+			RefSchema:  &schemaPublic,
+			RefTable:   &cfg.ref,
+		})
+		currentTables.Set("public."+cfg.name, tbl)
+	}
+
+	desiredEnums := orderedmap.New[string, *model.Enum]()
+	desiredDomains := orderedmap.New[string, *model.Domain]()
+	desiredTables := orderedmap.New[string, *model.Table]()
+	desiredViews := orderedmap.New[string, *model.View]()
+
+	enumDiff := &diff.EnumDiffResult{}
+	domainDiff := &diff.DomainDiffResult{}
+	tableDiff := &diff.TableDiffResult{
+		DropStmts: []string{"DROP TABLE public.a;", "DROP TABLE public.b;"},
+	}
+	viewDiff := &diff.ViewDiffResult{}
+
+	result := pistachio.OrderStatements(
+		currentEnums, currentDomains, currentTables, currentViews,
+		desiredEnums, desiredDomains, desiredTables, desiredViews,
+		enumDiff, domainDiff, tableDiff, viewDiff,
+	)
+
+	// Should still produce output via fallback (not panic or error)
+	require.Len(t, result, 2)
+}
+
+func TestExtractObjectName_QuotedWithEscapedQuote(t *testing.T) {
+	// COMMENT ON COLUMN with escaped quotes in identifier
+	got := pistachio.ExtractObjectName(`COMMENT ON COLUMN "My""Schema"."My""Table".col IS 'x';`)
+	assert.Equal(t, `"My""Schema"."My""Table"`, got)
+}

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -32,11 +32,16 @@ func TestExtractObjectName(t *testing.T) {
 		{"CREATE INDEX idx_users_name ON public.users USING btree (name);", "public.users"},
 		{"COMMENT ON TABLE public.users IS 'Users table';", "public.users"},
 		{"COMMENT ON COLUMN public.users.name IS 'Name';", "public.users"},
-		{`CREATE TABLE "MySchema"."MyTable" (id integer);`, "MySchema.MyTable"},
+		{`CREATE TABLE "MySchema"."MyTable" (id integer);`, `"MySchema"."MyTable"`},
 		// Edge cases
 		{"SELECT 1;", ""},
 		{"CREATE INDEX idx ON ONLY public.t (x);", "public.t"},
 		{"CREATE INDEX bad_no_on;", ""},
+		// DROP INDEX / ALTER INDEX
+		{`DROP INDEX public.idx_users_name;`, ""},
+		{`ALTER INDEX public.idx_old RENAME TO idx_new;`, ""},
+		{`COMMENT ON COLUMN "S"."T".col IS 'x';`, `"S"."T"`},
+		{`CREATE TABLE public."escaped""quote" (id integer);`, `public."escaped""quote"`},
 	}
 
 	for _, tt := range tests {

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -96,7 +96,13 @@ func TestOrderStatements_Fallback(t *testing.T) {
 	tableDiff := &diff.TableDiffResult{Stmts: []string{"CREATE TABLE public.a (id integer);"}}
 	viewDiff := &diff.ViewDiffResult{}
 
+	currentEnums := orderedmap.New[string, *model.Enum]()
+	currentDomains := orderedmap.New[string, *model.Domain]()
+	currentTables := orderedmap.New[string, *model.Table]()
+	currentViews := orderedmap.New[string, *model.View]()
+
 	result := pistachio.OrderStatements(
+		currentEnums, currentDomains, currentTables, currentViews,
 		desiredEnums, desiredDomains, desiredTables, desiredViews,
 		enumDiff, domainDiff, tableDiff, viewDiff,
 	)

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -42,6 +42,7 @@ func TestExtractObjectName(t *testing.T) {
 		{`ALTER INDEX public.idx_old RENAME TO idx_new;`, ""},
 		{`COMMENT ON COLUMN "S"."T".col IS 'x';`, `"S"."T"`},
 		{`CREATE TABLE public."escaped""quote" (id integer);`, `public."escaped""quote"`},
+		{`CREATE TABLE public.$foo (id integer);`, "public.$foo"},
 	}
 
 	for _, tt := range tests {
@@ -111,4 +112,56 @@ func TestOrderStatements_Fallback(t *testing.T) {
 	require.NotEmpty(t, result)
 	assert.Contains(t, result[0], "CREATE TYPE")
 	assert.Contains(t, result[1], "CREATE TABLE")
+}
+
+func TestOrderStatements_DropUsesCurrentSchema(t *testing.T) {
+	// View B depends on View A in the current schema.
+	// When both are dropped, B must be dropped before A.
+	currentEnums := orderedmap.New[string, *model.Enum]()
+	currentDomains := orderedmap.New[string, *model.Domain]()
+	currentTables := orderedmap.New[string, *model.Table]()
+	tbl := &model.Table{Schema: "public", Name: "users"}
+	tbl.Columns = orderedmap.New[string, *model.Column]()
+	tbl.Indexes = orderedmap.New[string, *model.Index]()
+	tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+	tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	currentTables.Set("public.users", tbl)
+
+	currentViews := orderedmap.New[string, *model.View]()
+	currentViews.Set("public.view_a", &model.View{
+		Schema: "public", Name: "view_a",
+		Definition: "SELECT id FROM public.users",
+	})
+	currentViews.Set("public.view_b", &model.View{
+		Schema: "public", Name: "view_b",
+		Definition: "SELECT id FROM public.view_a",
+	})
+
+	// Desired: only table, both views dropped
+	desiredEnums := orderedmap.New[string, *model.Enum]()
+	desiredDomains := orderedmap.New[string, *model.Domain]()
+	desiredTables := orderedmap.New[string, *model.Table]()
+	desiredTables.Set("public.users", tbl)
+	desiredViews := orderedmap.New[string, *model.View]()
+
+	enumDiff := &diff.EnumDiffResult{}
+	domainDiff := &diff.DomainDiffResult{}
+	tableDiff := &diff.TableDiffResult{}
+	viewDiff := &diff.ViewDiffResult{
+		DropStmts: []string{
+			"DROP VIEW public.view_a;",
+			"DROP VIEW public.view_b;",
+		},
+	}
+
+	result := pistachio.OrderStatements(
+		currentEnums, currentDomains, currentTables, currentViews,
+		desiredEnums, desiredDomains, desiredTables, desiredViews,
+		enumDiff, domainDiff, tableDiff, viewDiff,
+	)
+
+	require.Len(t, result, 2)
+	// view_b depends on view_a → view_b must be dropped first (reverse topo order)
+	assert.Contains(t, result[0], "view_b", "dependent view dropped first")
+	assert.Contains(t, result[1], "view_a", "dependency dropped second")
 }

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -213,6 +213,57 @@ func TestOrderStatements_DropFallbackOnCurrentCycle(t *testing.T) {
 	require.Len(t, result, 2)
 }
 
+func TestOrderStatements_UnknownPosBeforeKnown(t *testing.T) {
+	// Statements with unknown position (e.g., RENAME, INDEX ops) should
+	// be placed before topo-ordered statements, not after.
+	currentEnums := orderedmap.New[string, *model.Enum]()
+	currentDomains := orderedmap.New[string, *model.Domain]()
+	currentViews := orderedmap.New[string, *model.View]()
+
+	currentTables := orderedmap.New[string, *model.Table]()
+	tbl := &model.Table{Schema: "public", Name: "users"}
+	tbl.Columns = orderedmap.New[string, *model.Column]()
+	tbl.Indexes = orderedmap.New[string, *model.Index]()
+	tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+	tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	currentTables.Set("public.users", tbl)
+
+	desiredEnums := orderedmap.New[string, *model.Enum]()
+	desiredDomains := orderedmap.New[string, *model.Domain]()
+	desiredViews := orderedmap.New[string, *model.View]()
+
+	desiredTables := orderedmap.New[string, *model.Table]()
+	tbl2 := &model.Table{Schema: "public", Name: "accounts"}
+	tbl2.Columns = orderedmap.New[string, *model.Column]()
+	tbl2.Indexes = orderedmap.New[string, *model.Index]()
+	tbl2.Constraints = orderedmap.New[string, *model.Constraint]()
+	tbl2.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	desiredTables.Set("public.accounts", tbl2)
+
+	enumDiff := &diff.EnumDiffResult{}
+	domainDiff := &diff.DomainDiffResult{}
+	tableDiff := &diff.TableDiffResult{
+		Stmts: []string{
+			// RENAME uses old name → not in desired posMap → pos=-1
+			"ALTER TABLE public.users RENAME TO accounts;",
+			// Column change uses new name → in desired posMap
+			"ALTER TABLE public.accounts ADD COLUMN name text;",
+		},
+	}
+	viewDiff := &diff.ViewDiffResult{}
+
+	result := pistachio.OrderStatements(
+		currentEnums, currentDomains, currentTables, currentViews,
+		desiredEnums, desiredDomains, desiredTables, desiredViews,
+		enumDiff, domainDiff, tableDiff, viewDiff,
+	)
+
+	require.Len(t, result, 2)
+	// RENAME (unknown pos) must come before ADD COLUMN (known pos)
+	assert.Contains(t, result[0], "RENAME TO accounts")
+	assert.Contains(t, result[1], "ADD COLUMN name")
+}
+
 func TestExtractObjectName_QuotedWithEscapedQuote(t *testing.T) {
 	// COMMENT ON COLUMN with escaped quotes in identifier
 	got := pistachio.ExtractObjectName(`COMMENT ON COLUMN "My""Schema"."My""Table".col IS 'x';`)

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -1,0 +1,103 @@
+package pistachio_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio"
+	"github.com/winebarrel/pistachio/diff"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestExtractObjectName(t *testing.T) {
+	tests := []struct {
+		sql      string
+		expected string
+	}{
+		{"CREATE TABLE public.users (\n  id integer\n);", "public.users"},
+		{"CREATE UNLOGGED TABLE public.logs (id integer);", "public.logs"},
+		{"ALTER TABLE public.users ADD COLUMN name text;", "public.users"},
+		{"ALTER TABLE ONLY public.users ADD CONSTRAINT pk PRIMARY KEY (id);", "public.users"},
+		{"DROP TABLE public.users;", "public.users"},
+		{"CREATE TYPE public.status AS ENUM ('a', 'b');", "public.status"},
+		{"ALTER TYPE public.status ADD VALUE 'c';", "public.status"},
+		{"DROP TYPE public.status;", "public.status"},
+		{"CREATE DOMAIN public.pos_int AS integer;", "public.pos_int"},
+		{"ALTER DOMAIN public.pos_int SET NOT NULL;", "public.pos_int"},
+		{"DROP DOMAIN public.pos_int;", "public.pos_int"},
+		{"CREATE OR REPLACE VIEW public.v AS SELECT 1;", "public.v"},
+		{"DROP VIEW public.v;", "public.v"},
+		{"CREATE INDEX idx_users_name ON public.users USING btree (name);", "public.users"},
+		{"COMMENT ON TABLE public.users IS 'Users table';", "public.users"},
+		{"COMMENT ON COLUMN public.users.name IS 'Name';", "public.users"},
+		{`CREATE TABLE "MySchema"."MyTable" (id integer);`, "MySchema.MyTable"},
+		// Edge cases
+		{"SELECT 1;", ""},
+		{"CREATE INDEX idx ON ONLY public.t (x);", "public.t"},
+		{"CREATE INDEX bad_no_on;", ""},
+	}
+
+	for _, tt := range tests {
+		name := tt.sql
+		if len(name) > 40 {
+			name = name[:40]
+		}
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, pistachio.ExtractObjectName(tt.sql))
+		})
+	}
+}
+
+func TestOrderStatements_Fallback(t *testing.T) {
+	// Test that fallbackOrder is used when topological sort would fail
+	// (cyclic FK dependencies between desired tables)
+	desiredEnums := orderedmap.New[string, *model.Enum]()
+	desiredDomains := orderedmap.New[string, *model.Domain]()
+	desiredViews := orderedmap.New[string, *model.View]()
+
+	// Create two tables with mutual FK references → cycle
+	refA := "a"
+	refB := "b"
+	schemaPublic := "public"
+	desiredTables := orderedmap.New[string, *model.Table]()
+	tblA := &model.Table{Schema: "public", Name: "a"}
+	tblA.Columns = orderedmap.New[string, *model.Column]()
+	tblA.Indexes = orderedmap.New[string, *model.Index]()
+	tblA.Constraints = orderedmap.New[string, *model.Constraint]()
+	tblA.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tblA.ForeignKeys.Set("a_b_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "a_b_fk"},
+		RefSchema:  &schemaPublic,
+		RefTable:   &refB,
+	})
+	desiredTables.Set("public.a", tblA)
+
+	tblB := &model.Table{Schema: "public", Name: "b"}
+	tblB.Columns = orderedmap.New[string, *model.Column]()
+	tblB.Indexes = orderedmap.New[string, *model.Index]()
+	tblB.Constraints = orderedmap.New[string, *model.Constraint]()
+	tblB.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tblB.ForeignKeys.Set("b_a_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "b_a_fk"},
+		RefSchema:  &schemaPublic,
+		RefTable:   &refA,
+	})
+	desiredTables.Set("public.b", tblB)
+
+	enumDiff := &diff.EnumDiffResult{Stmts: []string{"CREATE TYPE public.s AS ENUM ('x');"}}
+	domainDiff := &diff.DomainDiffResult{}
+	tableDiff := &diff.TableDiffResult{Stmts: []string{"CREATE TABLE public.a (id integer);"}}
+	viewDiff := &diff.ViewDiffResult{}
+
+	result := pistachio.OrderStatements(
+		desiredEnums, desiredDomains, desiredTables, desiredViews,
+		enumDiff, domainDiff, tableDiff, viewDiff,
+	)
+
+	// Should still produce output (via fallback)
+	require.NotEmpty(t, result)
+	assert.Contains(t, result[0], "CREATE TYPE")
+	assert.Contains(t, result[1], "CREATE TABLE")
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,3 +1,7 @@
 package pistachio
 
-var ResolvePreSQL = resolvePreSQL
+var (
+	ResolvePreSQL     = resolvePreSQL
+	ExtractObjectName = extractObjectName
+	OrderStatements   = orderStatements
+)

--- a/testdata/apply/alter_column_type_and_drop_domain.yml
+++ b/testdata/apply/alter_column_type_and_drop_domain.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE DOMAIN public.user_name AS text;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name public.user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/create_enum_domain_table_view_chain.yml
+++ b/testdata/apply/create_enum_domain_table_view_chain.yml
@@ -1,0 +1,25 @@
+init: ""
+desired: |
+  CREATE VIEW public.user_list AS SELECT id, name FROM public.users;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name public.user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE DOMAIN public.user_name AS text;
+applied: |
+  -- public.user_name
+  CREATE DOMAIN public.user_name AS text;
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_list
+  CREATE OR REPLACE VIEW public.user_list AS
+  SELECT users.id,
+      users.name
+     FROM users;

--- a/testdata/apply/create_view_depends_on_view.yml
+++ b/testdata/apply/create_view_depends_on_view.yml
@@ -1,0 +1,33 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_user_count AS SELECT count(*) AS cnt FROM public.active_users;
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE name IS NOT NULL;
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_user_count
+  CREATE OR REPLACE VIEW public.active_user_count AS
+  SELECT count(*) AS cnt
+     FROM active_users;
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT users.id,
+      users.name
+     FROM users
+    WHERE users.name IS NOT NULL;

--- a/testdata/plan/alter_column_type_and_drop_domain.yml
+++ b/testdata/plan/alter_column_type_and_drop_domain.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE DOMAIN public.user_name AS text;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name public.user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;
+  ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;
+  DROP DOMAIN public.user_name;

--- a/testdata/plan/create_enum_domain_table_view_chain.yml
+++ b/testdata/plan/create_enum_domain_table_view_chain.yml
@@ -1,0 +1,18 @@
+init: ""
+desired: |
+  CREATE VIEW public.user_list AS SELECT id, name FROM public.users;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name public.user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE DOMAIN public.user_name AS text;
+plan: |
+  CREATE DOMAIN public.user_name AS text;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name public.user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE OR REPLACE VIEW public.user_list AS
+  SELECT id, name FROM public.users;

--- a/testdata/plan/create_view_depends_on_view.yml
+++ b/testdata/plan/create_view_depends_on_view.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE name IS NOT NULL;
+  CREATE VIEW public.active_user_count AS SELECT count(*) AS cnt FROM public.active_users;
+plan: |
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id, name FROM public.users WHERE name IS NOT NULL;
+  CREATE OR REPLACE VIEW public.active_user_count AS
+  SELECT count(*) AS cnt FROM public.active_users;

--- a/testdata/plan/create_view_depends_on_view_reverse_order.yml
+++ b/testdata/plan/create_view_depends_on_view_reverse_order.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_user_count AS SELECT count(*) AS cnt FROM public.active_users;
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE name IS NOT NULL;
+plan: |
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id, name FROM public.users WHERE name IS NOT NULL;
+  CREATE OR REPLACE VIEW public.active_user_count AS
+  SELECT count(*) AS cnt FROM public.active_users;

--- a/testdata/plan/drop_view_depends_on_view.yml
+++ b/testdata/plan/drop_view_depends_on_view.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE name IS NOT NULL;
+  CREATE VIEW public.active_user_count AS SELECT count(*) AS cnt FROM public.active_users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  DROP VIEW public.active_user_count;
+  DROP VIEW public.active_users;

--- a/toposort/deps.go
+++ b/toposort/deps.go
@@ -15,8 +15,14 @@ type StmtInfo struct {
 }
 
 // ExtractDeps parses SQL containing multiple CREATE statements and returns
-// dependency information for each object.
-func ExtractDeps(sql string) ([]*StmtInfo, error) {
+// dependency information for each object. It uses defaultSchema to qualify
+// unqualified identifiers.
+func ExtractDeps(sql string, defaultSchema ...string) ([]*StmtInfo, error) {
+	schema := "public"
+	if len(defaultSchema) > 0 && defaultSchema[0] != "" {
+		schema = defaultSchema[0]
+	}
+
 	result, err := pg_query.Parse(sql)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SQL: %w", err)
@@ -25,14 +31,14 @@ func ExtractDeps(sql string) ([]*StmtInfo, error) {
 	// First pass: collect all defined object names so we only track internal deps
 	defined := make(map[string]bool)
 	for _, rawStmt := range result.Stmts {
-		if name := objectName(rawStmt); name != "" {
+		if name := objectName(rawStmt, schema); name != "" {
 			defined[name] = true
 		}
 	}
 
 	var stmts []*StmtInfo
 	for _, rawStmt := range result.Stmts {
-		name := objectName(rawStmt)
+		name := objectName(rawStmt, schema)
 		if name == "" {
 			continue
 		}
@@ -44,7 +50,7 @@ func ExtractDeps(sql string) ([]*StmtInfo, error) {
 			return nil, fmt.Errorf("failed to deparse statement for %s: %w", name, err)
 		}
 
-		deps := extractStmtDeps(rawStmt, defined)
+		deps := extractStmtDeps(rawStmt, schema, defined)
 
 		stmts = append(stmts, &StmtInfo{
 			Name: name,
@@ -57,7 +63,7 @@ func ExtractDeps(sql string) ([]*StmtInfo, error) {
 }
 
 // objectName extracts the fully qualified name from a CREATE statement.
-func objectName(rawStmt *pg_query.RawStmt) string {
+func objectName(rawStmt *pg_query.RawStmt, defaultSchema string) string {
 	node := rawStmt.Stmt
 	if node == nil {
 		return ""
@@ -65,13 +71,13 @@ func objectName(rawStmt *pg_query.RawStmt) string {
 
 	switch n := node.Node.(type) {
 	case *pg_query.Node_CreateStmt:
-		return rangeVarName(n.CreateStmt.Relation)
+		return qualifyRangeVar(n.CreateStmt.Relation, defaultSchema)
 	case *pg_query.Node_ViewStmt:
-		return rangeVarName(n.ViewStmt.View)
+		return qualifyRangeVar(n.ViewStmt.View, defaultSchema)
 	case *pg_query.Node_CreateEnumStmt:
-		return typeNameFromNames(n.CreateEnumStmt.TypeName)
+		return typeNameFromNames(n.CreateEnumStmt.TypeName, defaultSchema)
 	case *pg_query.Node_CreateDomainStmt:
-		return typeNameFromNames(n.CreateDomainStmt.Domainname)
+		return typeNameFromNames(n.CreateDomainStmt.Domainname, defaultSchema)
 	}
 
 	return ""
@@ -79,22 +85,22 @@ func objectName(rawStmt *pg_query.RawStmt) string {
 
 // extractStmtDeps extracts dependency names from a statement, filtered to only
 // include names that are defined in the same SQL input.
-func extractStmtDeps(rawStmt *pg_query.RawStmt, defined map[string]bool) []string {
+func extractStmtDeps(rawStmt *pg_query.RawStmt, defaultSchema string, defined map[string]bool) []string {
 	node := rawStmt.Stmt
 	if node == nil {
 		return nil
 	}
 
 	seen := make(map[string]bool)
-	selfName := objectName(rawStmt)
+	selfName := objectName(rawStmt, defaultSchema)
 
 	switch n := node.Node.(type) {
 	case *pg_query.Node_CreateStmt:
-		extractCreateStmtDeps(n.CreateStmt, seen)
+		extractCreateStmtDeps(n.CreateStmt, defaultSchema, seen)
 	case *pg_query.Node_ViewStmt:
-		extractSelectDeps(n.ViewStmt.Query, seen)
+		extractSelectDeps(n.ViewStmt.Query, defaultSchema, seen)
 	case *pg_query.Node_CreateDomainStmt:
-		extractDomainDeps(n.CreateDomainStmt, seen)
+		extractDomainDeps(n.CreateDomainStmt, defaultSchema, seen)
 	}
 
 	var deps []string
@@ -108,18 +114,18 @@ func extractStmtDeps(rawStmt *pg_query.RawStmt, defined map[string]bool) []strin
 }
 
 // extractCreateStmtDeps extracts dependencies from a CREATE TABLE statement.
-func extractCreateStmtDeps(cs *pg_query.CreateStmt, seen map[string]bool) {
+func extractCreateStmtDeps(cs *pg_query.CreateStmt, defaultSchema string, seen map[string]bool) {
 	// Column type references
 	for _, elt := range cs.TableElts {
 		if cd := elt.GetColumnDef(); cd != nil {
-			if typeName := resolveTypeName(cd.TypeName); typeName != "" {
+			if typeName := resolveTypeName(cd.TypeName, defaultSchema); typeName != "" {
 				seen[typeName] = true
 			}
 			// Column-level constraints (inline FK)
 			for _, con := range cd.Constraints {
 				if c := con.GetConstraint(); c != nil {
 					if c.Contype == pg_query.ConstrType_CONSTR_FOREIGN && c.Pktable != nil {
-						seen[rangeVarName(c.Pktable)] = true
+						seen[qualifyRangeVar(c.Pktable, defaultSchema)] = true
 					}
 				}
 			}
@@ -127,7 +133,7 @@ func extractCreateStmtDeps(cs *pg_query.CreateStmt, seen map[string]bool) {
 		// Table-level constraints
 		if con := elt.GetConstraint(); con != nil {
 			if con.Contype == pg_query.ConstrType_CONSTR_FOREIGN && con.Pktable != nil {
-				seen[rangeVarName(con.Pktable)] = true
+				seen[qualifyRangeVar(con.Pktable, defaultSchema)] = true
 			}
 		}
 	}
@@ -135,13 +141,13 @@ func extractCreateStmtDeps(cs *pg_query.CreateStmt, seen map[string]bool) {
 	// Partition parent
 	for _, inh := range cs.InhRelations {
 		if rv := inh.GetRangeVar(); rv != nil {
-			seen[rangeVarName(rv)] = true
+			seen[qualifyRangeVar(rv, defaultSchema)] = true
 		}
 	}
 }
 
 // extractSelectDeps recursively extracts table references from a SELECT statement.
-func extractSelectDeps(node *pg_query.Node, seen map[string]bool) {
+func extractSelectDeps(node *pg_query.Node, defaultSchema string, seen map[string]bool) {
 	if node == nil {
 		return
 	}
@@ -153,62 +159,63 @@ func extractSelectDeps(node *pg_query.Node, seen map[string]bool) {
 
 	// FROM clause
 	for _, from := range ss.FromClause {
-		extractFromDeps(from, seen)
+		extractFromDeps(from, defaultSchema, seen)
 	}
 
 	// Set operations (UNION, INTERSECT, EXCEPT)
 	if ss.Larg != nil {
-		extractSelectDeps(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Larg}}, seen)
+		extractSelectDeps(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Larg}}, defaultSchema, seen)
 	}
 	if ss.Rarg != nil {
-		extractSelectDeps(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Rarg}}, seen)
+		extractSelectDeps(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Rarg}}, defaultSchema, seen)
 	}
 }
 
 // extractFromDeps extracts table references from FROM clause items.
-func extractFromDeps(node *pg_query.Node, seen map[string]bool) {
+func extractFromDeps(node *pg_query.Node, defaultSchema string, seen map[string]bool) {
 	if node == nil {
 		return
 	}
 
 	if rv := node.GetRangeVar(); rv != nil {
-		seen[rangeVarName(rv)] = true
+		seen[qualifyRangeVar(rv, defaultSchema)] = true
 		return
 	}
 
 	if join := node.GetJoinExpr(); join != nil {
-		extractFromDeps(join.Larg, seen)
-		extractFromDeps(join.Rarg, seen)
+		extractFromDeps(join.Larg, defaultSchema, seen)
+		extractFromDeps(join.Rarg, defaultSchema, seen)
 		return
 	}
 
 	if sub := node.GetRangeSubselect(); sub != nil {
-		extractSelectDeps(sub.Subquery, seen)
+		extractSelectDeps(sub.Subquery, defaultSchema, seen)
 		return
 	}
 }
 
 // extractDomainDeps extracts dependencies from a CREATE DOMAIN statement.
-func extractDomainDeps(ds *pg_query.CreateDomainStmt, seen map[string]bool) {
-	if typeName := resolveTypeName(ds.TypeName); typeName != "" {
+func extractDomainDeps(ds *pg_query.CreateDomainStmt, defaultSchema string, seen map[string]bool) {
+	if typeName := resolveTypeName(ds.TypeName, defaultSchema); typeName != "" {
 		seen[typeName] = true
 	}
 }
 
-// rangeVarName returns "schema.name" from a RangeVar, defaulting schema to "public".
-func rangeVarName(rv *pg_query.RangeVar) string {
-	if rv == nil {
+// qualifyRangeVar returns "schema.name" from a RangeVar, using defaultSchema
+// when the RangeVar has no schema.
+func qualifyRangeVar(rv *pg_query.RangeVar, defaultSchema string) string {
+	if rv == nil || rv.Relname == "" {
 		return ""
 	}
 	schema := rv.Schemaname
 	if schema == "" {
-		schema = "public"
+		schema = defaultSchema
 	}
 	return schema + "." + rv.Relname
 }
 
 // typeNameFromNames builds "schema.name" from a list of name nodes.
-func typeNameFromNames(names []*pg_query.Node) string {
+func typeNameFromNames(names []*pg_query.Node, defaultSchema string) string {
 	var parts []string
 	for _, n := range names {
 		if s := n.GetString_(); s != nil {
@@ -219,14 +226,14 @@ func typeNameFromNames(names []*pg_query.Node) string {
 		return ""
 	}
 	if len(parts) == 1 {
-		return "public." + parts[0]
+		return defaultSchema + "." + parts[0]
 	}
 	return strings.Join(parts, ".")
 }
 
 // resolveTypeName extracts a user-defined type name from a TypeName node.
 // Returns "" for built-in types (pg_catalog.*).
-func resolveTypeName(tn *pg_query.TypeName) string {
+func resolveTypeName(tn *pg_query.TypeName, defaultSchema string) string {
 	if tn == nil {
 		return ""
 	}
@@ -244,7 +251,7 @@ func resolveTypeName(tn *pg_query.TypeName) string {
 		return ""
 	}
 	if len(parts) == 1 {
-		return "public." + parts[0]
+		return defaultSchema + "." + parts[0]
 	}
 	return strings.Join(parts, ".")
 }

--- a/toposort/deps.go
+++ b/toposort/deps.go
@@ -2,6 +2,7 @@ package toposort
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
@@ -109,6 +110,7 @@ func extractStmtDeps(rawStmt *pg_query.RawStmt, defaultSchema string, defined ma
 			deps = append(deps, dep)
 		}
 	}
+	sort.Strings(deps)
 
 	return deps
 }

--- a/toposort/deps.go
+++ b/toposort/deps.go
@@ -220,6 +220,36 @@ func extractExprDeps(node *pg_query.Node, defaultSchema string, seen map[string]
 		}
 		return
 	}
+
+	if fc := node.GetFuncCall(); fc != nil {
+		for _, arg := range fc.Args {
+			extractExprDeps(arg, defaultSchema, seen)
+		}
+		return
+	}
+
+	if ce := node.GetCoalesceExpr(); ce != nil {
+		for _, arg := range ce.Args {
+			extractExprDeps(arg, defaultSchema, seen)
+		}
+		return
+	}
+
+	if cs := node.GetCaseExpr(); cs != nil {
+		if cs.Arg != nil {
+			extractExprDeps(cs.Arg, defaultSchema, seen)
+		}
+		for _, when := range cs.Args {
+			if w := when.GetCaseWhen(); w != nil {
+				extractExprDeps(w.Expr, defaultSchema, seen)
+				extractExprDeps(w.Result, defaultSchema, seen)
+			}
+		}
+		if cs.Defresult != nil {
+			extractExprDeps(cs.Defresult, defaultSchema, seen)
+		}
+		return
+	}
 }
 
 // extractFromDeps extracts table references from FROM clause items.

--- a/toposort/deps.go
+++ b/toposort/deps.go
@@ -1,0 +1,250 @@
+package toposort
+
+import (
+	"fmt"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// StmtInfo holds a parsed statement and its extracted metadata.
+type StmtInfo struct {
+	Name string   // Fully qualified object name (e.g. "public.users")
+	SQL  string   // Deparsed SQL statement
+	Deps []string // Names of objects this statement depends on
+}
+
+// ExtractDeps parses SQL containing multiple CREATE statements and returns
+// dependency information for each object.
+func ExtractDeps(sql string) ([]*StmtInfo, error) {
+	result, err := pg_query.Parse(sql)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SQL: %w", err)
+	}
+
+	// First pass: collect all defined object names so we only track internal deps
+	defined := make(map[string]bool)
+	for _, rawStmt := range result.Stmts {
+		if name := objectName(rawStmt); name != "" {
+			defined[name] = true
+		}
+	}
+
+	var stmts []*StmtInfo
+	for _, rawStmt := range result.Stmts {
+		name := objectName(rawStmt)
+		if name == "" {
+			continue
+		}
+
+		deparsed, err := pg_query.Deparse(&pg_query.ParseResult{
+			Stmts: []*pg_query.RawStmt{rawStmt},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to deparse statement for %s: %w", name, err)
+		}
+
+		deps := extractStmtDeps(rawStmt, defined)
+
+		stmts = append(stmts, &StmtInfo{
+			Name: name,
+			SQL:  deparsed,
+			Deps: deps,
+		})
+	}
+
+	return stmts, nil
+}
+
+// objectName extracts the fully qualified name from a CREATE statement.
+func objectName(rawStmt *pg_query.RawStmt) string {
+	node := rawStmt.Stmt
+	if node == nil {
+		return ""
+	}
+
+	switch n := node.Node.(type) {
+	case *pg_query.Node_CreateStmt:
+		return rangeVarName(n.CreateStmt.Relation)
+	case *pg_query.Node_ViewStmt:
+		return rangeVarName(n.ViewStmt.View)
+	case *pg_query.Node_CreateEnumStmt:
+		return typeNameFromNames(n.CreateEnumStmt.TypeName)
+	case *pg_query.Node_CreateDomainStmt:
+		return typeNameFromNames(n.CreateDomainStmt.Domainname)
+	}
+
+	return ""
+}
+
+// extractStmtDeps extracts dependency names from a statement, filtered to only
+// include names that are defined in the same SQL input.
+func extractStmtDeps(rawStmt *pg_query.RawStmt, defined map[string]bool) []string {
+	node := rawStmt.Stmt
+	if node == nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	selfName := objectName(rawStmt)
+
+	switch n := node.Node.(type) {
+	case *pg_query.Node_CreateStmt:
+		extractCreateStmtDeps(n.CreateStmt, seen)
+	case *pg_query.Node_ViewStmt:
+		extractSelectDeps(n.ViewStmt.Query, seen)
+	case *pg_query.Node_CreateDomainStmt:
+		extractDomainDeps(n.CreateDomainStmt, seen)
+	}
+
+	var deps []string
+	for dep := range seen {
+		if dep != selfName && defined[dep] {
+			deps = append(deps, dep)
+		}
+	}
+
+	return deps
+}
+
+// extractCreateStmtDeps extracts dependencies from a CREATE TABLE statement.
+func extractCreateStmtDeps(cs *pg_query.CreateStmt, seen map[string]bool) {
+	// Column type references
+	for _, elt := range cs.TableElts {
+		if cd := elt.GetColumnDef(); cd != nil {
+			if typeName := resolveTypeName(cd.TypeName); typeName != "" {
+				seen[typeName] = true
+			}
+			// Column-level constraints (inline FK)
+			for _, con := range cd.Constraints {
+				if c := con.GetConstraint(); c != nil {
+					if c.Contype == pg_query.ConstrType_CONSTR_FOREIGN && c.Pktable != nil {
+						seen[rangeVarName(c.Pktable)] = true
+					}
+				}
+			}
+		}
+		// Table-level constraints
+		if con := elt.GetConstraint(); con != nil {
+			if con.Contype == pg_query.ConstrType_CONSTR_FOREIGN && con.Pktable != nil {
+				seen[rangeVarName(con.Pktable)] = true
+			}
+		}
+	}
+
+	// Partition parent
+	for _, inh := range cs.InhRelations {
+		if rv := inh.GetRangeVar(); rv != nil {
+			seen[rangeVarName(rv)] = true
+		}
+	}
+}
+
+// extractSelectDeps recursively extracts table references from a SELECT statement.
+func extractSelectDeps(node *pg_query.Node, seen map[string]bool) {
+	if node == nil {
+		return
+	}
+
+	ss := node.GetSelectStmt()
+	if ss == nil {
+		return
+	}
+
+	// FROM clause
+	for _, from := range ss.FromClause {
+		extractFromDeps(from, seen)
+	}
+
+	// Set operations (UNION, INTERSECT, EXCEPT)
+	if ss.Larg != nil {
+		extractSelectDeps(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Larg}}, seen)
+	}
+	if ss.Rarg != nil {
+		extractSelectDeps(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Rarg}}, seen)
+	}
+}
+
+// extractFromDeps extracts table references from FROM clause items.
+func extractFromDeps(node *pg_query.Node, seen map[string]bool) {
+	if node == nil {
+		return
+	}
+
+	if rv := node.GetRangeVar(); rv != nil {
+		seen[rangeVarName(rv)] = true
+		return
+	}
+
+	if join := node.GetJoinExpr(); join != nil {
+		extractFromDeps(join.Larg, seen)
+		extractFromDeps(join.Rarg, seen)
+		return
+	}
+
+	if sub := node.GetRangeSubselect(); sub != nil {
+		extractSelectDeps(sub.Subquery, seen)
+		return
+	}
+}
+
+// extractDomainDeps extracts dependencies from a CREATE DOMAIN statement.
+func extractDomainDeps(ds *pg_query.CreateDomainStmt, seen map[string]bool) {
+	if typeName := resolveTypeName(ds.TypeName); typeName != "" {
+		seen[typeName] = true
+	}
+}
+
+// rangeVarName returns "schema.name" from a RangeVar, defaulting schema to "public".
+func rangeVarName(rv *pg_query.RangeVar) string {
+	if rv == nil {
+		return ""
+	}
+	schema := rv.Schemaname
+	if schema == "" {
+		schema = "public"
+	}
+	return schema + "." + rv.Relname
+}
+
+// typeNameFromNames builds "schema.name" from a list of name nodes.
+func typeNameFromNames(names []*pg_query.Node) string {
+	var parts []string
+	for _, n := range names {
+		if s := n.GetString_(); s != nil {
+			parts = append(parts, s.Sval)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	if len(parts) == 1 {
+		return "public." + parts[0]
+	}
+	return strings.Join(parts, ".")
+}
+
+// resolveTypeName extracts a user-defined type name from a TypeName node.
+// Returns "" for built-in types (pg_catalog.*).
+func resolveTypeName(tn *pg_query.TypeName) string {
+	if tn == nil {
+		return ""
+	}
+	var parts []string
+	for _, n := range tn.Names {
+		if s := n.GetString_(); s != nil {
+			parts = append(parts, s.Sval)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	// Built-in types are in pg_catalog
+	if parts[0] == "pg_catalog" {
+		return ""
+	}
+	if len(parts) == 1 {
+		return "public." + parts[0]
+	}
+	return strings.Join(parts, ".")
+}

--- a/toposort/deps.go
+++ b/toposort/deps.go
@@ -157,9 +157,35 @@ func extractSelectDeps(node *pg_query.Node, defaultSchema string, seen map[strin
 		return
 	}
 
+	// CTEs (WITH clause)
+	if ss.WithClause != nil {
+		for _, cte := range ss.WithClause.Ctes {
+			if c := cte.GetCommonTableExpr(); c != nil {
+				extractSelectDeps(c.Ctequery, defaultSchema, seen)
+			}
+		}
+	}
+
 	// FROM clause
 	for _, from := range ss.FromClause {
 		extractFromDeps(from, defaultSchema, seen)
+	}
+
+	// Target list (scalar subqueries in SELECT)
+	for _, target := range ss.TargetList {
+		if rt := target.GetResTarget(); rt != nil && rt.Val != nil {
+			extractExprDeps(rt.Val, defaultSchema, seen)
+		}
+	}
+
+	// WHERE clause
+	if ss.WhereClause != nil {
+		extractExprDeps(ss.WhereClause, defaultSchema, seen)
+	}
+
+	// HAVING clause
+	if ss.HavingClause != nil {
+		extractExprDeps(ss.HavingClause, defaultSchema, seen)
 	}
 
 	// Set operations (UNION, INTERSECT, EXCEPT)
@@ -168,6 +194,31 @@ func extractSelectDeps(node *pg_query.Node, defaultSchema string, seen map[strin
 	}
 	if ss.Rarg != nil {
 		extractSelectDeps(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Rarg}}, defaultSchema, seen)
+	}
+}
+
+// extractExprDeps walks expression nodes to find SubLink (subquery) references.
+func extractExprDeps(node *pg_query.Node, defaultSchema string, seen map[string]bool) {
+	if node == nil {
+		return
+	}
+
+	if sl := node.GetSubLink(); sl != nil {
+		extractSelectDeps(sl.Subselect, defaultSchema, seen)
+		return
+	}
+
+	if expr := node.GetAExpr(); expr != nil {
+		extractExprDeps(expr.Lexpr, defaultSchema, seen)
+		extractExprDeps(expr.Rexpr, defaultSchema, seen)
+		return
+	}
+
+	if boolExpr := node.GetBoolExpr(); boolExpr != nil {
+		for _, arg := range boolExpr.Args {
+			extractExprDeps(arg, defaultSchema, seen)
+		}
+		return
 	}
 }
 
@@ -185,6 +236,9 @@ func extractFromDeps(node *pg_query.Node, defaultSchema string, seen map[string]
 	if join := node.GetJoinExpr(); join != nil {
 		extractFromDeps(join.Larg, defaultSchema, seen)
 		extractFromDeps(join.Rarg, defaultSchema, seen)
+		if join.Quals != nil {
+			extractExprDeps(join.Quals, defaultSchema, seen)
+		}
 		return
 	}
 

--- a/toposort/graph.go
+++ b/toposort/graph.go
@@ -1,0 +1,89 @@
+package toposort
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Graph is a directed acyclic graph for topological sorting.
+type Graph struct {
+	nodes map[string]bool
+	edges map[string][]string // from → [to ...] meaning "from depends on to"
+}
+
+// NewGraph creates a new empty graph.
+func NewGraph() *Graph {
+	return &Graph{
+		nodes: make(map[string]bool),
+		edges: make(map[string][]string),
+	}
+}
+
+// AddNode adds a node to the graph.
+func (g *Graph) AddNode(name string) {
+	g.nodes[name] = true
+}
+
+// AddEdge adds a dependency edge: "from" depends on "to".
+// Both nodes are implicitly added.
+func (g *Graph) AddEdge(from, to string) {
+	g.nodes[from] = true
+	g.nodes[to] = true
+	g.edges[from] = append(g.edges[from], to)
+}
+
+// Sort performs topological sort using Kahn's algorithm.
+// Returns nodes in dependency order (dependencies first).
+// Returns an error if a cycle is detected.
+// Nodes with no dependency ordering are sorted alphabetically for stability.
+func (g *Graph) Sort() ([]string, error) {
+	// Build in-degree map and reverse adjacency list
+	inDegree := make(map[string]int)
+	dependents := make(map[string][]string) // to → [from ...] (who depends on to)
+
+	for n := range g.nodes {
+		inDegree[n] = 0
+	}
+
+	for from, tos := range g.edges {
+		for _, to := range tos {
+			// "from depends on to" means edge to → from in execution order
+			inDegree[from]++
+			dependents[to] = append(dependents[to], from)
+		}
+	}
+
+	// Collect nodes with no dependencies
+	var queue []string
+	for n := range g.nodes {
+		if inDegree[n] == 0 {
+			queue = append(queue, n)
+		}
+	}
+	sort.Strings(queue)
+
+	var result []string
+	for len(queue) > 0 {
+		// Pop first (alphabetically smallest for stability)
+		node := queue[0]
+		queue = queue[1:]
+		result = append(result, node)
+
+		// Reduce in-degree for dependents
+		deps := dependents[node]
+		sort.Strings(deps)
+		for _, dep := range deps {
+			inDegree[dep]--
+			if inDegree[dep] == 0 {
+				queue = append(queue, dep)
+			}
+		}
+		sort.Strings(queue)
+	}
+
+	if len(result) != len(g.nodes) {
+		return nil, fmt.Errorf("cycle detected: sorted %d of %d nodes", len(result), len(g.nodes))
+	}
+
+	return result, nil
+}

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -1,0 +1,167 @@
+package toposort
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// OrderFromSchema builds a dependency graph from parsed model objects and
+// returns the object names in topological order (dependencies first).
+func OrderFromSchema(
+	enums *orderedmap.Map[string, *model.Enum],
+	domains *orderedmap.Map[string, *model.Domain],
+	tables *orderedmap.Map[string, *model.Table],
+	views *orderedmap.Map[string, *model.View],
+) ([]string, error) {
+	g := NewGraph()
+	defined := collectDefined(enums, domains, tables, views)
+
+	// Enums: no dependencies (leaf nodes)
+	for k := range enums.Keys() {
+		g.AddNode(k)
+	}
+
+	// Domains: may depend on enums or other domains via base type
+	for k, d := range domains.All() {
+		g.AddNode(k)
+		if dep := resolveBaseTypeDep(d.BaseType, defined); dep != "" {
+			g.AddEdge(k, dep)
+		}
+	}
+
+	// Tables: may depend on enums/domains (column types) and other tables (FKs)
+	for k, t := range tables.All() {
+		g.AddNode(k)
+
+		// Column type dependencies
+		if t.Columns != nil {
+			for _, col := range t.Columns.CollectValues() {
+				if dep := resolveBaseTypeDep(col.TypeName, defined); dep != "" {
+					g.AddEdge(k, dep)
+				}
+			}
+		}
+
+		// FK dependencies
+		if t.ForeignKeys != nil {
+			for _, fk := range t.ForeignKeys.CollectValues() {
+				refSchema := "public"
+				if fk.RefSchema != nil {
+					refSchema = *fk.RefSchema
+				}
+				if fk.RefTable != nil {
+					ref := refSchema + "." + *fk.RefTable
+					if defined[ref] {
+						g.AddEdge(k, ref)
+					}
+				}
+			}
+		}
+
+		// Partition parent dependency
+		if t.PartitionOf != nil {
+			if defined[*t.PartitionOf] {
+				g.AddEdge(k, *t.PartitionOf)
+			}
+		}
+	}
+
+	// Views: depend on tables/views referenced in their definition
+	for k, v := range views.All() {
+		g.AddNode(k)
+		deps := extractViewDeps(v.Definition, defined)
+		for _, dep := range deps {
+			if dep != k {
+				g.AddEdge(k, dep)
+			}
+		}
+	}
+
+	order, err := g.Sort()
+	if err != nil {
+		return nil, fmt.Errorf("schema dependency sort failed: %w", err)
+	}
+
+	return order, nil
+}
+
+// collectDefined returns a set of all defined object names.
+func collectDefined(
+	enums *orderedmap.Map[string, *model.Enum],
+	domains *orderedmap.Map[string, *model.Domain],
+	tables *orderedmap.Map[string, *model.Table],
+	views *orderedmap.Map[string, *model.View],
+) map[string]bool {
+	defined := make(map[string]bool)
+	for k := range enums.Keys() {
+		defined[k] = true
+	}
+	for k := range domains.Keys() {
+		defined[k] = true
+	}
+	for k := range tables.Keys() {
+		defined[k] = true
+	}
+	for k := range views.Keys() {
+		defined[k] = true
+	}
+	return defined
+}
+
+// resolveBaseTypeDep checks if a type name refers to a defined object.
+// Handles both schema-qualified ("public.status") and unqualified ("status") names.
+func resolveBaseTypeDep(typeName string, defined map[string]bool) string {
+	if typeName == "" {
+		return ""
+	}
+
+	// Try as-is (already schema-qualified)
+	if defined[typeName] {
+		return typeName
+	}
+
+	// Try with public schema prefix
+	if !strings.Contains(typeName, ".") {
+		qualified := "public." + typeName
+		if defined[qualified] {
+			return qualified
+		}
+	}
+
+	// Array types: strip trailing []
+	base := strings.TrimSuffix(typeName, "[]")
+	if base != typeName {
+		return resolveBaseTypeDep(base, defined)
+	}
+
+	return ""
+}
+
+// extractViewDeps parses a view definition SQL to find referenced tables/views.
+// Uses simple identifier extraction since view definitions are already deparsed SQL.
+func extractViewDeps(definition string, defined map[string]bool) []string {
+	seen := make(map[string]bool)
+
+	// Check each defined object name to see if it appears in the view definition
+	for name := range defined {
+		if containsIdentifier(definition, name) {
+			seen[name] = true
+		}
+	}
+
+	deps := make([]string, 0, len(seen))
+	for dep := range seen {
+		deps = append(deps, dep)
+	}
+	sort.Strings(deps)
+	return deps
+}
+
+// containsIdentifier checks if a SQL string references a schema-qualified identifier.
+func containsIdentifier(sql, ident string) bool {
+	return strings.Contains(sql, ident)
+}

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -291,8 +291,6 @@ func collectRangeVars(node *pg_query.Node, defaultSchema string, defined map[str
 }
 
 // extractViewDepsFallback uses substring matching as a fallback when
-// pg_query parsing fails.
-// extractViewDepsFallback uses substring matching as a fallback when
 // pg_query parsing fails. It checks both fully-qualified names and
 // unqualified names (with defaultSchema prefix) to handle schemaless refs.
 func extractViewDepsFallback(definition, defaultSchema string, defined map[string]bool) []string {

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -187,12 +187,31 @@ func collectRangeVars(node *pg_query.Node, defaultSchema string, defined map[str
 
 	// Check if this is a SelectStmt and walk its parts
 	if ss := node.GetSelectStmt(); ss != nil {
+		// CTEs (WITH clause)
+		if ss.WithClause != nil {
+			for _, cte := range ss.WithClause.Ctes {
+				if c := cte.GetCommonTableExpr(); c != nil {
+					collectRangeVars(c.Ctequery, defaultSchema, defined, seen)
+				}
+			}
+		}
+		// FROM clause
 		for _, from := range ss.FromClause {
 			collectRangeVars(from, defaultSchema, defined, seen)
+		}
+		// Target list (scalar subqueries in SELECT)
+		for _, target := range ss.TargetList {
+			if rt := target.GetResTarget(); rt != nil && rt.Val != nil {
+				collectRangeVars(rt.Val, defaultSchema, defined, seen)
+			}
 		}
 		if ss.WhereClause != nil {
 			collectRangeVars(ss.WhereClause, defaultSchema, defined, seen)
 		}
+		if ss.HavingClause != nil {
+			collectRangeVars(ss.HavingClause, defaultSchema, defined, seen)
+		}
+		// Set operations (UNION, INTERSECT, EXCEPT)
 		if ss.Larg != nil {
 			collectRangeVars(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Larg}}, defaultSchema, defined, seen)
 		}
@@ -220,18 +239,6 @@ func collectRangeVars(node *pg_query.Node, defaultSchema string, defined map[str
 		collectRangeVars(sl.Subselect, defaultSchema, defined, seen)
 		return
 	}
-}
-
-// qualifyRangeVar returns the schema-qualified name from a RangeVar.
-func qualifyRangeVar(rv *pg_query.RangeVar, defaultSchema string) string {
-	if rv == nil || rv.Relname == "" {
-		return ""
-	}
-	schema := rv.Schemaname
-	if schema == "" {
-		schema = defaultSchema
-	}
-	return schema + "." + rv.Relname
 }
 
 // extractViewDepsFallback uses substring matching as a fallback when

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -148,9 +148,11 @@ func resolveTypeDep(typeName, defaultSchema string, defined map[string]bool) str
 func extractViewDeps(definition, defaultSchema string, defined map[string]bool) []string {
 	seen := make(map[string]bool)
 
-	// Parse the view definition as a SELECT statement
-	sql := "SELECT * FROM (" + definition + ") _sub"
-	result, err := pg_query.Parse(sql)
+	// Parse the view definition directly as a SELECT statement.
+	// pg_get_viewdef returns a standalone SELECT, so it can be parsed as-is.
+	def := strings.TrimSpace(definition)
+	def = strings.TrimSuffix(def, ";")
+	result, err := pg_query.Parse(def)
 	if err != nil {
 		// Fallback: try substring matching if parsing fails
 		return extractViewDepsFallback(definition, defined)
@@ -234,9 +236,53 @@ func collectRangeVars(node *pg_query.Node, defaultSchema string, defined map[str
 		return
 	}
 
-	// Walk sublink (subquery in WHERE clause, e.g., EXISTS, IN)
+	// Walk sublink (subquery in WHERE/HAVING clause, e.g., EXISTS, IN)
 	if sl := node.GetSubLink(); sl != nil {
 		collectRangeVars(sl.Subselect, defaultSchema, defined, seen)
+		return
+	}
+
+	// Walk expression nodes that may contain subqueries
+	if expr := node.GetAExpr(); expr != nil {
+		collectRangeVars(expr.Lexpr, defaultSchema, defined, seen)
+		collectRangeVars(expr.Rexpr, defaultSchema, defined, seen)
+		return
+	}
+
+	if boolExpr := node.GetBoolExpr(); boolExpr != nil {
+		for _, arg := range boolExpr.Args {
+			collectRangeVars(arg, defaultSchema, defined, seen)
+		}
+		return
+	}
+
+	if fc := node.GetFuncCall(); fc != nil {
+		for _, arg := range fc.Args {
+			collectRangeVars(arg, defaultSchema, defined, seen)
+		}
+		return
+	}
+
+	if ce := node.GetCoalesceExpr(); ce != nil {
+		for _, arg := range ce.Args {
+			collectRangeVars(arg, defaultSchema, defined, seen)
+		}
+		return
+	}
+
+	if cs := node.GetCaseExpr(); cs != nil {
+		if cs.Arg != nil {
+			collectRangeVars(cs.Arg, defaultSchema, defined, seen)
+		}
+		for _, when := range cs.Args {
+			if w := when.GetCaseWhen(); w != nil {
+				collectRangeVars(w.Expr, defaultSchema, defined, seen)
+				collectRangeVars(w.Result, defaultSchema, defined, seen)
+			}
+		}
+		if cs.Defresult != nil {
+			collectRangeVars(cs.Defresult, defaultSchema, defined, seen)
+		}
 		return
 	}
 }

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -155,7 +155,7 @@ func extractViewDeps(definition, defaultSchema string, defined map[string]bool) 
 	result, err := pg_query.Parse(def)
 	if err != nil {
 		// Fallback: try substring matching if parsing fails
-		return extractViewDepsFallback(definition, defined)
+		return extractViewDepsFallback(definition, defaultSchema, defined)
 	}
 
 	// Walk the AST to find RangeVar nodes
@@ -292,11 +292,22 @@ func collectRangeVars(node *pg_query.Node, defaultSchema string, defined map[str
 
 // extractViewDepsFallback uses substring matching as a fallback when
 // pg_query parsing fails.
-func extractViewDepsFallback(definition string, defined map[string]bool) []string {
+// extractViewDepsFallback uses substring matching as a fallback when
+// pg_query parsing fails. It checks both fully-qualified names and
+// unqualified names (with defaultSchema prefix) to handle schemaless refs.
+func extractViewDepsFallback(definition, defaultSchema string, defined map[string]bool) []string {
 	seen := make(map[string]bool)
 	for name := range defined {
 		if strings.Contains(definition, name) {
 			seen[name] = true
+			continue
+		}
+		// Try matching the unqualified part (e.g., "users" for "public.users")
+		parts := strings.SplitN(name, ".", 2)
+		if len(parts) == 2 && parts[0] == defaultSchema {
+			if strings.Contains(definition, parts[1]) {
+				seen[name] = true
+			}
 		}
 	}
 	deps := make([]string, 0, len(seen))

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -223,10 +223,13 @@ func collectRangeVars(node *pg_query.Node, defaultSchema string, defined map[str
 		return
 	}
 
-	// Walk JoinExpr
+	// Walk JoinExpr (including join qualifiers that may contain subqueries)
 	if join := node.GetJoinExpr(); join != nil {
 		collectRangeVars(join.Larg, defaultSchema, defined, seen)
 		collectRangeVars(join.Rarg, defaultSchema, defined, seen)
+		if join.Quals != nil {
+			collectRangeVars(join.Quals, defaultSchema, defined, seen)
+		}
 		return
 	}
 

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
 )
@@ -28,7 +29,7 @@ func OrderFromSchema(
 	// Domains: may depend on enums or other domains via base type
 	for k, d := range domains.All() {
 		g.AddNode(k)
-		if dep := resolveBaseTypeDep(d.BaseType, defined); dep != "" {
+		if dep := resolveTypeDep(d.BaseType, d.Schema, defined); dep != "" {
 			g.AddEdge(k, dep)
 		}
 	}
@@ -40,7 +41,7 @@ func OrderFromSchema(
 		// Column type dependencies
 		if t.Columns != nil {
 			for _, col := range t.Columns.CollectValues() {
-				if dep := resolveBaseTypeDep(col.TypeName, defined); dep != "" {
+				if dep := resolveTypeDep(col.TypeName, t.Schema, defined); dep != "" {
 					g.AddEdge(k, dep)
 				}
 			}
@@ -49,7 +50,7 @@ func OrderFromSchema(
 		// FK dependencies
 		if t.ForeignKeys != nil {
 			for _, fk := range t.ForeignKeys.CollectValues() {
-				refSchema := "public"
+				refSchema := t.Schema
 				if fk.RefSchema != nil {
 					refSchema = *fk.RefSchema
 				}
@@ -73,7 +74,7 @@ func OrderFromSchema(
 	// Views: depend on tables/views referenced in their definition
 	for k, v := range views.All() {
 		g.AddNode(k)
-		deps := extractViewDeps(v.Definition, defined)
+		deps := extractViewDeps(v.Definition, v.Schema, defined)
 		for _, dep := range deps {
 			if dep != k {
 				g.AddEdge(k, dep)
@@ -112,9 +113,10 @@ func collectDefined(
 	return defined
 }
 
-// resolveBaseTypeDep checks if a type name refers to a defined object.
-// Handles both schema-qualified ("public.status") and unqualified ("status") names.
-func resolveBaseTypeDep(typeName string, defined map[string]bool) string {
+// resolveTypeDep checks if a type name refers to a defined object.
+// Handles schema-qualified ("public.status"), unqualified ("status"),
+// and array types ("status[]"). Uses defaultSchema to qualify unqualified names.
+func resolveTypeDep(typeName, defaultSchema string, defined map[string]bool) string {
 	if typeName == "" {
 		return ""
 	}
@@ -124,9 +126,9 @@ func resolveBaseTypeDep(typeName string, defined map[string]bool) string {
 		return typeName
 	}
 
-	// Try with public schema prefix
+	// Try with default schema prefix for unqualified names
 	if !strings.Contains(typeName, ".") {
-		qualified := "public." + typeName
+		qualified := defaultSchema + "." + typeName
 		if defined[qualified] {
 			return qualified
 		}
@@ -135,22 +137,28 @@ func resolveBaseTypeDep(typeName string, defined map[string]bool) string {
 	// Array types: strip trailing []
 	base := strings.TrimSuffix(typeName, "[]")
 	if base != typeName {
-		return resolveBaseTypeDep(base, defined)
+		return resolveTypeDep(base, defaultSchema, defined)
 	}
 
 	return ""
 }
 
 // extractViewDeps parses a view definition SQL to find referenced tables/views.
-// Uses simple identifier extraction since view definitions are already deparsed SQL.
-func extractViewDeps(definition string, defined map[string]bool) []string {
+// Uses pg_query to parse the SELECT statement and extract RangeVar references.
+func extractViewDeps(definition, defaultSchema string, defined map[string]bool) []string {
 	seen := make(map[string]bool)
 
-	// Check each defined object name to see if it appears in the view definition
-	for name := range defined {
-		if containsIdentifier(definition, name) {
-			seen[name] = true
-		}
+	// Parse the view definition as a SELECT statement
+	sql := "SELECT * FROM (" + definition + ") _sub"
+	result, err := pg_query.Parse(sql)
+	if err != nil {
+		// Fallback: try substring matching if parsing fails
+		return extractViewDepsFallback(definition, defined)
+	}
+
+	// Walk the AST to find RangeVar nodes
+	for _, stmt := range result.Stmts {
+		collectRangeVars(stmt.Stmt, defaultSchema, defined, seen)
 	}
 
 	deps := make([]string, 0, len(seen))
@@ -161,7 +169,84 @@ func extractViewDeps(definition string, defined map[string]bool) []string {
 	return deps
 }
 
-// containsIdentifier checks if a SQL string references a schema-qualified identifier.
-func containsIdentifier(sql, ident string) bool {
-	return strings.Contains(sql, ident)
+// collectRangeVars recursively walks a pg_query Node tree to find all
+// RangeVar references (table/view names in FROM clauses, JOINs, subqueries).
+func collectRangeVars(node *pg_query.Node, defaultSchema string, defined map[string]bool, seen map[string]bool) {
+	if node == nil {
+		return
+	}
+
+	// Check if this node is a RangeVar
+	if rv := node.GetRangeVar(); rv != nil {
+		name := qualifyRangeVar(rv, defaultSchema)
+		if name != "" && defined[name] {
+			seen[name] = true
+		}
+		return
+	}
+
+	// Check if this is a SelectStmt and walk its parts
+	if ss := node.GetSelectStmt(); ss != nil {
+		for _, from := range ss.FromClause {
+			collectRangeVars(from, defaultSchema, defined, seen)
+		}
+		if ss.WhereClause != nil {
+			collectRangeVars(ss.WhereClause, defaultSchema, defined, seen)
+		}
+		if ss.Larg != nil {
+			collectRangeVars(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Larg}}, defaultSchema, defined, seen)
+		}
+		if ss.Rarg != nil {
+			collectRangeVars(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Rarg}}, defaultSchema, defined, seen)
+		}
+		return
+	}
+
+	// Walk JoinExpr
+	if join := node.GetJoinExpr(); join != nil {
+		collectRangeVars(join.Larg, defaultSchema, defined, seen)
+		collectRangeVars(join.Rarg, defaultSchema, defined, seen)
+		return
+	}
+
+	// Walk subselect
+	if sub := node.GetRangeSubselect(); sub != nil {
+		collectRangeVars(sub.Subquery, defaultSchema, defined, seen)
+		return
+	}
+
+	// Walk sublink (subquery in WHERE clause, e.g., EXISTS, IN)
+	if sl := node.GetSubLink(); sl != nil {
+		collectRangeVars(sl.Subselect, defaultSchema, defined, seen)
+		return
+	}
+}
+
+// qualifyRangeVar returns the schema-qualified name from a RangeVar.
+func qualifyRangeVar(rv *pg_query.RangeVar, defaultSchema string) string {
+	if rv == nil || rv.Relname == "" {
+		return ""
+	}
+	schema := rv.Schemaname
+	if schema == "" {
+		schema = defaultSchema
+	}
+	return schema + "." + rv.Relname
+}
+
+// extractViewDepsFallback uses substring matching as a fallback when
+// pg_query parsing fails.
+func extractViewDepsFallback(definition string, defined map[string]bool) []string {
+	seen := make(map[string]bool)
+	for name := range defined {
+		if strings.Contains(definition, name) {
+			seen[name] = true
+		}
+	}
+	deps := make([]string, 0, len(seen))
+	for dep := range seen {
+		deps = append(deps, dep)
+	}
+	sort.Strings(deps)
+	return deps
 }

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -221,3 +221,98 @@ func TestOrderFromSchema_CyclicFK(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cycle detected")
 }
+
+func TestOrderFromSchema_UnqualifiedDomainBaseType(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	enums.Set("public.status", &model.Enum{Schema: "public", Name: "status", Values: []string{"a", "b"}})
+
+	domains := orderedmap.New[string, *model.Domain]()
+	// Domain with unqualified base type "status" (not "public.status")
+	domains.Set("public.user_status", &model.Domain{Schema: "public", Name: "user_status", BaseType: "status"})
+
+	tables := orderedmap.New[string, *model.Table]()
+	views := orderedmap.New[string, *model.View]()
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.status"], idx["public.user_status"], "enum before domain with unqualified base type")
+}
+
+func TestOrderFromSchema_PartitionChild(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	parentFQTN := "public.events"
+
+	tables := orderedmap.New[string, *model.Table]()
+
+	parent := &model.Table{Schema: "public", Name: "events", Partitioned: true}
+	parent.Columns = orderedmap.New[string, *model.Column]()
+	parent.Indexes = orderedmap.New[string, *model.Index]()
+	parent.Constraints = orderedmap.New[string, *model.Constraint]()
+	parent.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.events", parent)
+
+	child := &model.Table{Schema: "public", Name: "events_2024", PartitionOf: &parentFQTN}
+	child.Columns = orderedmap.New[string, *model.Column]()
+	child.Indexes = orderedmap.New[string, *model.Index]()
+	child.Constraints = orderedmap.New[string, *model.Constraint]()
+	child.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.events_2024", child)
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.events"], idx["public.events_2024"], "partition parent before child")
+}
+
+func TestOrderFromSchema_FKWithDefaultSchema(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	// FK with nil RefSchema (should default to "public")
+	refTable := "users"
+
+	tables := orderedmap.New[string, *model.Table]()
+	users := &model.Table{Schema: "public", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", users)
+
+	posts := &model.Table{Schema: "public", Name: "posts"}
+	posts.Columns = orderedmap.New[string, *model.Column]()
+	posts.Indexes = orderedmap.New[string, *model.Index]()
+	posts.Constraints = orderedmap.New[string, *model.Constraint]()
+	posts.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	posts.ForeignKeys.Set("posts_user_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "posts_user_fk"},
+		RefSchema:  nil, // nil schema → defaults to "public"
+		RefTable:   &refTable,
+	})
+	tables.Set("public.posts", posts)
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.posts"], "FK target before source with nil schema")
+}

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -499,6 +499,40 @@ func TestOrderFromSchema_ViewWithExistsSubquery(t *testing.T) {
 	assert.Less(t, idx["public.orders"], idx["public.users_with_orders"])
 }
 
+func TestOrderFromSchema_ViewWithJoinOnSubquery(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"users", "posts", "config"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.v", &model.View{
+		Schema:     "public",
+		Name:       "v",
+		Definition: "SELECT u.id FROM users u JOIN posts p ON u.id = p.user_id AND p.id > (SELECT val FROM config LIMIT 1)",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.v"])
+	assert.Less(t, idx["public.posts"], idx["public.v"])
+	assert.Less(t, idx["public.config"], idx["public.v"], "config referenced in JOIN ON subquery")
+}
+
 func TestOrderFromSchema_ViewWithCoalesce(t *testing.T) {
 	enums := orderedmap.New[string, *model.Enum]()
 	domains := orderedmap.New[string, *model.Domain]()

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -664,3 +664,35 @@ func TestOrderFromSchema_ViewWithUnparseableDefinition(t *testing.T) {
 	// Fallback substring matching should still detect the dependency
 	assert.Less(t, idx["public.users"], idx["public.bad_view"])
 }
+
+func TestOrderFromSchema_ViewWithUnparseableDefinition_SchemalessRef(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	users := &model.Table{Schema: "public", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", users)
+
+	views := orderedmap.New[string, *model.View]()
+	// Invalid SQL with schemaless reference "users" (not "public.users")
+	views.Set("public.bad_view", &model.View{
+		Schema:     "public",
+		Name:       "bad_view",
+		Definition: "NOT VALID SQL BUT MENTIONS users TABLE",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	// Fallback should match "users" part of "public.users" using defaultSchema
+	assert.Less(t, idx["public.users"], idx["public.bad_view"])
+}

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -316,3 +316,56 @@ func TestOrderFromSchema_FKWithDefaultSchema(t *testing.T) {
 
 	assert.Less(t, idx["public.users"], idx["public.posts"], "FK target before source with nil schema")
 }
+
+func TestOrderFromSchema_NonPublicSchema(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	enums.Set("myapp.status", &model.Enum{Schema: "myapp", Name: "status", Values: []string{"a", "b"}})
+
+	domains := orderedmap.New[string, *model.Domain]()
+	// Unqualified base type "status" should resolve using domain's schema "myapp"
+	domains.Set("myapp.user_status", &model.Domain{Schema: "myapp", Name: "user_status", BaseType: "status"})
+
+	tables := orderedmap.New[string, *model.Table]()
+	views := orderedmap.New[string, *model.View]()
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["myapp.status"], idx["myapp.user_status"], "enum before domain in non-public schema")
+}
+
+func TestOrderFromSchema_ViewWithSchemalessTableRef(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	users := &model.Table{Schema: "public", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", users)
+
+	views := orderedmap.New[string, *model.View]()
+	// View definition without schema prefix (as PostgreSQL catalog returns)
+	views.Set("public.v", &model.View{
+		Schema:     "public",
+		Name:       "v",
+		Definition: "SELECT users.id FROM users",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.v"], "table before view with schemaless ref")
+}

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -1,0 +1,223 @@
+package toposort_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+	"github.com/winebarrel/pistachio/toposort"
+)
+
+func TestOrderFromSchema_Basic(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	enums.Set("public.status", &model.Enum{Schema: "public", Name: "status", Values: []string{"active", "inactive"}})
+
+	domains := orderedmap.New[string, *model.Domain]()
+	domains.Set("public.user_status", &model.Domain{Schema: "public", Name: "user_status", BaseType: "public.status"})
+
+	tables := orderedmap.New[string, *model.Table]()
+	users := &model.Table{Schema: "public", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+	users.Columns.Set("status", &model.Column{Name: "status", TypeName: "public.user_status"})
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", users)
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.active_users", &model.View{
+		Schema:     "public",
+		Name:       "active_users",
+		Definition: "SELECT id, status FROM public.users WHERE status = 'active'",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.status"], idx["public.user_status"], "enum before domain")
+	assert.Less(t, idx["public.user_status"], idx["public.users"], "domain before table")
+	assert.Less(t, idx["public.users"], idx["public.active_users"], "table before view")
+}
+
+func TestOrderFromSchema_ForeignKey(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	tables := orderedmap.New[string, *model.Table]()
+
+	refTable := "users"
+	refSchema := "public"
+
+	posts := &model.Table{Schema: "public", Name: "posts"}
+	posts.Columns = orderedmap.New[string, *model.Column]()
+	posts.Indexes = orderedmap.New[string, *model.Index]()
+	posts.Constraints = orderedmap.New[string, *model.Constraint]()
+	posts.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	posts.ForeignKeys.Set("posts_user_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "posts_user_fk"},
+		RefSchema:  &refSchema,
+		RefTable:   &refTable,
+	})
+	tables.Set("public.posts", posts)
+
+	users := &model.Table{Schema: "public", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", users)
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.posts"], "FK target before FK source")
+}
+
+func TestOrderFromSchema_ViewToView(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	users := &model.Table{Schema: "public", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", users)
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.active_users", &model.View{
+		Schema:     "public",
+		Name:       "active_users",
+		Definition: "SELECT id FROM public.users",
+	})
+	views.Set("public.active_user_count", &model.View{
+		Schema:     "public",
+		Name:       "active_user_count",
+		Definition: "SELECT count(*) FROM public.active_users",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.active_users"], "table before view")
+	assert.Less(t, idx["public.active_users"], idx["public.active_user_count"], "view before dependent view")
+}
+
+func TestOrderFromSchema_Empty(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	tables := orderedmap.New[string, *model.Table]()
+	views := orderedmap.New[string, *model.View]()
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+	assert.Empty(t, order)
+}
+
+func TestOrderFromSchema_Independent(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"c_table", "a_table", "b_table"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+	// Independent objects should be sorted alphabetically
+	assert.Equal(t, []string{"public.a_table", "public.b_table", "public.c_table"}, order)
+}
+
+func TestOrderFromSchema_ArrayColumnType(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	enums.Set("public.status", &model.Enum{Schema: "public", Name: "status", Values: []string{"a", "b"}})
+
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	tbl := &model.Table{Schema: "public", Name: "users"}
+	tbl.Columns = orderedmap.New[string, *model.Column]()
+	tbl.Columns.Set("statuses", &model.Column{Name: "statuses", TypeName: "public.status[]"})
+	tbl.Indexes = orderedmap.New[string, *model.Index]()
+	tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+	tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", tbl)
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.status"], idx["public.users"], "enum before table with array type dep")
+}
+
+func TestOrderFromSchema_CyclicFK(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	refA := "a"
+	refB := "b"
+	schemaPublic := "public"
+
+	tables := orderedmap.New[string, *model.Table]()
+
+	tblA := &model.Table{Schema: "public", Name: "a"}
+	tblA.Columns = orderedmap.New[string, *model.Column]()
+	tblA.Indexes = orderedmap.New[string, *model.Index]()
+	tblA.Constraints = orderedmap.New[string, *model.Constraint]()
+	tblA.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tblA.ForeignKeys.Set("a_b_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "a_b_fk"},
+		RefSchema:  &schemaPublic,
+		RefTable:   &refB,
+	})
+	tables.Set("public.a", tblA)
+
+	tblB := &model.Table{Schema: "public", Name: "b"}
+	tblB.Columns = orderedmap.New[string, *model.Column]()
+	tblB.Indexes = orderedmap.New[string, *model.Index]()
+	tblB.Constraints = orderedmap.New[string, *model.Constraint]()
+	tblB.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tblB.ForeignKeys.Set("b_a_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "b_a_fk"},
+		RefSchema:  &schemaPublic,
+		RefTable:   &refA,
+	})
+	tables.Set("public.b", tblB)
+
+	_, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle detected")
+}

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -369,3 +369,99 @@ func TestOrderFromSchema_ViewWithSchemalessTableRef(t *testing.T) {
 
 	assert.Less(t, idx["public.users"], idx["public.v"], "table before view with schemaless ref")
 }
+
+func TestOrderFromSchema_ViewWithCTE(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	users := &model.Table{Schema: "public", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", users)
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.cte_view", &model.View{
+		Schema:     "public",
+		Name:       "cte_view",
+		Definition: "WITH active AS (SELECT id FROM users WHERE id > 0) SELECT id FROM active",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.cte_view"], "table before view with CTE")
+}
+
+func TestOrderFromSchema_ViewWithHavingSubquery(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"orders", "thresholds"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.big_orders", &model.View{
+		Schema:     "public",
+		Name:       "big_orders",
+		Definition: "SELECT user_id, count(*) FROM orders GROUP BY user_id HAVING count(*) > (SELECT min(val) FROM thresholds)",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.orders"], idx["public.big_orders"], "orders before view")
+	assert.Less(t, idx["public.thresholds"], idx["public.big_orders"], "thresholds before view (HAVING subquery)")
+}
+
+func TestOrderFromSchema_ViewWithScalarSubquery(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"users", "settings"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.user_with_setting", &model.View{
+		Schema:     "public",
+		Name:       "user_with_setting",
+		Definition: "SELECT id, (SELECT val FROM settings LIMIT 1) AS setting FROM users",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.user_with_setting"], "users before view")
+	assert.Less(t, idx["public.settings"], idx["public.user_with_setting"], "settings before view (scalar subquery)")
+}

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -565,6 +565,39 @@ func TestOrderFromSchema_ViewWithCaseSubquery(t *testing.T) {
 	assert.Less(t, idx["public.config"], idx["public.v"])
 }
 
+func TestOrderFromSchema_ViewWithFuncCallSubquery(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"users", "roles"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.v", &model.View{
+		Schema:     "public",
+		Name:       "v",
+		Definition: "SELECT id, array_agg((SELECT name FROM roles WHERE roles.user_id = users.id)) FROM users",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.v"])
+	assert.Less(t, idx["public.roles"], idx["public.v"])
+}
+
 func TestOrderFromSchema_ViewWithUnparseableDefinition(t *testing.T) {
 	// View definition that pg_query can't parse triggers fallback
 	enums := orderedmap.New[string, *model.Enum]()

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -465,3 +465,135 @@ func TestOrderFromSchema_ViewWithScalarSubquery(t *testing.T) {
 	assert.Less(t, idx["public.users"], idx["public.user_with_setting"], "users before view")
 	assert.Less(t, idx["public.settings"], idx["public.user_with_setting"], "settings before view (scalar subquery)")
 }
+
+func TestOrderFromSchema_ViewWithExistsSubquery(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"users", "orders"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.users_with_orders", &model.View{
+		Schema:     "public",
+		Name:       "users_with_orders",
+		Definition: "SELECT id FROM users WHERE EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id)",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.users_with_orders"])
+	assert.Less(t, idx["public.orders"], idx["public.users_with_orders"])
+}
+
+func TestOrderFromSchema_ViewWithCoalesce(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"users", "defaults"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.v", &model.View{
+		Schema:     "public",
+		Name:       "v",
+		Definition: "SELECT id, COALESCE(name, (SELECT val FROM defaults LIMIT 1)) FROM users",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.v"])
+	assert.Less(t, idx["public.defaults"], idx["public.v"])
+}
+
+func TestOrderFromSchema_ViewWithCaseSubquery(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"users", "config"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.v", &model.View{
+		Schema:     "public",
+		Name:       "v",
+		Definition: "SELECT id, CASE WHEN active THEN (SELECT val FROM config LIMIT 1) ELSE 'none' END FROM users",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.v"])
+	assert.Less(t, idx["public.config"], idx["public.v"])
+}
+
+func TestOrderFromSchema_ViewWithUnparseableDefinition(t *testing.T) {
+	// View definition that pg_query can't parse triggers fallback
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	users := &model.Table{Schema: "public", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.users", users)
+
+	views := orderedmap.New[string, *model.View]()
+	// Invalid SQL that can't be parsed but contains "public.users"
+	views.Set("public.bad_view", &model.View{
+		Schema:     "public",
+		Name:       "bad_view",
+		Definition: "NOT VALID SQL BUT MENTIONS public.users",
+	})
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	// Fallback substring matching should still detect the dependency
+	assert.Less(t, idx["public.users"], idx["public.bad_view"])
+}

--- a/toposort/sort.go
+++ b/toposort/sort.go
@@ -4,8 +4,10 @@ import "fmt"
 
 // SortSQL parses SQL containing multiple CREATE statements and returns
 // the individual statements sorted in dependency order (dependencies first).
-func SortSQL(sql string) ([]string, error) {
-	stmts, err := ExtractDeps(sql)
+// An optional defaultSchema can be provided to qualify unqualified identifiers
+// (defaults to "public").
+func SortSQL(sql string, defaultSchema ...string) ([]string, error) {
+	stmts, err := ExtractDeps(sql, defaultSchema...)
 	if err != nil {
 		return nil, err
 	}

--- a/toposort/sort.go
+++ b/toposort/sort.go
@@ -1,0 +1,44 @@
+package toposort
+
+import "fmt"
+
+// SortSQL parses SQL containing multiple CREATE statements and returns
+// the individual statements sorted in dependency order (dependencies first).
+func SortSQL(sql string) ([]string, error) {
+	stmts, err := ExtractDeps(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(stmts) == 0 {
+		return nil, nil
+	}
+
+	g := NewGraph()
+	stmtByName := make(map[string]*StmtInfo, len(stmts))
+
+	for _, s := range stmts {
+		g.AddNode(s.Name)
+		stmtByName[s.Name] = s
+	}
+
+	for _, s := range stmts {
+		for _, dep := range s.Deps {
+			g.AddEdge(s.Name, dep)
+		}
+	}
+
+	order, err := g.Sort()
+	if err != nil {
+		return nil, fmt.Errorf("topological sort failed: %w", err)
+	}
+
+	sorted := make([]string, 0, len(order))
+	for _, name := range order {
+		if s, ok := stmtByName[name]; ok {
+			sorted = append(sorted, s.SQL)
+		}
+	}
+
+	return sorted, nil
+}

--- a/toposort/toposort_test.go
+++ b/toposort/toposort_test.go
@@ -430,6 +430,41 @@ func TestExtractDeps_ViewWithSchemalessTable(t *testing.T) {
 	assert.Contains(t, stmts[1].Deps, "public.users")
 }
 
+func TestExtractDeps_NonPublicSchema(t *testing.T) {
+	sql := `
+		CREATE TYPE myapp.status AS ENUM ('a', 'b');
+		CREATE TABLE myapp.users (
+			id integer NOT NULL,
+			status status
+		);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql, "myapp")
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "myapp.status", stmts[0].Name)
+	assert.Equal(t, "myapp.users", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "myapp.status")
+}
+
+func TestSortSQL_NonPublicSchema(t *testing.T) {
+	sql := `
+		CREATE TABLE myapp.posts (
+			id integer NOT NULL,
+			user_id integer NOT NULL,
+			CONSTRAINT posts_user_fk FOREIGN KEY (user_id) REFERENCES myapp.users(id)
+		);
+		CREATE TABLE myapp.users (id integer NOT NULL);
+	`
+
+	sorted, err := toposort.SortSQL(sql, "myapp")
+	require.NoError(t, err)
+	require.Len(t, sorted, 2)
+	assert.Contains(t, sorted[0], "myapp.users")
+	assert.Contains(t, sorted[1], "myapp.posts")
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/toposort/toposort_test.go
+++ b/toposort/toposort_test.go
@@ -1,6 +1,7 @@
 package toposort_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -214,15 +215,15 @@ func TestSortSQL_ComplexDeps(t *testing.T) {
 	idx := make(map[string]int)
 	for i, s := range sorted {
 		switch {
-		case contains(s, "CREATE TYPE"):
+		case strings.Contains(s, "CREATE TYPE"):
 			idx["enum"] = i
-		case contains(s, "CREATE DOMAIN"):
+		case strings.Contains(s, "CREATE DOMAIN"):
 			idx["domain"] = i
-		case contains(s, "CREATE TABLE") && contains(s, "public.posts"):
+		case strings.Contains(s, "CREATE TABLE") && strings.Contains(s, "public.posts"):
 			idx["posts"] = i
-		case contains(s, "CREATE TABLE") && contains(s, "public.users"):
+		case strings.Contains(s, "CREATE TABLE") && strings.Contains(s, "public.users"):
 			idx["users"] = i
-		case contains(s, "SELECT"):
+		case strings.Contains(s, "SELECT"):
 			idx["view"] = i
 		}
 	}
@@ -546,17 +547,4 @@ func TestExtractDeps_ViewWithCaseSubquery(t *testing.T) {
 	assert.Equal(t, "public.v", stmts[2].Name)
 	assert.Contains(t, stmts[2].Deps, "public.users")
 	assert.Contains(t, stmts[2].Deps, "public.config")
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/toposort/toposort_test.go
+++ b/toposort/toposort_test.go
@@ -516,6 +516,38 @@ func TestExtractDeps_JoinWithSubqueryInQuals(t *testing.T) {
 	assert.Contains(t, stmts[3].Deps, "public.config")
 }
 
+func TestExtractDeps_ViewWithCoalesceSubquery(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL, name text);
+		CREATE TABLE public.defaults (val text);
+		CREATE VIEW public.v AS SELECT id, COALESCE(name, (SELECT val FROM public.defaults LIMIT 1)) FROM public.users;
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 3)
+
+	assert.Equal(t, "public.v", stmts[2].Name)
+	assert.Contains(t, stmts[2].Deps, "public.users")
+	assert.Contains(t, stmts[2].Deps, "public.defaults")
+}
+
+func TestExtractDeps_ViewWithCaseSubquery(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL, active boolean);
+		CREATE TABLE public.config (val text);
+		CREATE VIEW public.v AS SELECT id, CASE WHEN active THEN (SELECT val FROM public.config LIMIT 1) ELSE 'none' END FROM public.users;
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 3)
+
+	assert.Equal(t, "public.v", stmts[2].Name)
+	assert.Contains(t, stmts[2].Deps, "public.users")
+	assert.Contains(t, stmts[2].Deps, "public.config")
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/toposort/toposort_test.go
+++ b/toposort/toposort_test.go
@@ -351,6 +351,85 @@ func TestExtractDeps_PartitionParent(t *testing.T) {
 	assert.Contains(t, stmts[1].Deps, "public.events")
 }
 
+func TestExtractDeps_SkipsNonCreateStatements(t *testing.T) {
+	// ALTER TABLE and other non-CREATE statements should be ignored
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL);
+		ALTER TABLE public.users ADD COLUMN name text;
+		CREATE TABLE public.posts (id integer NOT NULL);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	// Only CREATE statements are extracted
+	require.Len(t, stmts, 2)
+	assert.Equal(t, "public.users", stmts[0].Name)
+	assert.Equal(t, "public.posts", stmts[1].Name)
+}
+
+func TestExtractDeps_UnqualifiedEnumType(t *testing.T) {
+	// Enum type referenced without schema prefix in column type
+	sql := `
+		CREATE TYPE public.status AS ENUM ('a', 'b');
+		CREATE TABLE public.users (
+			id integer NOT NULL,
+			status status
+		);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.users", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.status")
+}
+
+func TestExtractDeps_UnqualifiedDomainBaseType(t *testing.T) {
+	// Domain with unqualified base type
+	sql := `
+		CREATE TYPE public.status AS ENUM ('a', 'b');
+		CREATE DOMAIN public.user_status AS status;
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.user_status", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.status")
+}
+
+func TestExtractDeps_TableWithNoColumns(t *testing.T) {
+	// Edge case: partition child with no explicit columns
+	sql := `
+		CREATE TABLE public.parent (id integer) PARTITION BY RANGE (id);
+		CREATE TABLE public.child PARTITION OF public.parent FOR VALUES FROM (1) TO (100);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.child", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.parent")
+}
+
+func TestExtractDeps_ViewWithSchemalessTable(t *testing.T) {
+	// View referencing a table without schema prefix
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL);
+		CREATE VIEW public.v AS SELECT id FROM users;
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.v", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.users")
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/toposort/toposort_test.go
+++ b/toposort/toposort_test.go
@@ -465,6 +465,57 @@ func TestSortSQL_NonPublicSchema(t *testing.T) {
 	assert.Contains(t, sorted[1], "myapp.posts")
 }
 
+func TestExtractDeps_ViewWithWhereSubquery(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL, active boolean);
+		CREATE TABLE public.config (key text, val integer);
+		CREATE VIEW public.v AS SELECT id FROM public.users WHERE id > (SELECT val FROM public.config WHERE key = 'min_id');
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 3)
+
+	assert.Equal(t, "public.v", stmts[2].Name)
+	assert.Contains(t, stmts[2].Deps, "public.users")
+	assert.Contains(t, stmts[2].Deps, "public.config")
+}
+
+func TestExtractDeps_ViewWithCTE(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL);
+		CREATE VIEW public.v AS WITH active AS (SELECT id FROM public.users) SELECT id FROM active;
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.v", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.users")
+}
+
+func TestExtractDeps_JoinWithSubqueryInQuals(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL);
+		CREATE TABLE public.config (key text, val integer);
+		CREATE TABLE public.posts (id integer NOT NULL, user_id integer);
+		CREATE VIEW public.v AS
+			SELECT u.id FROM public.users u
+			JOIN public.posts p ON u.id = p.user_id
+				AND p.id > (SELECT val FROM public.config WHERE key = 'min_post');
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 4)
+
+	assert.Equal(t, "public.v", stmts[3].Name)
+	assert.Contains(t, stmts[3].Deps, "public.users")
+	assert.Contains(t, stmts[3].Deps, "public.posts")
+	assert.Contains(t, stmts[3].Deps, "public.config")
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/toposort/toposort_test.go
+++ b/toposort/toposort_test.go
@@ -1,0 +1,365 @@
+package toposort_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/toposort"
+)
+
+func TestGraph_Sort_Simple(t *testing.T) {
+	g := toposort.NewGraph()
+	g.AddNode("a")
+	g.AddNode("b")
+	g.AddNode("c")
+	g.AddEdge("c", "b") // c depends on b
+	g.AddEdge("b", "a") // b depends on a
+
+	result, err := g.Sort()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, result)
+}
+
+func TestGraph_Sort_Independent(t *testing.T) {
+	g := toposort.NewGraph()
+	g.AddNode("c")
+	g.AddNode("a")
+	g.AddNode("b")
+
+	result, err := g.Sort()
+	require.NoError(t, err)
+	// Alphabetical order for independent nodes
+	assert.Equal(t, []string{"a", "b", "c"}, result)
+}
+
+func TestGraph_Sort_Cycle(t *testing.T) {
+	g := toposort.NewGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+
+	_, err := g.Sort()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle detected")
+}
+
+func TestGraph_Sort_Diamond(t *testing.T) {
+	g := toposort.NewGraph()
+	g.AddEdge("d", "b") // d depends on b
+	g.AddEdge("d", "c") // d depends on c
+	g.AddEdge("b", "a") // b depends on a
+	g.AddEdge("c", "a") // c depends on a
+
+	result, err := g.Sort()
+	require.NoError(t, err)
+	assert.Equal(t, "a", result[0])
+	assert.Equal(t, "d", result[3])
+	// b and c can be in either order, but alphabetical
+	assert.Equal(t, []string{"a", "b", "c", "d"}, result)
+}
+
+func TestExtractDeps_EnumDomainTableView(t *testing.T) {
+	sql := `
+		CREATE TYPE public.status AS ENUM ('active', 'inactive');
+		CREATE DOMAIN public.user_status AS public.status;
+		CREATE TABLE public.users (
+			id integer NOT NULL,
+			status public.user_status,
+			CONSTRAINT users_pkey PRIMARY KEY (id)
+		);
+		CREATE VIEW public.active_users AS SELECT id FROM public.users WHERE status = 'active';
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 4)
+
+	// enum: no deps
+	assert.Equal(t, "public.status", stmts[0].Name)
+	assert.Empty(t, stmts[0].Deps)
+
+	// domain: depends on enum
+	assert.Equal(t, "public.user_status", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.status")
+
+	// table: depends on domain
+	assert.Equal(t, "public.users", stmts[2].Name)
+	assert.Contains(t, stmts[2].Deps, "public.user_status")
+
+	// view: depends on table
+	assert.Equal(t, "public.active_users", stmts[3].Name)
+	assert.Contains(t, stmts[3].Deps, "public.users")
+}
+
+func TestExtractDeps_ForeignKey(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (
+			id integer NOT NULL,
+			CONSTRAINT users_pkey PRIMARY KEY (id)
+		);
+		CREATE TABLE public.posts (
+			id integer NOT NULL,
+			user_id integer NOT NULL,
+			CONSTRAINT posts_pkey PRIMARY KEY (id),
+			CONSTRAINT posts_user_fk FOREIGN KEY (user_id) REFERENCES public.users(id)
+		);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.users", stmts[0].Name)
+	assert.Empty(t, stmts[0].Deps)
+
+	assert.Equal(t, "public.posts", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.users")
+}
+
+func TestExtractDeps_ViewWithJoin(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL);
+		CREATE TABLE public.posts (id integer NOT NULL, user_id integer NOT NULL);
+		CREATE VIEW public.user_posts AS
+			SELECT u.id, p.id AS post_id
+			FROM public.users u
+			JOIN public.posts p ON u.id = p.user_id;
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 3)
+
+	assert.Equal(t, "public.user_posts", stmts[2].Name)
+	assert.Contains(t, stmts[2].Deps, "public.users")
+	assert.Contains(t, stmts[2].Deps, "public.posts")
+}
+
+func TestExtractDeps_IgnoresBuiltinTypes(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (
+			id integer NOT NULL,
+			name text NOT NULL,
+			created_at timestamp NOT NULL
+		);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	assert.Empty(t, stmts[0].Deps)
+}
+
+func TestExtractDeps_IgnoresExternalRefs(t *testing.T) {
+	// Reference to a table not defined in this SQL should not be a dep
+	sql := `
+		CREATE TABLE public.posts (
+			id integer NOT NULL,
+			user_id integer NOT NULL,
+			CONSTRAINT posts_user_fk FOREIGN KEY (user_id) REFERENCES public.users(id)
+		);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	assert.Empty(t, stmts[0].Deps)
+}
+
+func TestSortSQL_BasicOrder(t *testing.T) {
+	// Deliberately in reverse dependency order
+	sql := `
+		CREATE VIEW public.active_users AS SELECT id FROM public.users;
+		CREATE TABLE public.users (
+			id integer NOT NULL,
+			status public.status,
+			CONSTRAINT users_pkey PRIMARY KEY (id)
+		);
+		CREATE TYPE public.status AS ENUM ('active', 'inactive');
+	`
+
+	sorted, err := toposort.SortSQL(sql)
+	require.NoError(t, err)
+	require.Len(t, sorted, 3)
+
+	// enum first, then table, then view
+	assert.Contains(t, sorted[0], "CREATE TYPE")
+	assert.Contains(t, sorted[1], "CREATE TABLE")
+	assert.Contains(t, sorted[2], "SELECT")
+}
+
+func TestSortSQL_ComplexDeps(t *testing.T) {
+	sql := `
+		CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE status = 'active';
+		CREATE TABLE public.posts (
+			id integer NOT NULL,
+			user_id integer NOT NULL,
+			CONSTRAINT posts_user_fk FOREIGN KEY (user_id) REFERENCES public.users(id)
+		);
+		CREATE TABLE public.users (
+			id integer NOT NULL,
+			name text NOT NULL,
+			status public.status,
+			CONSTRAINT users_pkey PRIMARY KEY (id)
+		);
+		CREATE DOMAIN public.user_status AS public.status;
+		CREATE TYPE public.status AS ENUM ('active', 'inactive');
+	`
+
+	sorted, err := toposort.SortSQL(sql)
+	require.NoError(t, err)
+	require.Len(t, sorted, 5)
+
+	// Build index for checking relative order
+	idx := make(map[string]int)
+	for i, s := range sorted {
+		switch {
+		case contains(s, "CREATE TYPE"):
+			idx["enum"] = i
+		case contains(s, "CREATE DOMAIN"):
+			idx["domain"] = i
+		case contains(s, "CREATE TABLE") && contains(s, "public.posts"):
+			idx["posts"] = i
+		case contains(s, "CREATE TABLE") && contains(s, "public.users"):
+			idx["users"] = i
+		case contains(s, "SELECT"):
+			idx["view"] = i
+		}
+	}
+
+	assert.Less(t, idx["enum"], idx["domain"], "enum before domain")
+	assert.Less(t, idx["enum"], idx["users"], "enum before users (type dep)")
+	assert.Less(t, idx["users"], idx["posts"], "users before posts (FK dep)")
+	assert.Less(t, idx["users"], idx["view"], "users before view")
+}
+
+func TestSortSQL_CyclicError(t *testing.T) {
+	// This creates a cycle through FKs: a → b → a
+	sql := `
+		CREATE TABLE public.a (
+			id integer NOT NULL,
+			b_id integer NOT NULL,
+			CONSTRAINT a_b_fk FOREIGN KEY (b_id) REFERENCES public.b(id)
+		);
+		CREATE TABLE public.b (
+			id integer NOT NULL,
+			a_id integer NOT NULL,
+			CONSTRAINT b_a_fk FOREIGN KEY (a_id) REFERENCES public.a(id)
+		);
+	`
+
+	_, err := toposort.SortSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle detected")
+}
+
+func TestSortSQL_Empty(t *testing.T) {
+	sorted, err := toposort.SortSQL("")
+	require.NoError(t, err)
+	assert.Nil(t, sorted)
+}
+
+func TestSortSQL_ParseError(t *testing.T) {
+	_, err := toposort.SortSQL("NOT VALID SQL {{{}}")
+	require.Error(t, err)
+}
+
+func TestExtractDeps_ParseError(t *testing.T) {
+	_, err := toposort.ExtractDeps("NOT VALID SQL {{{}}")
+	require.Error(t, err)
+}
+
+func TestExtractDeps_ViewWithUnion(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL);
+		CREATE TABLE public.admins (id integer NOT NULL);
+		CREATE VIEW public.all_people AS
+			SELECT id FROM public.users
+			UNION
+			SELECT id FROM public.admins;
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 3)
+
+	assert.Equal(t, "public.all_people", stmts[2].Name)
+	assert.Contains(t, stmts[2].Deps, "public.users")
+	assert.Contains(t, stmts[2].Deps, "public.admins")
+}
+
+func TestExtractDeps_ViewWithSubselect(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL, active boolean);
+		CREATE VIEW public.active_count AS
+			SELECT count(*) FROM (SELECT id FROM public.users WHERE active) sub;
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.active_count", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.users")
+}
+
+func TestExtractDeps_InlineForeignKey(t *testing.T) {
+	sql := `
+		CREATE TABLE public.users (id integer NOT NULL);
+		CREATE TABLE public.posts (
+			id integer NOT NULL,
+			user_id integer REFERENCES public.users(id)
+		);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.posts", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.users")
+}
+
+func TestExtractDeps_ArrayType(t *testing.T) {
+	sql := `
+		CREATE TYPE public.status AS ENUM ('a', 'b');
+		CREATE TABLE public.users (
+			id integer NOT NULL,
+			statuses public.status[]
+		);
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	// The parser should handle the array type reference
+	assert.Equal(t, "public.users", stmts[1].Name)
+}
+
+func TestExtractDeps_PartitionParent(t *testing.T) {
+	sql := `
+		CREATE TABLE public.events (id integer, created_at date) PARTITION BY RANGE (created_at);
+		CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+	`
+
+	stmts, err := toposort.ExtractDeps(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	assert.Equal(t, "public.events_2024", stmts[1].Name)
+	assert.Contains(t, stmts[1].Deps, "public.events")
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add `toposort` package that extracts object dependencies from pg_query AST and sorts statements using Kahn's algorithm
- Replace the hardcoded category-based statement assembly in `diff_all.go` with dependency-aware topological sorting
- Creates are emitted in dependency order, drops in reverse dependency order
- Falls back to the original hardcoded ordering when cyclic dependencies are detected (e.g., mutual FK references)
- Add integration tests (plan + apply) for view-to-view dependencies and reverse-order dependency chains that would fail without topological sorting

## What this fixes
Previously, statement ordering was hardcoded as enum → domain → table → view. This worked for type-level ordering but did not handle:
- **View-to-view dependencies**: if view B selects from view A, A must be created first
- **Reverse-order input**: desired SQL written in reverse dependency order could produce invalid plans

## Test plan
- [x] `make test` — all existing + new tests pass
- [x] `make lint` — no issues
- [x] `make test-scenario` — all scenarios pass
- [x] Root package coverage: 98.0% → 98.3% (no decrease)
- [x] `toposort` package coverage: 92.2%
- [x] New plan tests: `create_view_depends_on_view`, `create_view_depends_on_view_reverse_order`, `create_enum_domain_table_view_chain`
- [x] New apply tests: `create_view_depends_on_view`, `create_enum_domain_table_view_chain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)