### PR TITLE
Add edge case tests for CONCURRENTLY index operations

### DIFF
--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -649,6 +649,71 @@ func TestDiffIndexes_mixedConcurrently(t *testing.T) {
 	assert.Equal(t, "CREATE INDEX idx_email ON public.users USING btree (email);", idxResult.Stmts[1])
 }
 
+func TestDiffIndexes_rename_perIndexConcurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("old_idx", &model.Index{Schema: "public", Name: "old_idx", Table: "users", Definition: "CREATE INDEX old_idx ON public.users USING btree (name)"})
+
+	oldName := "old_idx"
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)", Concurrently: true})
+
+	idxResult, err := diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	// Rename should NOT use CONCURRENTLY even with per-index directive
+	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
+	assert.False(t, idxResult.HasConcurrently)
+}
+
+func TestDiffIndexes_partialIndex_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_active", &model.Index{Schema: "public", Name: "idx_active", Definition: "CREATE INDEX idx_active ON public.users USING btree (name) WHERE (active = true)", Concurrently: true})
+
+	idxResult, err := diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	assert.Len(t, idxResult.Stmts, 1)
+	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
+	assert.Contains(t, idxResult.Stmts[0], "WHERE")
+}
+
+func TestDiffIndexes_expressionIndex_concurrently(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_lower", &model.Index{Schema: "public", Name: "idx_lower", Definition: "CREATE INDEX idx_lower ON public.users USING btree (lower(name))"})
+
+	idxResult, err := diffIndexes(current, desired, true)
+	require.NoError(t, err)
+	assert.Len(t, idxResult.Stmts, 1)
+	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
+	assert.Contains(t, idxResult.Stmts[0], "lower")
+}
+
+func TestDiffIndexes_hasConcurrently_flag(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+
+	// Global flag: HasConcurrently should be true
+	idxResult, err := diffIndexes(current, desired, true)
+	require.NoError(t, err)
+	assert.True(t, idxResult.HasConcurrently)
+
+	// No concurrently: HasConcurrently should be false
+	idxResult, err = diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	assert.False(t, idxResult.HasConcurrently)
+}
+
+func TestDiffIndexes_hasConcurrently_directive(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
+
+	idxResult, err := diffIndexes(current, desired, false)
+	require.NoError(t, err)
+	assert.True(t, idxResult.HasConcurrently)
+}
+
 func TestCreateIndexSQL_parseError(t *testing.T) {
 	_, err := createIndexSQL("NOT VALID SQL {{{{", true)
 	require.Error(t, err)

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -674,6 +674,7 @@ func TestDiffIndexes_partialIndex_concurrently(t *testing.T) {
 	assert.Len(t, idxResult.Stmts, 1)
 	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
 	assert.Contains(t, idxResult.Stmts[0], "WHERE")
+	assert.True(t, idxResult.HasConcurrently)
 }
 
 func TestDiffIndexes_expressionIndex_concurrently(t *testing.T) {
@@ -686,6 +687,7 @@ func TestDiffIndexes_expressionIndex_concurrently(t *testing.T) {
 	assert.Len(t, idxResult.Stmts, 1)
 	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
 	assert.Contains(t, idxResult.Stmts[0], "lower")
+	assert.True(t, idxResult.HasConcurrently)
 }
 
 func TestDiffIndexes_hasConcurrently_flag(t *testing.T) {
@@ -697,11 +699,15 @@ func TestDiffIndexes_hasConcurrently_flag(t *testing.T) {
 	idxResult, err := diffIndexes(current, desired, true)
 	require.NoError(t, err)
 	assert.True(t, idxResult.HasConcurrently)
+	assert.Len(t, idxResult.Stmts, 1)
+	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
 
 	// No concurrently: HasConcurrently should be false
 	idxResult, err = diffIndexes(current, desired, false)
 	require.NoError(t, err)
 	assert.False(t, idxResult.HasConcurrently)
+	assert.Len(t, idxResult.Stmts, 1)
+	assert.NotContains(t, idxResult.Stmts[0], "CONCURRENTLY")
 }
 
 func TestDiffIndexes_hasConcurrently_directive(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1776,3 +1776,19 @@ CREATE INDEX idx_name ON public.users (name);`
 	require.NotNil(t, idx.RenameFrom)
 	assert.Equal(t, "idx_old", *idx.RenameFrom)
 }
+
+func TestParseSQL_ConcurrentlyDirective_IgnoredOnNonIndex(t *testing.T) {
+	// -- pist:concurrently before a CREATE TABLE should be silently ignored
+	sql := `-- pist:concurrently
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	assert.NotNil(t, tbl)
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1779,11 +1779,13 @@ CREATE INDEX idx_name ON public.users (name);`
 
 func TestParseSQL_ConcurrentlyDirective_IgnoredOnNonIndex(t *testing.T) {
 	// -- pist:concurrently before a CREATE TABLE should be silently ignored
+	// and should NOT leak to the following CREATE INDEX
 	sql := `-- pist:concurrently
 CREATE TABLE public.users (
     id integer NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
-);`
+);
+CREATE INDEX idx_users_id ON public.users (id);`
 
 	result, err := parser.ParseSQL(sql)
 	require.NoError(t, err)
@@ -1791,4 +1793,8 @@ CREATE TABLE public.users (
 	tbl, ok := result.Tables.GetOk("public.users")
 	require.True(t, ok)
 	assert.NotNil(t, tbl)
+
+	idx, ok := tbl.Indexes.GetOk("idx_users_id")
+	require.True(t, ok)
+	assert.False(t, idx.Concurrently)
 }


### PR DESCRIPTION
## Summary

- Add unit tests for edge cases in CONCURRENTLY index operations that were missing from #96
- Rename with per-index `-- pist:concurrently` directive (verify CONCURRENTLY is not used)
- Partial index (`WHERE` clause) and expression index (`lower()`) with CONCURRENTLY
- `HasConcurrently` flag accuracy tests for both global flag and per-index directive
- `-- pist:concurrently` directive silently ignored on non-index statements (`CREATE TABLE`)

## Test plan

- [x] All new tests pass
- [x] Full test suite passes, lint clean
- [x] No production code changes — tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)