### PR TITLE
Allow --pre-sql / --pre-sql-file to be set via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ pist plan schema.sql --pre-sql "SET search_path TO myschema;"
 pist plan schema.sql --pre-sql-file pre.sql
 ```
 
+`--pre-sql` / `--pre-sql-file` are also available as `$PIST_PRE_SQL` / `$PIST_PRE_SQL_FILE`.
+
 ### apply
 
 Apply the diff to the database.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ pist apply schema.sql
 pist apply tables.sql views.sql
 ```
 
-Use `--pre-sql` or `--pre-sql-file` to run SQL before applying changes (mutually exclusive). Use `--with-tx` to wrap everything in a transaction.
+Use `--pre-sql` or `--pre-sql-file` to run SQL before applying changes (mutually exclusive). Also available as `$PIST_PRE_SQL` / `$PIST_PRE_SQL_FILE`. Use `--with-tx` to wrap everything in a transaction.
 
 ```bash
 # Inline SQL

--- a/apply.go
+++ b/apply.go
@@ -14,8 +14,8 @@ type ApplyOptions struct {
 	FilterOptions
 	DropPolicy
 	Files             []string `arg:"" help:"Path to the desired schema SQL file(s)."`
-	PreSQL            string   `xor:"pre-sql" help:"SQL to execute before applying changes."`
-	PreSQLFile        string   `type:"path" xor:"pre-sql" help:"Path to a SQL file to execute before applying changes."`
+	PreSQL            string   `xor:"pre-sql" env:"PIST_PRE_SQL" help:"SQL to execute before applying changes."`
+	PreSQLFile        string   `type:"path" xor:"pre-sql" env:"PIST_PRE_SQL_FILE" help:"Path to a SQL file to execute before applying changes."`
 	WithTx            bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
 	IndexConcurrently bool     `env:"PIST_INDEX_CONCURRENTLY" help:"Use CREATE/DROP INDEX CONCURRENTLY for index operations."`
 }

--- a/plan.go
+++ b/plan.go
@@ -12,8 +12,8 @@ type PlanOptions struct {
 	FilterOptions
 	DropPolicy
 	Files             []string `arg:"" help:"Path to the desired schema SQL file(s)."`
-	PreSQL            string   `xor:"pre-sql" help:"SQL to prepend to the plan output."`
-	PreSQLFile        string   `type:"path" xor:"pre-sql" help:"Path to a SQL file to prepend to the plan output."`
+	PreSQL            string   `xor:"pre-sql" env:"PIST_PRE_SQL" help:"SQL to prepend to the plan output."`
+	PreSQLFile        string   `type:"path" xor:"pre-sql" env:"PIST_PRE_SQL_FILE" help:"Path to a SQL file to prepend to the plan output."`
 	IndexConcurrently bool     `env:"PIST_INDEX_CONCURRENTLY" help:"Use CREATE/DROP INDEX CONCURRENTLY for index operations."`
 }
 


### PR DESCRIPTION
Add PIST_PRE_SQL and PIST_PRE_SQL_FILE so pre-SQL can be configured
without inline flags, matching the convention used by other options
such as PIST_INDEX_CONCURRENTLY.