### PR TITLE
Allow PIST_INCLUDE / PIST_EXCLUDE environment variables for filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ pist -n staging -m staging=public apply schema.sql
 
 ### Filtering objects
 
-Use `-I` / `--include` to include only matching objects by name, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names).
+Use `-I` / `--include` to include only matching objects by name, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names). Also available as `$PIST_INCLUDE` / `$PIST_EXCLUDE` environment variables.
 
 Use `--enable` to restrict operations to specific object types, or `--disable` to exclude specific types. Valid types: `table`, `view`, `enum`, `domain`. Can be repeated. Also available as `$PIST_ENABLE` / `$PIST_DISABLE` environment variables.
 
@@ -229,6 +229,8 @@ pist plan --enable enum schema.sql
 # Using environment variables
 PIST_ENABLE=enum pist dump
 PIST_DISABLE=view pist dump
+PIST_INCLUDE='user*' pist dump
+PIST_EXCLUDE='tmp_*' pist plan schema.sql
 ```
 
 > [!NOTE]

--- a/options.go
+++ b/options.go
@@ -13,8 +13,8 @@ type Options struct {
 }
 
 type FilterOptions struct {
-	Include []string `short:"I" help:"Include only tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
-	Exclude []string `short:"E" help:"Exclude tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
+	Include []string `short:"I" env:"PIST_INCLUDE" help:"Include only tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
+	Exclude []string `short:"E" env:"PIST_EXCLUDE" help:"Exclude tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
 	Enable  []string `enum:"table,view,enum,domain" env:"PIST_ENABLE" help:"Enable only specified object types (can be repeated)."`
 	Disable []string `enum:"table,view,enum,domain" env:"PIST_DISABLE" help:"Disable specified object types (can be repeated)."`
 }


### PR DESCRIPTION
## Summary
- Add `env:\"PIST_INCLUDE\"` / `env:\"PIST_EXCLUDE\"` to `FilterOptions.Include` / `Exclude` so the `-I` / `-E` flags on `dump` / `plan` / `apply` can be supplied via environment variables, mirroring `PIST_ENABLE` / `PIST_DISABLE`.
- Update README to document the new environment variables.

## Test plan
- [x] `make build` succeeds
- [x] `./pist plan --help` shows `($PIST_INCLUDE)` / `($PIST_EXCLUDE)` next to `-I` / `-E`

🤖 Generated with [Claude Code](https://claude.com/claude-code)