### PR TITLE
docs: document PIST_PASSWORD in getting-started guide

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -23,6 +23,14 @@ export PIST_CONN_STR='postgres://user:pass@host:5432/mydb'
 pist dump
 ```
 
+If you'd rather not embed credentials in the connection string, supply the password separately via `--password` or `$PIST_PASSWORD`:
+
+```bash
+export PIST_CONN_STR='postgres://user@host:5432/mydb'
+export PIST_PASSWORD='s3cret'
+pist dump
+```
+
 ## Step 2: Dump the current schema
 
 Export your existing database schema to a SQL file:


### PR DESCRIPTION
This pull request updates the `getting-started.md` documentation to provide a more secure way of handling database credentials. It adds instructions for specifying the database password separately, rather than embedding it in the connection string.

Documentation improvements:

* Added guidance on using the `--password` flag or the `$PIST_PASSWORD` environment variable to supply the database password, offering a safer alternative to embedding credentials directly in the `PIST_CONN_STR`.