### PR TITLE
Document idempotent function management with version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ Suppressed drops are emitted as commented-out DDL prefixed with `-- skipped:` so
 
 ### Executing arbitrary SQL
 
-Use `-- pist:execute` to include non-managed SQL (functions, triggers, grants) in your schema files. The check SQL after the directive is evaluated each run — when it returns `true` the statement is executed, otherwise it is skipped. The simplest form skips when an object already exists:
+Use `-- pist:execute` to include non-managed SQL (functions, triggers, grants) in your schema files. The check SQL after the directive is evaluated during `apply` — when it returns `true` the statement is executed, otherwise it is skipped. The simplest form skips when an object already exists:
 
 ```sql
--- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
+-- pist:execute SELECT to_regprocedure('public.my_func()') IS NULL
 CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ ... $$ LANGUAGE plpgsql;
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,12 +140,26 @@ Suppressed drops are emitted as commented-out DDL prefixed with `-- skipped:` so
 
 ### Executing arbitrary SQL
 
-Use `-- pist:execute` to include non-managed SQL (functions, triggers, grants) in your schema files. Add a check SQL to skip execution conditionally:
+Use `-- pist:execute` to include non-managed SQL (functions, triggers, grants) in your schema files. The check SQL after the directive is evaluated each run — when it returns `true` the statement is executed, otherwise it is skipped. The simplest form skips when an object already exists:
 
 ```sql
 -- pist:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'my_func')
 CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ ... $$ LANGUAGE plpgsql;
 ```
+
+For idempotent management of a function whose body changes over time, embed a version tag in `COMMENT ON FUNCTION` and execute only when the installed comment differs. Wrap the `CREATE` and `COMMENT` in a `DO` block so they are a single statement:
+
+```sql
+-- pist:execute SELECT obj_description(to_regprocedure('public.get_user_count()'), 'pg_proc') IS DISTINCT FROM 'v1'
+DO $do$ BEGIN
+  CREATE OR REPLACE FUNCTION public.get_user_count() RETURNS bigint AS $body$
+    SELECT count(*) FROM public.users;
+  $body$ LANGUAGE sql;
+  COMMENT ON FUNCTION public.get_user_count() IS 'v1';
+END $do$;
+```
+
+When you change the body, bump the tag in both places (e.g. `'v1'` → `'v2'`); the next `apply` will re-run.
 
 See [Getting Started](getting-started.md) for details.
 


### PR DESCRIPTION
## Summary
- Expand the `-- pist:execute` section with an idempotent pattern for managing PL/SQL functions whose body changes over time.
- Use `COMMENT ON FUNCTION` as a version sentinel and `obj_description(...) IS DISTINCT FROM 'v1'` as the check, wrapping `CREATE OR REPLACE` + `COMMENT` in a `DO` block so they form a single statement.
- Verified locally: re-running `pist apply` is a no-op until the tag is bumped (e.g. `'v1'` → `'v2'`), at which point the function body and comment are updated together.

## Test plan
- [x] First apply on empty schema installs the function and tag
- [x] Second apply with same tag is a no-op (`-- No changes`)
- [x] Bumping the tag with a body change triggers re-execution
- [x] Subsequent apply is again idempotent