### PR TITLE
Reject unknown -- pist: directives with an error

### DIFF
--- a/parser/directive.go
+++ b/parser/directive.go
@@ -12,7 +12,8 @@ import (
 var (
 	renameDirectivePattern  = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:renamed-from[ \t]+(.+?)[ \t]*$`)
 	executeDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:execute(?:[ \t]+(.+?))?[ \t]*$`)
-	unknownDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:(\S+)`)
+	// Matches any -- pist: directive, capturing the name (if any) after the colon.
+	anyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:[ \t]*(\S*)`)
 )
 
 // knownDirectives lists all recognized directive names.
@@ -24,9 +25,12 @@ var knownDirectives = map[string]bool{
 // ValidateDirectives checks for unknown -- pist: directives in the raw SQL
 // and returns an error if any are found.
 func ValidateDirectives(rawSQL string) error {
-	matches := unknownDirectivePattern.FindAllStringSubmatch(rawSQL, -1)
+	matches := anyDirectivePattern.FindAllStringSubmatch(rawSQL, -1)
 	for _, m := range matches {
-		name := m[1]
+		name := strings.TrimSpace(m[1])
+		if name == "" {
+			return fmt.Errorf("invalid directive: -- pist: (missing directive name)")
+		}
 		if !knownDirectives[name] {
 			return fmt.Errorf("unknown directive: -- pist:%s", name)
 		}

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -12,7 +12,27 @@ import (
 var (
 	renameDirectivePattern  = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:renamed-from[ \t]+(.+?)[ \t]*$`)
 	executeDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:execute(?:[ \t]+(.+?))?[ \t]*$`)
+	unknownDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:(\S+)`)
 )
+
+// knownDirectives lists all recognized directive names.
+var knownDirectives = map[string]bool{
+	"renamed-from": true,
+	"execute":      true,
+}
+
+// ValidateDirectives checks for unknown -- pist: directives in the raw SQL
+// and returns an error if any are found.
+func ValidateDirectives(rawSQL string) error {
+	matches := unknownDirectivePattern.FindAllStringSubmatch(rawSQL, -1)
+	for _, m := range matches {
+		name := m[1]
+		if !knownDirectives[name] {
+			return fmt.Errorf("unknown directive: -- pist:%s", name)
+		}
+	}
+	return nil
+}
 
 // ExecuteStmt represents an arbitrary SQL statement marked with -- pist:execute.
 type ExecuteStmt struct {

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -371,6 +371,18 @@ func TestValidateDirectives_UnknownFoobar(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown directive: -- pist:foobar")
 }
 
+func TestValidateDirectives_SpaceAfterColon(t *testing.T) {
+	err := ValidateDirectives("-- pist: exec")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown directive: -- pist:exec")
+}
+
+func TestValidateDirectives_MissingName(t *testing.T) {
+	err := ValidateDirectives("-- pist:")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing directive name")
+}
+
 func TestFormatExecuteStmt_WithCheck(t *testing.T) {
 	es := &ExecuteStmt{SQL: "CREATE FUNCTION f();", CheckSQL: "SELECT true"}
 	assert.Equal(t, "-- pist:execute SELECT true\nCREATE FUNCTION f();", FormatExecuteStmt(es))

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -346,6 +346,31 @@ func TestExtractExecuteDirectives_None(t *testing.T) {
 	assert.Empty(t, skip)
 }
 
+func TestValidateDirectives_Valid(t *testing.T) {
+	assert.NoError(t, ValidateDirectives("-- pist:renamed-from old"))
+	assert.NoError(t, ValidateDirectives("-- pist:execute SELECT true"))
+	assert.NoError(t, ValidateDirectives("-- pist:execute"))
+	assert.NoError(t, ValidateDirectives("SELECT 1; -- no directives"))
+}
+
+func TestValidateDirectives_UnknownDirective(t *testing.T) {
+	err := ValidateDirectives("-- pist:exec")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown directive: -- pist:exec")
+}
+
+func TestValidateDirectives_Typo(t *testing.T) {
+	err := ValidateDirectives("-- pist:rename-from old")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown directive: -- pist:rename-from")
+}
+
+func TestValidateDirectives_UnknownFoobar(t *testing.T) {
+	err := ValidateDirectives("-- pist:foobar something")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown directive: -- pist:foobar")
+}
+
 func TestFormatExecuteStmt_WithCheck(t *testing.T) {
 	es := &ExecuteStmt{SQL: "CREATE FUNCTION f();", CheckSQL: "SELECT true"}
 	assert.Equal(t, "-- pist:execute SELECT true\nCREATE FUNCTION f();", FormatExecuteStmt(es))

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -82,13 +82,13 @@ func ParseSQL(sql string) (*ParseResult, error) {
 }
 
 func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) {
+	if err := ValidateDirectives(sql); err != nil {
+		return nil, err
+	}
+
 	result, err := pg_query.Parse(sql)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SQL: %w", err)
-	}
-
-	if err := ValidateDirectives(sql); err != nil {
-		return nil, err
 	}
 
 	tables := orderedmap.New[string, *model.Table]()

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -87,6 +87,10 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		return nil, fmt.Errorf("failed to parse SQL: %w", err)
 	}
 
+	if err := ValidateDirectives(sql); err != nil {
+		return nil, err
+	}
+
 	tables := orderedmap.New[string, *model.Table]()
 	views := orderedmap.New[string, *model.View]()
 	enums := orderedmap.New[string, *model.Enum]()


### PR DESCRIPTION
## Summary
Typos in directives (e.g., `-- pist:exec` instead of `-- pist:execute`) were silently ignored, causing statements to be missed without any warning.

Add `ValidateDirectives()` that checks all `-- pist:` comments against known directives and returns an error for unrecognized ones.

```
$ pist plan schema.sql
pist: error: failed to parse SQL file: unknown directive: -- pist:exec
```

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — no issues
- [x] `make test-scenario` — all scenarios pass
- [x] Unit tests: valid directives pass, typos/unknown directives error

🤖 Generated with [Claude Code](https://claude.com/claude-code)