### PR TITLE
Add constraint, foreign_key, index to --allow-drop policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pist apply --disable-index-concurrently --with-tx schema.sql
 > [!NOTE]
 > When the generated diff includes `CREATE INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY`, `--with-tx` cannot be used because `CONCURRENTLY` operations cannot run inside a transaction. If there are no index changes, `--with-tx` is allowed even when an index is opted into `CONCURRENTLY`. To run `apply` inside a transaction in spite of the opt-in, combine `--with-tx` with `--disable-index-concurrently`.
 
-By default, `plan` and `apply` do not drop tables, views, enums, domains, or columns. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`). Also available as `$PIST_ALLOW_DROP`.
+By default, `plan` and `apply` do not drop tables, views, enums, domains, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `foreign_key`, `index`). Also available as `$PIST_ALLOW_DROP`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately.
 
 ```bash
 # Allow all drops
@@ -134,9 +134,9 @@ Suppressed drops are emitted as commented-out DDL prefixed with `-- skipped:` so
 ```
 
 > [!NOTE]
-> Constraints and indexes whose definitions change or are removed from the desired schema are always dropped, regardless of `--allow-drop`. This is because PostgreSQL does not support `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes — the only way to update them is DROP + ADD.
+> Only **pure removals** of constraints, foreign keys, and indexes (those absent from the desired schema) are governed by `--allow-drop=constraint` / `--allow-drop=foreign_key` / `--allow-drop=index`. **Definition changes** still execute as DROP + ADD regardless of `--allow-drop`, because PostgreSQL has no `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes.
 >
-> Foreign-key `DROP CONSTRAINT` statements that exist only to unblock a table drop follow the table-drop policy: if the table drop is suppressed, the FK drop is suppressed too and surfaces as `-- skipped:` alongside the table.
+> Foreign-key drops emitted because the owning table is being dropped follow the table-drop policy (not `foreign_key`): if the table drop is suppressed, the FK drop is suppressed too and surfaces as `-- skipped:` alongside the table.
 
 ### Executing arbitrary SQL
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Suppressed drops are emitted as commented-out DDL prefixed with `-- skipped:` so
 ```
 
 > [!NOTE]
-> Only **pure removals** of constraints, foreign keys, and indexes (those absent from the desired schema) are governed by `--allow-drop=constraint` / `--allow-drop=foreign_key` / `--allow-drop=index`. **Definition changes** still execute as DROP + ADD regardless of `--allow-drop`, because PostgreSQL has no `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes.
+> Only **pure removals** of constraints, foreign keys, and indexes (those absent from the desired schema) are governed by `--allow-drop=constraint` / `--allow-drop=foreign_key` / `--allow-drop=index`. **Definition changes** still execute regardless of `--allow-drop`: constraints and foreign keys as DROP + ADD, and indexes as DROP + CREATE, because PostgreSQL has no `ALTER CONSTRAINT` and no general `ALTER INDEX` form for definition changes.
 >
 > Foreign-key drops emitted because the owning table is being dropped follow the table-drop policy (not `foreign_key`): if the table drop is suppressed, the FK drop is suppressed too and surfaces as `-- skipped:` alongside the table.
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -17,7 +17,7 @@ type TableDiffResult struct {
 	Stmts               []string // CREATE/ALTER TABLE, columns, constraints, indexes, comments
 	FKAddStmts          []string // FK adds and renames (should run last)
 	DropStmts           []string // DROP TABLE (separate from Stmts for ordering)
-	DisallowedDropStmts []string // DROP TABLE / DROP COLUMN / FK DROP CONSTRAINT suppressed by DropChecker, with "-- skipped: " prefix
+	DisallowedDropStmts []string // DROP TABLE / DROP COLUMN / DROP CONSTRAINT (incl. FK) / DROP INDEX suppressed by DropChecker, with "-- skipped: " prefix
 	HasConcurrently     bool     // true if any index operation uses CONCURRENTLY
 }
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -125,20 +125,22 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	// Partition children inherit columns and constraints from the parent,
 	// so skip diffing them to avoid false DROP statements.
 	if desired.PartitionOf != nil && desired.PartitionBound != nil {
-		idxResult, err := diffIndexes(current.Indexes, desired.Indexes)
+		idxResult, err := diffIndexes(current.Indexes, desired.Indexes, dc)
 		if err != nil {
 			return nil, err
 		}
 		result.Stmts = append(result.Stmts, idxResult.Stmts...)
+		result.DisallowedDropStmts = append(result.DisallowedDropStmts, idxResult.DisallowedDropStmts...)
 		if idxResult.HasConcurrently {
 			result.HasConcurrently = true
 		}
-		fkDrops, fkAdds, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
+		fkDrops, fkAdds, fkDisallowed, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys, dc)
 		if err != nil {
 			return nil, err
 		}
 		result.FKDropStmts = append(result.FKDropStmts, fkDrops...)
 		result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
+		result.DisallowedDropStmts = append(result.DisallowedDropStmts, fkDisallowed...)
 		return result, nil
 	}
 
@@ -149,27 +151,30 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	result.Stmts = append(result.Stmts, colStmts...)
 	result.DisallowedDropStmts = append(result.DisallowedDropStmts, colDisallowed...)
 
-	conStmts, err := diffConstraints(fqtn, current.Constraints, desired.Constraints)
+	conStmts, conDisallowed, err := diffConstraints(fqtn, current.Constraints, desired.Constraints, dc)
 	if err != nil {
 		return nil, err
 	}
 	result.Stmts = append(result.Stmts, conStmts...)
+	result.DisallowedDropStmts = append(result.DisallowedDropStmts, conDisallowed...)
 
-	idxResult2, err := diffIndexes(current.Indexes, desired.Indexes)
+	idxResult2, err := diffIndexes(current.Indexes, desired.Indexes, dc)
 	if err != nil {
 		return nil, err
 	}
 	result.Stmts = append(result.Stmts, idxResult2.Stmts...)
+	result.DisallowedDropStmts = append(result.DisallowedDropStmts, idxResult2.DisallowedDropStmts...)
 	if idxResult2.HasConcurrently {
 		result.HasConcurrently = true
 	}
 
-	fkDrops, fkAdds, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys)
+	fkDrops, fkAdds, fkDisallowed, err := diffForeignKeys(fqtn, desired.Schema, current.ForeignKeys, desired.ForeignKeys, dc)
 	if err != nil {
 		return nil, err
 	}
 	result.FKDropStmts = append(result.FKDropStmts, fkDrops...)
 	result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
+	result.DisallowedDropStmts = append(result.DisallowedDropStmts, fkDisallowed...)
 
 	result.Stmts = append(result.Stmts, diffComments(current, desired)...)
 
@@ -401,13 +406,13 @@ func equalConstraintDef(a, b string) bool {
 	return normA == normB
 }
 
-func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *model.Constraint]) ([]string, error) {
-	var stmts []string
+func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *model.Constraint], dc DropChecker) (stmts []string, disallowed []string, err error) {
+	dc = NormalizeDropChecker(dc)
 
 	// Detect renames
 	renameStmts, current, renamedFrom, err := detectConstraintRenames(fqtn, current, desired)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Determine which renamed constraints need recreation instead of just rename
@@ -442,7 +447,10 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 		}
 	}
 
-	// Drop removed or changed constraints
+	// Drop removed or changed constraints. Pure removals (constraint absent
+	// from desired) honor the constraint-drop policy; definition changes still
+	// run DROP+ADD because PostgreSQL has no ALTER CONSTRAINT for definitions.
+	conAllowed := dc.IsDropAllowed("constraint")
 	for name, currentCon := range current.All() {
 		desiredCon, ok := desired.GetOk(name)
 		if !ok || !equalConstraintDef(currentCon.Definition, desiredCon.Definition) || currentCon.Validated != desiredCon.Validated {
@@ -454,7 +462,12 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 			if oldName, renamed := renamedFrom[name]; renamed {
 				dropName = oldName
 			}
-			stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP CONSTRAINT "+model.Ident(dropName)+";")
+			drop := "ALTER TABLE " + fqtn + " DROP CONSTRAINT " + model.Ident(dropName) + ";"
+			if !ok && !conAllowed {
+				disallowed = append(disallowed, "-- skipped: "+drop)
+				continue
+			}
+			stmts = append(stmts, drop)
 		}
 	}
 
@@ -475,15 +488,17 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 		}
 	}
 
-	return stmts, nil
+	return stmts, disallowed, nil
 }
 
 type diffIndexesResult struct {
-	Stmts           []string
-	HasConcurrently bool
+	Stmts               []string
+	DisallowedDropStmts []string
+	HasConcurrently     bool
 }
 
-func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) (*diffIndexesResult, error) {
+func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], dc DropChecker) (*diffIndexesResult, error) {
+	dc = NormalizeDropChecker(dc)
 	result := &diffIndexesResult{}
 
 	// Detect renames
@@ -493,7 +508,10 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) (*diffI
 	}
 	result.Stmts = append(result.Stmts, renameStmts...)
 
-	// Drop removed or changed indexes
+	// Drop removed or changed indexes. Pure removals (index absent from
+	// desired) honor the index-drop policy; definition changes still run
+	// DROP+CREATE because PostgreSQL has no ALTER INDEX for definitions.
+	idxAllowed := dc.IsDropAllowed("index")
 	for name, currentIdx := range current.All() {
 		desiredIdx, ok := desired.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
@@ -508,6 +526,10 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index]) (*diffI
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {
 				return nil, fmt.Errorf("drop index %s: %w", model.Ident(currentIdx.Schema, name), err)
+			}
+			if !ok && !idxAllowed {
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: "+stmt)
+				continue
 			}
 			result.Stmts = append(result.Stmts, stmt)
 			if useConcurrently {
@@ -589,15 +611,18 @@ func createIndexSQL(def string, concurrently bool) (string, error) {
 	return deparsed + ";", nil
 }
 
-// diffForeignKeys returns (dropStmts, addStmts, error).
+// diffForeignKeys returns (dropStmts, addStmts, disallowed, error).
 // Rename statements are included in addStmts (they depend on table renames being done first).
-func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[string, *model.ForeignKey]) ([]string, []string, error) {
-	var dropStmts, addStmts []string
+// Pure FK removals (FK absent from desired while the owning table stays) honor
+// --allow-drop=foreign_key; FK drops emitted because the owning table is being
+// dropped follow the table policy (handled in DiffTables).
+func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[string, *model.ForeignKey], dc DropChecker) (dropStmts, addStmts, disallowed []string, err error) {
+	dc = NormalizeDropChecker(dc)
 
 	// Detect renames (renames go into addStmts since they may depend on table renames)
 	renameStmts, current, renamedFrom, err := detectForeignKeyRenames(fqtn, current, desired)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Determine which renamed FKs need recreation (drop+add) instead of just rename
@@ -635,6 +660,7 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 	}
 
 	// Drop removed or changed FKs
+	fkAllowed := dc.IsDropAllowed("foreign_key")
 	for name := range current.All() {
 		desiredFk, ok := desired.GetOk(name)
 		currentFk := current.Get(name)
@@ -647,7 +673,12 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 			if oldName, renamed := renamedFrom[name]; renamed {
 				dropName = oldName
 			}
-			dropStmts = append(dropStmts, "ALTER TABLE "+fqtn+" DROP CONSTRAINT "+model.Ident(dropName)+";")
+			drop := "ALTER TABLE " + fqtn + " DROP CONSTRAINT " + model.Ident(dropName) + ";"
+			if !ok && !fkAllowed {
+				disallowed = append(disallowed, "-- skipped: "+drop)
+				continue
+			}
+			dropStmts = append(dropStmts, drop)
 		}
 	}
 
@@ -664,7 +695,7 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 		}
 	}
 
-	return dropStmts, addStmts, nil
+	return dropStmts, addStmts, disallowed, nil
 }
 
 func diffComments(current, desired *model.Table) []string {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -421,7 +421,7 @@ func TestDiffConstraints_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0);"}, stmts)
 }
@@ -431,9 +431,37 @@ func TestDiffConstraints_drop(t *testing.T) {
 	current.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
 	desired := orderedmap.New[string, *model.Constraint]()
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users DROP CONSTRAINT chk_age;"}, stmts)
+}
+
+func TestDiffConstraints_drop_denied(t *testing.T) {
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
+	desired := orderedmap.New[string, *model.Constraint]()
+
+	stmts, disallowed, err := diffConstraints("public.users", current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+	assert.Equal(t, []string{"-- skipped: ALTER TABLE public.users DROP CONSTRAINT chk_age;"}, disallowed)
+}
+
+func TestDiffConstraints_change_denied_alwaysExecutes(t *testing.T) {
+	// Definition changes go through DROP+ADD regardless of policy because
+	// PostgreSQL has no ALTER CONSTRAINT for definitions.
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age >= 18)", Validated: true})
+
+	stmts, disallowed, err := diffConstraints("public.users", current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, disallowed)
+	assert.Equal(t, []string{
+		"ALTER TABLE public.users DROP CONSTRAINT chk_age;",
+		"ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age >= 18);",
+	}, stmts)
 }
 
 func TestDiffConstraints_change(t *testing.T) {
@@ -442,7 +470,7 @@ func TestDiffConstraints_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age >= 18)", Validated: true})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_age;", stmts[0])
@@ -454,7 +482,7 @@ func TestDiffConstraints_addNotValid(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: false})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;", stmts[0])
@@ -466,7 +494,7 @@ func TestDiffConstraints_validatedToNotValid(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: false})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_age;", stmts[0])
@@ -479,7 +507,7 @@ func TestDiffConstraints_notValidToValidated(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users VALIDATE CONSTRAINT chk_age;", stmts[0])
@@ -491,7 +519,7 @@ func TestDiffConstraints_bothNotValid_noChange(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: false})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -502,7 +530,7 @@ func TestDiffConstraints_changeDefinitionAndValidated(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age >= 18)", Validated: false})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_age;", stmts[0])
@@ -515,7 +543,7 @@ func TestDiffConstraints_renameAndNotValid(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age > 0)", Validated: false, RenameFrom: ptr("chk_old")})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_old;", stmts[0])
@@ -528,7 +556,7 @@ func TestDiffConstraints_renameAndChangeDefinition(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age >= 18)", Validated: true, RenameFrom: ptr("chk_old")})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_old;", stmts[0])
@@ -541,7 +569,7 @@ func TestDiffConstraints_renameAndValidate(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age > 0)", Validated: true, RenameFrom: ptr("chk_old")})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users RENAME CONSTRAINT chk_old TO chk_new;", stmts[0])
@@ -554,7 +582,7 @@ func TestDiffConstraints_renameOnly(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age > 0)", Validated: true, RenameFrom: ptr("chk_old")})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users RENAME CONSTRAINT chk_old TO chk_new;", stmts[0])
@@ -566,7 +594,7 @@ func TestDiffConstraints_renameAlreadyAppliedAndNotValid(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age > 0)", Validated: false, RenameFrom: ptr("chk_old")})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_new;", stmts[0])
@@ -578,7 +606,7 @@ func TestDiffIndexes_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE INDEX idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -588,9 +616,35 @@ func TestDiffIndexes_drop(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
+}
+
+func TestDiffIndexes_drop_denied(t *testing.T) {
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+	desired := orderedmap.New[string, *model.Index]()
+
+	idxResult, err := diffIndexes(current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, idxResult.Stmts)
+	assert.Equal(t, []string{"-- skipped: DROP INDEX public.idx_name;"}, idxResult.DisallowedDropStmts)
+}
+
+func TestDiffIndexes_change_denied_alwaysExecutes(t *testing.T) {
+	// Definition changes go through DROP+CREATE regardless of policy because
+	// PostgreSQL has no ALTER INDEX for definitions.
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
+
+	idxResult, err := diffIndexes(current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, idxResult.DisallowedDropStmts)
+	assert.Len(t, idxResult.Stmts, 2)
+	assert.Equal(t, "DROP INDEX public.idx_name;", idxResult.Stmts[0])
 }
 
 func TestDiffIndexes_change(t *testing.T) {
@@ -599,7 +653,7 @@ func TestDiffIndexes_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "DROP INDEX public.idx_name;", idxResult.Stmts[0])
@@ -611,7 +665,7 @@ func TestDiffIndexes_add_uniqueConcurrently_perDirective(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE UNIQUE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE UNIQUE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -621,7 +675,7 @@ func TestDiffIndexes_add_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -633,7 +687,7 @@ func TestDiffIndexes_drop_pureDrop_neverConcurrently(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
 }
@@ -644,7 +698,7 @@ func TestDiffIndexes_change_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", idxResult.Stmts[0])
@@ -657,7 +711,7 @@ func TestDiffIndexes_mixedConcurrently(t *testing.T) {
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 	desired.Set("idx_email", &model.Index{Schema: "public", Name: "idx_email", Definition: "CREATE INDEX idx_email ON public.users USING btree (email)"})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);", idxResult.Stmts[0])
@@ -672,7 +726,7 @@ func TestDiffIndexes_rename_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	// Rename should NOT use CONCURRENTLY even with per-index directive
 	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
@@ -684,7 +738,7 @@ func TestDiffIndexes_partialIndex_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_active", &model.Index{Schema: "public", Name: "idx_active", Definition: "CREATE INDEX idx_active ON public.users USING btree (name) WHERE (active = true)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 1)
 	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
@@ -697,7 +751,7 @@ func TestDiffIndexes_expressionIndex_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_lower", &model.Index{Schema: "public", Name: "idx_lower", Definition: "CREATE INDEX idx_lower ON public.users USING btree (lower(name))", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 1)
 	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
@@ -710,7 +764,7 @@ func TestDiffIndexes_hasConcurrently_directive(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.True(t, idxResult.HasConcurrently)
 }
@@ -748,7 +802,7 @@ func TestDiffForeignKeys_add(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, addStmts, 1)
 	assert.Contains(t, addStmts[0], "ADD CONSTRAINT fk_user")
@@ -764,7 +818,7 @@ func TestDiffForeignKeys_addNotValid(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, addStmts, 1)
 	assert.Contains(t, addStmts[0], "ADD CONSTRAINT fk_user")
@@ -780,10 +834,95 @@ func TestDiffForeignKeys_drop(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, dropStmts)
 	assert.Empty(t, addStmts)
+}
+
+func TestDiffForeignKeys_drop_denied(t *testing.T) {
+	// Pure FK removals (FK absent from desired while the owning table stays)
+	// honor --allow-drop=constraint.
+	current := orderedmap.New[string, *model.ForeignKey]()
+	current.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	desired := orderedmap.New[string, *model.ForeignKey]()
+
+	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, dropStmts)
+	assert.Empty(t, addStmts)
+	assert.Equal(t, []string{"-- skipped: ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, disallowed)
+}
+
+func TestDiffForeignKeys_change_denied_alwaysExecutes(t *testing.T) {
+	// FK definition changes still go through DROP+ADD even when constraint
+	// drops are denied.
+	current := orderedmap.New[string, *model.ForeignKey]()
+	current.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	desired := orderedmap.New[string, *model.ForeignKey]()
+	desired.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, disallowed)
+	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, dropStmts)
+	require.Len(t, addStmts, 1)
+	assert.Contains(t, addStmts[0], "ON DELETE CASCADE")
+}
+
+func TestDiffForeignKeys_renamedAndChanged_denied_alwaysExecutes(t *testing.T) {
+	// Renamed FK with definition change → DROP (old name) + ADD (new name).
+	// The new name is in desired so it's not a "pure removal" — deny does not
+	// suppress it.
+	current := orderedmap.New[string, *model.ForeignKey]()
+	current.Set("fk_old", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	desired := orderedmap.New[string, *model.ForeignKey]()
+	desired.Set("fk_new", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true, RenameFrom: ptr("fk_old")},
+		Schema:     "public",
+		Table:      "orders",
+	})
+
+	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, disallowed)
+	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_old;"}, dropStmts)
+	require.Len(t, addStmts, 1)
+	assert.Contains(t, addStmts[0], "ADD CONSTRAINT fk_new")
+	assert.Contains(t, addStmts[0], "ON DELETE CASCADE")
+}
+
+func TestDiffConstraints_renamedAndChanged_denied_alwaysExecutes(t *testing.T) {
+	// Renamed-with-definition-change goes through DROP (old name) + ADD (new
+	// name). Since the new name still exists in desired, it is not a "pure
+	// removal" and is not suppressed by the deny policy.
+	current := orderedmap.New[string, *model.Constraint]()
+	current.Set("chk_old", &model.Constraint{Name: "chk_old", Definition: "CHECK (age > 0)", Validated: true})
+	desired := orderedmap.New[string, *model.Constraint]()
+	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age >= 18)", Validated: true, RenameFrom: ptr("chk_old")})
+
+	stmts, disallowed, err := diffConstraints("public.users", current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, disallowed)
+	require.Len(t, stmts, 2)
+	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_old;", stmts[0])
+	assert.Contains(t, stmts[1], "ADD CONSTRAINT chk_new")
 }
 
 func TestDiffComments_tableComment_add(t *testing.T) {
@@ -947,7 +1086,7 @@ func TestDiffForeignKeys_change(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, append(dropStmts, addStmts...), 2)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", dropStmts[0])
@@ -968,7 +1107,7 @@ func TestDiffForeignKeys_validatedToNotValid(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", dropStmts[0])
@@ -990,7 +1129,7 @@ func TestDiffForeignKeys_notValidToValidated(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Len(t, addStmts, 1)
@@ -1011,7 +1150,7 @@ func TestDiffForeignKeys_bothNotValid_noChange(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Empty(t, addStmts)
@@ -1031,7 +1170,7 @@ func TestDiffForeignKeys_changeDefinitionAndValidated(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", dropStmts[0])
@@ -1054,7 +1193,7 @@ func TestDiffForeignKeys_renameAndValidate(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Len(t, addStmts, 2)
@@ -1076,7 +1215,7 @@ func TestDiffForeignKeys_renameOnly(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Len(t, addStmts, 1)
@@ -1097,7 +1236,7 @@ func TestDiffForeignKeys_renameAndNotValid(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_old;", dropStmts[0])
@@ -1122,7 +1261,7 @@ func TestDiffForeignKeys_renameAlreadyAppliedAndNotValid(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_new;", dropStmts[0])
@@ -1145,7 +1284,7 @@ func TestDiffForeignKeys_renameAndChangeDefinition(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_old;", dropStmts[0])
@@ -1397,7 +1536,7 @@ func TestDiffConstraints_noChangeWithTextCast(t *testing.T) {
 		Definition: "CHECK (name <> '')",
 	})
 
-	stmts, err := diffConstraints("public.items", current, desired)
+	stmts, _, err := diffConstraints("public.items", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1414,7 +1553,7 @@ func TestDiffConstraints_noChangeWithInVsAny(t *testing.T) {
 		Definition: "CHECK (status IN ('active', 'pending'))",
 	})
 
-	stmts, err := diffConstraints("public.items", current, desired)
+	stmts, _, err := diffConstraints("public.items", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1431,7 +1570,7 @@ func TestDiffConstraints_noChangeWithFormattingDiff(t *testing.T) {
 		Definition: "CHECK (kind = ANY(ARRAY['x'::text, 'y'::text]))",
 	})
 
-	stmts, err := diffConstraints("public.items", current, desired)
+	stmts, _, err := diffConstraints("public.items", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1673,7 +1812,7 @@ func TestDiffConstraints_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("con", &model.Constraint{Name: "con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1686,7 +1825,7 @@ func TestDiffIndexes_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx", &model.Index{Schema: "public", Name: "idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.Stmts)
 }
@@ -1707,7 +1846,7 @@ func TestDiffForeignKeys_rename_selfRename_skipped(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Empty(t, addStmts)
@@ -1877,7 +2016,7 @@ func TestDiffConstraints_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME CONSTRAINT old_con TO new_con;"}, stmts)
 }
@@ -1890,7 +2029,7 @@ func TestDiffIndexes_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
 }
@@ -1903,7 +2042,7 @@ func TestDiffConstraints_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	stmts, err := diffConstraints("public.users", current, desired)
+	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1915,7 +2054,7 @@ func TestDiffConstraints_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	_, err := diffConstraints("public.users", current, desired)
+	_, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source constraint")
 }
@@ -1928,7 +2067,7 @@ func TestDiffIndexes_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired)
+	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.Stmts)
 }
@@ -1940,7 +2079,7 @@ func TestDiffIndexes_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	_, err := diffIndexes(current, desired)
+	_, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -1961,7 +2100,7 @@ func TestDiffForeignKeys_rename(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, err := diffForeignKeys("public.orders", "public", current, desired)
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME CONSTRAINT old_fk TO new_fk;"}, addStmts)
@@ -1983,7 +2122,7 @@ func TestDiffForeignKeys_rename_alreadyApplied(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, _, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.NoError(t, err)
 }
 
@@ -1998,7 +2137,7 @@ func TestDiffForeignKeys_rename_sourceNotFound(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, _, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -2012,7 +2151,7 @@ func TestDiffConstraints_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	_, err := diffConstraints("public.users", current, desired)
+	_, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -2026,7 +2165,7 @@ func TestDiffIndexes_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	_, err := diffIndexes(current, desired)
+	_, err := diffIndexes(current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -2052,7 +2191,7 @@ func TestDiffForeignKeys_rename_destinationExists_error(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, _, err := diffForeignKeys("public.orders", "public", current, desired)
+	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -842,7 +842,7 @@ func TestDiffForeignKeys_drop(t *testing.T) {
 
 func TestDiffForeignKeys_drop_denied(t *testing.T) {
 	// Pure FK removals (FK absent from desired while the owning table stays)
-	// honor --allow-drop=constraint.
+	// honor --allow-drop=foreign_key.
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
 		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
@@ -859,7 +859,7 @@ func TestDiffForeignKeys_drop_denied(t *testing.T) {
 }
 
 func TestDiffForeignKeys_change_denied_alwaysExecutes(t *testing.T) {
-	// FK definition changes still go through DROP+ADD even when constraint
+	// FK definition changes still go through DROP+ADD even when foreign_key
 	// drops are denied.
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{

--- a/diff/views.go
+++ b/diff/views.go
@@ -267,11 +267,12 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			}
 		} else if desiredView.Materialized {
 			// Definition unchanged, diff indexes
-			viewIdxStmts, viewIdxHasConcurrently, err := diffViewIndexes(currentView, desiredView)
+			viewIdxStmts, viewIdxDisallowed, viewIdxHasConcurrently, err := diffViewIndexes(currentView, desiredView, dc)
 			if err != nil {
 				return nil, err
 			}
 			result.CreateStmts = append(result.CreateStmts, viewIdxStmts...)
+			result.DisallowedDropStmts = append(result.DisallowedDropStmts, viewIdxDisallowed...)
 			if viewIdxHasConcurrently {
 				result.HasConcurrently = true
 			}
@@ -336,7 +337,8 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 }
 
 // diffViewIndexes generates DDL for index changes on materialized views.
-func diffViewIndexes(current, desired *model.View) (stmts []string, hasConcurrently bool, err error) {
+func diffViewIndexes(current, desired *model.View, dc DropChecker) (stmts []string, disallowed []string, hasConcurrently bool, err error) {
+	dc = NormalizeDropChecker(dc)
 	currentIndexes := orderedmap.New[string, *model.Index]()
 	if current.Indexes != nil {
 		currentIndexes = current.Indexes
@@ -346,7 +348,9 @@ func diffViewIndexes(current, desired *model.View) (stmts []string, hasConcurren
 		desiredIndexes = desired.Indexes
 	}
 
-	// Drop removed or changed indexes
+	// Drop removed or changed indexes. Pure removals honor the index-drop
+	// policy; definition changes still run DROP+CREATE.
+	idxAllowed := dc.IsDropAllowed("index")
 	for name, currentIdx := range currentIndexes.All() {
 		desiredIdx, ok := desiredIndexes.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
@@ -356,7 +360,11 @@ func diffViewIndexes(current, desired *model.View) (stmts []string, hasConcurren
 			}
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {
-				return nil, false, fmt.Errorf("drop index %s: %w", model.Ident(currentIdx.Schema, name), err)
+				return nil, nil, false, fmt.Errorf("drop index %s: %w", model.Ident(currentIdx.Schema, name), err)
+			}
+			if !ok && !idxAllowed {
+				disallowed = append(disallowed, "-- skipped: "+stmt)
+				continue
 			}
 			stmts = append(stmts, stmt)
 			if useConcurrently {
@@ -371,7 +379,7 @@ func diffViewIndexes(current, desired *model.View) (stmts []string, hasConcurren
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
 			stmt, err := createIndexSQL(desiredIdx.Definition, desiredIdx.Concurrently)
 			if err != nil {
-				return nil, false, fmt.Errorf("create index %s: %w", model.Ident(desiredIdx.Schema, name), err)
+				return nil, nil, false, fmt.Errorf("create index %s: %w", model.Ident(desiredIdx.Schema, name), err)
 			}
 			stmts = append(stmts, stmt)
 			if desiredIdx.Concurrently {
@@ -380,5 +388,5 @@ func diffViewIndexes(current, desired *model.View) (stmts []string, hasConcurren
 		}
 	}
 
-	return stmts, hasConcurrently, nil
+	return stmts, disallowed, hasConcurrently, nil
 }

--- a/diff/views.go
+++ b/diff/views.go
@@ -185,7 +185,7 @@ func stripQualifications(node *pg_query.Node) {
 type ViewDiffResult struct {
 	DropStmts           []string // DROP VIEW / DROP MATERIALIZED VIEW (should run before table changes)
 	CreateStmts         []string // ALTER VIEW RENAME, CREATE OR REPLACE VIEW, CREATE MATERIALIZED VIEW, indexes, comments (should run after table changes)
-	DisallowedDropStmts []string // DROP VIEW / DROP MATERIALIZED VIEW suppressed by DropChecker, with "-- skipped: " prefix
+	DisallowedDropStmts []string // DROP VIEW / DROP MATERIALIZED VIEW / DROP INDEX (on matview) suppressed by DropChecker, with "-- skipped: " prefix
 	HasConcurrently     bool     // true if any index operation uses CONCURRENTLY
 }
 

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -478,6 +478,32 @@ func TestDiffViews_matviewIndexDrop(t *testing.T) {
 	assert.Contains(t, result.CreateStmts[0], "DROP INDEX")
 }
 
+func TestDiffViews_matviewIndexAdd_concurrently_parseError(t *testing.T) {
+	// createIndexSQL with concurrently=true parses the definition through
+	// pg_query; an unparseable definition surfaces as a wrapped error from
+	// diffViewIndexes.
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	})
+	desired := orderedmap.New[string, *model.View]()
+	mv := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mv.Indexes.Set("idx_bad", &model.Index{
+		Schema: "public", Name: "idx_bad", Table: "mv",
+		Definition:   "NOT VALID SQL {{{{",
+		Concurrently: true,
+	})
+	desired.Set("public.mv", mv)
+
+	_, err := DiffViews(current, desired, AllowAllDrops{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create index")
+}
+
 func TestDiffViews_matviewIndexDrop_denied(t *testing.T) {
 	// Matview definition unchanged, only its index is removed.
 	// With --allow-drop denying index drops, the DROP INDEX is suppressed.

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -478,6 +478,32 @@ func TestDiffViews_matviewIndexDrop(t *testing.T) {
 	assert.Contains(t, result.CreateStmts[0], "DROP INDEX")
 }
 
+func TestDiffViews_matviewIndexDrop_denied(t *testing.T) {
+	// Matview definition unchanged, only its index is removed.
+	// With --allow-drop denying index drops, the DROP INDEX is suppressed.
+	current := orderedmap.New[string, *model.View]()
+	mv := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mv.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition: "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+	})
+	current.Set("public.mv", mv)
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	})
+
+	result, err := DiffViews(current, desired, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	assert.Empty(t, result.CreateStmts)
+	assert.Equal(t, []string{"-- skipped: DROP INDEX public.idx_mv_n;"}, result.DisallowedDropStmts)
+}
+
 func TestDiffViews_matviewCommentAdd(t *testing.T) {
 	comment := "stats"
 	current := orderedmap.New[string, *model.View]()

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -7,7 +7,7 @@ import "slices"
 // If AllowDrop contains "all", all drops are allowed.
 // Otherwise, only the listed object types are allowed to be dropped.
 type DropPolicy struct {
-	AllowDrop []string `enum:"all,table,view,enum,domain,column" env:"PIST_ALLOW_DROP" help:"Allow dropping specified object types (can be repeated). Use 'all' to allow all drops."`
+	AllowDrop []string `enum:"all,table,view,enum,domain,column,constraint,foreign_key,index" env:"PIST_ALLOW_DROP" help:"Allow dropping specified object types (can be repeated). Use 'all' to allow all drops."`
 }
 
 func (p *DropPolicy) IsDropAllowed(objectType string) bool {

--- a/drop_policy_test.go
+++ b/drop_policy_test.go
@@ -15,6 +15,9 @@ func TestDropPolicy_IsDropAllowed(t *testing.T) {
 		assert.False(t, p.IsDropAllowed("enum"))
 		assert.False(t, p.IsDropAllowed("domain"))
 		assert.False(t, p.IsDropAllowed("column"))
+		assert.False(t, p.IsDropAllowed("constraint"))
+		assert.False(t, p.IsDropAllowed("foreign_key"))
+		assert.False(t, p.IsDropAllowed("index"))
 	})
 
 	t.Run("all", func(t *testing.T) {
@@ -24,6 +27,9 @@ func TestDropPolicy_IsDropAllowed(t *testing.T) {
 		assert.True(t, p.IsDropAllowed("enum"))
 		assert.True(t, p.IsDropAllowed("domain"))
 		assert.True(t, p.IsDropAllowed("column"))
+		assert.True(t, p.IsDropAllowed("constraint"))
+		assert.True(t, p.IsDropAllowed("foreign_key"))
+		assert.True(t, p.IsDropAllowed("index"))
 	})
 
 	t.Run("specific types", func(t *testing.T) {

--- a/getting-started.md
+++ b/getting-started.md
@@ -212,7 +212,7 @@ PIST_ALLOW_DROP=all pist plan schema.sql
 Valid types: `all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `foreign_key`, `index`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately.
 
 > [!NOTE]
-> `--allow-drop=constraint`, `--allow-drop=foreign_key`, and `--allow-drop=index` only govern **pure removals** (objects absent from the desired schema). **Definition changes** still execute as DROP + ADD regardless of `--allow-drop`, because PostgreSQL has no `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes.
+> `--allow-drop=constraint`, `--allow-drop=foreign_key`, and `--allow-drop=index` only govern **pure removals** (objects absent from the desired schema). **Definition changes** still execute regardless of `--allow-drop`: constraints and foreign keys as DROP + ADD, and indexes as DROP + CREATE, because PostgreSQL has no `ALTER CONSTRAINT` and no general `ALTER INDEX` form for definition changes.
 
 ### Using transactions
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -195,7 +195,7 @@ pist dump --enable table,enum        # dump tables and enums only
 
 ### Controlling drops
 
-By default, `plan` and `apply` do **not** drop tables, views, enums, domains, or columns. Use `--allow-drop` to opt in:
+By default, `plan` and `apply` do **not** drop tables, views, enums, domains, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to opt in:
 
 ```bash
 # Allow all drops
@@ -209,10 +209,10 @@ pist apply --allow-drop column,table schema.sql
 PIST_ALLOW_DROP=all pist plan schema.sql
 ```
 
-Valid types: `all`, `table`, `view`, `enum`, `domain`, `column`.
+Valid types: `all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `foreign_key`, `index`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately.
 
 > [!NOTE]
-> Constraints and indexes are dropped when their definitions change or they are removed from the desired schema, regardless of `--allow-drop`. PostgreSQL does not support altering their definitions in place — the only way to update them is DROP + ADD.
+> `--allow-drop=constraint`, `--allow-drop=foreign_key`, and `--allow-drop=index` only govern **pure removals** (objects absent from the desired schema). **Definition changes** still execute as DROP + ADD regardless of `--allow-drop`, because PostgreSQL has no `ALTER CONSTRAINT` or `ALTER INDEX` for definition changes.
 
 ### Using transactions
 

--- a/plan_test.go
+++ b/plan_test.go
@@ -395,6 +395,284 @@ CREATE TYPE public.color AS ENUM ('red', 'blue');`)
 	assert.NotContains(t, got.SQL, "DROP TYPE")
 }
 
+func TestPlan_DisallowedDrops_Constraint(t *testing.T) {
+	// Pure removals of constraints honor --allow-drop=constraint.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    email text,
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    CONSTRAINT users_email_key UNIQUE (email)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    email text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL)
+	assert.Contains(t, got.DisallowedDrops, "-- skipped: ALTER TABLE public.users DROP CONSTRAINT users_email_key;")
+
+	got, err = client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"constraint"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "ALTER TABLE public.users DROP CONSTRAINT users_email_key;")
+	assert.Empty(t, got.DisallowedDrops)
+}
+
+func TestPlan_DisallowedDrops_Index(t *testing.T) {
+	// Pure removals of indexes honor --allow-drop=index.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL)
+	assert.Contains(t, got.DisallowedDrops, "-- skipped: DROP INDEX public.idx_users_name;")
+
+	got, err = client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"index"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "DROP INDEX public.idx_users_name;")
+	assert.Empty(t, got.DisallowedDrops)
+}
+
+func TestPlan_DisallowedDrops_IndexChange_AlwaysExecutes(t *testing.T) {
+	// Definition changes still produce DROP+CREATE because PostgreSQL has no
+	// ALTER INDEX for definitions, even when --allow-drop is empty.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING hash (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "DROP INDEX public.idx_users_name;")
+	assert.Contains(t, got.SQL, "CREATE INDEX idx_users_name")
+	assert.Empty(t, got.DisallowedDrops)
+}
+
+func TestPlan_DisallowedDrops_ConstraintAllowed_IndexDenied(t *testing.T) {
+	// --allow-drop=constraint allows constraint drops but does NOT allow index drops.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    email text,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    CONSTRAINT users_email_key UNIQUE (email)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    email text,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"constraint"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "ALTER TABLE public.users DROP CONSTRAINT users_email_key;")
+	assert.NotContains(t, got.SQL, "DROP INDEX")
+	assert.Contains(t, got.DisallowedDrops, "-- skipped: DROP INDEX public.idx_users_name;")
+}
+
+func TestPlan_DisallowedDrops_FK_byForeignKeyPolicy(t *testing.T) {
+	// FK pure removals follow --allow-drop=foreign_key, NOT --allow-drop=constraint.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id),
+    CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// Default (no --allow-drop): FK drop is suppressed.
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL)
+	assert.Contains(t, got.DisallowedDrops, "-- skipped: ALTER TABLE public.orders DROP CONSTRAINT orders_user_id_fkey;")
+
+	// --allow-drop=constraint alone does NOT allow FK drop.
+	got, err = client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"constraint"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL)
+	assert.Contains(t, got.DisallowedDrops, "-- skipped: ALTER TABLE public.orders DROP CONSTRAINT orders_user_id_fkey;")
+
+	// --allow-drop=foreign_key allows FK drop.
+	got, err = client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"foreign_key"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "ALTER TABLE public.orders DROP CONSTRAINT orders_user_id_fkey;")
+	assert.Empty(t, got.DisallowedDrops)
+}
+
+func TestPlan_DisallowedDrops_ConstraintAndForeignKey_Orthogonal(t *testing.T) {
+	// constraint and foreign_key are independent --allow-drop keys.
+	// constraint covers CHECK/UNIQUE/PK/EXCLUSION; FKs require foreign_key.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    qty integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id),
+    CONSTRAINT orders_qty_check CHECK (qty > 0),
+    CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+);`)
+
+	// Desired removes both the CHECK and the FK.
+	desired := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    qty integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id)
+);`
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(desired), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// constraint only → CHECK drops, FK suppressed.
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"constraint"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "DROP CONSTRAINT orders_qty_check;")
+	assert.NotContains(t, got.SQL, "orders_user_id_fkey")
+	assert.Contains(t, got.DisallowedDrops, "-- skipped: ALTER TABLE public.orders DROP CONSTRAINT orders_user_id_fkey;")
+
+	// foreign_key only → FK drops, CHECK suppressed.
+	got, err = client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"foreign_key"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "DROP CONSTRAINT orders_user_id_fkey;")
+	assert.NotContains(t, got.SQL, "orders_qty_check")
+	assert.Contains(t, got.DisallowedDrops, "-- skipped: ALTER TABLE public.orders DROP CONSTRAINT orders_qty_check;")
+
+	// Both → both drop.
+	got, err = client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"constraint", "foreign_key"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "DROP CONSTRAINT orders_qty_check;")
+	assert.Contains(t, got.SQL, "DROP CONSTRAINT orders_user_id_fkey;")
+	assert.Empty(t, got.DisallowedDrops)
+}
+
 func TestPlan_ConcurrentlyDirective(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)


### PR DESCRIPTION
## Summary
- Pure removals of CHECK/UNIQUE/PK/EXCLUSION constraints, foreign keys, and indexes (objects absent from the desired schema) are now governed by new `--allow-drop=constraint`, `--allow-drop=foreign_key`, and `--allow-drop=index` keys.
- `constraint` and `foreign_key` are independent keys: FK drops are common during cross-table migrations and have a different risk profile than structural CHECK/UNIQUE drops.
- Definition changes still execute as DROP + ADD regardless of `--allow-drop` because PostgreSQL has no `ALTER CONSTRAINT` or `ALTER INDEX` for definitions. FK drops emitted to unblock a table drop continue to follow the table-drop policy.

## Test plan
- [x] `make lint`
- [x] `make test` (all packages green)
- [x] Coverage: `diffConstraints`, `diffForeignKeys`, `IsDropAllowed`, `NormalizeDropChecker` at 100%; `diffIndexes` / `diffViewIndexes` reachable paths covered (residual gaps are pg_query defensive error paths)
- [x] Unit tests for each branch: pure drop denied (suppressed), definition change denied (still executes), renamed-with-definition-change under deny (still executes), matview index pure drop denied
- [x] Integration tests: `--allow-drop=constraint` only / `--allow-drop=foreign_key` only / both — verified orthogonal on a table with both a CHECK and an FK

🤖 Generated with [Claude Code](https://claude.com/claude-code)