### PR TITLE
Document that CLI flags override env vars for filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ PIST_EXCLUDE='tmp_*' pist plan schema.sql
 > [!NOTE]
 > `--enable` takes precedence over `--disable`. When `--enable` is set, only the specified types are included regardless of `--disable`. These flags may exclude dependent objects (e.g. `--enable table` omits enums/domains that table columns may reference), so use them primarily for inspection (`dump`, `plan`) rather than `apply`.
 
+> [!NOTE]
+> When both a CLI flag and its corresponding environment variable are set, the CLI flag overrides the environment variable (values are not merged). For example, running `PIST_EXCLUDE='tmp_*' pist plan -E 'foo_*' schema.sql` excludes only `foo_*`; `tmp_*` is ignored.
+
 ### Omit schema
 
 Use `--omit-schema` to omit schema names from the dump output.


### PR DESCRIPTION
## Summary
- Note that CLI flags (e.g. `-E`) completely override the corresponding environment variable (e.g. `PIST_EXCLUDE`); values are not merged.
- Verified against Kong v1.15.0: passing both env and flag results in only the flag values being applied.

## Test plan
- [x] README renders correctly on GitHub