### PR TITLE
Cover two naturally-testable branches

### DIFF
--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -627,6 +627,42 @@ func TestApply_Run(t *testing.T) {
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
 }
 
+func TestApply_Run_ExecutedWithSkippedDrops(t *testing.T) {
+	// Apply executes some changes AND has suppressed drops: both the executed
+	// SQL and the "-- skipped:" comment must appear in the output.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    legacy text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+
+	assert.Contains(t, got, "ADD COLUMN name")
+	assert.Contains(t, got, "-- skipped: ALTER TABLE public.users DROP COLUMN legacy;")
+	assert.NotContains(t, got, "-- No changes")
+}
+
 func TestFmt_Run(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "test.sql")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(`CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));`), 0o644))

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -658,8 +658,12 @@ func TestApply_Run_ExecutedWithSkippedDrops(t *testing.T) {
 	require.NoError(t, err)
 	got := buf.String()
 
-	assert.Contains(t, got, "ADD COLUMN name")
-	assert.Contains(t, got, "-- skipped: ALTER TABLE public.users DROP COLUMN legacy;")
+	addColPos := strings.Index(got, "ADD COLUMN name")
+	skippedPos := strings.Index(got, "-- skipped: ALTER TABLE public.users DROP COLUMN legacy;")
+	require.NotEqual(t, -1, addColPos, "executed DDL should be present")
+	require.NotEqual(t, -1, skippedPos, "skipped drop comment should be present")
+	// Apply mirrors Plan: executed SQL first, then "-- skipped:" comments.
+	assert.Less(t, addColPos, skippedPos, "executed DDL must precede skipped drop comment")
 	assert.NotContains(t, got, "-- No changes")
 }
 

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -319,3 +319,25 @@ func TestExtractObjectName_QuotedWithEscapedQuote(t *testing.T) {
 	got := pistachio.ExtractObjectName(`COMMENT ON COLUMN "My""Schema"."My""Table".col IS 'x';`)
 	assert.Equal(t, `"My""Schema"."My""Table"`, got)
 }
+
+func TestCompareTaggedPos(t *testing.T) {
+	// Both unknown: preserve original order via stable sort
+	assert.False(t, pistachio.CompareTaggedPos(-1, -1, false))
+	assert.False(t, pistachio.CompareTaggedPos(-1, -1, true))
+
+	// Only i unknown: unknown sorts before known
+	assert.True(t, pistachio.CompareTaggedPos(-1, 0, false))
+	assert.True(t, pistachio.CompareTaggedPos(-1, 5, true))
+
+	// Only j unknown: known never precedes unknown
+	assert.False(t, pistachio.CompareTaggedPos(0, -1, false))
+	assert.False(t, pistachio.CompareTaggedPos(5, -1, true))
+
+	// Both known: forward sort
+	assert.True(t, pistachio.CompareTaggedPos(1, 2, false))
+	assert.False(t, pistachio.CompareTaggedPos(2, 1, false))
+
+	// Both known: reverse sort
+	assert.True(t, pistachio.CompareTaggedPos(2, 1, true))
+	assert.False(t, pistachio.CompareTaggedPos(1, 2, true))
+}

--- a/export_test.go
+++ b/export_test.go
@@ -4,4 +4,5 @@ var (
 	ResolvePreSQL     = resolvePreSQL
 	ExtractObjectName = extractObjectName
 	OrderStatements   = orderStatements
+	CompareTaggedPos  = compareTaggedPos
 )


### PR DESCRIPTION
## Summary

Fill two coverage gaps surfaced by the latest audit. Both targets are reachable through the public API, so the new tests add real behavioral assertions rather than redundant defensive coverage.

- **`compareTaggedPos` "i unknown only" branch** — existing `OrderStatements` tests with two statements happened to invoke the comparator as `less(1, 0)`, landing in the symmetric `jUnknown` branch. A direct unit test (via `export_test.go`) now covers all four cases.
- **`cmd/command/apply.go` executed-SQL + suppressed-drop output** — analog of `TestPlan_Run_PreSQLBeforeSkippedDrops`, which was missing for `Apply.Run`.

## Test plan

- [x] `go test ./...` — new tests pass; existing tests unchanged
- [x] Function-level coverage: `compareTaggedPos` 88.9% → 100%; `cmd/command/apply.go:Run` 92.3% → 100%
- [x] Package coverage: pistachio 98.0% → 98.1%, cmd/command 97.2% → 98.6%
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)