### PR TITLE
Emit suppressed DROPs as commented-out DDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ pist plan --allow-drop all schema.sql
 pist apply --allow-drop column,table schema.sql
 ```
 
+Suppressed drops are emitted as commented-out DDL so you can see what would be dropped without executing it. The plan still reports `-- No changes` when the only diff would be a suppressed drop, since no executable DDL is generated:
+
+```sql
+-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
+-- DROP TABLE public.legacy_users;
+-- No changes
+```
+
 > [!NOTE]
 > Constraints and indexes are always dropped when their definitions change or they are removed from the desired schema, regardless of `--allow-drop`. This is because PostgreSQL does not support `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes — the only way to update them is DROP + ADD.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ Suppressed drops are emitted as commented-out DDL prefixed with `-- skipped:` so
 ```
 
 > [!NOTE]
-> Constraints and indexes are always dropped when their definitions change or they are removed from the desired schema, regardless of `--allow-drop`. This is because PostgreSQL does not support `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes — the only way to update them is DROP + ADD.
+> Constraints and indexes whose definitions change or are removed from the desired schema are always dropped, regardless of `--allow-drop`. This is because PostgreSQL does not support `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes — the only way to update them is DROP + ADD.
+>
+> Foreign-key `DROP CONSTRAINT` statements that exist only to unblock a table drop follow the table-drop policy: if the table drop is suppressed, the FK drop is suppressed too and surfaces as `-- skipped:` alongside the table.
 
 ### Executing arbitrary SQL
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ pist plan --allow-drop all schema.sql
 pist apply --allow-drop column,table schema.sql
 ```
 
-Suppressed drops are emitted as commented-out DDL so you can see what would be dropped without executing it. The plan still reports `-- No changes` when the only diff would be a suppressed drop, since no executable DDL is generated:
+Suppressed drops are emitted as commented-out DDL prefixed with `-- skipped:` so you can see what would be dropped without executing it. The plan still reports `-- No changes` when the only diff would be a suppressed drop, since no executable DDL is generated:
 
 ```sql
 -- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
--- DROP TABLE public.legacy_users;
+-- skipped: DROP TABLE public.legacy_users;
 -- No changes
 ```
 

--- a/apply.go
+++ b/apply.go
@@ -20,7 +20,13 @@ type ApplyOptions struct {
 	DisableIndexConcurrently bool     `env:"PIST_DISABLE_INDEX_CONCURRENTLY" help:"Ignore all CONCURRENTLY opt-ins (both -- pist:concurrently directives and inline CREATE/DROP INDEX CONCURRENTLY) and emit plain CREATE/DROP INDEX."`
 }
 
-func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (*ObjectCount, error) {
+// ApplyResult holds the result of an Apply operation.
+type ApplyResult struct {
+	Count           ObjectCount
+	DisallowedDrops string
+}
+
+func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (*ApplyResult, error) {
 	conn, err := client.connect()
 	if err != nil {
 		return nil, err
@@ -43,10 +49,13 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return nil, fmt.Errorf("--with-tx cannot be used with CONCURRENTLY index operations")
 	}
 
-	count := &result.Count
+	applyResult := &ApplyResult{
+		Count:           result.Count,
+		DisallowedDrops: strings.Join(result.DisallowedDrops, "\n"),
+	}
 
 	if len(result.Stmts) == 0 && len(result.ExecuteStmts) == 0 {
-		return count, nil
+		return applyResult, nil
 	}
 
 	exec := conn.Exec
@@ -112,5 +121,5 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return nil, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	return count, nil
+	return applyResult, nil
 }

--- a/apply_test.go
+++ b/apply_test.go
@@ -705,6 +705,46 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
 	assert.Contains(t, buf.String(), "CREATE INDEX CONCURRENTLY idx_users_name")
 }
 
+func TestApply_DisallowedDrops_MultipleTypes(t *testing.T) {
+	// ApplyResult.DisallowedDrops aggregates skipped DROPs across object types
+	// when --allow-drop is empty. The buffer must stay empty (no executable DDL).
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    legacy text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TYPE public.color AS ENUM ('red', 'blue');`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	result, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files: []string{desiredFile},
+	}, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "no executable DDL should be written")
+	assert.Contains(t, result.DisallowedDrops, "-- skipped: ALTER TABLE public.users DROP COLUMN legacy;")
+	assert.Contains(t, result.DisallowedDrops, "-- skipped: DROP TYPE public.color;")
+
+	// Confirm DB state was not mutated by the comments.
+	var n int
+	require.NoError(t, conn.QueryRow(ctx, "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema='public' AND table_name='users' AND column_name='legacy'").Scan(&n))
+	assert.Equal(t, 1, n, "skipped column drop must not actually drop the column")
+}
+
 func TestApply_InlineConcurrently_NoDriftAfterApply(t *testing.T) {
 	// Regression: after applying inline CREATE INDEX CONCURRENTLY, a subsequent
 	// plan against the same SQL must produce no diff. Validates that the parser

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -22,14 +22,19 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 
 	fmt.Fprintf(w, "-- Apply to %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 
-	if result.DisallowedDrops != "" {
-		fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
-	}
-
+	// Same ordering as Plan: executed SQL (incl. pre-SQL) first, then skipped
+	// DROPs as comments. When nothing was executed, skipped DROPs precede
+	// "-- No changes".
 	if buf.Len() == 0 {
+		if result.DisallowedDrops != "" {
+			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
+		}
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {
 		w.Write(buf.Bytes()) //nolint:errcheck
+		if result.DisallowedDrops != "" {
+			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
+		}
 	}
 
 	return nil

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -15,12 +15,16 @@ type Apply struct {
 
 func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer) error {
 	var buf bytes.Buffer
-	count, err := client.Apply(ctx, &cmd.ApplyOptions, &buf)
+	result, err := client.Apply(ctx, &cmd.ApplyOptions, &buf)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(w, "-- Apply to %s (%s)\n", count.SchemaLabel(), count.Summary()) //nolint:errcheck
+	fmt.Fprintf(w, "-- Apply to %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
+
+	if result.DisallowedDrops != "" {
+		fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
+	}
 
 	if buf.Len() == 0 {
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -314,7 +314,7 @@ func TestPlan_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
-	assert.Contains(t, got, "-- DROP TABLE public.users;")
+	assert.Contains(t, got, "-- skipped: DROP TABLE public.users;")
 	assert.Contains(t, got, "-- No changes")
 	// Plain DROP (no comment) must NOT appear.
 	for _, line := range strings.Split(got, "\n") {

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -287,10 +288,9 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 }
 
 func TestPlan_Run_DropDeniedShowsNoChanges(t *testing.T) {
-	// Current behavior: when the only diff would be a DROP and --allow-drop
-	// is not set, the DROP is silently suppressed and the plan reports
-	// "-- No changes". This documents the existing UX so any change to it
-	// (e.g., emitting commented DROPs) is intentional.
+	// When the only diff would be a DROP and --allow-drop is not set,
+	// the DROP is emitted as a comment for visibility while the "No changes"
+	// message is preserved (since no executable DDL is generated).
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
@@ -313,8 +313,16 @@ func TestPlan_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- No changes")
-	assert.NotContains(t, buf.String(), "DROP TABLE")
+	got := buf.String()
+	assert.Contains(t, got, "-- DROP TABLE public.users;")
+	assert.Contains(t, got, "-- No changes")
+	// Plain DROP (no comment) must NOT appear.
+	for _, line := range strings.Split(got, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "DROP TABLE") {
+			t.Fatalf("unexpected uncommented DROP TABLE: %q", line)
+		}
+	}
 }
 
 func TestApply_Run_NoChanges(t *testing.T) {

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -325,6 +325,42 @@ func TestPlan_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	}
 }
 
+func TestApply_Run_DropDeniedShowsNoChanges(t *testing.T) {
+	// Apply CLI counterpart of TestPlan_Run_DropDeniedShowsNoChanges.
+	// When the only diff is a suppressed DROP, the apply prints the skipped
+	// DROP as a comment AND reports "-- No changes" (no DDL was executed).
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(""), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "-- skipped: DROP TABLE public.users;")
+	assert.Contains(t, got, "-- No changes")
+
+	// The table must still exist in the database (skip is only emitted as a
+	// comment; no DDL is actually executed).
+	var n int
+	require.NoError(t, conn.QueryRow(ctx, "SELECT COUNT(*) FROM pg_tables WHERE schemaname = 'public' AND tablename = 'users'").Scan(&n))
+	assert.Equal(t, 1, n)
+}
+
 func TestApply_Run_NoChanges(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -325,6 +325,53 @@ func TestPlan_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	}
 }
 
+func TestPlan_Run_PreSQLBeforeSkippedDrops(t *testing.T) {
+	// pre-SQL is prepended to executable SQL and must appear above any
+	// "-- skipped:" comments so the output remains a runnable script when
+	// piped to psql.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    legacy text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	// Desired removes "legacy" (suppressed by default --allow-drop) and adds
+	// "name" so we get both an executable diff and a skipped comment.
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{
+		Files:  []string{desiredFile},
+		PreSQL: "SELECT 1;",
+	}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+
+	preSQLPos := strings.Index(got, "SELECT 1;")
+	addColPos := strings.Index(got, "ADD COLUMN name")
+	skippedPos := strings.Index(got, "-- skipped:")
+	require.NotEqual(t, -1, preSQLPos, "pre-SQL should be present")
+	require.NotEqual(t, -1, addColPos, "executable diff should be present")
+	require.NotEqual(t, -1, skippedPos, "skipped comment should be present")
+	assert.Less(t, preSQLPos, addColPos, "pre-SQL must precede executable diff")
+	assert.Less(t, addColPos, skippedPos, "skipped comments must follow executable SQL")
+}
+
 func TestApply_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	// Apply CLI counterpart of TestPlan_Run_DropDeniedShowsNoChanges.
 	// When the only diff is a suppressed DROP, the apply prints the skipped

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -286,6 +286,37 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	assert.Contains(t, buf.String(), "-- No changes")
 }
 
+func TestPlan_Run_DropDeniedShowsNoChanges(t *testing.T) {
+	// Current behavior: when the only diff would be a DROP and --allow-drop
+	// is not set, the DROP is silently suppressed and the plan reports
+	// "-- No changes". This documents the existing UX so any change to it
+	// (e.g., emitting commented DROPs) is intentional.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	// Desired schema removes public.users entirely.
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(""), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "-- No changes")
+	assert.NotContains(t, buf.String(), "DROP TABLE")
+}
+
 func TestApply_Run_NoChanges(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -20,6 +20,10 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 
 	fmt.Fprintf(w, "-- Plan for %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 
+	if result.DisallowedDrops != "" {
+		fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
+	}
+
 	if result.SQL == "" {
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -20,14 +20,20 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 
 	fmt.Fprintf(w, "-- Plan for %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 
-	if result.DisallowedDrops != "" {
-		fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
-	}
-
+	// Order: executable SQL (incl. pre-SQL) first so it can be piped/copied
+	// as a runnable script; skipped DROPs follow as informational comments.
+	// In the no-SQL case, skipped DROPs come before "-- No changes" so the
+	// summary line reads naturally at the end.
 	if result.SQL == "" {
+		if result.DisallowedDrops != "" {
+			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
+		}
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {
 		fmt.Fprintln(w, result.SQL) //nolint:errcheck
+		if result.DisallowedDrops != "" {
+			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
+		}
 	}
 
 	return nil

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -9,8 +9,9 @@ import (
 )
 
 type DomainDiffResult struct {
-	Stmts     []string
-	DropStmts []string
+	Stmts               []string
+	DropStmts           []string
+	DisallowedDropStmts []string
 }
 
 func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain], dc DropChecker) (*DomainDiffResult, error) {
@@ -48,11 +49,14 @@ func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain], dc Dro
 		result.Stmts = append(result.Stmts, stmts...)
 	}
 
-	// Dropped domains
-	if dc.IsDropAllowed("domain") {
-		for k := range current.Keys() {
-			if _, ok := desired.GetOk(k); !ok {
+	// Dropped domains. When the domain-drop policy disallows it, emit a commented DROP.
+	domainAllowed := dc.IsDropAllowed("domain")
+	for k := range current.Keys() {
+		if _, ok := desired.GetOk(k); !ok {
+			if domainAllowed {
 				result.DropStmts = append(result.DropStmts, "DROP DOMAIN "+k+";")
+			} else {
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP DOMAIN "+k+";")
 			}
 		}
 	}

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -56,7 +56,7 @@ func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain], dc Dro
 			if domainAllowed {
 				result.DropStmts = append(result.DropStmts, "DROP DOMAIN "+k+";")
 			} else {
-				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP DOMAIN "+k+";")
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP DOMAIN "+k+";")
 			}
 		}
 	}

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -54,6 +54,7 @@ func TestDiffDomains_Drop_Denied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
+	assert.Equal(t, []string{"-- DROP DOMAIN public.pos_int;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffDomains_NoDiff(t *testing.T) {

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -54,7 +54,7 @@ func TestDiffDomains_Drop_Denied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
-	assert.Equal(t, []string{"-- DROP DOMAIN public.pos_int;"}, result.DisallowedDropStmts)
+	assert.Equal(t, []string{"-- skipped: DROP DOMAIN public.pos_int;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffDomains_NoDiff(t *testing.T) {

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -65,7 +65,7 @@ func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum], dc DropChe
 			if enumAllowed {
 				result.DropStmts = append(result.DropStmts, "DROP TYPE "+k+";")
 			} else {
-				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP TYPE "+k+";")
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP TYPE "+k+";")
 			}
 		}
 	}

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -9,8 +9,9 @@ import (
 )
 
 type EnumDiffResult struct {
-	Stmts     []string
-	DropStmts []string
+	Stmts               []string
+	DropStmts           []string
+	DisallowedDropStmts []string
 }
 
 func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum], dc DropChecker) (*EnumDiffResult, error) {
@@ -57,11 +58,14 @@ func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum], dc DropChe
 		}
 	}
 
-	// Dropped enums
-	if dc.IsDropAllowed("enum") {
-		for k := range current.Keys() {
-			if _, ok := desired.GetOk(k); !ok {
+	// Dropped enums. When the enum-drop policy disallows it, emit a commented DROP.
+	enumAllowed := dc.IsDropAllowed("enum")
+	for k := range current.Keys() {
+		if _, ok := desired.GetOk(k); !ok {
+			if enumAllowed {
 				result.DropStmts = append(result.DropStmts, "DROP TYPE "+k+";")
+			} else {
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP TYPE "+k+";")
 			}
 		}
 	}

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -56,6 +56,7 @@ func TestDiffEnums_DropExisting_Denied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
+	assert.Equal(t, []string{"-- DROP TYPE public.status;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffEnums_AddValue(t *testing.T) {

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -56,7 +56,7 @@ func TestDiffEnums_DropExisting_Denied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
-	assert.Equal(t, []string{"-- DROP TYPE public.status;"}, result.DisallowedDropStmts)
+	assert.Equal(t, []string{"-- skipped: DROP TYPE public.status;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffEnums_AddValue(t *testing.T) {

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -67,7 +67,7 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 
 	// Dropped tables: drop FKs on dropped tables first to avoid dependency errors.
 	// When the table-drop policy disallows it, emit the same DROPs as comments
-	// (with "-- " prefix) into DisallowedDropStmts for visibility.
+	// (with "-- skipped: " prefix) into DisallowedDropStmts for visibility.
 	tableAllowed := dc.IsDropAllowed("table")
 	for k, tbl := range current.All() {
 		if _, ok := desired.GetOk(k); !ok {

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -13,11 +13,12 @@ import (
 // TableDiffResult separates FK operations from other statements to allow
 // correct ordering: FK drops first, then schema changes, then FK adds last.
 type TableDiffResult struct {
-	FKDropStmts     []string // FK drops (should run first)
-	Stmts           []string // CREATE/ALTER TABLE, columns, constraints, indexes, comments
-	FKAddStmts      []string // FK adds and renames (should run last)
-	DropStmts       []string // DROP TABLE (separate from Stmts for ordering)
-	HasConcurrently bool     // true if any index operation uses CONCURRENTLY
+	FKDropStmts         []string // FK drops (should run first)
+	Stmts               []string // CREATE/ALTER TABLE, columns, constraints, indexes, comments
+	FKAddStmts          []string // FK adds and renames (should run last)
+	DropStmts           []string // DROP TABLE (separate from Stmts for ordering)
+	DisallowedDropStmts []string // DROP TABLE/COLUMN suppressed by DropChecker, with "-- " prefix
+	HasConcurrently     bool     // true if any index operation uses CONCURRENTLY
 }
 
 func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) (*TableDiffResult, error) {
@@ -57,20 +58,29 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 			result.FKDropStmts = append(result.FKDropStmts, tableResult.FKDropStmts...)
 			result.Stmts = append(result.Stmts, tableResult.Stmts...)
 			result.FKAddStmts = append(result.FKAddStmts, tableResult.FKAddStmts...)
+			result.DisallowedDropStmts = append(result.DisallowedDropStmts, tableResult.DisallowedDropStmts...)
 			if tableResult.HasConcurrently {
 				result.HasConcurrently = true
 			}
 		}
 	}
 
-	// Dropped tables: drop FKs on dropped tables first to avoid dependency errors
-	if dc.IsDropAllowed("table") {
-		for k, tbl := range current.All() {
-			if _, ok := desired.GetOk(k); !ok {
+	// Dropped tables: drop FKs on dropped tables first to avoid dependency errors.
+	// When the table-drop policy disallows it, emit the same DROPs as comments
+	// (with "-- " prefix) into DisallowedDropStmts for visibility.
+	tableAllowed := dc.IsDropAllowed("table")
+	for k, tbl := range current.All() {
+		if _, ok := desired.GetOk(k); !ok {
+			if tableAllowed {
 				for name := range tbl.ForeignKeys.Keys() {
 					result.FKDropStmts = append(result.FKDropStmts, "ALTER TABLE "+k+" DROP CONSTRAINT "+model.Ident(name)+";")
 				}
 				result.DropStmts = append(result.DropStmts, "DROP TABLE "+k+";")
+			} else {
+				for name := range tbl.ForeignKeys.Keys() {
+					result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- ALTER TABLE "+k+" DROP CONSTRAINT "+model.Ident(name)+";")
+				}
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP TABLE "+k+";")
 			}
 		}
 	}
@@ -100,10 +110,11 @@ func newTableExtras(t *model.Table) (stmts []string, fkStmts []string, hasConcur
 }
 
 type tableDiffResult struct {
-	FKDropStmts     []string
-	Stmts           []string
-	FKAddStmts      []string
-	HasConcurrently bool
+	FKDropStmts         []string
+	Stmts               []string
+	FKAddStmts          []string
+	DisallowedDropStmts []string
+	HasConcurrently     bool
 }
 
 func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult, error) {
@@ -131,11 +142,12 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		return result, nil
 	}
 
-	colStmts, err := diffColumns(fqtn, current.Columns, desired.Columns, dc)
+	colStmts, colDisallowed, err := diffColumns(fqtn, current.Columns, desired.Columns, dc)
 	if err != nil {
 		return nil, err
 	}
 	result.Stmts = append(result.Stmts, colStmts...)
+	result.DisallowedDropStmts = append(result.DisallowedDropStmts, colDisallowed...)
 
 	conStmts, err := diffConstraints(fqtn, current.Constraints, desired.Constraints)
 	if err != nil {
@@ -164,14 +176,13 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	return result, nil
 }
 
-func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column], dc DropChecker) ([]string, error) {
+func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column], dc DropChecker) (stmts []string, disallowed []string, err error) {
 	dc = NormalizeDropChecker(dc)
-	var stmts []string
 
 	// Detect renames
 	renameStmts, current, err := detectColumnRenames(fqtn, current, desired)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	stmts = append(stmts, renameStmts...)
 
@@ -189,16 +200,20 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 		}
 	}
 
-	// Drop removed columns
-	if dc.IsDropAllowed("column") {
-		for name := range current.Keys() {
-			if _, ok := desired.GetOk(name); !ok {
+	// Drop removed columns. When the column-drop policy disallows it, emit
+	// the same DROP as a comment for visibility.
+	colAllowed := dc.IsDropAllowed("column")
+	for name := range current.Keys() {
+		if _, ok := desired.GetOk(name); !ok {
+			if colAllowed {
 				stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
+			} else {
+				disallowed = append(disallowed, "-- ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
 			}
 		}
 	}
 
-	return stmts, nil
+	return stmts, disallowed, nil
 }
 
 func addColumnSQL(fqtn string, col *model.Column) string {

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -17,7 +17,7 @@ type TableDiffResult struct {
 	Stmts               []string // CREATE/ALTER TABLE, columns, constraints, indexes, comments
 	FKAddStmts          []string // FK adds and renames (should run last)
 	DropStmts           []string // DROP TABLE (separate from Stmts for ordering)
-	DisallowedDropStmts []string // DROP TABLE/COLUMN suppressed by DropChecker, with "-- " prefix
+	DisallowedDropStmts []string // DROP TABLE / DROP COLUMN / FK DROP CONSTRAINT suppressed by DropChecker, with "-- skipped: " prefix
 	HasConcurrently     bool     // true if any index operation uses CONCURRENTLY
 }
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -78,9 +78,9 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 				result.DropStmts = append(result.DropStmts, "DROP TABLE "+k+";")
 			} else {
 				for name := range tbl.ForeignKeys.Keys() {
-					result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- ALTER TABLE "+k+" DROP CONSTRAINT "+model.Ident(name)+";")
+					result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: ALTER TABLE "+k+" DROP CONSTRAINT "+model.Ident(name)+";")
 				}
-				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP TABLE "+k+";")
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP TABLE "+k+";")
 			}
 		}
 	}
@@ -208,7 +208,7 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 			if colAllowed {
 				stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
 			} else {
-				disallowed = append(disallowed, "-- ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
+				disallowed = append(disallowed, "-- skipped: ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
 			}
 		}
 	}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -146,9 +146,9 @@ func TestDiffTables_dropTable_withFK_denied(t *testing.T) {
 	assert.Empty(t, result.FKDropStmts)
 	assert.Empty(t, result.DropStmts)
 	assert.Equal(t, []string{
-		"-- DROP TABLE public.users;",
-		"-- ALTER TABLE public.posts DROP CONSTRAINT posts_user_id_fkey;",
-		"-- DROP TABLE public.posts;",
+		"-- skipped: DROP TABLE public.users;",
+		"-- skipped: ALTER TABLE public.posts DROP CONSTRAINT posts_user_id_fkey;",
+		"-- skipped: DROP TABLE public.posts;",
 	}, result.DisallowedDropStmts)
 }
 
@@ -184,7 +184,7 @@ func TestDiffTables_dropTable_denied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
-	assert.Equal(t, []string{"-- DROP TABLE public.users;"}, result.DisallowedDropStmts)
+	assert.Equal(t, []string{"-- skipped: DROP TABLE public.users;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffColumns_dropColumn_denied(t *testing.T) {
@@ -198,7 +198,7 @@ func TestDiffColumns_dropColumn_denied(t *testing.T) {
 	stmts, disallowed, err := diffColumns("public.users", current, desired, DenyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
-	assert.Equal(t, []string{"-- ALTER TABLE public.users DROP COLUMN name;"}, disallowed)
+	assert.Equal(t, []string{"-- skipped: ALTER TABLE public.users DROP COLUMN name;"}, disallowed)
 }
 
 func TestDiffTables_noChange(t *testing.T) {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -145,6 +145,11 @@ func TestDiffTables_dropTable_withFK_denied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.FKDropStmts)
 	assert.Empty(t, result.DropStmts)
+	assert.Equal(t, []string{
+		"-- DROP TABLE public.users;",
+		"-- ALTER TABLE public.posts DROP CONSTRAINT posts_user_id_fkey;",
+		"-- DROP TABLE public.posts;",
+	}, result.DisallowedDropStmts)
 }
 
 func TestNormalizeDropChecker_nil(t *testing.T) {
@@ -178,6 +183,8 @@ func TestDiffTables_dropTable_denied(t *testing.T) {
 	result, err := DiffTables(current, desired, DenyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+	assert.Equal(t, []string{"-- DROP TABLE public.users;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffColumns_dropColumn_denied(t *testing.T) {
@@ -188,9 +195,10 @@ func TestDiffColumns_dropColumn_denied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, err := diffColumns("public.users", current, desired, DenyAllDrops{})
+	stmts, disallowed, err := diffColumns("public.users", current, desired, DenyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
+	assert.Equal(t, []string{"-- ALTER TABLE public.users DROP COLUMN name;"}, disallowed)
 }
 
 func TestDiffTables_noChange(t *testing.T) {
@@ -218,7 +226,7 @@ func TestDiffColumns_addColumn(t *testing.T) {
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ADD COLUMN name text NOT NULL;", stmts[0])
@@ -232,7 +240,7 @@ func TestDiffColumns_dropColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users DROP COLUMN name;", stmts[0])
@@ -245,7 +253,7 @@ func TestDiffColumns_alterType(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;", stmts[0])
@@ -258,7 +266,7 @@ func TestDiffColumns_alterType_withCollation(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], `COLLATE "en_US"`)
@@ -271,7 +279,7 @@ func TestDiffColumns_alterDefault_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer", Default: ptr("0")})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age SET DEFAULT 0;", stmts[0])
@@ -284,7 +292,7 @@ func TestDiffColumns_alterDefault_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer"})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age DROP DEFAULT;", stmts[0])
@@ -297,7 +305,7 @@ func TestDiffColumns_alterNotNull_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;", stmts[0])
@@ -310,7 +318,7 @@ func TestDiffColumns_alterNotNull_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;", stmts[0])
@@ -323,7 +331,7 @@ func TestDiffColumns_identitySkipsNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", Identity: model.ColumnIdentity('a')})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1604,7 +1612,7 @@ func TestDiffColumns_renameColumn_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1763,7 +1771,7 @@ func TestDiffColumns_renameColumn_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	_, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	_, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -1795,7 +1803,7 @@ func TestDiffColumns_renameColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME COLUMN name TO display_name;"}, stmts)
 }
@@ -1808,7 +1816,7 @@ func TestDiffColumns_renameColumn_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -2042,7 +2050,7 @@ func TestDiffColumns_renameColumn_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	_, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	_, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source column")
 }

--- a/diff/views.go
+++ b/diff/views.go
@@ -200,8 +200,12 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 	}
 	result.CreateStmts = append(result.CreateStmts, renameStmts...)
 
-	// Track views that are recreated (DROP+CREATE) so comments can be re-applied
+	// Track views that are recreated (DROP+CREATE) so comments can be re-applied.
 	recreated := make(map[string]bool)
+	// Track views whose recreation was suppressed by --allow-drop. For these we
+	// skip the executable comment diff too, so the output reflects "nothing
+	// executable" rather than emitting half of the intended change.
+	recreateDenied := make(map[string]bool)
 
 	// New or modified views (CREATE OR REPLACE / recreate for materialized)
 	for k, desiredView := range desired.All() {
@@ -255,6 +259,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 					} else {
 						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP VIEW "+k+";")
 					}
+					recreateDenied[k] = true
 				}
 			} else {
 				// Regular view: CREATE OR REPLACE
@@ -292,6 +297,14 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 	// Comment changes
 	for k, desiredView := range desired.All() {
 		currentView, ok := current.GetOk(k)
+
+		// If the recreation was blocked by --allow-drop (type change or
+		// matview definition change), the object on disk still matches the
+		// pre-recreation shape, so skip comment diff to keep the output
+		// consistent with "nothing executable was emitted for this view".
+		if recreateDenied[k] {
+			continue
+		}
 
 		// If the type changed (VIEW ↔ MATERIALIZED VIEW) but drop was denied,
 		// the object type hasn't changed yet — skip comment diff.

--- a/diff/views.go
+++ b/diff/views.go
@@ -251,9 +251,9 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 					recreated[k] = true
 				} else {
 					if currentView.Materialized {
-						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP MATERIALIZED VIEW "+k+";")
+						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP MATERIALIZED VIEW "+k+";")
 					} else {
-						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP VIEW "+k+";")
+						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP VIEW "+k+";")
 					}
 				}
 			} else {
@@ -284,7 +284,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			if viewAllowed {
 				result.DropStmts = append(result.DropStmts, drop)
 			} else {
-				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- "+drop)
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: "+drop)
 			}
 		}
 	}

--- a/diff/views.go
+++ b/diff/views.go
@@ -183,9 +183,10 @@ func stripQualifications(node *pg_query.Node) {
 // ViewDiffResult separates view DROP and CREATE/MODIFY statements.
 // Drops should run before table changes, creates after.
 type ViewDiffResult struct {
-	DropStmts       []string // DROP VIEW / DROP MATERIALIZED VIEW (should run before table changes)
-	CreateStmts     []string // ALTER VIEW RENAME, CREATE OR REPLACE VIEW, CREATE MATERIALIZED VIEW, indexes, comments (should run after table changes)
-	HasConcurrently bool     // true if any index operation uses CONCURRENTLY
+	DropStmts           []string // DROP VIEW / DROP MATERIALIZED VIEW (should run before table changes)
+	CreateStmts         []string // ALTER VIEW RENAME, CREATE OR REPLACE VIEW, CREATE MATERIALIZED VIEW, indexes, comments (should run after table changes)
+	DisallowedDropStmts []string // DROP VIEW / DROP MATERIALIZED VIEW suppressed by DropChecker, with "-- " prefix
+	HasConcurrently     bool     // true if any index operation uses CONCURRENTLY
 }
 
 func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker) (*ViewDiffResult, error) {
@@ -225,7 +226,9 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			needsDropCreate := desiredView.Materialized || currentView.Materialized != desiredView.Materialized
 			if needsDropCreate {
 				// Materialized views or type changes (VIEW ↔ MATERIALIZED VIEW)
-				// require DROP and recreate. Only proceed if drops are allowed.
+				// require DROP and recreate. Only proceed if drops are allowed;
+				// otherwise emit a commented DROP for visibility (no CREATE,
+				// since recreation requires the drop).
 				if dc.IsDropAllowed("view") {
 					if currentView.Materialized {
 						result.DropStmts = append(result.DropStmts, "DROP MATERIALIZED VIEW "+k+";")
@@ -246,6 +249,12 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 						}
 					}
 					recreated[k] = true
+				} else {
+					if currentView.Materialized {
+						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP MATERIALIZED VIEW "+k+";")
+					} else {
+						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- DROP VIEW "+k+";")
+					}
 				}
 			} else {
 				// Regular view: CREATE OR REPLACE
@@ -264,15 +273,18 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 		}
 	}
 
-	// Dropped views
-	if dc.IsDropAllowed("view") {
-		for k, v := range current.All() {
-			if _, ok := desired.GetOk(k); !ok {
-				if v.Materialized {
-					result.DropStmts = append(result.DropStmts, "DROP MATERIALIZED VIEW "+k+";")
-				} else {
-					result.DropStmts = append(result.DropStmts, "DROP VIEW "+k+";")
-				}
+	// Dropped views. When the view-drop policy disallows it, emit a commented DROP.
+	viewAllowed := dc.IsDropAllowed("view")
+	for k, v := range current.All() {
+		if _, ok := desired.GetOk(k); !ok {
+			drop := "DROP VIEW " + k + ";"
+			if v.Materialized {
+				drop = "DROP MATERIALIZED VIEW " + k + ";"
+			}
+			if viewAllowed {
+				result.DropStmts = append(result.DropStmts, drop)
+			} else {
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- "+drop)
 			}
 		}
 	}

--- a/diff/views.go
+++ b/diff/views.go
@@ -185,7 +185,7 @@ func stripQualifications(node *pg_query.Node) {
 type ViewDiffResult struct {
 	DropStmts           []string // DROP VIEW / DROP MATERIALIZED VIEW (should run before table changes)
 	CreateStmts         []string // ALTER VIEW RENAME, CREATE OR REPLACE VIEW, CREATE MATERIALIZED VIEW, indexes, comments (should run after table changes)
-	DisallowedDropStmts []string // DROP VIEW / DROP MATERIALIZED VIEW suppressed by DropChecker, with "-- " prefix
+	DisallowedDropStmts []string // DROP VIEW / DROP MATERIALIZED VIEW suppressed by DropChecker, with "-- skipped: " prefix
 	HasConcurrently     bool     // true if any index operation uses CONCURRENTLY
 }
 

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -402,6 +402,34 @@ func TestDiffViews_modifyMatview_dropDenied(t *testing.T) {
 	assert.Equal(t, []string{"-- skipped: DROP MATERIALIZED VIEW public.mv;"}, result.DisallowedDropStmts)
 }
 
+func TestDiffViews_modifyMatview_dropDenied_withCommentChange(t *testing.T) {
+	// When a matview definition change is blocked by --allow-drop and the
+	// desired matview also has a different comment, the comment change must
+	// NOT be emitted: the matview on disk still has the old definition, so
+	// only suppressing the recreation but updating the comment would be a
+	// half-applied change. The whole recreation is skipped instead.
+	oldComment := "old"
+	newComment := "new"
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Comment: &oldComment,
+		Indexes: orderedmap.New[string, *model.Index](),
+	})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 2 AS n", Comment: &newComment,
+		Indexes: orderedmap.New[string, *model.Index](),
+	})
+
+	result, err := DiffViews(current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	assert.Empty(t, result.CreateStmts, "no executable DDL when recreation is denied, even if comment differs")
+	assert.Equal(t, []string{"-- skipped: DROP MATERIALIZED VIEW public.mv;"}, result.DisallowedDropStmts)
+}
+
 func TestDiffViews_matviewIndexAdd(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.mv", &model.View{

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -39,6 +39,7 @@ func TestDiffViews_dropView_denied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
+	assert.Equal(t, []string{"-- DROP VIEW public.v1;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffViews_modifyView(t *testing.T) {
@@ -332,6 +333,7 @@ func TestDiffViews_dropMatview_denied(t *testing.T) {
 	result, err := DiffViews(current, desired, DenyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
+	assert.Equal(t, []string{"-- DROP MATERIALIZED VIEW public.mv;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffViews_modifyMatview(t *testing.T) {

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -39,7 +39,7 @@ func TestDiffViews_dropView_denied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
-	assert.Equal(t, []string{"-- DROP VIEW public.v1;"}, result.DisallowedDropStmts)
+	assert.Equal(t, []string{"-- skipped: DROP VIEW public.v1;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffViews_modifyView(t *testing.T) {
@@ -333,7 +333,7 @@ func TestDiffViews_dropMatview_denied(t *testing.T) {
 	result, err := DiffViews(current, desired, DenyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
-	assert.Equal(t, []string{"-- DROP MATERIALIZED VIEW public.mv;"}, result.DisallowedDropStmts)
+	assert.Equal(t, []string{"-- skipped: DROP MATERIALIZED VIEW public.mv;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffViews_modifyMatview(t *testing.T) {

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -395,9 +395,11 @@ func TestDiffViews_modifyMatview_dropDenied(t *testing.T) {
 
 	result, err := DiffViews(current, desired, DenyAllDrops{})
 	require.NoError(t, err)
-	// Drop denied: no DROP or CREATE should be generated
+	// Drop denied: no executable DROP or CREATE; the suppressed recreation
+	// is surfaced as a skipped comment so users can see what was blocked.
 	assert.Empty(t, result.DropStmts)
 	assert.Empty(t, result.CreateStmts)
+	assert.Equal(t, []string{"-- skipped: DROP MATERIALIZED VIEW public.mv;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffViews_matviewIndexAdd(t *testing.T) {
@@ -613,9 +615,11 @@ func TestDiffViews_viewToMatview_dropDenied(t *testing.T) {
 
 	result, err := DiffViews(current, desired, DenyAllDrops{})
 	require.NoError(t, err)
-	// Type change denied: no DROP, no CREATE, no comment change
+	// Type change denied: no executable DROP/CREATE/comment change; the
+	// suppressed recreation is surfaced as a skipped comment.
 	assert.Empty(t, result.DropStmts)
 	assert.Empty(t, result.CreateStmts)
+	assert.Equal(t, []string{"-- skipped: DROP VIEW public.v;"}, result.DisallowedDropStmts)
 }
 
 func TestDiffViews_renameTypeMismatch(t *testing.T) {

--- a/diff_all.go
+++ b/diff_all.go
@@ -28,6 +28,7 @@ type diffAllOptions struct {
 // diffAllResult holds the result of diffAll.
 type diffAllResult struct {
 	Stmts                []string
+	DisallowedDrops      []string
 	PreSQL               string
 	Count                ObjectCount
 	ExecuteStmts         []*parser.ExecuteStmt
@@ -122,8 +123,15 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, err
 	}
 
+	var disallowed []string
+	disallowed = append(disallowed, viewDiff.DisallowedDropStmts...)
+	disallowed = append(disallowed, tableDiff.DisallowedDropStmts...)
+	disallowed = append(disallowed, domainDiff.DisallowedDropStmts...)
+	disallowed = append(disallowed, enumDiff.DisallowedDropStmts...)
+
 	return &diffAllResult{
 		Stmts:                stmts,
+		DisallowedDrops:      disallowed,
 		PreSQL:               preSQL,
 		Count:                count,
 		ExecuteStmts:         desired.ExecuteStmts,

--- a/plan.go
+++ b/plan.go
@@ -51,8 +51,9 @@ func pluralize(n int, singular string) string {
 
 // PlanResult holds the result of a Plan operation.
 type PlanResult struct {
-	SQL   string
-	Count ObjectCount
+	SQL             string
+	DisallowedDrops string
+	Count           ObjectCount
 }
 
 func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResult, error) {
@@ -86,7 +87,8 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	}
 
 	return &PlanResult{
-		SQL:   strings.Join(stmts, "\n"),
-		Count: result.Count,
+		SQL:             strings.Join(stmts, "\n"),
+		DisallowedDrops: strings.Join(result.DisallowedDrops, "\n"),
+		Count:           result.Count,
 	}, nil
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -305,6 +305,96 @@ func TestPlan(t *testing.T) {
 	}
 }
 
+func TestPlan_DisallowedDrops_MultipleTypes(t *testing.T) {
+	// PlanResult.DisallowedDrops aggregates skipped DROPs across object types
+	// (table, view, matview, column, enum, domain) when --allow-drop is empty.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    legacy text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.user_v AS SELECT id FROM public.users;
+CREATE MATERIALIZED VIEW public.user_mv AS SELECT id FROM public.users;
+CREATE TYPE public.color AS ENUM ('red', 'blue');
+CREATE DOMAIN public.pos_int AS integer CHECK (VALUE > 0);
+CREATE TABLE public.legacy_users (
+    id integer NOT NULL,
+    CONSTRAINT legacy_users_pkey PRIMARY KEY (id)
+);`)
+
+	// Desired removes everything except public.users (and even the legacy
+	// column on public.users).
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files: []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL, "no executable DDL should be generated when all drops are denied")
+	dd := got.DisallowedDrops
+	assert.Contains(t, dd, "-- skipped: DROP VIEW public.user_v;")
+	assert.Contains(t, dd, "-- skipped: DROP MATERIALIZED VIEW public.user_mv;")
+	assert.Contains(t, dd, "-- skipped: DROP TABLE public.legacy_users;")
+	assert.Contains(t, dd, "-- skipped: ALTER TABLE public.users DROP COLUMN legacy;")
+	assert.Contains(t, dd, "-- skipped: DROP TYPE public.color;")
+	assert.Contains(t, dd, "-- skipped: DROP DOMAIN public.pos_int;")
+}
+
+func TestPlan_DisallowedDrops_PartiallyAllowed(t *testing.T) {
+	// When only --allow-drop=table is set, table DROPs execute while other
+	// type DROPs are surfaced as skipped comments.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    legacy text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.legacy_users (
+    id integer NOT NULL,
+    CONSTRAINT legacy_users_pkey PRIMARY KEY (id)
+);
+CREATE TYPE public.color AS ENUM ('red', 'blue');`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    legacy text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"table"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	// Table drop is executable.
+	assert.Contains(t, got.SQL, "DROP TABLE public.legacy_users;")
+	// Enum drop is skipped.
+	assert.Contains(t, got.DisallowedDrops, "-- skipped: DROP TYPE public.color;")
+	assert.NotContains(t, got.SQL, "DROP TYPE")
+}
+
 func TestPlan_ConcurrentlyDirective(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/schema_filter_test.go
+++ b/schema_filter_test.go
@@ -76,14 +76,14 @@ CREATE TABLE other.stuff (
 	})
 
 	var buf bytes.Buffer
-	count, err := client.Apply(ctx, &pistachio.ApplyOptions{
+	result, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
 		Files:      []string{desiredFile},
 	}, &buf)
 	require.NoError(t, err)
 	// No changes (other.stuff ignored)
 	assert.Empty(t, buf.String())
-	assert.Equal(t, 1, count.Tables)
+	assert.Equal(t, 1, result.Count.Tables)
 }
 
 func TestObjectCount_SchemaLabel(t *testing.T) {

--- a/test/scenario/drop_policy.test.sh
+++ b/test/scenario/drop_policy.test.sh
@@ -42,6 +42,29 @@ setup_db "$DATA/init.sql"
 assert_no_drop "no-drop: matview removed" "$DATA/desired_drop_matview.sql" || true
 
 # ============================================================
+# Part 1b: Suppressed drops are surfaced as commented DROPs,
+# while -- No changes is still reported (no executable DDL).
+# ============================================================
+
+setup_db "$DATA/init.sql"
+assert_commented_drop "no-drop: table commented" "table" "$DATA/desired_drop_table.sql" || true
+
+setup_db "$DATA/init.sql"
+assert_commented_drop "no-drop: view commented" "view" "$DATA/desired_drop_view.sql" || true
+
+setup_db "$DATA/init.sql"
+assert_commented_drop "no-drop: column commented" "column" "$DATA/desired_drop_column.sql" || true
+
+setup_db "$DATA/init.sql"
+assert_commented_drop "no-drop: enum commented" "enum" "$DATA/desired_drop_enum.sql" || true
+
+setup_db "$DATA/init.sql"
+assert_commented_drop "no-drop: domain commented" "domain" "$DATA/desired_drop_domain.sql" || true
+
+setup_db "$DATA/init.sql"
+assert_commented_drop "no-drop: matview commented" "view" "$DATA/desired_drop_matview.sql" || true
+
+# ============================================================
 # Part 2: Individual --allow-drop types
 # Each type allows only its own drop; others are suppressed.
 # ============================================================

--- a/test/scenario/drop_policy.test.sh
+++ b/test/scenario/drop_policy.test.sh
@@ -65,6 +65,22 @@ setup_db "$DATA/init.sql"
 assert_commented_drop "no-drop: matview commented" "view" "$DATA/desired_drop_matview.sql" || true
 
 # ============================================================
+# Part 1c: With --allow-drop=table, the table DROP executes while
+# DROPs of other types still appear as skipped comments.
+# ============================================================
+
+setup_db "$DATA/init.sql"
+assert_drop_type_present "allow-drop table: table drop executable" "table" "table" "$DATA/desired_drop_all.sql" || true
+setup_db "$DATA/init.sql"
+assert_commented_drop_with_allowed "allow-drop table: view drop skipped" "view" "table" "$DATA/desired_drop_all.sql" || true
+setup_db "$DATA/init.sql"
+assert_commented_drop_with_allowed "allow-drop table: column drop skipped" "column" "table" "$DATA/desired_drop_all.sql" || true
+setup_db "$DATA/init.sql"
+assert_commented_drop_with_allowed "allow-drop table: enum drop skipped" "enum" "table" "$DATA/desired_drop_all.sql" || true
+setup_db "$DATA/init.sql"
+assert_commented_drop_with_allowed "allow-drop table: domain drop skipped" "domain" "table" "$DATA/desired_drop_all.sql" || true
+
+# ============================================================
 # Part 2: Individual --allow-drop types
 # Each type allows only its own drop; others are suppressed.
 # ============================================================

--- a/test/scenario/helper.sh
+++ b/test/scenario/helper.sh
@@ -84,6 +84,45 @@ assert_no_drop() {
   pass
 }
 
+# Assert that plan output contains a commented DROP for a specific type.
+# Used to verify that suppressed drops are still surfaced as comments.
+# Usage: assert_commented_drop "step name" "expected_type" files...
+assert_commented_drop() {
+  local step_name="$1"
+  local expected_type="$2"
+  shift 2
+  local files=("$@")
+
+  step "$step_name"
+
+  local plan_output
+  plan_output=$(pist_plan_no_drop "${files[@]}") || { fail "plan failed: $plan_output"; return 1; }
+
+  local drop_pattern
+  case "$expected_type" in
+    table)  drop_pattern='^-- DROP TABLE' ;;
+    view)   drop_pattern='^-- DROP (MATERIALIZED )?VIEW' ;;
+    column) drop_pattern='^-- ALTER TABLE .* DROP COLUMN' ;;
+    enum)   drop_pattern='^-- DROP TYPE' ;;
+    domain) drop_pattern='^-- DROP DOMAIN' ;;
+    *) fail "unknown expected_type: $expected_type"; return 1 ;;
+  esac
+
+  if ! echo "$plan_output" | grep -qE "$drop_pattern"; then
+    fail "expected commented $expected_type drop in plan"
+    echo "    $plan_output" >&2
+    return 1
+  fi
+
+  if ! echo "$plan_output" | grep -qF -e '-- No changes'; then
+    fail "expected -- No changes when only commented drops were emitted"
+    echo "    $plan_output" >&2
+    return 1
+  fi
+
+  pass
+}
+
 # Assert that plan output does NOT contain DROP for a specific type,
 # even when other drop types are allowed.
 # Usage: assert_no_drop_type "step name" "protected_type" "allowed_types" files...
@@ -101,11 +140,11 @@ assert_no_drop_type() {
 
   local drop_pattern
   case "$protected_type" in
-    table)  drop_pattern='DROP TABLE' ;;
-    view)   drop_pattern='DROP (MATERIALIZED )?VIEW' ;;
-    column) drop_pattern='DROP COLUMN' ;;
-    enum)   drop_pattern='DROP TYPE' ;;
-    domain) drop_pattern='DROP DOMAIN' ;;
+    table)  drop_pattern='^[[:space:]]*DROP TABLE' ;;
+    view)   drop_pattern='^[[:space:]]*DROP (MATERIALIZED )?VIEW' ;;
+    column) drop_pattern='^[[:space:]]*ALTER TABLE .* DROP COLUMN' ;;
+    enum)   drop_pattern='^[[:space:]]*DROP TYPE' ;;
+    domain) drop_pattern='^[[:space:]]*DROP DOMAIN' ;;
     *) fail "unknown protected_type: $protected_type"; return 1 ;;
   esac
 
@@ -134,11 +173,11 @@ assert_drop_type_present() {
 
   local drop_pattern
   case "$expected_type" in
-    table)  drop_pattern='DROP TABLE' ;;
-    view)   drop_pattern='DROP (MATERIALIZED )?VIEW' ;;
-    column) drop_pattern='DROP COLUMN' ;;
-    enum)   drop_pattern='DROP TYPE' ;;
-    domain) drop_pattern='DROP DOMAIN' ;;
+    table)  drop_pattern='^[[:space:]]*DROP TABLE' ;;
+    view)   drop_pattern='^[[:space:]]*DROP (MATERIALIZED )?VIEW' ;;
+    column) drop_pattern='^[[:space:]]*ALTER TABLE .* DROP COLUMN' ;;
+    enum)   drop_pattern='^[[:space:]]*DROP TYPE' ;;
+    domain) drop_pattern='^[[:space:]]*DROP DOMAIN' ;;
     *) fail "unknown expected_type: $expected_type"; return 1 ;;
   esac
 

--- a/test/scenario/helper.sh
+++ b/test/scenario/helper.sh
@@ -100,16 +100,16 @@ assert_commented_drop() {
 
   local drop_pattern
   case "$expected_type" in
-    table)  drop_pattern='^-- DROP TABLE' ;;
-    view)   drop_pattern='^-- DROP (MATERIALIZED )?VIEW' ;;
-    column) drop_pattern='^-- ALTER TABLE .* DROP COLUMN' ;;
-    enum)   drop_pattern='^-- DROP TYPE' ;;
-    domain) drop_pattern='^-- DROP DOMAIN' ;;
+    table)  drop_pattern='^-- skipped: DROP TABLE' ;;
+    view)   drop_pattern='^-- skipped: DROP (MATERIALIZED )?VIEW' ;;
+    column) drop_pattern='^-- skipped: ALTER TABLE .* DROP COLUMN' ;;
+    enum)   drop_pattern='^-- skipped: DROP TYPE' ;;
+    domain) drop_pattern='^-- skipped: DROP DOMAIN' ;;
     *) fail "unknown expected_type: $expected_type"; return 1 ;;
   esac
 
   if ! echo "$plan_output" | grep -qE "$drop_pattern"; then
-    fail "expected commented $expected_type drop in plan"
+    fail "expected skipped $expected_type drop in plan"
     echo "    $plan_output" >&2
     return 1
   fi

--- a/test/scenario/helper.sh
+++ b/test/scenario/helper.sh
@@ -123,6 +123,40 @@ assert_commented_drop() {
   pass
 }
 
+# Assert that plan output contains a commented DROP for a specific type
+# even when --allow-drop is set for other types.
+# Usage: assert_commented_drop_with_allowed "step name" "expected_type" "allowed_types" files...
+assert_commented_drop_with_allowed() {
+  local step_name="$1"
+  local expected_type="$2"
+  local allowed_types="$3"
+  shift 3
+  local files=("$@")
+
+  step "$step_name"
+
+  local plan_output
+  plan_output=$(pist_plan_allow_drop "$allowed_types" "${files[@]}") || { fail "plan failed: $plan_output"; return 1; }
+
+  local drop_pattern
+  case "$expected_type" in
+    table)  drop_pattern='^-- skipped: DROP TABLE' ;;
+    view)   drop_pattern='^-- skipped: DROP (MATERIALIZED )?VIEW' ;;
+    column) drop_pattern='^-- skipped: ALTER TABLE .* DROP COLUMN' ;;
+    enum)   drop_pattern='^-- skipped: DROP TYPE' ;;
+    domain) drop_pattern='^-- skipped: DROP DOMAIN' ;;
+    *) fail "unknown expected_type: $expected_type"; return 1 ;;
+  esac
+
+  if ! echo "$plan_output" | grep -qE "$drop_pattern"; then
+    fail "expected skipped $expected_type drop in plan with --allow-drop $allowed_types"
+    echo "    $plan_output" >&2
+    return 1
+  fi
+
+  pass
+}
+
 # Assert that plan output does NOT contain DROP for a specific type,
 # even when other drop types are allowed.
 # Usage: assert_no_drop_type "step name" "protected_type" "allowed_types" files...

--- a/test/scenario/helper.sh
+++ b/test/scenario/helper.sh
@@ -64,7 +64,8 @@ pist_plan_allow_drop() {
   "$PIST" plan --allow-drop "$drop_types" "$@" 2>&1
 }
 
-# Assert that plan output does NOT contain any DROP/drop statements.
+# Assert that plan output does NOT contain any executable (uncommented) DROP
+# statements. Commented "-- skipped: ..." DROPs may still be present.
 assert_no_drop() {
   local step_name="$1"
   shift
@@ -157,8 +158,9 @@ assert_commented_drop_with_allowed() {
   pass
 }
 
-# Assert that plan output does NOT contain DROP for a specific type,
-# even when other drop types are allowed.
+# Assert that plan output does NOT contain an executable (uncommented) DROP
+# for a specific type, even when other drop types are allowed. Commented
+# "-- skipped: ..." DROPs are not flagged by this check.
 # Usage: assert_no_drop_type "step name" "protected_type" "allowed_types" files...
 assert_no_drop_type() {
   local step_name="$1"
@@ -191,7 +193,8 @@ assert_no_drop_type() {
   pass
 }
 
-# Assert that plan output DOES contain DROP for a specific type.
+# Assert that plan output DOES contain an executable (uncommented) DROP
+# for a specific type when --allow-drop covers it.
 # Usage: assert_drop_type_present "step name" "expected_type" "allowed_types" files...
 assert_drop_type_present() {
   local step_name="$1"


### PR DESCRIPTION
## Summary
When `--allow-drop` does not cover the affected object type, DROPs were silently dropped from the plan output, making it easy to miss diffs the policy was blocking. Emit those DROPs as comment-prefixed lines instead so they surface in `plan` / `apply` output:

```
-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
-- DROP TABLE public.legacy_users;
-- No changes
```

The `-- No changes` semantics is preserved — `DisallowedDropStmts` is tracked separately from executable DDL, so the plan still reports no changes when no real statements were generated. The comments are never executed by `apply`.

## API changes
- `TableDiffResult` / `ViewDiffResult` / `EnumDiffResult` / `DomainDiffResult` gain a `DisallowedDropStmts []string` field.
- `diffColumns` now returns `(stmts, disallowed, err)`.
- `Client.Apply` returns `*ApplyResult` instead of `*ObjectCount`, with `Count` + `DisallowedDrops` on the result.
- `PlanResult` gains a `DisallowedDrops string`.

## Test plan
- [x] `make vet`
- [x] `make lint`
- [x] `make test` (unit + integration)
- [x] `make test-scenario` (all suites pass; new `assert_commented_drop` cases under `drop_policy` confirm commented DROPs + `-- No changes` for table / view / matview / column / enum / domain)
- [x] New `TestPlan_Run_DropDeniedShowsNoChanges` covers the CLI-level UX
- [x] Existing `_denied` diff-package tests updated to also assert the commented form

🤖 Generated with [Claude Code](https://claude.com/claude-code)