### PR TITLE
Fix --allow-drop section placement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,6 @@ pist apply schema.sql --pre-sql-file pre.sql --with-tx
 
 By default, `plan` and `apply` do not drop tables, views, enums, domains, or columns. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
 
-### Executing arbitrary SQL
-
-Use `-- pist:execute` to include non-managed SQL (functions, triggers, grants) in your schema files. Add a check SQL to skip execution conditionally:
-
-```sql
--- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
-CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ ... $$ LANGUAGE plpgsql;
-```
-
-See [Getting Started](getting-started.md) for details.
-
 ```bash
 # Allow all drops
 pist plan --allow-drop all schema.sql
@@ -113,6 +102,17 @@ pist apply --allow-drop column,table schema.sql
 
 > [!NOTE]
 > Constraints and indexes are always dropped when their definitions change or they are removed from the desired schema, regardless of `--allow-drop`. This is because PostgreSQL does not support `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes — the only way to update them is DROP + ADD.
+
+### Executing arbitrary SQL
+
+Use `-- pist:execute` to include non-managed SQL (functions, triggers, grants) in your schema files. Add a check SQL to skip execution conditionally:
+
+```sql
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
+CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ ... $$ LANGUAGE plpgsql;
+```
+
+See [Getting Started](getting-started.md) for details.
 
 ### dump
 


### PR DESCRIPTION
## Summary
- `--allow-drop` の説明文とコード例・NOTEが「Executing arbitrary SQL」セクションによって分断されていたのを修正
- コード例とNOTEを説明文の直後に移動し、セクションの順序を整理

## Test plan
- [ ] README のレンダリングを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)