### PR TITLE
Add --omit-schema scenario test and fix schemaless index bug

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -581,17 +581,20 @@ func parseTableConstraint(con *pg_query.Constraint, tableName string) (*model.Co
 }
 
 func parseIndexStmt(is *pg_query.IndexStmt, rawStmt *pg_query.RawStmt, defaultSchema string) (*model.Index, error) {
+	schema := is.Relation.Schemaname
+	if schema == "" {
+		schema = defaultSchema
+		// Qualify the relation with the default schema before deparsing
+		// so the Definition contains the fully-qualified table name.
+		is.Relation.Schemaname = defaultSchema
+	}
+
 	result := &pg_query.ParseResult{
 		Stmts: []*pg_query.RawStmt{{Stmt: rawStmt.Stmt}},
 	}
 	def, err := pg_query.Deparse(result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deparse index: %w", err)
-	}
-
-	schema := is.Relation.Schemaname
-	if schema == "" {
-		schema = defaultSchema
 	}
 
 	var tablespace *string

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -869,6 +869,50 @@ CREATE INDEX idx ON public.mv (cnt);`
 	assert.Contains(t, err.Error(), "duplicate index")
 }
 
+func TestParseSQL_IndexOnSchemalessTable(t *testing.T) {
+	// When using --omit-schema, indexes reference tables without schema prefix.
+	// The parser should still attach the index to the correct table.
+	sql := `CREATE TABLE users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON users USING btree (name);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Tables.Len())
+
+	t1, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	assert.Equal(t, 1, t1.Indexes.Len())
+
+	idx, ok := t1.Indexes.GetOk("idx_users_name")
+	require.True(t, ok)
+	assert.Equal(t, "users", idx.Table)
+}
+
+func TestParseSQL_IndexOnSchemalessMatview(t *testing.T) {
+	sql := `CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE MATERIALIZED VIEW user_stats AS SELECT count(*) AS cnt FROM users;
+CREATE INDEX idx_user_stats_cnt ON user_stats (cnt);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	v, ok := result.Views.GetOk("public.user_stats")
+	require.True(t, ok)
+	assert.True(t, v.Materialized)
+	assert.Equal(t, 1, v.Indexes.Len())
+
+	idx, ok := v.Indexes.GetOk("idx_user_stats_cnt")
+	require.True(t, ok)
+	assert.Equal(t, "user_stats", idx.Table)
+}
+
 func TestParseSQL_IndexOnUnknownTableSkipped(t *testing.T) {
 	sql := `CREATE INDEX idx_name ON public.nonexistent USING btree (name);`
 	result, err := parser.ParseSQL(sql)

--- a/test/scenario/omit_schema.test.sh
+++ b/test/scenario/omit_schema.test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Scenario test: --omit-schema dump → plan round-trip
+# Verifies that dump --omit-schema output can be fed back to plan
+# with no diff, covering all object types including materialized views.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/omit_schema"
+
+# --- Setup: load initial schema ---
+setup_db "$DATA/init.sql"
+
+# --- Step 1: dump --omit-schema produces no public. prefix ---
+step "01 dump --omit-schema strips schema"
+dump_output=$("$PIST" dump --omit-schema 2>&1)
+if echo "$dump_output" | grep -q 'public\.'; then
+  fail "dump output contains 'public.' prefix"
+  echo "    $(echo "$dump_output" | grep 'public\.' | head -3)" >&2
+else
+  pass
+fi
+
+# --- Step 2: dump --omit-schema contains all object types ---
+step "02 dump contains all object types"
+has_all=true
+echo "$dump_output" | grep -q 'CREATE TABLE' || has_all=false
+echo "$dump_output" | grep -q 'CREATE OR REPLACE VIEW' || has_all=false
+echo "$dump_output" | grep -q 'CREATE MATERIALIZED VIEW' || has_all=false
+echo "$dump_output" | grep -q 'CREATE TYPE' || has_all=false
+echo "$dump_output" | grep -q 'CREATE DOMAIN' || has_all=false
+echo "$dump_output" | grep -q 'CREATE INDEX' || has_all=false
+if $has_all; then
+  pass
+else
+  fail "missing object types in dump"
+  echo "    $dump_output" >&2
+fi
+
+# --- Step 3: dump --omit-schema → plan has no diff ---
+step "03 dump --omit-schema → plan no diff"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+echo "$dump_output" > "$tmp_dir/schema.sql"
+plan_output=$("$PIST" plan "$tmp_dir/schema.sql" 2>&1)
+if echo "$plan_output" | grep -q 'No changes'; then
+  pass
+else
+  fail "plan shows changes for omit-schema dump"
+  echo "    $plan_output" >&2
+fi
+
+# --- Step 4: matview index is in dump --omit-schema ---
+step "04 matview index in omit-schema dump"
+if echo "$dump_output" | grep -q 'idx_user_stats_cnt'; then
+  pass
+else
+  fail "matview index not found in dump"
+fi
+
+summary

--- a/test/scenario/omit_schema.test.sh
+++ b/test/scenario/omit_schema.test.sh
@@ -59,4 +59,16 @@ else
   fail "matview index not found in dump"
 fi
 
+# --- Step 5: dump --omit-schema → apply to empty DB → no drift ---
+step "05 dump --omit-schema → apply → no drift"
+setup_db ""
+apply_output=$("$PIST" apply "$tmp_dir/schema.sql" 2>&1) || { fail "apply failed: $apply_output"; summary; exit 1; }
+plan_output=$("$PIST" plan "$tmp_dir/schema.sql" 2>&1)
+if echo "$plan_output" | grep -q 'No changes'; then
+  pass
+else
+  fail "drift after apply with omit-schema dump"
+  echo "    $plan_output" >&2
+fi
+
 summary

--- a/test/scenario/omit_schema.test.sh
+++ b/test/scenario/omit_schema.test.sh
@@ -14,8 +14,9 @@ setup_db "$DATA/init.sql"
 
 # --- Step 1: dump --omit-schema produces no public. prefix ---
 step "01 dump --omit-schema strips schema"
-dump_output=$("$PIST" dump --omit-schema 2>&1)
-if echo "$dump_output" | grep -q 'public\.'; then
+if ! dump_output=$("$PIST" dump --omit-schema 2>&1); then
+  fail "dump failed: $dump_output"
+elif echo "$dump_output" | grep -q 'public\.'; then
   fail "dump output contains 'public.' prefix"
   echo "    $(echo "$dump_output" | grep 'public\.' | head -3)" >&2
 else
@@ -43,8 +44,9 @@ step "03 dump --omit-schema → plan no diff"
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 echo "$dump_output" > "$tmp_dir/schema.sql"
-plan_output=$("$PIST" plan "$tmp_dir/schema.sql" 2>&1)
-if echo "$plan_output" | grep -q 'No changes'; then
+if ! plan_output=$("$PIST" plan "$tmp_dir/schema.sql" 2>&1); then
+  fail "plan failed: $plan_output"
+elif echo "$plan_output" | grep -q 'No changes'; then
   pass
 else
   fail "plan shows changes for omit-schema dump"
@@ -62,9 +64,11 @@ fi
 # --- Step 5: dump --omit-schema → apply to empty DB → no drift ---
 step "05 dump --omit-schema → apply → no drift"
 setup_db ""
-apply_output=$("$PIST" apply "$tmp_dir/schema.sql" 2>&1) || { fail "apply failed: $apply_output"; summary; exit 1; }
-plan_output=$("$PIST" plan "$tmp_dir/schema.sql" 2>&1)
-if echo "$plan_output" | grep -q 'No changes'; then
+if ! apply_output=$("$PIST" apply "$tmp_dir/schema.sql" 2>&1); then
+  fail "apply failed: $apply_output"
+elif ! plan_output=$("$PIST" plan "$tmp_dir/schema.sql" 2>&1); then
+  fail "post-apply plan failed: $plan_output"
+elif echo "$plan_output" | grep -q 'No changes'; then
   pass
 else
   fail "drift after apply with omit-schema dump"

--- a/test/scenario/testdata/omit_schema/init.sql
+++ b/test/scenario/testdata/omit_schema/init.sql
@@ -1,0 +1,27 @@
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    status public.status,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_users_name ON public.users (name);
+
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    title text NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);
+
+ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_fk FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE status = 'active'::public.status;
+
+CREATE MATERIALIZED VIEW public.user_stats AS SELECT count(*) AS cnt FROM public.users;
+
+CREATE INDEX idx_user_stats_cnt ON public.user_stats (cnt);

--- a/testdata/plan/create_table_with_schemaless_index.yml
+++ b/testdata/plan/create_table_with_schemaless_index.yml
@@ -1,0 +1,15 @@
+init: ""
+desired: |
+  CREATE TABLE users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON users USING btree (name);
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users USING btree (name);


### PR DESCRIPTION
## Summary
- Add CLI scenario test for `dump --omit-schema` round-trip behavior
- Fix bug where schemaless index definitions (from `--omit-schema` dump) were not schema-qualified, causing indexes to appear before table CREATE in plan output

## Bug fix
`parseIndexStmt` did not set `Relation.Schemaname` before deparsing, so the `Definition` field contained `ON users` instead of `ON public.users`. This caused the index to be treated as an orphan statement in diff output when applying to an empty database.

## Tests added
**Scenario** (`omit_schema.test.sh`):
1. `dump --omit-schema` strips `public.` prefix
2. Dump includes all object types (table, view, matview, enum, domain, index)
3. `dump --omit-schema` → `plan` shows "No changes" (round-trip)
4. Materialized view index in omit-schema dump
5. `dump --omit-schema` → `apply` to empty DB → no drift

**Parser unit tests**:
- Schemaless index on table attaches correctly
- Schemaless index on materialized view attaches correctly

**Plan integration test**:
- `create_table_with_schemaless_index` — empty DB, correct CREATE TABLE → CREATE INDEX order

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — no issues
- [x] `make test-scenario` — all scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)