### PR TITLE
Pin plan/apply 'No changes' behavior for -- pist:execute

### DIFF
--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -444,6 +444,85 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	assert.True(t, exists)
 }
 
+func TestPlan_Run_ExecuteCheckFalse_StillPrintsExecute(t *testing.T) {
+	// Plan does not evaluate check SQL — it shows every -- pist:execute
+	// statement regardless. So even when the check would return false at
+	// apply time, plan output must contain the execute SQL and must NOT
+	// say "-- No changes".
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	// Check SQL returns false (function already exists), so apply would skip.
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "CREATE OR REPLACE FUNCTION public.test_func", "plan should always show execute SQL")
+	assert.Contains(t, got, "-- pist:execute", "plan should annotate with the directive")
+	assert.NotContains(t, got, "-- No changes")
+}
+
+func TestApply_Run_ExecuteCheckFalse_ShowsNoChanges(t *testing.T) {
+	// Apply DOES evaluate check SQL. When it returns false, the execute is
+	// skipped (not printed, not executed). With no schema diff either, the
+	// buffer is empty so the CLI prints "-- No changes".
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.NotContains(t, got, "CREATE OR REPLACE FUNCTION", "skipped execute must not be printed")
+	assert.Contains(t, got, "-- No changes", "buffer is empty so CLI prints No changes")
+}
+
 func TestApply_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	// Apply CLI counterpart of TestPlan_Run_DropDeniedShowsNoChanges.
 	// When the only diff is a suppressed DROP, the apply prints the skipped

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -372,6 +372,78 @@ func TestPlan_Run_PreSQLBeforeSkippedDrops(t *testing.T) {
 	assert.Less(t, addColPos, skippedPos, "skipped comments must follow executable SQL")
 }
 
+func TestPlan_Run_ExecuteOnly_NotNoChanges(t *testing.T) {
+	// When the only diff is a -- pist:execute statement (no schema diff),
+	// the plan must surface the execute SQL and must NOT print "-- No changes".
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL+`
+-- pist:execute
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "CREATE OR REPLACE FUNCTION public.test_func")
+	assert.NotContains(t, got, "-- No changes")
+}
+
+func TestApply_Run_ExecuteOnly_NotNoChanges(t *testing.T) {
+	// CLI Apply counterpart: only -- pist:execute runs (no schema diff).
+	// "No changes" must not be printed since the function gets emitted and
+	// executed.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL+`
+-- pist:execute
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "CREATE OR REPLACE FUNCTION public.test_func")
+	assert.NotContains(t, got, "-- No changes")
+
+	// Function should actually exist in DB.
+	var exists bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')").Scan(&exists))
+	assert.True(t, exists)
+}
+
 func TestApply_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	// Apply CLI counterpart of TestPlan_Run_DropDeniedShowsNoChanges.
 	// When the only diff is a suppressed DROP, the apply prints the skipped


### PR DESCRIPTION
## Summary
Add CLI-level tests covering when `-- No changes` is and isn't printed for `-- pist:execute` directives.

| Case | Plan | Apply |
|------|------|-------|
| schema diff: none, execute present, check ✅ true (or no check) | execute SQL emitted | execute SQL emitted & runs |
| schema diff: none, execute present, check ❌ false | execute SQL emitted (plan does not evaluate check) | **`-- No changes`** (skipped, neither printed nor executed) |
| schema diff: none, no execute | `-- No changes` | `-- No changes` |

The previously existing `TestApply_ExecuteOnly_NoSchemaChange` only checked the lib API; nothing pinned the CLI-level "No changes" decision. This PR adds:

- `TestPlan_Run_ExecuteOnly_NotNoChanges`
- `TestApply_Run_ExecuteOnly_NotNoChanges` (also confirms the function lands in the database)
- `TestPlan_Run_ExecuteCheckFalse_StillPrintsExecute`
- `TestApply_Run_ExecuteCheckFalse_ShowsNoChanges`

## Test plan
- [x] `make vet`
- [x] `make lint`
- [x] `make test` — new tests pass; existing tests untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)