### PR TITLE
Add materialized view dependency and filter tests

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -156,6 +156,43 @@ CREATE TABLE public.users (
 	assert.NotContains(t, output, "CREATE TABLE")
 }
 
+func TestPlan_Disable_View_IncludesMatview(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.v AS SELECT id FROM public.users;
+CREATE MATERIALIZED VIEW public.mv AS SELECT count(*) AS cnt FROM public.users;`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		FilterOptions: pistachio.FilterOptions{Disable: []string{"view"}},
+		Files:         []string{desiredFile},
+	})
+	require.NoError(t, err)
+	// --disable view should suppress both regular views AND materialized views
+	assert.NotContains(t, got.SQL, "CREATE OR REPLACE VIEW")
+	assert.NotContains(t, got.SQL, "CREATE MATERIALIZED VIEW")
+	assert.Contains(t, got.SQL, "ADD COLUMN name")
+}
+
 func TestPlan_Disable_Table(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/testdata/apply/create_matview_depends_on_matview.yml
+++ b/testdata/apply/create_matview_depends_on_matview.yml
@@ -1,0 +1,28 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.has_users AS SELECT cnt > 0 AS result FROM public.user_count;
+  CREATE MATERIALIZED VIEW public.user_count AS SELECT count(*) AS cnt FROM public.users;
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.has_users
+  CREATE MATERIALIZED VIEW public.has_users AS
+  SELECT user_count.cnt > 0 AS result
+     FROM user_count;
+
+  -- public.user_count
+  CREATE MATERIALIZED VIEW public.user_count AS
+  SELECT count(*) AS cnt
+     FROM users;

--- a/testdata/plan/create_matview_depends_on_matview.yml
+++ b/testdata/plan/create_matview_depends_on_matview.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_count AS SELECT count(*) AS cnt FROM public.users;
+  CREATE MATERIALIZED VIEW public.has_users AS SELECT cnt > 0 AS result FROM public.user_count;
+plan: |
+  CREATE MATERIALIZED VIEW public.user_count AS
+  SELECT count(*) AS cnt FROM public.users;
+  CREATE MATERIALIZED VIEW public.has_users AS
+  SELECT cnt > 0 AS result FROM public.user_count;

--- a/testdata/plan/create_matview_depends_on_matview_reverse_order.yml
+++ b/testdata/plan/create_matview_depends_on_matview_reverse_order.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.has_users AS SELECT cnt > 0 AS result FROM public.user_count;
+  CREATE MATERIALIZED VIEW public.user_count AS SELECT count(*) AS cnt FROM public.users;
+plan: |
+  CREATE MATERIALIZED VIEW public.user_count AS
+  SELECT count(*) AS cnt FROM public.users;
+  CREATE MATERIALIZED VIEW public.has_users AS
+  SELECT cnt > 0 AS result FROM public.user_count;

--- a/testdata/plan/create_matview_with_domain_chain.yml
+++ b/testdata/plan/create_matview_with_domain_chain.yml
@@ -1,0 +1,18 @@
+init: ""
+desired: |
+  CREATE MATERIALIZED VIEW public.user_list AS SELECT id, name FROM public.users;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name public.user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE DOMAIN public.user_name AS text;
+plan: |
+  CREATE DOMAIN public.user_name AS text;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name public.user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_list AS
+  SELECT id, name FROM public.users;

--- a/testdata/plan/drop_matview_depends_on_matview.yml
+++ b/testdata/plan/drop_matview_depends_on_matview.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_count AS SELECT count(*) AS cnt FROM public.users;
+  CREATE MATERIALIZED VIEW public.has_users AS SELECT cnt > 0 AS result FROM public.user_count;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  DROP MATERIALIZED VIEW public.has_users;
+  DROP MATERIALIZED VIEW public.user_count;


### PR DESCRIPTION
## Summary
Add missing test patterns for materialized view dependency ordering and filter behavior.

## Tests added
- **plan**: matview→matview dependency ordering (create in correct order)
- **plan**: matview→matview dependency with reverse-order desired SQL (toposort fixes order)
- **plan**: drop dependent matviews in correct order (dependent first)
- **plan**: domain→table→matview dependency chain (toposort handles full chain)
- **apply**: matview→matview dependency with reverse-order desired SQL
- **filter**: `--disable view` suppresses both regular views AND materialized views

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — no issues
- [x] `make test-scenario` — all scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)