### PR TITLE
Add --index-concurrently option for CREATE/DROP INDEX CONCURRENTLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ CREATE INDEX idx_users_email ON public.users USING btree (email);
 ```
 
 > [!NOTE]
-> Both `--index-concurrently` and `-- pist:concurrently` cannot be used with `--with-tx` because `CONCURRENTLY` operations cannot run inside a transaction.
+> When the generated diff includes `CREATE INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY` (via `--index-concurrently` or `-- pist:concurrently`), `--with-tx` cannot be used because `CONCURRENTLY` operations cannot run inside a transaction. If there are no index changes, `--with-tx` is allowed even when the flag or directive is present.
 
 By default, `plan` and `apply` do not drop tables, views, enums, domains, or columns. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ pist apply schema.sql --pre-sql "SET search_path TO myschema;" --with-tx
 pist apply schema.sql --pre-sql-file pre.sql --with-tx
 ```
 
+Use `--index-concurrently` to generate `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` statements. Also available as `$PIST_INDEX_CONCURRENTLY`. This option cannot be used with `--with-tx` because `CONCURRENTLY` operations cannot run inside a transaction.
+
+```bash
+pist plan --index-concurrently schema.sql
+pist apply --index-concurrently schema.sql
+```
+
 By default, `plan` and `apply` do not drop tables, views, enums, domains, or columns. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -90,12 +90,25 @@ pist apply schema.sql --pre-sql "SET search_path TO myschema;" --with-tx
 pist apply schema.sql --pre-sql-file pre.sql --with-tx
 ```
 
-Use `--index-concurrently` to generate `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` statements. Also available as `$PIST_INDEX_CONCURRENTLY`. This option cannot be used with `--with-tx` because `CONCURRENTLY` operations cannot run inside a transaction.
+Use `--index-concurrently` to generate `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` for **all** index operations. Also available as `$PIST_INDEX_CONCURRENTLY`.
 
 ```bash
 pist plan --index-concurrently schema.sql
 pist apply --index-concurrently schema.sql
 ```
+
+To apply `CONCURRENTLY` to **individual** indexes, use the `-- pist:concurrently` directive before the `CREATE INDEX` statement:
+
+```sql
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);
+
+-- This index will NOT use CONCURRENTLY
+CREATE INDEX idx_users_email ON public.users USING btree (email);
+```
+
+> [!NOTE]
+> Both `--index-concurrently` and `-- pist:concurrently` cannot be used with `--with-tx` because `CONCURRENTLY` operations cannot run inside a transaction.
 
 By default, `plan` and `apply` do not drop tables, views, enums, domains, or columns. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
 

--- a/apply.go
+++ b/apply.go
@@ -43,6 +43,10 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return nil, err
 	}
 
+	if options.WithTx && result.HasConcurrentlyIndex {
+		return nil, fmt.Errorf("--with-tx cannot be used when schema contains -- pist:concurrently directive (CONCURRENTLY cannot run inside a transaction)")
+	}
+
 	count := &result.Count
 
 	if len(result.Stmts) == 0 && len(result.ExecuteStmts) == 0 {

--- a/apply.go
+++ b/apply.go
@@ -13,13 +13,18 @@ import (
 type ApplyOptions struct {
 	FilterOptions
 	DropPolicy
-	Files      []string `arg:"" help:"Path to the desired schema SQL file(s)."`
-	PreSQL     string   `xor:"pre-sql" help:"SQL to execute before applying changes."`
-	PreSQLFile string   `type:"path" xor:"pre-sql" help:"Path to a SQL file to execute before applying changes."`
-	WithTx     bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
+	Files             []string `arg:"" help:"Path to the desired schema SQL file(s)."`
+	PreSQL            string   `xor:"pre-sql" help:"SQL to execute before applying changes."`
+	PreSQLFile        string   `type:"path" xor:"pre-sql" help:"Path to a SQL file to execute before applying changes."`
+	WithTx            bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
+	IndexConcurrently bool     `env:"PIST_INDEX_CONCURRENTLY" help:"Use CREATE/DROP INDEX CONCURRENTLY for index operations."`
 }
 
 func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (*ObjectCount, error) {
+	if options.IndexConcurrently && options.WithTx {
+		return nil, fmt.Errorf("--index-concurrently and --with-tx cannot be used together (CONCURRENTLY cannot run inside a transaction)")
+	}
+
 	conn, err := client.connect()
 	if err != nil {
 		return nil, err
@@ -27,11 +32,12 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	defer conn.Close(ctx) //nolint:errcheck
 
 	result, err := client.diffAll(ctx, conn, &diffAllOptions{
-		FilterOptions: options.FilterOptions,
-		DropPolicy:    options.DropPolicy,
-		Files:         options.Files,
-		PreSQL:        options.PreSQL,
-		PreSQLFile:    options.PreSQLFile,
+		FilterOptions:     options.FilterOptions,
+		DropPolicy:        options.DropPolicy,
+		Files:             options.Files,
+		PreSQL:            options.PreSQL,
+		PreSQLFile:        options.PreSQLFile,
+		IndexConcurrently: options.IndexConcurrently,
 	})
 	if err != nil {
 		return nil, err

--- a/apply.go
+++ b/apply.go
@@ -21,10 +21,6 @@ type ApplyOptions struct {
 }
 
 func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (*ObjectCount, error) {
-	if options.IndexConcurrently && options.WithTx {
-		return nil, fmt.Errorf("--index-concurrently and --with-tx cannot be used together (CONCURRENTLY cannot run inside a transaction)")
-	}
-
 	conn, err := client.connect()
 	if err != nil {
 		return nil, err
@@ -44,7 +40,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	}
 
 	if options.WithTx && result.HasConcurrentlyIndex {
-		return nil, fmt.Errorf("--with-tx cannot be used when schema contains -- pist:concurrently directive (CONCURRENTLY cannot run inside a transaction)")
+		return nil, fmt.Errorf("--with-tx cannot be used with CONCURRENTLY index operations (from --index-concurrently flag or -- pist:concurrently directive)")
 	}
 
 	count := &result.Count

--- a/apply_test.go
+++ b/apply_test.go
@@ -701,6 +701,39 @@ func TestApply_IndexConcurrently_WithTx_NoIndexChanges_OK(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestApply_ConcurrentlyDirective_WithTx_NoIndexChanges_OK(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	// Schema already has the index — no changes will be generated
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_id ON public.users USING btree (id);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_id ON public.users USING btree (id);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// Should succeed: no index DDL is generated, so --with-tx is safe
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:  []string{desiredFile},
+		WithTx: true,
+	}, io.Discard)
+	require.NoError(t, err)
+}
+
 func TestApply_ConcurrentlyDirective_WithTx_Error(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/apply_test.go
+++ b/apply_test.go
@@ -643,13 +643,25 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
 
 func TestApply_IndexConcurrently_WithTx_Error(t *testing.T) {
 	ctx := context.Background()
-	client := pistachio.NewClient(&pistachio.Options{
-		ConnString: "postgres://postgres@localhost/postgres",
-		Schemas:    []string{"public"},
-	})
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
 
 	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
-	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_id ON public.users USING btree (id);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
 
 	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:             []string{desiredFile},
@@ -657,7 +669,36 @@ func TestApply_IndexConcurrently_WithTx_Error(t *testing.T) {
 		WithTx:            true,
 	}, io.Discard)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--index-concurrently and --with-tx cannot be used together")
+	assert.Contains(t, err.Error(), "CONCURRENTLY")
+}
+
+func TestApply_IndexConcurrently_WithTx_NoIndexChanges_OK(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:             []string{desiredFile},
+		IndexConcurrently: true,
+		WithTx:            true,
+	}, io.Discard)
+	require.NoError(t, err)
 }
 
 func TestApply_ConcurrentlyDirective_WithTx_Error(t *testing.T) {

--- a/apply_test.go
+++ b/apply_test.go
@@ -659,3 +659,67 @@ func TestApply_IndexConcurrently_WithTx_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--index-concurrently and --with-tx cannot be used together")
 }
+
+func TestApply_ConcurrentlyDirective_WithTx_Error(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_id ON public.users USING btree (id);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:  []string{desiredFile},
+		WithTx: true,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pist:concurrently")
+}
+
+func TestApply_ConcurrentlyDirective(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files: []string{desiredFile},
+	}, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE INDEX CONCURRENTLY idx_users_name")
+}

--- a/apply_test.go
+++ b/apply_test.go
@@ -607,3 +607,55 @@ func TestApply_InvalidPreSQLFile(t *testing.T) {
 	}, io.Discard)
 	require.Error(t, err)
 }
+
+func TestApply_IndexConcurrently(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:             []string{desiredFile},
+		IndexConcurrently: true,
+	}, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE INDEX CONCURRENTLY idx_users_name")
+}
+
+func TestApply_IndexConcurrently_WithTx_Error(t *testing.T) {
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "postgres://postgres@localhost/postgres",
+		Schemas:    []string{"public"},
+	})
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:             []string{desiredFile},
+		IndexConcurrently: true,
+		WithTx:            true,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--index-concurrently and --with-tx cannot be used together")
+}

--- a/apply_test.go
+++ b/apply_test.go
@@ -723,3 +723,28 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE INDEX CONCURRENTLY idx_users_name")
 }
+
+func TestApply_ConcurrentlyDirective_MatviewIndex_WithTx_Error(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE MATERIALIZED VIEW public.mv AS SELECT 1 AS n;
+-- pist:concurrently
+CREATE INDEX idx_mv_n ON public.mv USING btree (n);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:  []string{desiredFile},
+		WithTx: true,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pist:concurrently")
+}

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -19,7 +19,7 @@ type TableDiffResult struct {
 	DropStmts   []string // DROP TABLE (separate from Stmts for ordering)
 }
 
-func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) (*TableDiffResult, error) {
+func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker, indexConcurrently bool) (*TableDiffResult, error) {
 	dc = NormalizeDropChecker(dc)
 	result := &TableDiffResult{}
 
@@ -34,7 +34,10 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 	for k, v := range desired.All() {
 		if _, ok := current.GetOk(k); !ok {
 			result.Stmts = append(result.Stmts, v.SQL())
-			stmts, fkStmts := newTableExtras(v)
+			stmts, fkStmts, err := newTableExtras(v, indexConcurrently)
+			if err != nil {
+				return nil, err
+			}
 			result.Stmts = append(result.Stmts, stmts...)
 			result.FKAddStmts = append(result.FKAddStmts, fkStmts...)
 		}
@@ -43,7 +46,7 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 	// Modified tables
 	for k, desiredTable := range desired.All() {
 		if currentTable, ok := current.GetOk(k); ok {
-			tableResult, err := diffTable(currentTable, desiredTable, dc)
+			tableResult, err := diffTable(currentTable, desiredTable, dc, indexConcurrently)
 			if err != nil {
 				return nil, err
 			}
@@ -69,9 +72,13 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 }
 
 // newTableExtras returns non-FK extras and FK statements separately.
-func newTableExtras(t *model.Table) (stmts []string, fkStmts []string) {
+func newTableExtras(t *model.Table, indexConcurrently bool) (stmts []string, fkStmts []string, err error) {
 	for _, idx := range t.Indexes.CollectValues() {
-		stmts = append(stmts, idx.SQL())
+		stmt, err := createIndexSQL(idx.Definition, indexConcurrently)
+		if err != nil {
+			return nil, nil, err
+		}
+		stmts = append(stmts, stmt)
 	}
 	for _, fk := range t.ForeignKeys.CollectValues() {
 		fkStmts = append(fkStmts, fk.SQL())
@@ -88,7 +95,7 @@ type tableDiffResult struct {
 	FKAddStmts  []string
 }
 
-func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult, error) {
+func diffTable(current, desired *model.Table, dc DropChecker, indexConcurrently bool) (*tableDiffResult, error) {
 	dc = NormalizeDropChecker(dc)
 	result := &tableDiffResult{}
 	fqtn := desired.FQTN()
@@ -96,7 +103,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	// Partition children inherit columns and constraints from the parent,
 	// so skip diffing them to avoid false DROP statements.
 	if desired.PartitionOf != nil && desired.PartitionBound != nil {
-		idxStmts, err := diffIndexes(current.Indexes, desired.Indexes)
+		idxStmts, err := diffIndexes(current.Indexes, desired.Indexes, indexConcurrently)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +129,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	}
 	result.Stmts = append(result.Stmts, conStmts...)
 
-	idxStmts, err := diffIndexes(current.Indexes, desired.Indexes)
+	idxStmts, err := diffIndexes(current.Indexes, desired.Indexes, indexConcurrently)
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +444,7 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 	return stmts, nil
 }
 
-func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) ([]string, error) {
+func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurrently bool) ([]string, error) {
 	var stmts []string
 
 	// Detect renames
@@ -451,7 +458,7 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) ([]stri
 	for name, currentIdx := range current.All() {
 		desiredIdx, ok := desired.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmts = append(stmts, "DROP INDEX "+model.Ident(currentIdx.Schema, name)+";")
+			stmts = append(stmts, dropIndexSQL(currentIdx.Schema, name, concurrently))
 		}
 	}
 
@@ -459,11 +466,52 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) ([]stri
 	for name, desiredIdx := range desired.All() {
 		currentIdx, ok := current.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmts = append(stmts, desiredIdx.Definition+";")
+			stmt, err := createIndexSQL(desiredIdx.Definition, concurrently)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, stmt)
 		}
 	}
 
 	return stmts, nil
+}
+
+// dropIndexSQL builds a DROP INDEX statement, optionally with CONCURRENTLY.
+func dropIndexSQL(schema, name string, concurrently bool) string {
+	stmt := "DROP INDEX "
+	if concurrently {
+		stmt += "CONCURRENTLY "
+	}
+	stmt += model.Ident(schema, name) + ";"
+	return stmt
+}
+
+// createIndexSQL returns a CREATE INDEX statement with the CONCURRENTLY flag
+// set via the pg_query AST when concurrently is true.
+func createIndexSQL(def string, concurrently bool) (string, error) {
+	if !concurrently {
+		return def + ";", nil
+	}
+
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse index definition: %w", err)
+	}
+
+	is := result.Stmts[0].Stmt.GetIndexStmt()
+	if is == nil {
+		return "", fmt.Errorf("expected IndexStmt for: %s", def)
+	}
+
+	is.Concurrent = true
+
+	deparsed, err := pg_query.Deparse(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to deparse index definition: %w", err)
+	}
+
+	return deparsed + ";", nil
 }
 
 // diffForeignKeys returns (dropStmts, addStmts, error).

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -467,7 +467,7 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 			}
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("drop index %s: %w", model.Ident(currentIdx.Schema, name), err)
 			}
 			stmts = append(stmts, stmt)
 		}
@@ -479,7 +479,7 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			stmt, err := createIndexSQL(desiredIdx.Definition, concurrently || desiredIdx.Concurrently)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("create index %s: %w", model.Ident(desiredIdx.Schema, name), err)
 			}
 			stmts = append(stmts, stmt)
 		}

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -13,10 +13,11 @@ import (
 // TableDiffResult separates FK operations from other statements to allow
 // correct ordering: FK drops first, then schema changes, then FK adds last.
 type TableDiffResult struct {
-	FKDropStmts []string // FK drops (should run first)
-	Stmts       []string // CREATE/ALTER TABLE, columns, constraints, indexes, comments
-	FKAddStmts  []string // FK adds and renames (should run last)
-	DropStmts   []string // DROP TABLE (separate from Stmts for ordering)
+	FKDropStmts     []string // FK drops (should run first)
+	Stmts           []string // CREATE/ALTER TABLE, columns, constraints, indexes, comments
+	FKAddStmts      []string // FK adds and renames (should run last)
+	DropStmts       []string // DROP TABLE (separate from Stmts for ordering)
+	HasConcurrently bool     // true if any index operation uses CONCURRENTLY
 }
 
 func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker, indexConcurrently bool) (*TableDiffResult, error) {
@@ -34,12 +35,15 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 	for k, v := range desired.All() {
 		if _, ok := current.GetOk(k); !ok {
 			result.Stmts = append(result.Stmts, v.SQL())
-			stmts, fkStmts, err := newTableExtras(v, indexConcurrently)
+			stmts, fkStmts, extraHasConcurrently, err := newTableExtras(v, indexConcurrently)
 			if err != nil {
 				return nil, err
 			}
 			result.Stmts = append(result.Stmts, stmts...)
 			result.FKAddStmts = append(result.FKAddStmts, fkStmts...)
+			if extraHasConcurrently {
+				result.HasConcurrently = true
+			}
 		}
 	}
 
@@ -53,6 +57,9 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 			result.FKDropStmts = append(result.FKDropStmts, tableResult.FKDropStmts...)
 			result.Stmts = append(result.Stmts, tableResult.Stmts...)
 			result.FKAddStmts = append(result.FKAddStmts, tableResult.FKAddStmts...)
+			if tableResult.HasConcurrently {
+				result.HasConcurrently = true
+			}
 		}
 	}
 
@@ -72,13 +79,17 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 }
 
 // newTableExtras returns non-FK extras and FK statements separately.
-func newTableExtras(t *model.Table, indexConcurrently bool) (stmts []string, fkStmts []string, err error) {
+func newTableExtras(t *model.Table, indexConcurrently bool) (stmts []string, fkStmts []string, hasConcurrently bool, err error) {
 	for _, idx := range t.Indexes.CollectValues() {
-		stmt, err := createIndexSQL(idx.Definition, indexConcurrently || idx.Concurrently)
+		useConcurrently := indexConcurrently || idx.Concurrently
+		stmt, err := createIndexSQL(idx.Definition, useConcurrently)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		stmts = append(stmts, stmt)
+		if useConcurrently {
+			hasConcurrently = true
+		}
 	}
 	for _, fk := range t.ForeignKeys.CollectValues() {
 		fkStmts = append(fkStmts, fk.SQL())
@@ -90,9 +101,10 @@ func newTableExtras(t *model.Table, indexConcurrently bool) (stmts []string, fkS
 }
 
 type tableDiffResult struct {
-	FKDropStmts []string
-	Stmts       []string
-	FKAddStmts  []string
+	FKDropStmts     []string
+	Stmts           []string
+	FKAddStmts      []string
+	HasConcurrently bool
 }
 
 func diffTable(current, desired *model.Table, dc DropChecker, indexConcurrently bool) (*tableDiffResult, error) {
@@ -103,11 +115,14 @@ func diffTable(current, desired *model.Table, dc DropChecker, indexConcurrently 
 	// Partition children inherit columns and constraints from the parent,
 	// so skip diffing them to avoid false DROP statements.
 	if desired.PartitionOf != nil && desired.PartitionBound != nil {
-		idxStmts, err := diffIndexes(current.Indexes, desired.Indexes, indexConcurrently)
+		idxResult, err := diffIndexes(current.Indexes, desired.Indexes, indexConcurrently)
 		if err != nil {
 			return nil, err
 		}
-		result.Stmts = append(result.Stmts, idxStmts...)
+		result.Stmts = append(result.Stmts, idxResult.Stmts...)
+		if idxResult.HasConcurrently {
+			result.HasConcurrently = true
+		}
 		fkDrops, fkAdds, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
 		if err != nil {
 			return nil, err
@@ -129,11 +144,14 @@ func diffTable(current, desired *model.Table, dc DropChecker, indexConcurrently 
 	}
 	result.Stmts = append(result.Stmts, conStmts...)
 
-	idxStmts, err := diffIndexes(current.Indexes, desired.Indexes, indexConcurrently)
+	idxResult2, err := diffIndexes(current.Indexes, desired.Indexes, indexConcurrently)
 	if err != nil {
 		return nil, err
 	}
-	result.Stmts = append(result.Stmts, idxStmts...)
+	result.Stmts = append(result.Stmts, idxResult2.Stmts...)
+	if idxResult2.HasConcurrently {
+		result.HasConcurrently = true
+	}
 
 	fkDrops, fkAdds, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
 	if err != nil {
@@ -444,15 +462,20 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 	return stmts, nil
 }
 
-func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurrently bool) ([]string, error) {
-	var stmts []string
+type diffIndexesResult struct {
+	Stmts           []string
+	HasConcurrently bool
+}
+
+func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurrently bool) (*diffIndexesResult, error) {
+	result := &diffIndexesResult{}
 
 	// Detect renames
 	renameStmts, current, err := detectIndexRenames(current, desired)
 	if err != nil {
 		return nil, err
 	}
-	stmts = append(stmts, renameStmts...)
+	result.Stmts = append(result.Stmts, renameStmts...)
 
 	// Drop removed or changed indexes
 	for name, currentIdx := range current.All() {
@@ -469,7 +492,10 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 			if err != nil {
 				return nil, fmt.Errorf("drop index %s: %w", model.Ident(currentIdx.Schema, name), err)
 			}
-			stmts = append(stmts, stmt)
+			result.Stmts = append(result.Stmts, stmt)
+			if useConcurrently {
+				result.HasConcurrently = true
+			}
 		}
 	}
 
@@ -477,15 +503,19 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 	for name, desiredIdx := range desired.All() {
 		currentIdx, ok := current.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmt, err := createIndexSQL(desiredIdx.Definition, concurrently || desiredIdx.Concurrently)
+			useConcurrently := concurrently || desiredIdx.Concurrently
+			stmt, err := createIndexSQL(desiredIdx.Definition, useConcurrently)
 			if err != nil {
 				return nil, fmt.Errorf("create index %s: %w", model.Ident(desiredIdx.Schema, name), err)
 			}
-			stmts = append(stmts, stmt)
+			result.Stmts = append(result.Stmts, stmt)
+			if useConcurrently {
+				result.HasConcurrently = true
+			}
 		}
 	}
 
-	return stmts, nil
+	return result, nil
 }
 
 // dropIndexSQL builds a DROP INDEX statement, optionally with CONCURRENTLY

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -460,15 +460,10 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			// Use CONCURRENTLY if the global flag is set, or if the desired index
 			// (when it exists and is being changed) has the per-index directive.
-			// For pure drops (index removed), use the current index's directive
-			// or the global flag.
+			// For pure drops (index removed), only the global flag applies.
 			useConcurrently := concurrently
-			if !useConcurrently {
-				if ok {
-					useConcurrently = desiredIdx.Concurrently
-				} else {
-					useConcurrently = currentIdx.Concurrently
-				}
+			if !useConcurrently && ok {
+				useConcurrently = desiredIdx.Concurrently
 			}
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -458,7 +458,11 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 	for name, currentIdx := range current.All() {
 		desiredIdx, ok := desired.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmts = append(stmts, dropIndexSQL(currentIdx.Schema, name, concurrently))
+			stmt, err := dropIndexSQL(currentIdx.Schema, name, concurrently)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, stmt)
 		}
 	}
 
@@ -477,14 +481,32 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 	return stmts, nil
 }
 
-// dropIndexSQL builds a DROP INDEX statement, optionally with CONCURRENTLY.
-func dropIndexSQL(schema, name string, concurrently bool) string {
-	stmt := "DROP INDEX "
-	if concurrently {
-		stmt += "CONCURRENTLY "
+// dropIndexSQL builds a DROP INDEX statement, optionally with CONCURRENTLY
+// set via the pg_query AST.
+func dropIndexSQL(schema, name string, concurrently bool) (string, error) {
+	base := "DROP INDEX " + model.Ident(schema, name)
+	if !concurrently {
+		return base + ";", nil
 	}
-	stmt += model.Ident(schema, name) + ";"
-	return stmt
+
+	result, err := pg_query.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse drop index statement: %w", err)
+	}
+
+	ds := result.Stmts[0].Stmt.GetDropStmt()
+	if ds == nil {
+		return "", fmt.Errorf("expected DropStmt for: %s", base)
+	}
+
+	ds.Concurrent = true
+
+	deparsed, err := pg_query.Deparse(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to deparse drop index statement: %w", err)
+	}
+
+	return deparsed + ";", nil
 }
 
 // createIndexSQL returns a CREATE INDEX statement with the CONCURRENTLY flag

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -74,7 +74,7 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 // newTableExtras returns non-FK extras and FK statements separately.
 func newTableExtras(t *model.Table, indexConcurrently bool) (stmts []string, fkStmts []string, err error) {
 	for _, idx := range t.Indexes.CollectValues() {
-		stmt, err := createIndexSQL(idx.Definition, indexConcurrently)
+		stmt, err := createIndexSQL(idx.Definition, indexConcurrently || idx.Concurrently)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -458,7 +458,19 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 	for name, currentIdx := range current.All() {
 		desiredIdx, ok := desired.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmt, err := dropIndexSQL(currentIdx.Schema, name, concurrently)
+			// Use CONCURRENTLY if the global flag is set, or if the desired index
+			// (when it exists and is being changed) has the per-index directive.
+			// For pure drops (index removed), use the current index's directive
+			// or the global flag.
+			useConcurrently := concurrently
+			if !useConcurrently {
+				if ok {
+					useConcurrently = desiredIdx.Concurrently
+				} else {
+					useConcurrently = currentIdx.Concurrently
+				}
+			}
+			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {
 				return nil, err
 			}
@@ -470,7 +482,7 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], concurr
 	for name, desiredIdx := range desired.All() {
 		currentIdx, ok := current.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmt, err := createIndexSQL(desiredIdx.Definition, concurrently)
+			stmt, err := createIndexSQL(desiredIdx.Definition, concurrently || desiredIdx.Concurrently)
 			if err != nil {
 				return nil, err
 			}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -607,12 +607,18 @@ func TestDiffIndexes_add_perIndexConcurrently(t *testing.T) {
 	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, stmts)
 }
 
-func TestDiffIndexes_drop_perIndexConcurrently(t *testing.T) {
+func TestDiffIndexes_drop_perIndexConcurrently_pureDropUsesGlobalFlag(t *testing.T) {
+	// Pure drops (index removed from desired) only use the global flag,
+	// since catalog-derived indexes don't carry the Concurrently field.
 	current := orderedmap.New[string, *model.Index]()
-	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
 	stmts, err := diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, stmts)
+
+	stmts, err = diffIndexes(current, desired, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, stmts)
 }

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -501,9 +501,9 @@ func TestDiffIndexes_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"CREATE INDEX idx_name ON public.users USING btree (name);"}, stmts)
+	assert.Equal(t, []string{"CREATE INDEX idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
 
 func TestDiffIndexes_drop(t *testing.T) {
@@ -511,9 +511,9 @@ func TestDiffIndexes_drop(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, stmts)
+	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
 }
 
 func TestDiffIndexes_change(t *testing.T) {
@@ -522,11 +522,11 @@ func TestDiffIndexes_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Len(t, stmts, 2)
-	assert.Equal(t, "DROP INDEX public.idx_name;", stmts[0])
-	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING hash (name);", stmts[1])
+	assert.Len(t, idxResult.Stmts, 2)
+	assert.Equal(t, "DROP INDEX public.idx_name;", idxResult.Stmts[0])
+	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING hash (name);", idxResult.Stmts[1])
 }
 
 func TestDiffIndexes_add_concurrently(t *testing.T) {
@@ -534,9 +534,9 @@ func TestDiffIndexes_add_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired, true)
+	idxResult, err := diffIndexes(current, desired, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, stmts)
+	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
 
 func TestDiffIndexes_drop_concurrently(t *testing.T) {
@@ -544,9 +544,9 @@ func TestDiffIndexes_drop_concurrently(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	stmts, err := diffIndexes(current, desired, true)
+	idxResult, err := diffIndexes(current, desired, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, stmts)
+	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, idxResult.Stmts)
 }
 
 func TestDiffIndexes_change_concurrently(t *testing.T) {
@@ -555,11 +555,11 @@ func TestDiffIndexes_change_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	stmts, err := diffIndexes(current, desired, true)
+	idxResult, err := diffIndexes(current, desired, true)
 	require.NoError(t, err)
-	assert.Len(t, stmts, 2)
-	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", stmts[0])
-	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING hash (name);", stmts[1])
+	assert.Len(t, idxResult.Stmts, 2)
+	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", idxResult.Stmts[0])
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING hash (name);", idxResult.Stmts[1])
 }
 
 func TestDiffIndexes_add_unique_concurrently(t *testing.T) {
@@ -567,9 +567,9 @@ func TestDiffIndexes_add_unique_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE UNIQUE INDEX idx_name ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired, true)
+	idxResult, err := diffIndexes(current, desired, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"CREATE UNIQUE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, stmts)
+	assert.Equal(t, []string{"CREATE UNIQUE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
 
 func TestDiffIndexes_rename_concurrently(t *testing.T) {
@@ -580,10 +580,10 @@ func TestDiffIndexes_rename_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired, true)
+	idxResult, err := diffIndexes(current, desired, true)
 	require.NoError(t, err)
 	// Rename should NOT use CONCURRENTLY
-	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, stmts)
+	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
 }
 
 func TestDiffIndexes_noChange_concurrently(t *testing.T) {
@@ -592,9 +592,9 @@ func TestDiffIndexes_noChange_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired, true)
+	idxResult, err := diffIndexes(current, desired, true)
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, idxResult.Stmts)
 }
 
 func TestDiffIndexes_add_perIndexConcurrently(t *testing.T) {
@@ -602,9 +602,9 @@ func TestDiffIndexes_add_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, stmts)
+	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
 
 func TestDiffIndexes_drop_perIndexConcurrently_pureDropUsesGlobalFlag(t *testing.T) {
@@ -614,13 +614,13 @@ func TestDiffIndexes_drop_perIndexConcurrently_pureDropUsesGlobalFlag(t *testing
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, stmts)
+	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
 
-	stmts, err = diffIndexes(current, desired, true)
+	idxResult, err = diffIndexes(current, desired, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, stmts)
+	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, idxResult.Stmts)
 }
 
 func TestDiffIndexes_change_perIndexConcurrently(t *testing.T) {
@@ -629,11 +629,11 @@ func TestDiffIndexes_change_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)", Concurrently: true})
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Len(t, stmts, 2)
-	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", stmts[0])
-	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING hash (name);", stmts[1])
+	assert.Len(t, idxResult.Stmts, 2)
+	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", idxResult.Stmts[0])
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING hash (name);", idxResult.Stmts[1])
 }
 
 func TestDiffIndexes_mixedConcurrently(t *testing.T) {
@@ -642,11 +642,11 @@ func TestDiffIndexes_mixedConcurrently(t *testing.T) {
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 	desired.Set("idx_email", &model.Index{Schema: "public", Name: "idx_email", Definition: "CREATE INDEX idx_email ON public.users USING btree (email)"})
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Len(t, stmts, 2)
-	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);", stmts[0])
-	assert.Equal(t, "CREATE INDEX idx_email ON public.users USING btree (email);", stmts[1])
+	assert.Len(t, idxResult.Stmts, 2)
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);", idxResult.Stmts[0])
+	assert.Equal(t, "CREATE INDEX idx_email ON public.users USING btree (email);", idxResult.Stmts[1])
 }
 
 func TestCreateIndexSQL_parseError(t *testing.T) {
@@ -1620,9 +1620,9 @@ func TestDiffIndexes_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx", &model.Index{Schema: "public", Name: "idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX idx ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, idxResult.Stmts)
 }
 
 func TestDiffForeignKeys_rename_selfRename_skipped(t *testing.T) {
@@ -1824,9 +1824,9 @@ func TestDiffIndexes_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, stmts)
+	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
 }
 
 func TestDiffConstraints_rename_alreadyApplied(t *testing.T) {
@@ -1862,9 +1862,9 @@ func TestDiffIndexes_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired, false)
+	idxResult, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
-	assert.Empty(t, stmts)
+	assert.Empty(t, idxResult.Stmts)
 }
 
 func TestDiffIndexes_rename_sourceNotFound(t *testing.T) {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -33,7 +33,7 @@ func TestDiffTables_newTable(t *testing.T) {
 	tbl.Constraints.Set("users_pkey", &model.Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
 	desired.Set("public.users", tbl)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "CREATE TABLE public.users")
@@ -49,12 +49,28 @@ func TestDiffTables_newTable_withExtras(t *testing.T) {
 	tbl.Comment = ptr("Users table")
 	desired.Set("public.users", tbl)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 3)
 	assert.Contains(t, result.Stmts[0], "CREATE TABLE")
 	assert.Contains(t, result.Stmts[1], "CREATE INDEX idx_name")
 	assert.Contains(t, result.Stmts[2], "COMMENT ON TABLE")
+}
+
+func TestDiffTables_newTable_withExtras_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	tbl := newTable("public", "users")
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.Indexes.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Table: "users", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+	desired.Set("public.users", tbl)
+
+	result, err := DiffTables(current, desired, AllowAllDrops{}, true)
+	require.NoError(t, err)
+	assert.Len(t, result.Stmts, 2)
+	assert.Contains(t, result.Stmts[0], "CREATE TABLE")
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);", result.Stmts[1])
 }
 
 func TestDiffTables_dropTable(t *testing.T) {
@@ -63,7 +79,7 @@ func TestDiffTables_dropTable(t *testing.T) {
 
 	current.Set("public.users", newTable("public", "users"))
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP TABLE public.users;"}, result.DropStmts)
 }
@@ -83,7 +99,7 @@ func TestDiffTables_dropTable_withFK(t *testing.T) {
 	})
 	current.Set("public.posts", posts)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.posts DROP CONSTRAINT posts_user_id_fkey;"}, result.FKDropStmts)
 	assert.Equal(t, []string{"DROP TABLE public.users;", "DROP TABLE public.posts;"}, result.DropStmts)
@@ -104,7 +120,7 @@ func TestDiffTables_dropTable_withFK_denied(t *testing.T) {
 	})
 	current.Set("public.posts", posts)
 
-	result, err := DiffTables(current, desired, DenyAllDrops{})
+	result, err := DiffTables(current, desired, DenyAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.FKDropStmts)
 	assert.Empty(t, result.DropStmts)
@@ -127,7 +143,7 @@ func TestDiffTables_nilDropChecker(t *testing.T) {
 	current.Set("public.users", newTable("public", "users"))
 
 	// nil DropChecker should not panic, drops should be denied
-	result, err := DiffTables(current, desired, nil)
+	result, err := DiffTables(current, desired, nil, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -138,7 +154,7 @@ func TestDiffTables_dropTable_denied(t *testing.T) {
 
 	current.Set("public.users", newTable("public", "users"))
 
-	result, err := DiffTables(current, desired, DenyAllDrops{})
+	result, err := DiffTables(current, desired, DenyAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -168,7 +184,7 @@ func TestDiffTables_noChange(t *testing.T) {
 	tbl2.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 	desired.Set("public.users", tbl2)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -485,7 +501,7 @@ func TestDiffIndexes_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE INDEX idx_name ON public.users USING btree (name);"}, stmts)
 }
@@ -495,7 +511,7 @@ func TestDiffIndexes_drop(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	stmts, err := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, stmts)
 }
@@ -506,11 +522,91 @@ func TestDiffIndexes_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	stmts, err := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "DROP INDEX public.idx_name;", stmts[0])
 	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING hash (name);", stmts[1])
+}
+
+func TestDiffIndexes_add_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+
+	stmts, err := diffIndexes(current, desired, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, stmts)
+}
+
+func TestDiffIndexes_drop_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+	desired := orderedmap.New[string, *model.Index]()
+
+	stmts, err := diffIndexes(current, desired, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, stmts)
+}
+
+func TestDiffIndexes_change_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
+
+	stmts, err := diffIndexes(current, desired, true)
+	require.NoError(t, err)
+	assert.Len(t, stmts, 2)
+	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", stmts[0])
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING hash (name);", stmts[1])
+}
+
+func TestDiffIndexes_add_unique_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE UNIQUE INDEX idx_name ON public.users USING btree (name)"})
+
+	stmts, err := diffIndexes(current, desired, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CREATE UNIQUE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, stmts)
+}
+
+func TestDiffIndexes_rename_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("old_idx", &model.Index{Schema: "public", Name: "old_idx", Table: "users", Definition: "CREATE INDEX old_idx ON public.users USING btree (name)"})
+
+	oldName := "old_idx"
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
+
+	stmts, err := diffIndexes(current, desired, true)
+	require.NoError(t, err)
+	// Rename should NOT use CONCURRENTLY
+	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, stmts)
+}
+
+func TestDiffIndexes_noChange_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+
+	stmts, err := diffIndexes(current, desired, true)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestCreateIndexSQL_parseError(t *testing.T) {
+	_, err := createIndexSQL("NOT VALID SQL {{{{", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse index definition")
+}
+
+func TestCreateIndexSQL_notIndexStmt(t *testing.T) {
+	_, err := createIndexSQL("SELECT 1", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected IndexStmt")
 }
 
 func TestDiffForeignKeys_add(t *testing.T) {
@@ -663,7 +759,7 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 	})
 	desired.Set("public.orders", tbl)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "CREATE TABLE")
@@ -941,7 +1037,7 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	desired.PartitionBound = &bound
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
 
-	tableResult, err := diffTable(current, desired, AllowAllDrops{})
+	tableResult, err := diffTable(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, tableResult.Stmts, 1)
 	assert.Contains(t, tableResult.Stmts[0], "CREATE INDEX idx_new")
@@ -961,7 +1057,7 @@ func TestDiffTable_partitionChild_indexRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", RenameFrom: &oldName, Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -984,7 +1080,7 @@ func TestDiffTable_partitionChild_fkRenameError(t *testing.T) {
 		Table:      "events_2024",
 	})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -998,7 +1094,7 @@ func TestDiffTable_constraintRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Constraints.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (id)"})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source constraint")
 }
@@ -1012,7 +1108,7 @@ func TestDiffTable_indexRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", RenameFrom: &oldName, Definition: "CREATE INDEX idx_new ON public.users (id)"})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -1030,7 +1126,7 @@ func TestDiffTable_fkRenameError(t *testing.T) {
 		Table:      "users",
 	})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -1299,7 +1395,7 @@ func TestDiffTables_indexWhereClauseSchemaInsensitive(t *testing.T) {
 	})
 	desired.Set("public.products", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -1383,7 +1479,7 @@ func TestDiffTables_indexSchemaInsensitive(t *testing.T) {
 	dt.Indexes.Set("idx", &model.Index{Schema: "", Name: "idx", Table: "users", Definition: "CREATE INDEX idx ON users USING btree (id)"})
 	desired.Set("public.users", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -1402,7 +1498,7 @@ func TestDiffTables_renameTable(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, result.Stmts)
 }
@@ -1421,7 +1517,7 @@ func TestDiffTables_renameTable_selfRename_skipped(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.users", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -1460,7 +1556,7 @@ func TestDiffIndexes_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx", &model.Index{Schema: "public", Name: "idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX idx ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1501,7 +1597,7 @@ func TestDiffTables_renameTable_alreadyApplied(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -1524,7 +1620,7 @@ func TestDiffTables_renameTable_withIndex(t *testing.T) {
 	dt.Indexes.Set("idx_users_name", &model.Index{Schema: "public", Name: "idx_users_name", Table: "accounts", Definition: "CREATE INDEX idx_users_name ON public.accounts USING btree (name)"})
 	desired.Set("public.accounts", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	// Should only rename the table, no DROP/CREATE index
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, result.Stmts)
@@ -1556,7 +1652,7 @@ func TestDiffTables_renameTable_withFK(t *testing.T) {
 	})
 	desired.Set("public.purchases", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME TO purchases;"}, result.Stmts)
 }
@@ -1579,7 +1675,7 @@ func TestDiffTables_renameTable_destinationExists_error(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	_, err := DiffTables(current, desired, AllowAllDrops{})
+	_, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -1612,7 +1708,7 @@ func TestDiffTables_renameTable_crossSchema_error(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("other.users", dt)
 
-	_, err := DiffTables(current, desired, AllowAllDrops{})
+	_, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
@@ -1664,7 +1760,7 @@ func TestDiffIndexes_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, stmts)
 }
@@ -1702,7 +1798,7 @@ func TestDiffIndexes_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	stmts, err := diffIndexes(current, desired)
+	stmts, err := diffIndexes(current, desired, false)
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1714,7 +1810,7 @@ func TestDiffIndexes_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	_, err := diffIndexes(current, desired)
+	_, err := diffIndexes(current, desired, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -1800,7 +1896,7 @@ func TestDiffIndexes_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	_, err := diffIndexes(current, desired)
+	_, err := diffIndexes(current, desired, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -1841,7 +1937,7 @@ func TestDiffTables_renameTable_sourceNotFound(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	_, err := DiffTables(current, desired, AllowAllDrops{})
+	_, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }
@@ -1860,7 +1956,7 @@ func TestDiffTables_renameColumn_error_propagates(t *testing.T) {
 	dt.Columns.Set("new_col", &model.Column{Name: "new_col", RenameFrom: &oldName, TypeName: "text"})
 	desired.Set("public.users", dt)
 
-	_, err := DiffTables(current, desired, AllowAllDrops{})
+	_, err := DiffTables(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source column")
 }

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -597,6 +597,52 @@ func TestDiffIndexes_noChange_concurrently(t *testing.T) {
 	assert.Empty(t, stmts)
 }
 
+func TestDiffIndexes_add_perIndexConcurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
+
+	stmts, err := diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, stmts)
+}
+
+func TestDiffIndexes_drop_perIndexConcurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
+	desired := orderedmap.New[string, *model.Index]()
+
+	stmts, err := diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, stmts)
+}
+
+func TestDiffIndexes_change_perIndexConcurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)", Concurrently: true})
+
+	stmts, err := diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	assert.Len(t, stmts, 2)
+	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", stmts[0])
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING hash (name);", stmts[1])
+}
+
+func TestDiffIndexes_mixedConcurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
+	desired.Set("idx_email", &model.Index{Schema: "public", Name: "idx_email", Definition: "CREATE INDEX idx_email ON public.users USING btree (email)"})
+
+	stmts, err := diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	assert.Len(t, stmts, 2)
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);", stmts[0])
+	assert.Equal(t, "CREATE INDEX idx_email ON public.users USING btree (email);", stmts[1])
+}
+
 func TestCreateIndexSQL_parseError(t *testing.T) {
 	_, err := createIndexSQL("NOT VALID SQL {{{{", true)
 	require.Error(t, err)

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -655,6 +655,18 @@ func TestCreateIndexSQL_notIndexStmt(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected IndexStmt")
 }
 
+func TestDropIndexSQL_concurrently(t *testing.T) {
+	stmt, err := dropIndexSQL("public", "idx_name", true)
+	require.NoError(t, err)
+	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", stmt)
+}
+
+func TestDropIndexSQL_noConcurrently(t *testing.T) {
+	stmt, err := dropIndexSQL("public", "idx_name", false)
+	require.NoError(t, err)
+	assert.Equal(t, "DROP INDEX public.idx_name;", stmt)
+}
+
 func TestDiffForeignKeys_add(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	desired := orderedmap.New[string, *model.ForeignKey]()

--- a/diff/views.go
+++ b/diff/views.go
@@ -185,7 +185,7 @@ type ViewDiffResult struct {
 	CreateStmts []string // ALTER VIEW RENAME, CREATE OR REPLACE VIEW, CREATE MATERIALIZED VIEW, indexes, comments (should run after table changes)
 }
 
-func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker) (*ViewDiffResult, error) {
+func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker, indexConcurrently bool) (*ViewDiffResult, error) {
 	dc = NormalizeDropChecker(dc)
 	result := &ViewDiffResult{}
 
@@ -208,7 +208,11 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			// Add indexes for new materialized views
 			if desiredView.Materialized && desiredView.Indexes != nil {
 				for _, idx := range desiredView.Indexes.CollectValues() {
-					result.CreateStmts = append(result.CreateStmts, idx.SQL())
+					stmt, err := createIndexSQL(idx.Definition, indexConcurrently || idx.Concurrently)
+					if err != nil {
+						return nil, err
+					}
+					result.CreateStmts = append(result.CreateStmts, stmt)
 				}
 			}
 		} else if !equalViewDef(currentView.Definition, desiredView.Definition) || currentView.Materialized != desiredView.Materialized {
@@ -225,7 +229,11 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 					result.CreateStmts = append(result.CreateStmts, desiredView.SQL())
 					if desiredView.Materialized && desiredView.Indexes != nil {
 						for _, idx := range desiredView.Indexes.CollectValues() {
-							result.CreateStmts = append(result.CreateStmts, idx.SQL())
+							stmt, err := createIndexSQL(idx.Definition, indexConcurrently || idx.Concurrently)
+							if err != nil {
+								return nil, err
+							}
+							result.CreateStmts = append(result.CreateStmts, stmt)
 						}
 					}
 					recreated[k] = true
@@ -236,7 +244,11 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			}
 		} else if desiredView.Materialized {
 			// Definition unchanged, diff indexes
-			result.CreateStmts = append(result.CreateStmts, diffViewIndexes(currentView, desiredView)...)
+			viewIdxStmts, err := diffViewIndexes(currentView, desiredView, indexConcurrently)
+			if err != nil {
+				return nil, err
+			}
+			result.CreateStmts = append(result.CreateStmts, viewIdxStmts...)
 		}
 	}
 
@@ -287,7 +299,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 }
 
 // diffViewIndexes generates DDL for index changes on materialized views.
-func diffViewIndexes(current, desired *model.View) []string {
+func diffViewIndexes(current, desired *model.View, concurrently bool) ([]string, error) {
 	var stmts []string
 
 	currentIndexes := orderedmap.New[string, *model.Index]()
@@ -303,7 +315,19 @@ func diffViewIndexes(current, desired *model.View) []string {
 	for name, currentIdx := range currentIndexes.All() {
 		desiredIdx, ok := desiredIndexes.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmts = append(stmts, "DROP INDEX "+model.Ident(currentIdx.Schema, name)+";")
+			useConcurrently := concurrently
+			if !useConcurrently {
+				if ok {
+					useConcurrently = desiredIdx.Concurrently
+				} else {
+					useConcurrently = currentIdx.Concurrently
+				}
+			}
+			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, stmt)
 		}
 	}
 
@@ -311,9 +335,13 @@ func diffViewIndexes(current, desired *model.View) []string {
 	for name, desiredIdx := range desiredIndexes.All() {
 		currentIdx, ok := currentIndexes.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmts = append(stmts, desiredIdx.SQL())
+			stmt, err := createIndexSQL(desiredIdx.Definition, concurrently || desiredIdx.Concurrently)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, stmt)
 		}
 	}
 
-	return stmts
+	return stmts, nil
 }

--- a/diff/views.go
+++ b/diff/views.go
@@ -316,12 +316,8 @@ func diffViewIndexes(current, desired *model.View, concurrently bool) ([]string,
 		desiredIdx, ok := desiredIndexes.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			useConcurrently := concurrently
-			if !useConcurrently {
-				if ok {
-					useConcurrently = desiredIdx.Concurrently
-				} else {
-					useConcurrently = currentIdx.Concurrently
-				}
+			if !useConcurrently && ok {
+				useConcurrently = desiredIdx.Concurrently
 			}
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {

--- a/diff/views.go
+++ b/diff/views.go
@@ -1,6 +1,8 @@
 package diff
 
 import (
+	"fmt"
+
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
@@ -210,7 +212,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 				for _, idx := range desiredView.Indexes.CollectValues() {
 					stmt, err := createIndexSQL(idx.Definition, indexConcurrently || idx.Concurrently)
 					if err != nil {
-						return nil, err
+						return nil, fmt.Errorf("create index %s on %s: %w", model.Ident(idx.Schema, idx.Name), k, err)
 					}
 					result.CreateStmts = append(result.CreateStmts, stmt)
 				}
@@ -231,7 +233,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 						for _, idx := range desiredView.Indexes.CollectValues() {
 							stmt, err := createIndexSQL(idx.Definition, indexConcurrently || idx.Concurrently)
 							if err != nil {
-								return nil, err
+								return nil, fmt.Errorf("create index %s on %s: %w", model.Ident(idx.Schema, idx.Name), k, err)
 							}
 							result.CreateStmts = append(result.CreateStmts, stmt)
 						}
@@ -321,7 +323,7 @@ func diffViewIndexes(current, desired *model.View, concurrently bool) ([]string,
 			}
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("drop index %s: %w", model.Ident(currentIdx.Schema, name), err)
 			}
 			stmts = append(stmts, stmt)
 		}
@@ -333,7 +335,7 @@ func diffViewIndexes(current, desired *model.View, concurrently bool) ([]string,
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			stmt, err := createIndexSQL(desiredIdx.Definition, concurrently || desiredIdx.Concurrently)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("create index %s: %w", model.Ident(desiredIdx.Schema, name), err)
 			}
 			stmts = append(stmts, stmt)
 		}

--- a/diff/views.go
+++ b/diff/views.go
@@ -183,8 +183,9 @@ func stripQualifications(node *pg_query.Node) {
 // ViewDiffResult separates view DROP and CREATE/MODIFY statements.
 // Drops should run before table changes, creates after.
 type ViewDiffResult struct {
-	DropStmts   []string // DROP VIEW / DROP MATERIALIZED VIEW (should run before table changes)
-	CreateStmts []string // ALTER VIEW RENAME, CREATE OR REPLACE VIEW, CREATE MATERIALIZED VIEW, indexes, comments (should run after table changes)
+	DropStmts       []string // DROP VIEW / DROP MATERIALIZED VIEW (should run before table changes)
+	CreateStmts     []string // ALTER VIEW RENAME, CREATE OR REPLACE VIEW, CREATE MATERIALIZED VIEW, indexes, comments (should run after table changes)
+	HasConcurrently bool     // true if any index operation uses CONCURRENTLY
 }
 
 func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker, indexConcurrently bool) (*ViewDiffResult, error) {
@@ -210,11 +211,15 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			// Add indexes for new materialized views
 			if desiredView.Materialized && desiredView.Indexes != nil {
 				for _, idx := range desiredView.Indexes.CollectValues() {
-					stmt, err := createIndexSQL(idx.Definition, indexConcurrently || idx.Concurrently)
+					useConcurrently := indexConcurrently || idx.Concurrently
+					stmt, err := createIndexSQL(idx.Definition, useConcurrently)
 					if err != nil {
 						return nil, fmt.Errorf("create index %s on %s: %w", model.Ident(idx.Schema, idx.Name), k, err)
 					}
 					result.CreateStmts = append(result.CreateStmts, stmt)
+					if useConcurrently {
+						result.HasConcurrently = true
+					}
 				}
 			}
 		} else if !equalViewDef(currentView.Definition, desiredView.Definition) || currentView.Materialized != desiredView.Materialized {
@@ -231,11 +236,15 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 					result.CreateStmts = append(result.CreateStmts, desiredView.SQL())
 					if desiredView.Materialized && desiredView.Indexes != nil {
 						for _, idx := range desiredView.Indexes.CollectValues() {
-							stmt, err := createIndexSQL(idx.Definition, indexConcurrently || idx.Concurrently)
+							useConcurrently := indexConcurrently || idx.Concurrently
+							stmt, err := createIndexSQL(idx.Definition, useConcurrently)
 							if err != nil {
 								return nil, fmt.Errorf("create index %s on %s: %w", model.Ident(idx.Schema, idx.Name), k, err)
 							}
 							result.CreateStmts = append(result.CreateStmts, stmt)
+							if useConcurrently {
+								result.HasConcurrently = true
+							}
 						}
 					}
 					recreated[k] = true
@@ -246,11 +255,14 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			}
 		} else if desiredView.Materialized {
 			// Definition unchanged, diff indexes
-			viewIdxStmts, err := diffViewIndexes(currentView, desiredView, indexConcurrently)
+			viewIdxStmts, viewIdxHasConcurrently, err := diffViewIndexes(currentView, desiredView, indexConcurrently)
 			if err != nil {
 				return nil, err
 			}
 			result.CreateStmts = append(result.CreateStmts, viewIdxStmts...)
+			if viewIdxHasConcurrently {
+				result.HasConcurrently = true
+			}
 		}
 	}
 
@@ -301,9 +313,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 }
 
 // diffViewIndexes generates DDL for index changes on materialized views.
-func diffViewIndexes(current, desired *model.View, concurrently bool) ([]string, error) {
-	var stmts []string
-
+func diffViewIndexes(current, desired *model.View, concurrently bool) (stmts []string, hasConcurrently bool, err error) {
 	currentIndexes := orderedmap.New[string, *model.Index]()
 	if current.Indexes != nil {
 		currentIndexes = current.Indexes
@@ -323,9 +333,12 @@ func diffViewIndexes(current, desired *model.View, concurrently bool) ([]string,
 			}
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {
-				return nil, fmt.Errorf("drop index %s: %w", model.Ident(currentIdx.Schema, name), err)
+				return nil, false, fmt.Errorf("drop index %s: %w", model.Ident(currentIdx.Schema, name), err)
 			}
 			stmts = append(stmts, stmt)
+			if useConcurrently {
+				hasConcurrently = true
+			}
 		}
 	}
 
@@ -333,13 +346,17 @@ func diffViewIndexes(current, desired *model.View, concurrently bool) ([]string,
 	for name, desiredIdx := range desiredIndexes.All() {
 		currentIdx, ok := currentIndexes.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			stmt, err := createIndexSQL(desiredIdx.Definition, concurrently || desiredIdx.Concurrently)
+			useConcurrently := concurrently || desiredIdx.Concurrently
+			stmt, err := createIndexSQL(desiredIdx.Definition, useConcurrently)
 			if err != nil {
-				return nil, fmt.Errorf("create index %s: %w", model.Ident(desiredIdx.Schema, name), err)
+				return nil, false, fmt.Errorf("create index %s: %w", model.Ident(desiredIdx.Schema, name), err)
 			}
 			stmts = append(stmts, stmt)
+			if useConcurrently {
+				hasConcurrently = true
+			}
 		}
 	}
 
-	return stmts, nil
+	return stmts, hasConcurrently, nil
 }

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -14,7 +14,7 @@ func TestDiffViews_newView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v1")
@@ -25,7 +25,7 @@ func TestDiffViews_dropView(t *testing.T) {
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 	desired := orderedmap.New[string, *model.View]()
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP VIEW public.v1;"}, result.DropStmts)
 }
@@ -35,7 +35,7 @@ func TestDiffViews_dropView_denied(t *testing.T) {
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 	desired := orderedmap.New[string, *model.View]()
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, DenyAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -47,7 +47,7 @@ func TestDiffViews_modifyView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 2"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v1")
@@ -59,7 +59,7 @@ func TestDiffViews_noChange(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -71,7 +71,7 @@ func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -83,7 +83,7 @@ func TestDiffViews_commentAdd(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", Comment: ptr("my view")})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS 'my view';", result.CreateStmts[0])
@@ -95,7 +95,7 @@ func TestDiffViews_commentDrop(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS NULL;", result.CreateStmts[0])
@@ -109,7 +109,7 @@ func TestDiffViews_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER VIEW public.v1 RENAME TO v2;"}, result.CreateStmts)
 }
@@ -122,7 +122,7 @@ func TestDiffViews_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -136,7 +136,7 @@ func TestDiffViews_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -151,7 +151,7 @@ func TestDiffViews_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -164,7 +164,7 @@ func TestDiffViews_rename_crossSchema_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("other.v2", &model.View{Schema: "other", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
@@ -176,7 +176,7 @@ func TestDiffViews_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }
@@ -280,7 +280,7 @@ func TestDiffViews_newMatview(t *testing.T) {
 		Indexes:    orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW public.mv")
@@ -300,7 +300,7 @@ func TestDiffViews_newMatviewWithIndex(t *testing.T) {
 	})
 	desired.Set("public.mv", mv)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	require.Len(t, result.CreateStmts, 2)
 	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW")
@@ -315,7 +315,7 @@ func TestDiffViews_dropMatview(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.View]()
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.DropStmts, 1)
 	assert.Contains(t, result.DropStmts[0], "DROP MATERIALIZED VIEW public.mv")
@@ -329,7 +329,7 @@ func TestDiffViews_dropMatview_denied(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.View]()
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, DenyAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 }
@@ -346,7 +346,7 @@ func TestDiffViews_modifyMatview(t *testing.T) {
 		Definition: "SELECT 2 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	// Materialized views must be dropped and recreated
 	assert.Len(t, result.DropStmts, 1)
@@ -370,7 +370,7 @@ func TestDiffViews_modifyMatview_preservesComment(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	// DROP+CREATE loses the comment, so it must be re-applied
 	assert.Len(t, result.DropStmts, 1)
@@ -391,7 +391,7 @@ func TestDiffViews_modifyMatview_dropDenied(t *testing.T) {
 		Definition: "SELECT 2 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, DenyAllDrops{}, false)
 	require.NoError(t, err)
 	// Drop denied: no DROP or CREATE should be generated
 	assert.Empty(t, result.DropStmts)
@@ -415,7 +415,7 @@ func TestDiffViews_matviewIndexAdd(t *testing.T) {
 	})
 	desired.Set("public.mv", mv)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Len(t, result.CreateStmts, 1)
@@ -439,7 +439,7 @@ func TestDiffViews_matviewIndexDrop(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Len(t, result.CreateStmts, 1)
@@ -459,7 +459,7 @@ func TestDiffViews_matviewCommentAdd(t *testing.T) {
 		Definition: "SELECT 1", Comment: &comment, Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "COMMENT ON MATERIALIZED VIEW")
@@ -478,7 +478,7 @@ func TestDiffViews_matviewCommentDrop(t *testing.T) {
 		Definition: "SELECT 1", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "COMMENT ON MATERIALIZED VIEW public.mv IS NULL")
@@ -507,7 +507,7 @@ func TestDiffViews_matviewIndexChange(t *testing.T) {
 	})
 	desired.Set("public.mv", mvDesired)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	require.Len(t, result.CreateStmts, 2)
@@ -527,7 +527,7 @@ func TestDiffViews_matviewNoChange(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Empty(t, result.CreateStmts)
@@ -547,7 +547,7 @@ func TestDiffViews_renameMatview(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	require.Len(t, result.CreateStmts, 1)
@@ -567,7 +567,7 @@ func TestDiffViews_viewToMatview(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	require.Len(t, result.DropStmts, 1)
 	assert.Contains(t, result.DropStmts[0], "DROP VIEW public.v")
@@ -587,7 +587,7 @@ func TestDiffViews_matviewToView(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.NoError(t, err)
 	require.Len(t, result.DropStmts, 1)
 	assert.Contains(t, result.DropStmts[0], "DROP MATERIALIZED VIEW public.v")
@@ -609,7 +609,7 @@ func TestDiffViews_viewToMatview_dropDenied(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, DenyAllDrops{}, false)
 	require.NoError(t, err)
 	// Type change denied: no DROP, no CREATE, no comment change
 	assert.Empty(t, result.DropStmts)
@@ -630,7 +630,7 @@ func TestDiffViews_renameTypeMismatch(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, AllowAllDrops{}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "view type mismatch")
 }

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -634,3 +634,176 @@ func TestDiffViews_renameTypeMismatch(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "view type mismatch")
 }
+
+func TestDiffViews_newMatviewWithIndex_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	desired := orderedmap.New[string, *model.View]()
+	mv := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n",
+		Indexes:    orderedmap.New[string, *model.Index](),
+	}
+	mv.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition: "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+	})
+	desired.Set("public.mv", mv)
+
+	result, err := DiffViews(current, desired, AllowAllDrops{}, true)
+	require.NoError(t, err)
+	require.Len(t, result.CreateStmts, 2)
+	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW")
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_mv_n ON public.mv USING btree (n);", result.CreateStmts[1])
+}
+
+func TestDiffViews_newMatviewWithIndex_perIndexDirective(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	desired := orderedmap.New[string, *model.View]()
+	mv := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n",
+		Indexes:    orderedmap.New[string, *model.Index](),
+	}
+	mv.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition:   "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+		Concurrently: true,
+	})
+	desired.Set("public.mv", mv)
+
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
+	require.NoError(t, err)
+	require.Len(t, result.CreateStmts, 2)
+	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW")
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_mv_n ON public.mv USING btree (n);", result.CreateStmts[1])
+}
+
+func TestDiffViews_matviewIndexAdd_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	})
+	desired := orderedmap.New[string, *model.View]()
+	mv := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mv.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition: "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+	})
+	desired.Set("public.mv", mv)
+
+	result, err := DiffViews(current, desired, AllowAllDrops{}, true)
+	require.NoError(t, err)
+	assert.Len(t, result.CreateStmts, 1)
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_mv_n ON public.mv USING btree (n);", result.CreateStmts[0])
+}
+
+func TestDiffViews_matviewIndexDrop_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	mv := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mv.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition: "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+	})
+	current.Set("public.mv", mv)
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	})
+
+	result, err := DiffViews(current, desired, AllowAllDrops{}, true)
+	require.NoError(t, err)
+	assert.Len(t, result.CreateStmts, 1)
+	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_mv_n;", result.CreateStmts[0])
+}
+
+func TestDiffViews_matviewIndexChange_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	mvCurrent := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mvCurrent.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition: "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+	})
+	current.Set("public.mv", mvCurrent)
+
+	desired := orderedmap.New[string, *model.View]()
+	mvDesired := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mvDesired.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition: "CREATE UNIQUE INDEX idx_mv_n ON public.mv USING btree (n)",
+	})
+	desired.Set("public.mv", mvDesired)
+
+	result, err := DiffViews(current, desired, AllowAllDrops{}, true)
+	require.NoError(t, err)
+	require.Len(t, result.CreateStmts, 2)
+	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_mv_n;", result.CreateStmts[0])
+	assert.Equal(t, "CREATE UNIQUE INDEX CONCURRENTLY idx_mv_n ON public.mv USING btree (n);", result.CreateStmts[1])
+}
+
+func TestDiffViews_matviewIndexAdd_perIndexDirective(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	})
+	desired := orderedmap.New[string, *model.View]()
+	mv := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mv.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition:   "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+		Concurrently: true,
+	})
+	mv.Indexes.Set("idx_mv_n2", &model.Index{
+		Schema: "public", Name: "idx_mv_n2", Table: "mv",
+		Definition: "CREATE INDEX idx_mv_n2 ON public.mv USING btree (n)",
+	})
+	desired.Set("public.mv", mv)
+
+	result, err := DiffViews(current, desired, AllowAllDrops{}, false)
+	require.NoError(t, err)
+	assert.Len(t, result.CreateStmts, 2)
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_mv_n ON public.mv USING btree (n);", result.CreateStmts[0])
+	assert.Equal(t, "CREATE INDEX idx_mv_n2 ON public.mv USING btree (n);", result.CreateStmts[1])
+}
+
+func TestDiffViews_modifyMatviewWithIndex_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	})
+	desired := orderedmap.New[string, *model.View]()
+	mv := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 2 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mv.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition: "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+	})
+	desired.Set("public.mv", mv)
+
+	result, err := DiffViews(current, desired, AllowAllDrops{}, true)
+	require.NoError(t, err)
+	assert.Len(t, result.DropStmts, 1)
+	require.Len(t, result.CreateStmts, 2)
+	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW")
+	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_mv_n ON public.mv USING btree (n);", result.CreateStmts[1])
+}

--- a/diff_all.go
+++ b/diff_all.go
@@ -123,28 +123,17 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		PreSQL:               preSQL,
 		Count:                count,
 		ExecuteStmts:         desired.ExecuteStmts,
-		HasConcurrentlyIndex: hasConcurrentlyIndex(desiredTables, desiredViews),
+		HasConcurrentlyIndex: hasConcurrentlyStmt(stmts),
 	}, nil
 }
 
-// hasConcurrentlyIndex returns true if any index in the desired schema has the
-// -- pist:concurrently directive.
-func hasConcurrentlyIndex(
-	tables *orderedmap.Map[string, *model.Table],
-	views *orderedmap.Map[string, *model.View],
-) bool {
-	for _, t := range tables.CollectValues() {
-		for _, idx := range t.Indexes.CollectValues() {
-			if idx.Concurrently {
-				return true
-			}
-		}
-	}
-	for _, v := range views.CollectValues() {
-		for _, idx := range v.Indexes.CollectValues() {
-			if idx.Concurrently {
-				return true
-			}
+// hasConcurrentlyStmt returns true if any generated statement uses
+// CREATE/DROP INDEX CONCURRENTLY.
+func hasConcurrentlyStmt(stmts []string) bool {
+	for _, stmt := range stmts {
+		upper := strings.ToUpper(stmt)
+		if strings.Contains(upper, "INDEX CONCURRENTLY") {
+			return true
 		}
 	}
 	return false

--- a/diff_all.go
+++ b/diff_all.go
@@ -19,9 +19,10 @@ import (
 type diffAllOptions struct {
 	FilterOptions
 	DropPolicy
-	Files      []string
-	PreSQL     string
-	PreSQLFile string
+	Files             []string
+	PreSQL            string
+	PreSQLFile        string
+	IndexConcurrently bool
 }
 
 // diffAllResult holds the result of diffAll.
@@ -95,7 +96,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, fmt.Errorf("failed to diff domains: %w", err)
 	}
 
-	tableDiff, err := diff.DiffTables(filteredTables, desiredTables, &options.DropPolicy)
+	tableDiff, err := diff.DiffTables(filteredTables, desiredTables, &options.DropPolicy, options.IndexConcurrently)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
@@ -317,9 +318,12 @@ func extractObjectName(sql string) string {
 		{"CREATE MATERIALIZED VIEW "},
 		{"CREATE OR REPLACE VIEW "},
 		{"CREATE VIEW "},
+		{"CREATE UNIQUE INDEX CONCURRENTLY "},
 		{"CREATE UNIQUE INDEX "},
+		{"CREATE INDEX CONCURRENTLY "},
 		{"CREATE INDEX "},
 		{"ALTER INDEX "},
+		{"DROP INDEX CONCURRENTLY "},
 		{"DROP INDEX "},
 		{"ALTER TABLE ONLY "},
 		{"ALTER TABLE "},
@@ -346,8 +350,11 @@ func extractObjectName(sql string) string {
 			continue
 		}
 
-		if strings.HasPrefix(upper, "CREATE UNIQUE INDEX ") ||
+		if strings.HasPrefix(upper, "CREATE UNIQUE INDEX CONCURRENTLY ") ||
+			strings.HasPrefix(upper, "CREATE UNIQUE INDEX ") ||
+			strings.HasPrefix(upper, "CREATE INDEX CONCURRENTLY ") ||
 			strings.HasPrefix(upper, "CREATE INDEX ") ||
+			strings.HasPrefix(upper, "DROP INDEX CONCURRENTLY ") ||
 			strings.HasPrefix(upper, "DROP INDEX ") {
 			// CREATE/DROP INDEX name ON [ONLY] schema.table ...
 			return extractIndexTable(sql)

--- a/diff_all.go
+++ b/diff_all.go
@@ -27,10 +27,11 @@ type diffAllOptions struct {
 
 // diffAllResult holds the result of diffAll.
 type diffAllResult struct {
-	Stmts        []string
-	PreSQL       string
-	Count        ObjectCount
-	ExecuteStmts []*parser.ExecuteStmt
+	Stmts                []string
+	PreSQL               string
+	Count                ObjectCount
+	ExecuteStmts         []*parser.ExecuteStmt
+	HasConcurrentlyIndex bool
 }
 
 // diffAll performs the common catalog fetch, parse, diff, and statement
@@ -118,11 +119,35 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	}
 
 	return &diffAllResult{
-		Stmts:        stmts,
-		PreSQL:       preSQL,
-		Count:        count,
-		ExecuteStmts: desired.ExecuteStmts,
+		Stmts:                stmts,
+		PreSQL:               preSQL,
+		Count:                count,
+		ExecuteStmts:         desired.ExecuteStmts,
+		HasConcurrentlyIndex: hasConcurrentlyIndex(desiredTables, desiredViews),
 	}, nil
+}
+
+// hasConcurrentlyIndex returns true if any index in the desired schema has the
+// -- pist:concurrently directive.
+func hasConcurrentlyIndex(
+	tables *orderedmap.Map[string, *model.Table],
+	views *orderedmap.Map[string, *model.View],
+) bool {
+	for _, t := range tables.CollectValues() {
+		for _, idx := range t.Indexes.CollectValues() {
+			if idx.Concurrently {
+				return true
+			}
+		}
+	}
+	for _, v := range views.CollectValues() {
+		for _, idx := range v.Indexes.CollectValues() {
+			if idx.Concurrently {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // orderStatements uses topological sort to determine the correct execution

--- a/diff_all.go
+++ b/diff_all.go
@@ -123,20 +123,8 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		PreSQL:               preSQL,
 		Count:                count,
 		ExecuteStmts:         desired.ExecuteStmts,
-		HasConcurrentlyIndex: hasConcurrentlyStmt(stmts),
+		HasConcurrentlyIndex: tableDiff.HasConcurrently || viewDiff.HasConcurrently,
 	}, nil
-}
-
-// hasConcurrentlyStmt returns true if any generated statement uses
-// CREATE/DROP INDEX CONCURRENTLY.
-func hasConcurrentlyStmt(stmts []string) bool {
-	for _, stmt := range stmts {
-		upper := strings.ToUpper(stmt)
-		if strings.Contains(upper, "INDEX CONCURRENTLY") {
-			return true
-		}
-	}
-	return false
 }
 
 // orderStatements uses topological sort to determine the correct execution

--- a/diff_all.go
+++ b/diff_all.go
@@ -356,7 +356,8 @@ func extractObjectName(sql string) string {
 			strings.HasPrefix(upper, "CREATE INDEX ") ||
 			strings.HasPrefix(upper, "DROP INDEX CONCURRENTLY ") ||
 			strings.HasPrefix(upper, "DROP INDEX ") {
-			// CREATE/DROP INDEX name ON [ONLY] schema.table ...
+			// CREATE INDEX ... ON [ONLY] schema.table ...
+			// DROP INDEX returns "" (no ON clause) → pos=-1
 			return extractIndexTable(sql)
 		}
 

--- a/diff_all.go
+++ b/diff_all.go
@@ -102,7 +102,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
 
-	viewDiff, err := diff.DiffViews(filteredViews, desiredViews, &options.DropPolicy)
+	viewDiff, err := diff.DiffViews(filteredViews, desiredViews, &options.DropPolicy, options.IndexConcurrently)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff views: %w", err)
 	}

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -47,6 +47,10 @@ func TestExtractObjectName(t *testing.T) {
 		{`ALTER MATERIALIZED VIEW public.mv RENAME TO mv2;`, "public.mv"},
 		// CREATE UNIQUE INDEX should be recognized like CREATE INDEX
 		{"CREATE UNIQUE INDEX idx_users_email ON public.users USING btree (email);", "public.users"},
+		// CONCURRENTLY variants
+		{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);", "public.users"},
+		{"CREATE UNIQUE INDEX CONCURRENTLY idx_email ON public.users USING btree (email);", "public.users"},
+		{"DROP INDEX CONCURRENTLY public.idx_name;", ""},
 	}
 
 	for _, tt := range tests {

--- a/model/index.go
+++ b/model/index.go
@@ -1,13 +1,14 @@
 package model
 
 type Index struct {
-	OID        uint32
-	Schema     string
-	Name       string
-	RenameFrom *string
-	Table      string
-	Definition string
-	TableSpace *string
+	OID          uint32
+	Schema       string
+	Name         string
+	RenameFrom   *string
+	Table        string
+	Definition   string
+	TableSpace   *string
+	Concurrently bool
 }
 
 func (idx Index) FQTN() string {

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -13,6 +13,8 @@ var (
 	renameDirectivePattern       = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:renamed-from[ \t]+(.+?)[ \t]*$`)
 	executeDirectivePattern      = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:execute(?:[ \t]+(.+?))?[ \t]*$`)
 	concurrentlyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:concurrently[ \t]*$`)
+	// Matches -- pist:concurrently with trailing content (invalid usage).
+	concurrentlyWithArgsPattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:concurrently[ \t]+\S`)
 	// Matches any -- pist: directive, capturing the name (if any) after the colon.
 	anyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:[ \t]*(\S*)`)
 )
@@ -37,6 +39,11 @@ func ValidateDirectives(rawSQL string) error {
 			return fmt.Errorf("unknown directive: -- pist:%s", name)
 		}
 	}
+
+	if concurrentlyWithArgsPattern.MatchString(rawSQL) {
+		return fmt.Errorf("-- pist:concurrently does not accept arguments")
+	}
+
 	return nil
 }
 

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	renameDirectivePattern  = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:renamed-from[ \t]+(.+?)[ \t]*$`)
-	executeDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:execute(?:[ \t]+(.+?))?[ \t]*$`)
+	renameDirectivePattern       = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:renamed-from[ \t]+(.+?)[ \t]*$`)
+	executeDirectivePattern      = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:execute(?:[ \t]+(.+?))?[ \t]*$`)
+	concurrentlyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:concurrently[ \t]*$`)
 	// Matches any -- pist: directive, capturing the name (if any) after the colon.
 	anyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pist:[ \t]*(\S*)`)
 )
@@ -20,6 +21,7 @@ var (
 var knownDirectives = map[string]bool{
 	"renamed-from": true,
 	"execute":      true,
+	"concurrently": true,
 }
 
 // ValidateDirectives checks for unknown -- pist: directives in the raw SQL
@@ -219,6 +221,31 @@ func ExtractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]s
 			if renameFrom != "" {
 				directives[loc] = renameFrom
 			}
+		}
+	}
+
+	return directives
+}
+
+// ExtractConcurrentlyDirectives scans raw SQL for `-- pist:concurrently` comments
+// that appear in each statement's leading comment region.
+// Returns a set of StmtLocations that have the directive.
+func ExtractConcurrentlyDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]bool {
+	directives := make(map[int32]bool)
+
+	for _, stmt := range stmts {
+		loc := stmt.StmtLocation
+		end := loc + stmt.StmtLen
+		if end > int32(len(rawSQL)) {
+			end = int32(len(rawSQL))
+		}
+
+		region := rawSQL[loc:end]
+		leadingEnd := findLeadingCommentEnd(region)
+		leading := region[:leadingEnd]
+
+		if concurrentlyDirectivePattern.MatchString(leading) {
+			directives[loc] = true
 		}
 	}
 

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -346,10 +346,46 @@ func TestExtractExecuteDirectives_None(t *testing.T) {
 	assert.Empty(t, skip)
 }
 
+func TestExtractConcurrentlyDirectives(t *testing.T) {
+	sql := `-- pist:concurrently
+CREATE INDEX idx_name ON public.users USING btree (name);
+CREATE INDEX idx_email ON public.users USING btree (email);`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	directives := ExtractConcurrentlyDirectives(sql, result.Stmts)
+	assert.True(t, directives[result.Stmts[0].StmtLocation])
+	assert.False(t, directives[result.Stmts[1].StmtLocation])
+}
+
+func TestExtractConcurrentlyDirectives_withRenamedFrom(t *testing.T) {
+	sql := `-- pist:renamed-from idx_old
+-- pist:concurrently
+CREATE INDEX idx_name ON public.users USING btree (name);`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	directives := ExtractConcurrentlyDirectives(sql, result.Stmts)
+	assert.True(t, directives[result.Stmts[0].StmtLocation])
+}
+
+func TestExtractConcurrentlyDirectives_noDirective(t *testing.T) {
+	sql := `CREATE INDEX idx_name ON public.users USING btree (name);`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	directives := ExtractConcurrentlyDirectives(sql, result.Stmts)
+	assert.Empty(t, directives)
+}
+
 func TestValidateDirectives_Valid(t *testing.T) {
 	assert.NoError(t, ValidateDirectives("-- pist:renamed-from old"))
 	assert.NoError(t, ValidateDirectives("-- pist:execute SELECT true"))
 	assert.NoError(t, ValidateDirectives("-- pist:execute"))
+	assert.NoError(t, ValidateDirectives("-- pist:concurrently"))
 	assert.NoError(t, ValidateDirectives("SELECT 1; -- no directives"))
 }
 

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -389,6 +389,12 @@ func TestValidateDirectives_Valid(t *testing.T) {
 	assert.NoError(t, ValidateDirectives("SELECT 1; -- no directives"))
 }
 
+func TestValidateDirectives_ConcurrentlyWithArgs(t *testing.T) {
+	err := ValidateDirectives("-- pist:concurrently extra")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-- pist:concurrently does not accept arguments")
+}
+
 func TestValidateDirectives_UnknownDirective(t *testing.T) {
 	err := ValidateDirectives("-- pist:exec")
 	require.Error(t, err)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -97,6 +97,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	domains := orderedmap.New[string, *model.Domain]()
 
 	stmtDirectives := ExtractStmtDirectives(sql, result.Stmts)
+	concurrentlyDirectives := ExtractConcurrentlyDirectives(sql, result.Stmts)
 	executeStmts, executeSkipLocations, err := ExtractExecuteDirectives(sql, result.Stmts)
 	if err != nil {
 		return nil, err
@@ -212,6 +213,9 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if renameFrom != "" {
 				unquoted := normalizeUnqualifiedDirective(renameFrom)
 				idx.RenameFrom = &unquoted
+			}
+			if concurrentlyDirectives[rawStmt.StmtLocation] {
+				idx.Concurrently = true
 			}
 			fqtn := model.Ident(idx.Schema, idx.Table)
 			if t, ok := tables.GetOk(fqtn); ok {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1717,3 +1717,62 @@ func TestParseSQL_NoRenameDirective(t *testing.T) {
 	col, _ := tbl.Columns.GetOk("name")
 	assert.Nil(t, col.RenameFrom)
 }
+
+func TestParseSQL_ConcurrentlyDirective_Index(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_name ON public.users (name);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	idx, ok := tbl.Indexes.GetOk("idx_name")
+	require.True(t, ok)
+	assert.True(t, idx.Concurrently)
+}
+
+func TestParseSQL_ConcurrentlyDirective_NotSet(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_name ON public.users (name);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	idx, ok := tbl.Indexes.GetOk("idx_name")
+	require.True(t, ok)
+	assert.False(t, idx.Concurrently)
+}
+
+func TestParseSQL_ConcurrentlyDirective_WithRenamed(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:renamed-from idx_old
+-- pist:concurrently
+CREATE INDEX idx_name ON public.users (name);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	idx, ok := tbl.Indexes.GetOk("idx_name")
+	require.True(t, ok)
+	assert.True(t, idx.Concurrently)
+	require.NotNil(t, idx.RenameFrom)
+	assert.Equal(t, "idx_old", *idx.RenameFrom)
+}

--- a/plan.go
+++ b/plan.go
@@ -11,9 +11,10 @@ import (
 type PlanOptions struct {
 	FilterOptions
 	DropPolicy
-	Files      []string `arg:"" help:"Path to the desired schema SQL file(s)."`
-	PreSQL     string   `xor:"pre-sql" help:"SQL to prepend to the plan output."`
-	PreSQLFile string   `type:"path" xor:"pre-sql" help:"Path to a SQL file to prepend to the plan output."`
+	Files             []string `arg:"" help:"Path to the desired schema SQL file(s)."`
+	PreSQL            string   `xor:"pre-sql" help:"SQL to prepend to the plan output."`
+	PreSQLFile        string   `type:"path" xor:"pre-sql" help:"Path to a SQL file to prepend to the plan output."`
+	IndexConcurrently bool     `env:"PIST_INDEX_CONCURRENTLY" help:"Use CREATE/DROP INDEX CONCURRENTLY for index operations."`
 }
 
 // ObjectCount holds the number of objects inspected by type.
@@ -62,11 +63,12 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	defer conn.Close(ctx) //nolint:errcheck
 
 	result, err := client.diffAll(ctx, conn, &diffAllOptions{
-		FilterOptions: options.FilterOptions,
-		DropPolicy:    options.DropPolicy,
-		Files:         options.Files,
-		PreSQL:        options.PreSQL,
-		PreSQLFile:    options.PreSQLFile,
+		FilterOptions:     options.FilterOptions,
+		DropPolicy:        options.DropPolicy,
+		Files:             options.Files,
+		PreSQL:            options.PreSQL,
+		PreSQLFile:        options.PreSQLFile,
+		IndexConcurrently: options.IndexConcurrently,
 	})
 	if err != nil {
 		return nil, err

--- a/plan_test.go
+++ b/plan_test.go
@@ -304,3 +304,68 @@ func TestPlan(t *testing.T) {
 		})
 	}
 }
+
+func TestPlan_IndexConcurrently(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files:             []string{desiredFile},
+		IndexConcurrently: true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "CREATE INDEX CONCURRENTLY idx_users_name")
+}
+
+func TestPlan_IndexConcurrently_DropIndex(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy:        pistachio.DropPolicy{AllowDrop: []string{"all"}},
+		Files:             []string{desiredFile},
+		IndexConcurrently: true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "DROP INDEX CONCURRENTLY public.idx_users_name;")
+}

--- a/plan_test.go
+++ b/plan_test.go
@@ -369,3 +369,38 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`)
 	require.NoError(t, err)
 	assert.Contains(t, got.SQL, "DROP INDEX CONCURRENTLY public.idx_users_name;")
 }
+
+func TestPlan_ConcurrentlyDirective(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);
+CREATE INDEX idx_users_id ON public.users USING btree (id);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files: []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "CREATE INDEX CONCURRENTLY idx_users_name")
+	assert.Contains(t, got.SQL, "CREATE INDEX idx_users_id")
+	assert.NotContains(t, got.SQL, "CREATE INDEX CONCURRENTLY idx_users_id")
+}

--- a/test/scenario/index_concurrently.test.sh
+++ b/test/scenario/index_concurrently.test.sh
@@ -89,4 +89,27 @@ else
   fi
 fi
 
+# --- Step 5: per-index directive (no --index-concurrently flag) ---
+# Reset to initial schema
+setup_db "$DATA/init.sql"
+
+step "05 per-index directive (pist:concurrently)"
+plan_output=$(pist_plan "$DATA/steps/05_directive.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'CREATE INDEX CONCURRENTLY idx_users_name'; then
+  fail "expected CREATE INDEX CONCURRENTLY for idx_users_name"
+  echo "    $plan_output" >&2
+elif echo "$plan_output" | grep -qF 'CREATE UNIQUE INDEX CONCURRENTLY'; then
+  fail "idx_users_email should NOT be CONCURRENTLY"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply "$DATA/steps/05_directive.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan "$DATA/steps/05_directive.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
 summary

--- a/test/scenario/index_concurrently.test.sh
+++ b/test/scenario/index_concurrently.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Scenario test: --index-concurrently flag
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/index_concurrently"
+
+pist_plan_concurrent() {
+  "$PIST" plan --allow-drop all --index-concurrently "$@" 2>&1
+}
+
+pist_apply_concurrent() {
+  "$PIST" apply --allow-drop all --index-concurrently "$@" 2>&1
+}
+
+# --- Setup: load initial schema ---
+setup_db "$DATA/init.sql"
+
+# --- Step 1: ADD INDEX with CONCURRENTLY ---
+step "01 add index (concurrently)"
+plan_output=$(pist_plan_concurrent "$DATA/steps/01_add_index.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'CREATE INDEX CONCURRENTLY'; then
+  fail "expected CREATE INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply_concurrent "$DATA/steps/01_add_index.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan_concurrent "$DATA/steps/01_add_index.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 2: ADD UNIQUE INDEX with CONCURRENTLY ---
+step "02 add unique index (concurrently)"
+plan_output=$(pist_plan_concurrent "$DATA/steps/02_add_unique_index.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'CREATE UNIQUE INDEX CONCURRENTLY'; then
+  fail "expected CREATE UNIQUE INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply_concurrent "$DATA/steps/02_add_unique_index.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan_concurrent "$DATA/steps/02_add_unique_index.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 3: CHANGE INDEX with CONCURRENTLY (drop + create) ---
+step "03 change index (concurrently)"
+plan_output=$(pist_plan_concurrent "$DATA/steps/03_change_index.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'DROP INDEX CONCURRENTLY'; then
+  fail "expected DROP INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+elif ! echo "$plan_output" | grep -qF 'CREATE INDEX CONCURRENTLY'; then
+  fail "expected CREATE INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply_concurrent "$DATA/steps/03_change_index.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan_concurrent "$DATA/steps/03_change_index.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 4: DROP INDEX with CONCURRENTLY ---
+step "04 drop index (concurrently)"
+plan_output=$(pist_plan_concurrent "$DATA/steps/04_drop_index.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'DROP INDEX CONCURRENTLY'; then
+  fail "expected DROP INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply_concurrent "$DATA/steps/04_drop_index.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan_concurrent "$DATA/steps/04_drop_index.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+summary

--- a/test/scenario/testdata/index_concurrently/init.sql
+++ b/test/scenario/testdata/index_concurrently/init.sql
@@ -1,0 +1,6 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/index_concurrently/steps/01_add_index.sql
+++ b/test/scenario/testdata/index_concurrently/steps/01_add_index.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_users_name ON public.users USING btree (name);

--- a/test/scenario/testdata/index_concurrently/steps/02_add_unique_index.sql
+++ b/test/scenario/testdata/index_concurrently/steps/02_add_unique_index.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_users_name ON public.users USING btree (name);
+
+CREATE UNIQUE INDEX idx_users_email ON public.users USING btree (email);

--- a/test/scenario/testdata/index_concurrently/steps/03_change_index.sql
+++ b/test/scenario/testdata/index_concurrently/steps/03_change_index.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_users_name ON public.users USING hash (name);
+
+CREATE UNIQUE INDEX idx_users_email ON public.users USING btree (email);

--- a/test/scenario/testdata/index_concurrently/steps/04_drop_index.sql
+++ b/test/scenario/testdata/index_concurrently/steps/04_drop_index.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX idx_users_email ON public.users USING btree (email);

--- a/test/scenario/testdata/index_concurrently/steps/05_directive.sql
+++ b/test/scenario/testdata/index_concurrently/steps/05_directive.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);
+
+CREATE UNIQUE INDEX idx_users_email ON public.users USING btree (email);


### PR DESCRIPTION
## Summary

- Add `--index-concurrently` flag to `plan` and `apply` commands that generates `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` statements instead of regular index DDL
- Also available via `$PIST_INDEX_CONCURRENTLY` environment variable
- Returns an error when combined with `--with-tx` (CONCURRENTLY cannot run inside a transaction)
- Uses pg_query AST (`IndexStmt.Concurrent` / `DropStmt.Concurrent`) to insert the CONCURRENTLY flag, rather than string manipulation

## Test plan

- [x] Unit tests for `diffIndexes` with `concurrently=true` (add, drop, change, unique, rename, no-change)
- [x] Unit tests for `createIndexSQL` error paths (parse error, non-IndexStmt)
- [x] Unit tests for `DiffTables` with `indexConcurrently=true` (new table with index)
- [x] Unit tests for `extractObjectName` with CONCURRENTLY variants
- [x] Integration tests for `Plan` and `Apply` with `IndexConcurrently`
- [x] Integration test for `--index-concurrently` + `--with-tx` error
- [x] Scenario test (`index_concurrently.test.sh`) covering add, add unique, change (drop+create), and drop index
- [x] Verified with sample schemas (`make schema` → `pist plan --index-concurrently`)
- [x] All existing tests pass, lint clean, no coverage regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)