### PR TITLE
Add tests for inline CREATE INDEX CONCURRENTLY parity

### DIFF
--- a/apply_test.go
+++ b/apply_test.go
@@ -705,6 +705,127 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
 	assert.Contains(t, buf.String(), "CREATE INDEX CONCURRENTLY idx_users_name")
 }
 
+func TestApply_InlineConcurrently_NoDriftAfterApply(t *testing.T) {
+	// Regression: after applying inline CREATE INDEX CONCURRENTLY, a subsequent
+	// plan against the same SQL must produce no diff. Validates that the parser
+	// strips CONCURRENTLY from Index.Definition so it matches the catalog-derived
+	// definition (which never contains CONCURRENTLY).
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);
+CREATE UNIQUE INDEX CONCURRENTLY idx_users_id ON public.users USING btree (id);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files: []string{desiredFile},
+	}, io.Discard)
+	require.NoError(t, err)
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files: []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL, "expected no drift after applying inline CONCURRENTLY indexes")
+}
+
+func TestApply_InlineConcurrently_ChangeIndex(t *testing.T) {
+	// Changing an inline-CONCURRENTLY index emits DROP + CREATE, both of which
+	// must use CONCURRENTLY (since the desired carries Concurrently=true).
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING hash (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
+		Files:      []string{desiredFile},
+	}, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "DROP INDEX CONCURRENTLY public.idx_users_name;")
+	assert.Contains(t, got, "CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING hash (name);")
+}
+
+func TestApply_InlineConcurrently_MatviewIndex(t *testing.T) {
+	// Inline CREATE INDEX CONCURRENTLY on a materialized view index must emit
+	// CONCURRENTLY in the apply output and leave no drift.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE MATERIALIZED VIEW public.user_names AS SELECT id, name FROM public.users;
+CREATE INDEX CONCURRENTLY idx_user_names ON public.user_names USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files: []string{desiredFile},
+	}, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "CREATE INDEX CONCURRENTLY idx_user_names")
+
+	// No drift after apply.
+	plan, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files: []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, plan.SQL)
+}
+
 func TestApply_InlineConcurrently_Preserved(t *testing.T) {
 	// Inline CREATE INDEX CONCURRENTLY (without -- pist:concurrently and
 	// without --disable-index-concurrently) must round-trip to CONCURRENTLY

--- a/test/scenario/inline_concurrently.test.sh
+++ b/test/scenario/inline_concurrently.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Scenario test: inline CREATE INDEX CONCURRENTLY (without -- pist:concurrently directive)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/inline_concurrently"
+
+# --- Setup: load initial schema ---
+setup_db "$DATA/init.sql"
+
+# --- Step 1: ADD inline CONCURRENTLY index → no drift after apply ---
+step "01 add index (inline CONCURRENTLY)"
+plan_output=$(pist_plan "$DATA/steps/01_add_index.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'CREATE INDEX CONCURRENTLY'; then
+  fail "expected CREATE INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply "$DATA/steps/01_add_index.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan "$DATA/steps/01_add_index.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 2: CHANGE inline CONCURRENTLY index → DROP + CREATE both CONCURRENTLY ---
+step "02 change index (inline CONCURRENTLY)"
+plan_output=$(pist_plan "$DATA/steps/02_change_index.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'DROP INDEX CONCURRENTLY'; then
+  fail "expected DROP INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+elif ! echo "$plan_output" | grep -qF 'CREATE INDEX CONCURRENTLY'; then
+  fail "expected CREATE INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply "$DATA/steps/02_change_index.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan "$DATA/steps/02_change_index.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 3: ADD UNIQUE inline CONCURRENTLY index ---
+step "03 add unique index (inline CONCURRENTLY)"
+plan_output=$(pist_plan "$DATA/steps/03_add_unique.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'CREATE UNIQUE INDEX CONCURRENTLY'; then
+  fail "expected CREATE UNIQUE INDEX CONCURRENTLY in plan"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply "$DATA/steps/03_add_unique.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan "$DATA/steps/03_add_unique.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 4: matview index with inline CONCURRENTLY ---
+setup_db "$DATA/init.sql"
+
+step "04 matview index (inline CONCURRENTLY)"
+plan_output=$(pist_plan "$DATA/steps/04_matview_index.sql") || { fail "plan failed: $plan_output"; true; }
+if ! echo "$plan_output" | grep -qF 'CREATE INDEX CONCURRENTLY idx_user_names'; then
+  fail "expected CREATE INDEX CONCURRENTLY idx_user_names in plan"
+  echo "    $plan_output" >&2
+else
+  apply_output=$(pist_apply "$DATA/steps/04_matview_index.sql") || { fail "apply failed: $apply_output"; true; }
+  drift=$(pist_plan "$DATA/steps/04_matview_index.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 5: --with-tx without --disable-index-concurrently fails on inline form ---
+setup_db "$DATA/init.sql"
+
+step "05 with-tx + inline CONCURRENTLY fails"
+apply_output=$("$PIST" apply --allow-drop all --with-tx "$DATA/steps/01_add_index.sql" 2>&1) && {
+  fail "expected apply to fail with --with-tx + inline CONCURRENTLY"
+  echo "    $apply_output" >&2
+  true
+}
+if echo "$apply_output" | grep -qF 'CONCURRENTLY'; then
+  pass
+else
+  fail "expected error mentioning CONCURRENTLY"
+  echo "    $apply_output" >&2
+fi
+
+summary

--- a/test/scenario/testdata/inline_concurrently/init.sql
+++ b/test/scenario/testdata/inline_concurrently/init.sql
@@ -1,0 +1,6 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/inline_concurrently/steps/01_add_index.sql
+++ b/test/scenario/testdata/inline_concurrently/steps/01_add_index.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);

--- a/test/scenario/testdata/inline_concurrently/steps/02_change_index.sql
+++ b/test/scenario/testdata/inline_concurrently/steps/02_change_index.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING hash (name);

--- a/test/scenario/testdata/inline_concurrently/steps/03_add_unique.sql
+++ b/test/scenario/testdata/inline_concurrently/steps/03_add_unique.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING hash (name);
+
+CREATE UNIQUE INDEX CONCURRENTLY idx_users_email ON public.users USING btree (email);

--- a/test/scenario/testdata/inline_concurrently/steps/04_matview_index.sql
+++ b/test/scenario/testdata/inline_concurrently/steps/04_matview_index.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE MATERIALIZED VIEW public.user_names AS
+SELECT id, name FROM public.users;
+
+CREATE INDEX CONCURRENTLY idx_user_names ON public.user_names USING btree (name);


### PR DESCRIPTION
## Summary
Cover three previously untested cases for inline `CREATE INDEX CONCURRENTLY` (i.e. no `-- pist:concurrently` directive):

- **Round-trip / no-drift after apply** — regression test for the parser normalization that strips `CONCURRENTLY` from `Index.Definition` so it matches catalog-derived definitions.
- **Change index** — emits `DROP` + `CREATE` both with `CONCURRENTLY` when an inline-CONCURRENTLY index changes.
- **Materialized view index** — inline `CONCURRENTLY` honored end-to-end on matview indexes.

Adds Go integration tests (`TestApply_InlineConcurrently_*`) and a scenario suite (`inline_concurrently.test.sh`, 5 steps) mirroring the directive flow but using inline `CONCURRENTLY` in input SQL.

## Test plan
- [x] `make vet`
- [x] `make lint`
- [x] `make test` (all unit + integration tests pass)
- [x] `make test-scenario` (all scenario suites pass, including the new `inline_concurrently` scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)