### PR TITLE
Add schema summary comment to dump output

### DIFF
--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -59,6 +59,7 @@ func TestDump_Run(t *testing.T) {
 	cmd := &command.Dump{}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "-- Dump of schema public (1 table, 0 views, 0 enums, 0 domains)")
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
 }
 
@@ -98,6 +99,26 @@ CREATE TABLE public.posts (
 
 	assert.Contains(t, buf.String(), "public.users.sql")
 	assert.Contains(t, buf.String(), "public.posts.sql")
+	assert.NotContains(t, buf.String(), "-- Dump of")
+}
+
+func TestDump_Run_Empty(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Dump{}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains)")
 }
 
 func TestDump_Run_Split_WithView(t *testing.T) {

--- a/cmd/command/dump.go
+++ b/cmd/command/dump.go
@@ -21,7 +21,8 @@ func (cmd *Dump) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 	}
 
 	if cmd.Split == "" {
-		fmt.Fprintln(w, result) //nolint:errcheck
+		fmt.Fprintf(w, "-- Dump of %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
+		fmt.Fprintln(w, result)                                                                    //nolint:errcheck
 		return nil
 	}
 

--- a/dump.go
+++ b/dump.go
@@ -22,6 +22,7 @@ type DumpResult struct {
 	Enums      *orderedmap.Map[string, *model.Enum]
 	Domains    *orderedmap.Map[string, *model.Domain]
 	OmitSchema bool
+	Count      ObjectCount
 }
 
 func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
@@ -208,11 +209,23 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 		return nil, fmt.Errorf("failed to fetch domains: %w", err)
 	}
 
+	filteredTables := options.filterTables(client.remapTableSchemas(tables))
+	filteredViews := options.filterViews(client.remapViewSchemas(views))
+	filteredEnums := options.filterEnums(client.remapEnumSchemas(enums))
+	filteredDomains := options.filterDomains(client.remapDomainSchemas(domains))
+
 	return &DumpResult{
-		Tables:     options.filterTables(client.remapTableSchemas(tables)),
-		Views:      options.filterViews(client.remapViewSchemas(views)),
-		Enums:      options.filterEnums(client.remapEnumSchemas(enums)),
-		Domains:    options.filterDomains(client.remapDomainSchemas(domains)),
+		Tables:     filteredTables,
+		Views:      filteredViews,
+		Enums:      filteredEnums,
+		Domains:    filteredDomains,
 		OmitSchema: options.OmitSchema,
+		Count: ObjectCount{
+			Schemas: client.Schemas,
+			Tables:  filteredTables.Len(),
+			Views:   filteredViews.Len(),
+			Enums:   filteredEnums.Len(),
+			Domains: filteredDomains.Len(),
+		},
 	}, nil
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -94,6 +94,85 @@ func TestDumpResult_String_Empty(t *testing.T) {
 	assert.Equal(t, "", got.String())
 }
 
+func TestDump_Count(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"public"}, got.Count.Schemas)
+	assert.Equal(t, 1, got.Count.Tables)
+	assert.Equal(t, 1, got.Count.Views)
+	assert.Equal(t, 1, got.Count.Enums)
+	assert.Equal(t, 1, got.Count.Domains)
+	assert.Equal(t, "schema public", got.Count.SchemaLabel())
+	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain", got.Count.Summary())
+}
+
+func TestDump_Count_Empty(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.Count.Tables)
+	assert.Equal(t, 0, got.Count.Views)
+	assert.Equal(t, 0, got.Count.Enums)
+	assert.Equal(t, 0, got.Count.Domains)
+	assert.Equal(t, "0 tables, 0 views, 0 enums, 0 domains", got.Count.Summary())
+}
+
+func TestDump_Count_Filtered(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{
+		FilterOptions: pistachio.FilterOptions{Exclude: []string{"posts"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Count.Tables)
+	assert.Equal(t, "1 table, 0 views, 0 enums, 0 domains", got.Count.Summary())
+}
+
 func TestDumpResult_Files_Tables(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)


### PR DESCRIPTION
## Summary
- `pist dump` now prints a header comment like `-- Dump of schema public (1 table, 0 views, 0 enums, 0 domains)` before the SQL body, matching the existing `plan` / `apply` header style.
- Reuses `ObjectCount` (with `SchemaLabel()` / `Summary()`) from `plan.go` so multi-schema and singular/plural rendering stay consistent across commands.
- Header is suppressed in `--split` mode (each file is per-object, summary doesn't fit).

## Test plan
- [x] `make build`
- [x] `make lint`
- [x] `go test -p 1 -run Dump ./...` (all dump tests pass)
- [x] Coverage unchanged — `cmd/command/dump.go` 100%, `dump.go` 97.5% (remaining uncovered paths are pre-existing defensive error branches)
- [x] Manual: `./pist dump` shows header line, `./pist dump --split <dir>` does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)