### PR TITLE
Support column collation changes

### DIFF
--- a/diff/tables.go
+++ b/diff/tables.go
@@ -246,8 +246,10 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 	var stmts []string
 	colIdent := model.Ident(desired.Name)
 
-	// Type change
-	if !equalTypeName(current.TypeName, desired.TypeName) {
+	// Type or collation change. Collation is altered via SET DATA TYPE
+	// because PostgreSQL has no separate "set collation" syntax — re-issuing
+	// SET DATA TYPE without COLLATE reverts to the type's default collation.
+	if !equalTypeName(current.TypeName, desired.TypeName) || !equalPtr(current.Collation, desired.Collation) {
 		sql := "ALTER TABLE " + fqtn + " ALTER COLUMN " + colIdent + " SET DATA TYPE " + desired.TypeName
 		if desired.Collation != nil {
 			sql += " COLLATE " + model.Ident(*desired.Collation)

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -272,6 +272,54 @@ func TestDiffColumns_alterType_withCollation(t *testing.T) {
 	assert.Contains(t, stmts[0], `COLLATE "en_US"`)
 }
 
+func TestDiffColumns_alterCollation_change(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("fr_FR")})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{`ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text COLLATE "fr_FR";`}, stmts)
+}
+
+func TestDiffColumns_alterCollation_add(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text"})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{`ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text COLLATE "en_US";`}, stmts)
+}
+
+func TestDiffColumns_alterCollation_drop(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;"}, stmts)
+}
+
+func TestDiffColumns_alterCollation_unchanged(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
 func TestDiffColumns_alterDefault_set(t *testing.T) {
 	current := orderedmap.New[string, *model.Column]()
 	current.Set("age", &model.Column{Name: "age", TypeName: "integer"})

--- a/testdata/apply/alter_column_collation.yml
+++ b/testdata/apply/alter_column_collation.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "C" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "POSIX" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "POSIX" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/alter_column_collation_add.yml
+++ b/testdata/apply/alter_column_collation_add.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "C" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "C" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/alter_column_collation_drop.yml
+++ b/testdata/apply/alter_column_collation_drop.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "C" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/alter_column_collation.yml
+++ b/testdata/plan/alter_column_collation.yml
@@ -1,0 +1,14 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "C" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text COLLATE "POSIX" NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text COLLATE "POSIX";


### PR DESCRIPTION
## Summary

- Detect `Collation` differences in `alterColumnSQL` and emit `ALTER COLUMN ... SET DATA TYPE <type> [COLLATE ...]` (PostgreSQL has no separate "set collation" syntax; omitting COLLATE reverts to the type's default).
- Previously, collation-only changes were silently dropped because the alter branch fired only when the type name differed.

## Test plan

- [x] `go test ./diff/` — new unit tests cover change / add / drop / unchanged
- [x] `go test .` — new `testdata/apply/alter_column_collation{,_add,_drop}.yml` exercise real-DB round-trips; `testdata/plan/alter_column_collation.yml` pins the generated DDL
- [x] `make test` (full suite, sequential) passes
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)