### PR TITLE
Add -- pist:execute directive for arbitrary SQL execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ pist apply schema.sql --pre-sql-file pre.sql --with-tx
 
 By default, `plan` and `apply` do not drop tables, views, enums, domains, or columns. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
 
+### Executing arbitrary SQL
+
+Use `-- pist:execute` to include non-managed SQL (functions, triggers, grants) in your schema files. Add a check SQL to skip execution conditionally:
+
+```sql
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
+CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ ... $$ LANGUAGE plpgsql;
+```
+
+See [Getting Started](getting-started.md) for details.
+
 ```bash
 # Allow all drops
 pist plan --allow-drop all schema.sql

--- a/apply.go
+++ b/apply.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+
+	"github.com/winebarrel/pistachio/parser"
 )
 
 type ApplyOptions struct {
@@ -35,11 +37,12 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 
 	count := &result.Count
 
-	if len(result.Stmts) == 0 {
+	if len(result.Stmts) == 0 && len(result.ExecuteStmts) == 0 {
 		return count, nil
 	}
 
 	exec := conn.Exec
+	query := conn.Query
 	commit := func(context.Context) error { return nil }
 
 	if options.WithTx {
@@ -49,6 +52,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		}
 		defer tx.Rollback(ctx) //nolint:errcheck
 		exec = tx.Exec
+		query = tx.Query
 		commit = tx.Commit
 	}
 
@@ -63,6 +67,32 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		fmt.Fprintln(w, stmt) //nolint:errcheck
 		if _, err := exec(ctx, stmt); err != nil {
 			return nil, fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)
+		}
+	}
+
+	// Execute -- pist:execute statements after schema changes
+	for _, es := range result.ExecuteStmts {
+		shouldExecute := true
+
+		if es.CheckSQL != "" {
+			rows, err := query(ctx, es.CheckSQL)
+			if err != nil {
+				return nil, fmt.Errorf("failed to execute check SQL: %s: %w", es.CheckSQL, err)
+			}
+			if rows.Next() {
+				if err := rows.Scan(&shouldExecute); err != nil {
+					rows.Close()
+					return nil, fmt.Errorf("failed to scan check SQL result: %s: %w", es.CheckSQL, err)
+				}
+			}
+			rows.Close()
+		}
+
+		if shouldExecute {
+			fmt.Fprintln(w, parser.FormatExecuteStmt(es)) //nolint:errcheck
+			if _, err := exec(ctx, es.SQL); err != nil {
+				return nil, fmt.Errorf("failed to execute SQL: %s: %w", es.SQL, err)
+			}
 		}
 	}
 

--- a/apply.go
+++ b/apply.go
@@ -74,7 +74,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	// Execute -- pist:execute statements after schema changes.
 	// Set search_path so unqualified names resolve to the configured schemas.
 	if len(result.ExecuteStmts) > 0 && len(client.Schemas) > 0 {
-		searchPath := "SET LOCAL search_path TO " + strings.Join(client.Schemas, ", ")
+		searchPath := "SET search_path TO " + strings.Join(client.Schemas, ", ")
 		if _, err := exec(ctx, searchPath); err != nil {
 			return nil, fmt.Errorf("failed to set search_path: %w", err)
 		}

--- a/apply.go
+++ b/apply.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/parser"
 )
 
@@ -74,7 +75,11 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	// Execute -- pist:execute statements after schema changes.
 	// Set search_path so unqualified names resolve to the configured schemas.
 	if len(result.ExecuteStmts) > 0 && len(client.Schemas) > 0 {
-		searchPath := "SET search_path TO " + strings.Join(client.Schemas, ", ")
+		quoted := make([]string, len(client.Schemas))
+		for i, s := range client.Schemas {
+			quoted[i] = model.Ident(s)
+		}
+		searchPath := "SET search_path TO " + strings.Join(quoted, ", ")
 		if _, err := exec(ctx, searchPath); err != nil {
 			return nil, fmt.Errorf("failed to set search_path: %w", err)
 		}

--- a/apply.go
+++ b/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/winebarrel/pistachio/parser"
 )
@@ -70,7 +71,15 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		}
 	}
 
-	// Execute -- pist:execute statements after schema changes
+	// Execute -- pist:execute statements after schema changes.
+	// Set search_path so unqualified names resolve to the configured schemas.
+	if len(result.ExecuteStmts) > 0 && len(client.Schemas) > 0 {
+		searchPath := "SET LOCAL search_path TO " + strings.Join(client.Schemas, ", ")
+		if _, err := exec(ctx, searchPath); err != nil {
+			return nil, fmt.Errorf("failed to set search_path: %w", err)
+		}
+	}
+
 	for _, es := range result.ExecuteStmts {
 		shouldExecute := true
 

--- a/apply.go
+++ b/apply.go
@@ -42,7 +42,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	}
 
 	exec := conn.Exec
-	query := conn.Query
+	queryRow := conn.QueryRow
 	commit := func(context.Context) error { return nil }
 
 	if options.WithTx {
@@ -52,7 +52,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		}
 		defer tx.Rollback(ctx) //nolint:errcheck
 		exec = tx.Exec
-		query = tx.Query
+		queryRow = tx.QueryRow
 		commit = tx.Commit
 	}
 
@@ -75,17 +75,9 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		shouldExecute := true
 
 		if es.CheckSQL != "" {
-			rows, err := query(ctx, es.CheckSQL)
-			if err != nil {
-				return nil, fmt.Errorf("failed to execute check SQL: %s: %w", es.CheckSQL, err)
+			if err := queryRow(ctx, es.CheckSQL).Scan(&shouldExecute); err != nil {
+				return nil, fmt.Errorf("failed to evaluate check SQL: %s: %w", es.CheckSQL, err)
 			}
-			if rows.Next() {
-				if err := rows.Scan(&shouldExecute); err != nil {
-					rows.Close()
-					return nil, fmt.Errorf("failed to scan check SQL result: %s: %w", es.CheckSQL, err)
-				}
-			}
-			rows.Close()
 		}
 
 		if shouldExecute {

--- a/apply_test.go
+++ b/apply_test.go
@@ -233,6 +233,113 @@ func TestApply_WithTx_Success(t *testing.T) {
 	assert.Contains(t, got.String(), "CREATE TABLE public.users")
 }
 
+func TestApply_ExecuteWithCheck_Executes(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
+	require.NoError(t, err)
+	// Function should be executed (check returns true — function doesn't exist yet)
+	assert.Contains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
+
+	// Verify function exists
+	var exists bool
+	err = conn.QueryRow(ctx, "SELECT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')").Scan(&exists)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestApply_ExecuteWithCheck_Skipped(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
+	require.NoError(t, err)
+	// Function should be SKIPPED (check returns false — function already exists)
+	assert.NotContains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
+}
+
+func TestApply_ExecuteWithoutCheck(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
+	require.NoError(t, err)
+	// No check SQL → always execute
+	assert.Contains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
+}
+
 func TestApply_NoDiff(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/apply_test.go
+++ b/apply_test.go
@@ -340,6 +340,80 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	assert.Contains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
 }
 
+func TestApply_ExecuteWithTx(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute SELECT true
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:  []string{desiredFile},
+		WithTx: true,
+	}, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
+
+	// Verify function was created
+	var exists bool
+	err = conn.QueryRow(ctx, "SELECT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')").Scan(&exists)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestApply_ExecuteOnly_NoSchemaChange(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
+	require.NoError(t, err)
+	// Execute-only (no schema diff) should still run
+	assert.Contains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
+}
+
 func TestApply_NoDiff(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/apply_test.go
+++ b/apply_test.go
@@ -414,6 +414,47 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	assert.Contains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
 }
 
+func TestApply_ExecuteSchemalessFunction(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	// Schemaless function — should resolve to public via search_path
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`
+CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute
+CREATE OR REPLACE FUNCTION get_count() RETURNS bigint AS $$
+  SELECT count(*) FROM users;
+$$ LANGUAGE sql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
+
+	// Verify function was created in public schema
+	var schema string
+	err = conn.QueryRow(ctx, "SELECT n.nspname FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE p.proname = 'get_count'").Scan(&schema)
+	require.NoError(t, err)
+	assert.Equal(t, "public", schema)
+}
+
 func TestApply_NoDiff(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package pistachio
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -27,19 +26,6 @@ func (client *Client) connect() (*pgx.Conn, error) {
 
 	if client.Password != "" {
 		cfg.Password = client.Password
-	}
-
-	if len(client.Schemas) > 0 {
-		if cfg.RuntimeParams == nil {
-			cfg.RuntimeParams = make(map[string]string)
-		}
-		// Use remapped schema names for search_path so unqualified names
-		// in execute statements and pg_get_viewdef resolve correctly.
-		remapped := make([]string, len(client.Schemas))
-		for i, s := range client.Schemas {
-			remapped[i] = client.RemapSchema(s)
-		}
-		cfg.RuntimeParams["search_path"] = strings.Join(remapped, ", ")
 	}
 
 	conn, err := pgx.ConnectConfig(context.Background(), cfg)

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package pistachio
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -26,6 +27,19 @@ func (client *Client) connect() (*pgx.Conn, error) {
 
 	if client.Password != "" {
 		cfg.Password = client.Password
+	}
+
+	if len(client.Schemas) > 0 {
+		if cfg.RuntimeParams == nil {
+			cfg.RuntimeParams = make(map[string]string)
+		}
+		// Use remapped schema names for search_path so unqualified names
+		// in execute statements and pg_get_viewdef resolve correctly.
+		remapped := make([]string, len(client.Schemas))
+		for i, s := range client.Schemas {
+			remapped[i] = client.RemapSchema(s)
+		}
+		cfg.RuntimeParams["search_path"] = strings.Join(remapped, ", ")
 	}
 
 	conn, err := pgx.ConnectConfig(context.Background(), cfg)

--- a/diff_all.go
+++ b/diff_all.go
@@ -26,9 +26,10 @@ type diffAllOptions struct {
 
 // diffAllResult holds the result of diffAll.
 type diffAllResult struct {
-	Stmts  []string
-	PreSQL string
-	Count  ObjectCount
+	Stmts        []string
+	PreSQL       string
+	Count        ObjectCount
+	ExecuteStmts []*parser.ExecuteStmt
 }
 
 // diffAll performs the common catalog fetch, parse, diff, and statement
@@ -116,9 +117,10 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	}
 
 	return &diffAllResult{
-		Stmts:  stmts,
-		PreSQL: preSQL,
-		Count:  count,
+		Stmts:        stmts,
+		PreSQL:       preSQL,
+		Count:        count,
+		ExecuteStmts: desired.ExecuteStmts,
 	}, nil
 }
 

--- a/fmt.go
+++ b/fmt.go
@@ -29,7 +29,21 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse SQL file %q: %w", path, err)
 		}
-		results[path] = formatSchemaSQL(result.Domains, result.Enums, result.Tables, result.Views)
+		formatted := formatSchemaSQL(result.Domains, result.Enums, result.Tables, result.Views)
+
+		// Append execute statements
+		if len(result.ExecuteStmts) > 0 {
+			var executeParts []string
+			for _, es := range result.ExecuteStmts {
+				executeParts = append(executeParts, parser.FormatExecuteStmt(es))
+			}
+			if formatted != "" {
+				formatted += "\n\n"
+			}
+			formatted += strings.Join(executeParts, "\n\n")
+		}
+
+		results[path] = formatted
 	}
 
 	return results, nil

--- a/getting-started.md
+++ b/getting-started.md
@@ -231,6 +231,34 @@ pist apply schema.sql --pre-sql "CREATE EXTENSION IF NOT EXISTS pgcrypto;" --wit
 pist apply schema.sql --pre-sql-file pre.sql --with-tx
 ```
 
+### Executing arbitrary SQL
+
+Use the `-- pist:execute` directive to include SQL statements that pistachio doesn't manage declaratively (functions, triggers, grants, etc.). These are executed after schema changes during `apply`.
+
+```sql
+-- pist:execute
+CREATE OR REPLACE FUNCTION public.update_timestamp() RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+Add a check SQL after `-- pist:execute` to conditionally execute — the SQL runs only when the check returns `true`:
+
+```sql
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'update_timestamp')
+CREATE OR REPLACE FUNCTION public.update_timestamp() RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+Execute statements appear in `plan` output and are preserved by `fmt`. During `apply`, the check SQL is evaluated and the statement is skipped if it returns `false`.
+
 ## CI integration
 
 A typical CI pipeline:

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -75,7 +75,11 @@ func FormatExecuteStmt(es *ExecuteStmt) string {
 	if es.CheckSQL != "" {
 		directive += " " + es.CheckSQL
 	}
-	return fmt.Sprintf("%s\n%s", directive, es.SQL)
+	sql := strings.TrimRight(es.SQL, " \t\r\n")
+	if !strings.HasSuffix(sql, ";") {
+		sql += ";"
+	}
+	return fmt.Sprintf("%s\n%s", directive, sql)
 }
 
 // QualifyRenameFrom qualifies a renamed-from value with the default schema

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -57,6 +57,9 @@ func ExtractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*Exec
 		checkSQL := ""
 		if len(lastMatch) > 1 {
 			checkSQL = strings.TrimSpace(lastMatch[1])
+			// Remove trailing semicolons — pgx extended protocol doesn't allow them
+			checkSQL = strings.TrimRight(checkSQL, ";")
+			checkSQL = strings.TrimSpace(checkSQL)
 		}
 
 		executeStmts = append(executeStmts, &ExecuteStmt{

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -24,7 +24,7 @@ type ExecuteStmt struct {
 // comments and pairs them with the following SQL statement.
 // Returns the execute statements and a set of statement locations to skip
 // during normal parsing.
-func ExtractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*ExecuteStmt, map[int32]bool) {
+func ExtractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*ExecuteStmt, map[int32]bool, error) {
 	var executeStmts []*ExecuteStmt
 	skipLocations := make(map[int32]bool)
 
@@ -49,7 +49,7 @@ func ExtractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*Exec
 			Stmts: []*pg_query.RawStmt{stmt},
 		})
 		if err != nil {
-			continue
+			return nil, nil, fmt.Errorf("failed to deparse execute statement: %w", err)
 		}
 
 		// Use the last match (closest to the actual SQL statement)
@@ -66,7 +66,7 @@ func ExtractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*Exec
 		skipLocations[loc] = true
 	}
 
-	return executeStmts, skipLocations
+	return executeStmts, skipLocations, nil
 }
 
 // FormatExecuteStmt formats an ExecuteStmt as SQL with the directive comment.

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -8,7 +9,74 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-var renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:renamed-from[ \t]+(.+?)[ \t]*$`)
+var (
+	renameDirectivePattern  = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:renamed-from[ \t]+(.+?)[ \t]*$`)
+	executeDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:execute(?:[ \t]+(.+?))?[ \t]*$`)
+)
+
+// ExecuteStmt represents an arbitrary SQL statement marked with -- pist:execute.
+type ExecuteStmt struct {
+	SQL      string // The SQL statement to execute
+	CheckSQL string // Optional condition check SQL (empty = always execute)
+}
+
+// ExtractExecuteDirectives scans raw SQL for `-- pist:execute [<check SQL>]`
+// comments and pairs them with the following SQL statement.
+// Returns the execute statements and a set of statement locations to skip
+// during normal parsing.
+func ExtractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*ExecuteStmt, map[int32]bool) {
+	var executeStmts []*ExecuteStmt
+	skipLocations := make(map[int32]bool)
+
+	for _, stmt := range stmts {
+		loc := stmt.StmtLocation
+		end := loc + stmt.StmtLen
+		if end > int32(len(rawSQL)) {
+			end = int32(len(rawSQL))
+		}
+
+		region := rawSQL[loc:end]
+		leadingEnd := findLeadingCommentEnd(region)
+		leading := region[:leadingEnd]
+
+		matches := executeDirectivePattern.FindAllStringSubmatch(leading, -1)
+		if len(matches) == 0 {
+			continue
+		}
+
+		// Deparse the statement to get canonical SQL
+		deparsed, err := pg_query.Deparse(&pg_query.ParseResult{
+			Stmts: []*pg_query.RawStmt{stmt},
+		})
+		if err != nil {
+			continue
+		}
+
+		// Use the last match (closest to the actual SQL statement)
+		lastMatch := matches[len(matches)-1]
+		checkSQL := ""
+		if len(lastMatch) > 1 {
+			checkSQL = strings.TrimSpace(lastMatch[1])
+		}
+
+		executeStmts = append(executeStmts, &ExecuteStmt{
+			SQL:      deparsed,
+			CheckSQL: checkSQL,
+		})
+		skipLocations[loc] = true
+	}
+
+	return executeStmts, skipLocations
+}
+
+// FormatExecuteStmt formats an ExecuteStmt as SQL with the directive comment.
+func FormatExecuteStmt(es *ExecuteStmt) string {
+	directive := "-- pist:execute"
+	if es.CheckSQL != "" {
+		directive += " " + es.CheckSQL
+	}
+	return fmt.Sprintf("%s\n%s", directive, es.SQL)
+}
 
 // QualifyRenameFrom qualifies a renamed-from value with the default schema
 // if it does not already contain a schema. Quoted identifiers containing

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -263,7 +263,8 @@ CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LAN
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0].SQL, "CREATE OR REPLACE FUNCTION")
 	assert.Equal(t, "SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')", stmts[0].CheckSQL)
@@ -277,7 +278,8 @@ GRANT SELECT ON public.users TO readonly_role;`
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0].SQL, "GRANT select")
 	assert.Equal(t, "", stmts[0].CheckSQL)
@@ -292,7 +294,8 @@ CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LAN
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0].SQL, "CREATE OR REPLACE FUNCTION")
 	assert.Len(t, skip, 1)
@@ -309,7 +312,8 @@ CREATE OR REPLACE FUNCTION public.func2() RETURNS void AS $$ BEGIN END; $$ LANGU
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	require.NoError(t, err)
 	require.Len(t, stmts, 2)
 	assert.Equal(t, "", stmts[0].CheckSQL)
 	assert.Equal(t, "SELECT true", stmts[1].CheckSQL)
@@ -322,7 +326,8 @@ func TestExtractExecuteDirectives_None(t *testing.T) {
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	require.NoError(t, err)
 	assert.Empty(t, stmts)
 	assert.Empty(t, skip)
 }

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -271,6 +271,20 @@ CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LAN
 	assert.Len(t, skip, 1)
 }
 
+func TestExtractExecuteDirectives_CheckSQLTrailingSemicolon(t *testing.T) {
+	sql := `-- pist:execute SELECT true;
+CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	stmts, _, err := ExtractExecuteDirectives(sql, result.Stmts)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	// Trailing semicolon should be stripped from check SQL
+	assert.Equal(t, "SELECT true", stmts[0].CheckSQL)
+}
+
 func TestExtractExecuteDirectives_WithoutCheckSQL(t *testing.T) {
 	sql := `-- pist:execute
 GRANT SELECT ON public.users TO readonly_role;`

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -337,6 +337,12 @@ func TestFormatExecuteStmt_WithCheck(t *testing.T) {
 	assert.Equal(t, "-- pist:execute SELECT true\nCREATE FUNCTION f();", FormatExecuteStmt(es))
 }
 
+func TestFormatExecuteStmt_WithoutSemicolon(t *testing.T) {
+	// Deparse output has no trailing semicolon — FormatExecuteStmt should add one
+	es := &ExecuteStmt{SQL: "CREATE FUNCTION f() RETURNS void LANGUAGE plpgsql", CheckSQL: ""}
+	assert.Equal(t, "-- pist:execute\nCREATE FUNCTION f() RETURNS void LANGUAGE plpgsql;", FormatExecuteStmt(es))
+}
+
 func TestFormatExecuteStmt_WithoutCheck(t *testing.T) {
 	es := &ExecuteStmt{SQL: "GRANT SELECT ON t TO r;", CheckSQL: ""}
 	assert.Equal(t, "-- pist:execute\nGRANT SELECT ON t TO r;", FormatExecuteStmt(es))

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -255,3 +255,84 @@ func TestExtractColumnName(t *testing.T) {
 	// Unquoted names are lowercased
 	assert.Equal(t, "displayname", extractColumnName("DisplayName text NOT NULL"))
 }
+
+func TestExtractExecuteDirectives_WithCheckSQL(t *testing.T) {
+	sql := `-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
+CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	require.Len(t, stmts, 1)
+	assert.Contains(t, stmts[0].SQL, "CREATE OR REPLACE FUNCTION")
+	assert.Equal(t, "SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')", stmts[0].CheckSQL)
+	assert.Len(t, skip, 1)
+}
+
+func TestExtractExecuteDirectives_WithoutCheckSQL(t *testing.T) {
+	sql := `-- pist:execute
+GRANT SELECT ON public.users TO readonly_role;`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	require.Len(t, stmts, 1)
+	assert.Contains(t, stmts[0].SQL, "GRANT select")
+	assert.Equal(t, "", stmts[0].CheckSQL)
+	assert.Len(t, skip, 1)
+}
+
+func TestExtractExecuteDirectives_MixedWithManaged(t *testing.T) {
+	sql := `CREATE TABLE public.users (id integer NOT NULL);
+-- pist:execute
+CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	require.Len(t, stmts, 1)
+	assert.Contains(t, stmts[0].SQL, "CREATE OR REPLACE FUNCTION")
+	assert.Len(t, skip, 1)
+	// The CREATE TABLE should NOT be in skip
+	assert.False(t, skip[result.Stmts[0].StmtLocation])
+}
+
+func TestExtractExecuteDirectives_Multiple(t *testing.T) {
+	sql := `-- pist:execute
+CREATE OR REPLACE FUNCTION public.func1() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+-- pist:execute SELECT true
+CREATE OR REPLACE FUNCTION public.func2() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	require.Len(t, stmts, 2)
+	assert.Equal(t, "", stmts[0].CheckSQL)
+	assert.Equal(t, "SELECT true", stmts[1].CheckSQL)
+	assert.Len(t, skip, 2)
+}
+
+func TestExtractExecuteDirectives_None(t *testing.T) {
+	sql := `CREATE TABLE public.users (id integer NOT NULL);`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	stmts, skip := ExtractExecuteDirectives(sql, result.Stmts)
+	assert.Empty(t, stmts)
+	assert.Empty(t, skip)
+}
+
+func TestFormatExecuteStmt_WithCheck(t *testing.T) {
+	es := &ExecuteStmt{SQL: "CREATE FUNCTION f();", CheckSQL: "SELECT true"}
+	assert.Equal(t, "-- pist:execute SELECT true\nCREATE FUNCTION f();", FormatExecuteStmt(es))
+}
+
+func TestFormatExecuteStmt_WithoutCheck(t *testing.T) {
+	es := &ExecuteStmt{SQL: "GRANT SELECT ON t TO r;", CheckSQL: ""}
+	assert.Equal(t, "-- pist:execute\nGRANT SELECT ON t TO r;", FormatExecuteStmt(es))
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -12,10 +12,11 @@ import (
 )
 
 type ParseResult struct {
-	Tables  *orderedmap.Map[string, *model.Table]
-	Views   *orderedmap.Map[string, *model.View]
-	Enums   *orderedmap.Map[string, *model.Enum]
-	Domains *orderedmap.Map[string, *model.Domain]
+	Tables       *orderedmap.Map[string, *model.Table]
+	Views        *orderedmap.Map[string, *model.View]
+	Enums        *orderedmap.Map[string, *model.Enum]
+	Domains      *orderedmap.Map[string, *model.Domain]
+	ExecuteStmts []*ExecuteStmt
 }
 
 func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error {
@@ -92,8 +93,14 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	domains := orderedmap.New[string, *model.Domain]()
 
 	stmtDirectives := ExtractStmtDirectives(sql, result.Stmts)
+	executeStmts, executeSkipLocations := ExtractExecuteDirectives(sql, result.Stmts)
 
 	for _, rawStmt := range result.Stmts {
+		// Skip statements marked with -- pist:execute
+		if executeSkipLocations[rawStmt.StmtLocation] {
+			continue
+		}
+
 		node := rawStmt.Stmt
 		renameFrom := stmtDirectives[rawStmt.StmtLocation]
 
@@ -250,7 +257,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		}
 	}
 
-	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains}, nil
+	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains, ExecuteStmts: executeStmts}, nil
 }
 
 func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Table, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -93,7 +93,10 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	domains := orderedmap.New[string, *model.Domain]()
 
 	stmtDirectives := ExtractStmtDirectives(sql, result.Stmts)
-	executeStmts, executeSkipLocations := ExtractExecuteDirectives(sql, result.Stmts)
+	executeStmts, executeSkipLocations, err := ExtractExecuteDirectives(sql, result.Stmts)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, rawStmt := range result.Stmts {
 		// Skip statements marked with -- pist:execute

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -913,6 +913,41 @@ CREATE INDEX idx_user_stats_cnt ON user_stats (cnt);`
 	assert.Equal(t, "user_stats", idx.Table)
 }
 
+func TestParseSQL_ExecuteDirective(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
+CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	// Table should be parsed normally
+	assert.Equal(t, 1, result.Tables.Len())
+	// Function should be in ExecuteStmts, not Views/Tables
+	assert.Equal(t, 0, result.Views.Len())
+	require.Len(t, result.ExecuteStmts, 1)
+	assert.Contains(t, result.ExecuteStmts[0].SQL, "CREATE OR REPLACE FUNCTION")
+	assert.Contains(t, result.ExecuteStmts[0].CheckSQL, "pg_proc")
+}
+
+func TestParseSQL_ExecuteDirective_NoCheck(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute
+GRANT SELECT ON public.users TO readonly_role;`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Tables.Len())
+	require.Len(t, result.ExecuteStmts, 1)
+	assert.Contains(t, result.ExecuteStmts[0].SQL, "GRANT select")
+	assert.Equal(t, "", result.ExecuteStmts[0].CheckSQL)
+}
+
 func TestParseSQL_IndexOnUnknownTableSkipped(t *testing.T) {
 	sql := `CREATE INDEX idx_name ON public.nonexistent USING btree (name);`
 	result, err := parser.ParseSQL(sql)

--- a/plan.go
+++ b/plan.go
@@ -73,13 +73,14 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	}
 
 	stmts := result.Stmts
-	if result.PreSQL != "" && len(stmts) > 0 {
-		stmts = append([]string{result.PreSQL}, stmts...)
-	}
 
 	// Append execute statements after schema changes
 	for _, es := range result.ExecuteStmts {
 		stmts = append(stmts, parser.FormatExecuteStmt(es))
+	}
+
+	if result.PreSQL != "" && len(stmts) > 0 {
+		stmts = append([]string{result.PreSQL}, stmts...)
 	}
 
 	return &PlanResult{

--- a/plan.go
+++ b/plan.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/winebarrel/pistachio/parser"
 )
 
 type PlanOptions struct {
@@ -73,6 +75,11 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	stmts := result.Stmts
 	if result.PreSQL != "" && len(stmts) > 0 {
 		stmts = append([]string{result.PreSQL}, stmts...)
+	}
+
+	// Append execute statements after schema changes
+	for _, es := range result.ExecuteStmts {
+		stmts = append(stmts, parser.FormatExecuteStmt(es))
 	}
 
 	return &PlanResult{

--- a/test/scenario/execute.test.sh
+++ b/test/scenario/execute.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Scenario test: -- pist:execute directive
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/execute"
+
+# --- Setup: load initial schema ---
+setup_db "$DATA/init.sql"
+
+# --- Step 1: execute adds function ---
+step "01 execute creates function"
+plan_output=$(pist_plan "$DATA/steps/01_add_function.sql") || { fail "plan failed: $plan_output"; true; }
+if echo "$plan_output" | grep -qF 'pist:execute'; then
+  # Apply and verify function exists
+  apply_output=$(pist_apply "$DATA/steps/01_add_function.sql") || { fail "apply failed: $apply_output"; true; }
+  func_exists=$(psql -X "$PIST_CONN_STR" -tAc "SELECT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'get_user_count')")
+  if [ "$func_exists" = "t" ]; then
+    pass
+  else
+    fail "function not created"
+  fi
+else
+  fail "expected pist:execute in plan"
+  echo "    $plan_output" >&2
+fi
+
+# --- Step 2: check SQL skips execution (function already exists) ---
+step "02 check SQL skips existing function"
+apply_output=$(pist_apply "$DATA/steps/02_function_exists_skip.sql") || { fail "apply failed: $apply_output"; true; }
+# The function should NOT appear in apply output (skipped)
+if echo "$apply_output" | grep -qF 'CREATE OR REPLACE FUNCTION'; then
+  fail "function should have been skipped by check SQL"
+  echo "    $apply_output" >&2
+else
+  pass
+fi
+
+# --- Step 3: execute without check always runs ---
+step "03 execute without check always runs"
+apply_output=$(pist_apply "$DATA/steps/03_always_execute.sql") || { fail "apply failed: $apply_output"; true; }
+if echo "$apply_output" | grep -qF 'CREATE OR REPLACE FUNCTION'; then
+  pass
+else
+  fail "expected function in apply output"
+  echo "    $apply_output" >&2
+fi
+
+summary

--- a/test/scenario/testdata/execute/init.sql
+++ b/test/scenario/testdata/execute/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/execute/steps/01_add_function.sql
+++ b/test/scenario/testdata/execute/steps/01_add_function.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'get_user_count')
+CREATE OR REPLACE FUNCTION public.get_user_count() RETURNS bigint AS $$
+  SELECT count(*) FROM public.users;
+$$ LANGUAGE sql;

--- a/test/scenario/testdata/execute/steps/02_function_exists_skip.sql
+++ b/test/scenario/testdata/execute/steps/02_function_exists_skip.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'get_user_count')
+CREATE OR REPLACE FUNCTION public.get_user_count() RETURNS bigint AS $$
+  SELECT count(*) FROM public.users;
+$$ LANGUAGE sql;

--- a/test/scenario/testdata/execute/steps/03_always_execute.sql
+++ b/test/scenario/testdata/execute/steps/03_always_execute.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+-- pist:execute
+CREATE OR REPLACE FUNCTION public.get_user_count() RETURNS bigint AS $$
+  SELECT count(*) FROM public.users;
+$$ LANGUAGE sql;

--- a/testdata/fmt/execute.yml
+++ b/testdata/fmt/execute.yml
@@ -10,4 +10,4 @@ expected: |
   );
 
   -- pist:execute SELECT true
-  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;

--- a/testdata/fmt/execute.yml
+++ b/testdata/fmt/execute.yml
@@ -1,0 +1,13 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  -- pist:execute SELECT true
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- pist:execute SELECT true
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql

--- a/testdata/plan/execute_only_no_schema_change.yml
+++ b/testdata/plan/execute_only_no_schema_change.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:execute
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+plan: |
+  -- pist:execute
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql

--- a/testdata/plan/execute_only_no_schema_change.yml
+++ b/testdata/plan/execute_only_no_schema_change.yml
@@ -12,4 +12,4 @@ desired: |
   CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
 plan: |
   -- pist:execute
-  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;

--- a/testdata/plan/execute_with_check.yml
+++ b/testdata/plan/execute_with_check.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+plan: |
+  -- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql

--- a/testdata/plan/execute_with_check.yml
+++ b/testdata/plan/execute_with_check.yml
@@ -12,4 +12,4 @@ desired: |
   CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
 plan: |
   -- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
-  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;

--- a/testdata/plan/execute_without_check.yml
+++ b/testdata/plan/execute_without_check.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:execute
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+plan: |
+  ALTER TABLE public.users ADD COLUMN name text;
+  -- pist:execute
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql

--- a/testdata/plan/execute_without_check.yml
+++ b/testdata/plan/execute_without_check.yml
@@ -14,4 +14,4 @@ desired: |
 plan: |
   ALTER TABLE public.users ADD COLUMN name text;
   -- pist:execute
-  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Add `-- pist:execute` directive to include non-managed SQL (functions, triggers, grants, etc.) in schema files. Statements are executed after schema changes during `apply` and appear in `plan` and `fmt` output.

### Syntax

```sql
-- Always execute
-- pist:execute
CREATE OR REPLACE FUNCTION public.my_func() ...;

-- Conditional execution (skip if check returns false)
-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
CREATE OR REPLACE FUNCTION public.my_func() ...;
```

## Changes
- **parser/directive.go**: `ExecuteStmt` type, `ExtractExecuteDirectives()`, `FormatExecuteStmt()`
- **parser/parser.go**: Skip execute-marked statements from managed object parsing
- **diff_all.go**: Pass `ExecuteStmts` through `diffAllResult`
- **plan.go**: Append execute statements after schema changes in plan output
- **apply.go**: Execute with condition check; skip if check returns `false`
- **fmt.go**: Preserve execute directives in formatted output
- **README.md**, **getting-started.md**: Documentation

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — no issues
- [x] `make test-scenario` — all scenarios pass
- [x] Directive unit tests: 7 cases (with/without check, mixed, multiple, none, format)
- [x] Parser unit tests: execute with and without check
- [x] Plan fixtures: `execute_with_check`, `execute_without_check`
- [x] Fmt fixture: `execute`
- [x] Scenario test: create function, skip existing (check), always execute (no check)
- [x] pagila sample schema: unaffected (dump→plan "No changes")

🤖 Generated with [Claude Code](https://claude.com/claude-code)