### PR TITLE
Cover Apply CLI mixed output and execute error paths

### DIFF
--- a/apply_test.go
+++ b/apply_test.go
@@ -509,6 +509,68 @@ CREATE TABLE public.users (
 	assert.Contains(t, got.String(), "name text")
 }
 
+func TestApply_ExecuteCheckSQLError(t *testing.T) {
+	// User-supplied check SQL that itself errors (e.g., references a missing
+	// table) must surface as a "failed to evaluate check SQL" error.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute SELECT * FROM public.does_not_exist
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to evaluate check SQL")
+}
+
+func TestApply_ExecuteSQLError(t *testing.T) {
+	// User-supplied execute SQL that fails at execution time must surface as
+	// a "failed to execute SQL" error.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:execute
+INSERT INTO public.does_not_exist VALUES (1);
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute SQL")
+}
+
 func TestApply_ExecError(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/apply_test.go
+++ b/apply_test.go
@@ -526,7 +526,7 @@ func TestApply_ExecuteCheckSQLError(t *testing.T) {
     id integer NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );
--- pist:execute SELECT * FROM public.does_not_exist
+-- pist:execute SELECT EXISTS (SELECT 1 FROM public.does_not_exist)
 CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
 `), 0o644))
 

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -372,6 +372,46 @@ func TestPlan_Run_PreSQLBeforeSkippedDrops(t *testing.T) {
 	assert.Less(t, addColPos, skippedPos, "skipped comments must follow executable SQL")
 }
 
+func TestApply_Run_RealDiffPlusSkippedDrop(t *testing.T) {
+	// Apply CLI must emit both the executed diff and the suppressed DROPs as
+	// "-- skipped:" comments, with skipped lines after the executable SQL.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    legacy text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	// Removes "legacy" (suppressed by default --allow-drop) and adds "name".
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+
+	addColPos := strings.Index(got, "ADD COLUMN name")
+	skippedPos := strings.Index(got, "-- skipped: ALTER TABLE public.users DROP COLUMN legacy")
+	require.NotEqual(t, -1, addColPos, "executable diff should be emitted")
+	require.NotEqual(t, -1, skippedPos, "skipped column drop should be emitted")
+	assert.Less(t, addColPos, skippedPos, "skipped lines must follow executable SQL")
+	assert.NotContains(t, got, "-- No changes")
+}
+
 func TestApply_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	// Apply CLI counterpart of TestPlan_Run_DropDeniedShowsNoChanges.
 	// When the only diff is a suppressed DROP, the apply prints the skipped


### PR DESCRIPTION
## Summary
Pin three reachable-but-untested paths in `Apply` and the apply CLI:

1. **`cmd/command/apply.go`** — real diff + skipped DROP combined output. Plan had `TestPlan_Run_PreSQLBeforeSkippedDrops`; Apply was missing the counterpart. New `TestApply_Run_RealDiffPlusSkippedDrop` asserts the order *executable SQL → skipped comments* and that `-- No changes` is not emitted.
2. **`apply.go: failed to evaluate check SQL`** — user-supplied check SQL may itself error (e.g., reference a missing relation). New `TestApply_ExecuteCheckSQLError` pins the error message.
3. **`apply.go: failed to execute SQL` for `-- pist:execute`** — user-supplied execute SQL may fail at execution time. New `TestApply_ExecuteSQLError` pins that error path.

## Coverage
- root: 97.7% → **98.0%**
- cmd/command: 97.2% → **98.6%** (`Apply.Run` reaches **100%**)
- `apply.go`'s `Apply`: 90.2% → **94.1%**

## Test plan
- [x] `make vet`
- [x] `make lint`
- [x] `make test` — new tests pass; existing tests untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)