### PR TITLE
Document make fix, build output path, and psql env vars in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,15 +7,17 @@ Pistachio is a declarative schema management tool for PostgreSQL, written in Go.
 ## Build & test
 
 ```sh
-make build          # go build ./cmd/pist
+make build          # go build ./cmd/pist (outputs ./pist at the repo root)
 make vet            # go vet ./...
 make test           # go test -p 1 -v ./... $(TEST_OPTS)
 make test-scenario  # CLI scenario tests (bash, requires PostgreSQL)
 make lint           # golangci-lint run
+make fix            # golangci-lint run --fix (auto-fix lint errors)
 ```
 
 - Tests require a running PostgreSQL instance (default: `postgres://postgres@localhost/postgres`, override with `TEST_PIST_CONN_STR`).
 - Tests run with `-p 1` (sequential packages) because integration tests share a single database.
+- `make schema` and other `psql`-based targets rely on `PGHOST=localhost` / `PGUSER=postgres` (exported from the Makefile).
 
 ## Project structure
 


### PR DESCRIPTION
## Summary
- Note that `make build` outputs `./pist` at the repo root.
- Document `make fix` (golangci-lint --fix) alongside the other Make targets.
- Mention that `make schema` and other psql-based targets rely on `PGHOST` / `PGUSER` exported from the Makefile.

## Test plan
- [x] Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)