### PR TITLE
Preserve SQL comments through pist fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ pist fmt --check schema.sql
 > [!NOTE]
 > `dump` output uses PostgreSQL's own formatting (e.g. `pg_get_viewdef`), while `fmt` normalizes through the pg_query parser. This means `dump` output may not pass `fmt --check` directly. Run `fmt -w` once after the initial `dump` to normalize, then use `--check` in CI going forward.
 
+> [!NOTE]
+> `fmt` preserves `--` and `/* */` comments between top-level statements. Each comment is attached to the entity that owns the surrounding region: a comment between an entity's `CREATE` and its associated `CREATE INDEX` / `ALTER TABLE ADD CONSTRAINT` / `COMMENT ON` belongs to that entity; otherwise it becomes a leading comment of the next entity. Comments inside a `CREATE` body (e.g. inline column comments) are dropped by the underlying parser and cannot be recovered.
+
 ### Schema name mapping
 
 Use `-m` / `--schema-map` to remap schema names. This is useful when you want to manage a database whose schema name differs from the one used in your SQL files.

--- a/fmt.go
+++ b/fmt.go
@@ -12,23 +12,19 @@ import (
 func formatEntity(result *parser.ParseResult, ref parser.EntityRef) string {
 	switch ref.Kind {
 	case parser.EntityKindEnum:
-		if e, ok := result.Enums.GetOk(ref.FQN); ok {
-			return model.EnumToSQLBare(e)
-		}
+		e, _ := result.Enums.GetOk(ref.FQN)
+		return model.EnumToSQLBare(e)
 	case parser.EntityKindDomain:
-		if d, ok := result.Domains.GetOk(ref.FQN); ok {
-			return model.DomainToSQLBare(d)
-		}
+		d, _ := result.Domains.GetOk(ref.FQN)
+		return model.DomainToSQLBare(d)
 	case parser.EntityKindTable:
-		if t, ok := result.Tables.GetOk(ref.FQN); ok {
-			return model.TableToSQLBare(t)
-		}
+		t, _ := result.Tables.GetOk(ref.FQN)
+		return model.TableToSQLBare(t)
 	case parser.EntityKindView:
-		if v, ok := result.Views.GetOk(ref.FQN); ok {
-			return model.ViewToSQLBare(v)
-		}
+		v, _ := result.Views.GetOk(ref.FQN)
+		return model.ViewToSQLBare(v)
 	}
-	return ""
+	panic(fmt.Sprintf("unknown entity kind: %v", ref.Kind))
 }
 
 // formatWithComments emits entities in source order. Each entity gets:
@@ -50,9 +46,6 @@ func formatWithComments(result *parser.ParseResult) string {
 			cIdx++
 		}
 		entity := formatEntity(result, ref)
-		if entity == "" {
-			continue
-		}
 		var trailing []string
 		for cIdx < len(result.Comments) && result.Comments[cIdx].End <= ref.OwnershipEnd {
 			trailing = append(trailing, result.Comments[cIdx].Text)

--- a/fmt.go
+++ b/fmt.go
@@ -2,6 +2,7 @@ package pistachio
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/winebarrel/orderedmap"
@@ -27,31 +28,55 @@ func formatEntity(result *parser.ParseResult, ref parser.EntityRef) string {
 	panic(fmt.Sprintf("unknown entity kind: %v", ref.Kind))
 }
 
-// formatWithComments emits entities in source order. Each entity gets:
-//   - leading comments: those between the previous entity's ownership end and
-//     this entity's CREATE keyword.
-//   - the entity's bare SQL (CREATE + indexes + FKs + COMMENT ON statements).
-//   - trailing comments: those between this entity's CREATE statement end and
-//     its ownership end (e.g. a comment placed before a CREATE INDEX that
-//     belongs to this entity).
+// fmtItem represents a top-level statement (entity or pist:execute) for
+// source-order emission with surrounding comments.
+type fmtItem struct {
+	location     int32
+	ownershipEnd int32
+	sql          string
+}
+
+// formatWithComments emits entities and pist:execute statements in source
+// order. Each item gets:
+//   - leading comments: those between the previous item's ownership end and
+//     this item's start.
+//   - the item's bare SQL.
+//   - trailing comments: those between this item's stmt end and its ownership
+//     end (e.g. a comment placed before a CREATE INDEX owned by an entity).
 //
-// Comments after the last entity's ownership end are appended at the very end.
+// Comments after the last item's ownership end are appended at the very end.
 func formatWithComments(result *parser.ParseResult) string {
+	items := make([]fmtItem, 0, len(result.Order)+len(result.ExecuteStmts))
+	for _, ref := range result.Order {
+		items = append(items, fmtItem{
+			location:     ref.Location,
+			ownershipEnd: ref.OwnershipEnd,
+			sql:          formatEntity(result, ref),
+		})
+	}
+	for _, es := range result.ExecuteStmts {
+		items = append(items, fmtItem{
+			location:     es.Location,
+			ownershipEnd: es.StmtEnd,
+			sql:          parser.FormatExecuteStmt(es),
+		})
+	}
+	sort.SliceStable(items, func(i, j int) bool { return items[i].location < items[j].location })
+
 	var parts []string
 	cIdx := 0
-	for _, ref := range result.Order {
+	for _, it := range items {
 		var leading []string
-		for cIdx < len(result.Comments) && result.Comments[cIdx].End <= ref.Location {
+		for cIdx < len(result.Comments) && result.Comments[cIdx].End <= it.location {
 			leading = append(leading, result.Comments[cIdx].Text)
 			cIdx++
 		}
-		entity := formatEntity(result, ref)
 		var trailing []string
-		for cIdx < len(result.Comments) && result.Comments[cIdx].End <= ref.OwnershipEnd {
+		for cIdx < len(result.Comments) && result.Comments[cIdx].End <= it.ownershipEnd {
 			trailing = append(trailing, result.Comments[cIdx].Text)
 			cIdx++
 		}
-		block := entity
+		block := it.sql
 		if len(leading) > 0 {
 			block = strings.Join(leading, "\n") + "\n" + block
 		}
@@ -86,25 +111,19 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 	results := make(map[string]string, len(options.Files))
 
 	for _, path := range options.Files {
-		result, err := parser.ParseSQLFileWithSchema(path, defaultSchema)
+		sql, err := parser.ReadSQLFile(path)
+		if err != nil {
+			return nil, err
+		}
+		result, err := parser.ParseSQLWithSchema(sql, defaultSchema)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse SQL file %q: %w", path, err)
 		}
-		formatted := formatWithComments(result)
-
-		// Append execute statements
-		if len(result.ExecuteStmts) > 0 {
-			var executeParts []string
-			for _, es := range result.ExecuteStmts {
-				executeParts = append(executeParts, parser.FormatExecuteStmt(es))
-			}
-			if formatted != "" {
-				formatted += "\n\n"
-			}
-			formatted += strings.Join(executeParts, "\n\n")
+		result.Comments, err = parser.ScanTopLevelComments(sql)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan comments in %q: %w", path, err)
 		}
-
-		results[path] = formatted
+		results[path] = formatWithComments(result)
 	}
 
 	return results, nil

--- a/fmt.go
+++ b/fmt.go
@@ -9,6 +9,74 @@ import (
 	"github.com/winebarrel/pistachio/parser"
 )
 
+func formatEntity(result *parser.ParseResult, ref parser.EntityRef) string {
+	switch ref.Kind {
+	case parser.EntityKindEnum:
+		if e, ok := result.Enums.GetOk(ref.FQN); ok {
+			return model.EnumToSQLBare(e)
+		}
+	case parser.EntityKindDomain:
+		if d, ok := result.Domains.GetOk(ref.FQN); ok {
+			return model.DomainToSQLBare(d)
+		}
+	case parser.EntityKindTable:
+		if t, ok := result.Tables.GetOk(ref.FQN); ok {
+			return model.TableToSQLBare(t)
+		}
+	case parser.EntityKindView:
+		if v, ok := result.Views.GetOk(ref.FQN); ok {
+			return model.ViewToSQLBare(v)
+		}
+	}
+	return ""
+}
+
+// formatWithComments emits entities in source order. Each entity gets:
+//   - leading comments: those between the previous entity's ownership end and
+//     this entity's CREATE keyword.
+//   - the entity's bare SQL (CREATE + indexes + FKs + COMMENT ON statements).
+//   - trailing comments: those between this entity's CREATE statement end and
+//     its ownership end (e.g. a comment placed before a CREATE INDEX that
+//     belongs to this entity).
+//
+// Comments after the last entity's ownership end are appended at the very end.
+func formatWithComments(result *parser.ParseResult) string {
+	var parts []string
+	cIdx := 0
+	for _, ref := range result.Order {
+		var leading []string
+		for cIdx < len(result.Comments) && result.Comments[cIdx].End <= ref.Location {
+			leading = append(leading, result.Comments[cIdx].Text)
+			cIdx++
+		}
+		entity := formatEntity(result, ref)
+		if entity == "" {
+			continue
+		}
+		var trailing []string
+		for cIdx < len(result.Comments) && result.Comments[cIdx].End <= ref.OwnershipEnd {
+			trailing = append(trailing, result.Comments[cIdx].Text)
+			cIdx++
+		}
+		block := entity
+		if len(leading) > 0 {
+			block = strings.Join(leading, "\n") + "\n" + block
+		}
+		if len(trailing) > 0 {
+			block = block + "\n" + strings.Join(trailing, "\n")
+		}
+		parts = append(parts, block)
+	}
+	if cIdx < len(result.Comments) {
+		var tail []string
+		for ; cIdx < len(result.Comments); cIdx++ {
+			tail = append(tail, result.Comments[cIdx].Text)
+		}
+		parts = append(parts, strings.Join(tail, "\n"))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
 type FmtOptions struct {
 	Files []string `arg:"" help:"Path to the SQL file(s) to format."`
 	Write bool     `short:"w" xor:"mode" help:"Write result to source file(s) instead of stdout."`
@@ -29,7 +97,7 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse SQL file %q: %w", path, err)
 		}
-		formatted := formatSchemaSQL(result.Domains, result.Enums, result.Tables, result.Views)
+		formatted := formatWithComments(result)
 
 		// Append execute statements
 		if len(result.ExecuteStmts) > 0 {
@@ -49,8 +117,9 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 	return results, nil
 }
 
-// formatSchemaSQL formats domains, enums, tables, and views into canonical SQL output.
-// This is the shared formatting logic used by both dump and fmt.
+// formatSchemaSQL formats domains, enums, tables, and views into canonical SQL
+// output for dump. fmt uses formatWithComments instead, which preserves source
+// order and SQL comments.
 // Order: enums → domains → tables → views (enums first since domains may depend on them).
 func formatSchemaSQL(
 	domains *orderedmap.Map[string, *model.Domain],

--- a/fmt.go
+++ b/fmt.go
@@ -111,16 +111,11 @@ func (client *Client) Format(options *FmtOptions) (map[string]string, error) {
 	results := make(map[string]string, len(options.Files))
 
 	for _, path := range options.Files {
-		sql, err := parser.ReadSQLFile(path)
-		if err != nil {
-			return nil, err
-		}
-		result, err := parser.ParseSQLWithSchema(sql, defaultSchema)
+		result, err := parser.ParseSQLFileWithSchema(path, defaultSchema)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse SQL file %q: %w", path, err)
 		}
-		result.Comments, err = parser.ScanTopLevelComments(sql)
-		if err != nil {
+		if err := result.AttachComments(); err != nil {
 			return nil, fmt.Errorf("failed to scan comments in %q: %w", path, err)
 		}
 		results[path] = formatWithComments(result)

--- a/model/domain.go
+++ b/model/domain.go
@@ -64,7 +64,11 @@ func (d Domain) CommentSQL() string {
 }
 
 func DomainToSQL(d *Domain) string {
-	parts := []string{"-- " + d.FQDN(), d.SQL()}
+	return "-- " + d.FQDN() + "\n" + DomainToSQLBare(d)
+}
+
+func DomainToSQLBare(d *Domain) string {
+	parts := []string{d.SQL()}
 	if s := d.CommentSQL(); s != "" {
 		parts = append(parts, s)
 	}

--- a/model/domain.go
+++ b/model/domain.go
@@ -68,7 +68,7 @@ func DomainToSQL(d *Domain) string {
 }
 
 func DomainToSQLBare(d *Domain) string {
-	parts := []string{d.SQL()}
+	parts := []string{withDirectives(d.SQL(), renamedFromDirective(d.RenameFrom))}
 	if s := d.CommentSQL(); s != "" {
 		parts = append(parts, s)
 	}

--- a/model/enum.go
+++ b/model/enum.go
@@ -40,7 +40,7 @@ func EnumToSQL(e *Enum) string {
 }
 
 func EnumToSQLBare(e *Enum) string {
-	parts := []string{e.SQL()}
+	parts := []string{withDirectives(e.SQL(), renamedFromDirective(e.RenameFrom))}
 	if s := e.CommentSQL(); s != "" {
 		parts = append(parts, s)
 	}

--- a/model/enum.go
+++ b/model/enum.go
@@ -36,7 +36,11 @@ func (e Enum) CommentSQL() string {
 }
 
 func EnumToSQL(e *Enum) string {
-	parts := []string{"-- " + e.FQEN(), e.SQL()}
+	return "-- " + e.FQEN() + "\n" + EnumToSQLBare(e)
+}
+
+func EnumToSQLBare(e *Enum) string {
+	parts := []string{e.SQL()}
 	if s := e.CommentSQL(); s != "" {
 		parts = append(parts, s)
 	}

--- a/model/table.go
+++ b/model/table.go
@@ -79,10 +79,17 @@ func (t Table) SQL() string {
 					if col.NotNull && !col.Identity.IsIdentityColumn() {
 						q += " NOT NULL"
 					}
+					if col.RenameFrom != nil {
+						q = "    -- pist:renamed-from " + *col.RenameFrom + "\n" + q
+					}
 					return q
 				}),
 				orderedmap.TransformSlice(t.Constraints, func(_ string, con *Constraint) string {
-					return "    CONSTRAINT " + Ident(con.Name) + " " + con.Definition
+					q := "    CONSTRAINT " + Ident(con.Name) + " " + con.Definition
+					if con.RenameFrom != nil {
+						q = "    -- pist:renamed-from " + *con.RenameFrom + "\n" + q
+					}
+					return q
 				}),
 			),
 			",\n",

--- a/model/table.go
+++ b/model/table.go
@@ -128,7 +128,11 @@ func (t Table) CommentSQL() string {
 }
 
 func TableToSQL(t *Table) string {
-	parts := []string{"-- " + t.FQTN(), t.SQL()}
+	return "-- " + t.FQTN() + "\n" + TableToSQLBare(t)
+}
+
+func TableToSQLBare(t *Table) string {
+	parts := []string{t.SQL()}
 	if s := t.IdxSQL(); s != "" {
 		parts = append(parts, s)
 	}

--- a/model/table.go
+++ b/model/table.go
@@ -102,14 +102,18 @@ func (t Table) SQL() string {
 
 func (t Table) IdxSQL() string {
 	return strings.Join(
-		orderedmap.TransformSlice(t.Indexes, func(_ string, idx *Index) string { return idx.SQL() }),
+		orderedmap.TransformSlice(t.Indexes, func(_ string, idx *Index) string {
+			return withDirectives(idx.SQL(), renamedFromDirective(idx.RenameFrom), concurrentlyDirective(idx.Concurrently))
+		}),
 		"\n",
 	)
 }
 
 func (t Table) FkSQL() string {
 	return strings.Join(
-		orderedmap.TransformSlice(t.ForeignKeys, func(_ string, fk *ForeignKey) string { return fk.SQL() }),
+		orderedmap.TransformSlice(t.ForeignKeys, func(_ string, fk *ForeignKey) string {
+			return withDirectives(fk.SQL(), renamedFromDirective(fk.RenameFrom))
+		}),
 		"\n",
 	)
 }
@@ -132,7 +136,7 @@ func TableToSQL(t *Table) string {
 }
 
 func TableToSQLBare(t *Table) string {
-	parts := []string{t.SQL()}
+	parts := []string{withDirectives(t.SQL(), renamedFromDirective(t.RenameFrom))}
 	if s := t.IdxSQL(); s != "" {
 		parts = append(parts, s)
 	}

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -156,6 +156,38 @@ func TestTable_IdxSQL(t *testing.T) {
 	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING btree (name);", tbl.IdxSQL())
 }
 
+func TestTable_IdxSQL_withDirectives(t *testing.T) {
+	tbl := newTable("public", "users")
+	old := "old_idx"
+	tbl.Indexes.Set("idx_name", &Index{
+		Definition:   "CREATE INDEX idx_name ON public.users USING btree (name)",
+		Concurrently: true,
+		RenameFrom:   &old,
+	})
+	got := tbl.IdxSQL()
+	assert.Equal(t, "-- pist:renamed-from old_idx\n-- pist:concurrently\nCREATE INDEX idx_name ON public.users USING btree (name);", got)
+}
+
+func TestTable_FkSQL_renamed(t *testing.T) {
+	tbl := newTable("public", "orders")
+	old := "old_fk"
+	tbl.ForeignKeys.Set("fk_user", &ForeignKey{
+		Constraint: Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", RenameFrom: &old, Validated: true},
+		Schema:     "public",
+		Table:      "orders",
+	})
+	assert.Contains(t, tbl.FkSQL(), "-- pist:renamed-from old_fk\nALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user")
+}
+
+func TestTableToSQLBare_renamed(t *testing.T) {
+	tbl := newTable("public", "users")
+	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true})
+	old := "public.old_users"
+	tbl.RenameFrom = &old
+	got := TableToSQLBare(tbl)
+	assert.Contains(t, got, "-- pist:renamed-from public.old_users\nCREATE TABLE public.users")
+}
+
 func TestTable_IdxSQL_empty(t *testing.T) {
 	tbl := newTable("public", "users")
 	assert.Equal(t, "", tbl.IdxSQL())

--- a/model/util.go
+++ b/model/util.go
@@ -51,3 +51,32 @@ func quote(name string) string {
 func QuoteLiteral(s string) string {
 	return `'` + strings.ReplaceAll(s, `'`, `''`) + `'`
 }
+
+// withDirectives prepends pist:* directive lines (joined with \n) to sql.
+// Empty directive entries are skipped.
+func withDirectives(sql string, directives ...string) string {
+	var lines []string
+	for _, d := range directives {
+		if d != "" {
+			lines = append(lines, d)
+		}
+	}
+	if len(lines) == 0 {
+		return sql
+	}
+	return strings.Join(lines, "\n") + "\n" + sql
+}
+
+func renamedFromDirective(renameFrom *string) string {
+	if renameFrom == nil {
+		return ""
+	}
+	return "-- pist:renamed-from " + *renameFrom
+}
+
+func concurrentlyDirective(concurrently bool) string {
+	if !concurrently {
+		return ""
+	}
+	return "-- pist:concurrently"
+}

--- a/model/view.go
+++ b/model/view.go
@@ -46,10 +46,10 @@ func ViewToSQL(v *View) string {
 }
 
 func ViewToSQLBare(v *View) string {
-	parts := []string{v.SQL()}
+	parts := []string{withDirectives(v.SQL(), renamedFromDirective(v.RenameFrom))}
 	if v.Indexes != nil {
 		for _, idx := range v.Indexes.CollectValues() {
-			parts = append(parts, idx.SQL())
+			parts = append(parts, withDirectives(idx.SQL(), renamedFromDirective(idx.RenameFrom), concurrentlyDirective(idx.Concurrently)))
 		}
 	}
 	if s := v.CommentSQL(); s != "" {

--- a/model/view.go
+++ b/model/view.go
@@ -42,7 +42,11 @@ func (v View) CommentSQL() string {
 }
 
 func ViewToSQL(v *View) string {
-	parts := []string{"-- " + v.FQVN(), v.SQL()}
+	return "-- " + v.FQVN() + "\n" + ViewToSQLBare(v)
+}
+
+func ViewToSQLBare(v *View) string {
+	parts := []string{v.SQL()}
 	if v.Indexes != nil {
 		for _, idx := range v.Indexes.CollectValues() {
 			parts = append(parts, idx.SQL())

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -1,0 +1,173 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// CodeStart returns the offset of the first non-whitespace, non-comment
+// character at or after pos in sql. pg_query's StmtLocation lumps preceding
+// comments with the statement, so we use this to find the real start of the
+// SQL code (e.g. the "C" of "CREATE").
+func CodeStart(sql string, pos int32) int32 {
+	end := int32(len(sql))
+	i := pos
+	for i < end {
+		switch {
+		case sql[i] == ' ' || sql[i] == '\t' || sql[i] == '\n' || sql[i] == '\r':
+			i++
+		case i+1 < end && sql[i] == '-' && sql[i+1] == '-':
+			for i < end && sql[i] != '\n' {
+				i++
+			}
+		case i+1 < end && sql[i] == '/' && sql[i+1] == '*':
+			i += 2
+			for i+1 < end && (sql[i] != '*' || sql[i+1] != '/') {
+				i++
+			}
+			if i+1 < end {
+				i += 2
+			}
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+// filterTopLevelComments drops comments whose byte range falls inside any
+// parsed statement's actual code region (after leading comments are skipped).
+// Such comments (e.g. inline column comments) cannot be safely relocated.
+func filterTopLevelComments(sql string, comments []Comment, stmts []*pg_query.RawStmt) []Comment {
+	if len(comments) == 0 || len(stmts) == 0 {
+		return comments
+	}
+	type span struct{ start, end int32 }
+	spans := make([]span, 0, len(stmts))
+	for _, s := range stmts {
+		if s.StmtLen == 0 {
+			continue
+		}
+		spans = append(spans, span{
+			start: CodeStart(sql, s.StmtLocation),
+			end:   s.StmtLocation + s.StmtLen,
+		})
+	}
+	out := make([]Comment, 0, len(comments))
+	for _, c := range comments {
+		inside := false
+		for _, sp := range spans {
+			if c.Start >= sp.start && c.End <= sp.end {
+				inside = true
+				break
+			}
+		}
+		if !inside {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+type Comment struct {
+	Start int32
+	End   int32
+	Text  string
+}
+
+// ScanComments returns SQL line comments (--) and C-style block comments (/* */)
+// from sql, in source order, with byte offsets into sql.
+// Comments matching pistachio directives (-- pist:...) are filtered out.
+func ScanComments(sql string) ([]Comment, error) {
+	scan, err := pg_query.Scan(sql)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan SQL for comments: %w", err)
+	}
+
+	var out []Comment
+	for _, tok := range scan.Tokens {
+		if tok.Token != pg_query.Token_SQL_COMMENT && tok.Token != pg_query.Token_C_COMMENT {
+			continue
+		}
+		start, end := tok.Start, tok.End
+		if start < 0 || end > int32(len(sql)) || start >= end {
+			continue
+		}
+		text := sql[start:end]
+		if isDirectiveComment(text) {
+			continue
+		}
+		out = append(out, Comment{Start: start, End: end, Text: text})
+	}
+	return out, nil
+}
+
+func isDirectiveComment(text string) bool {
+	t := strings.TrimSpace(text)
+	if !strings.HasPrefix(t, "--") {
+		return false
+	}
+	t = strings.TrimSpace(strings.TrimPrefix(t, "--"))
+	return strings.HasPrefix(t, "pist:")
+}
+
+// commentStmtTargetFQN returns the FQN of the entity targeted by a COMMENT ON
+// statement. For COMMENT ON COLUMN/CONSTRAINT, the FQN of the parent table is
+// returned. The second return value is false if the target cannot be determined.
+func commentStmtTargetFQN(cs *pg_query.CommentStmt, defaultSchema string) (string, bool) {
+	switch cs.Objtype {
+	case pg_query.ObjectType_OBJECT_TYPE, pg_query.ObjectType_OBJECT_DOMAIN:
+		tn := cs.Object.GetTypeName()
+		if tn == nil {
+			return "", false
+		}
+		names := stringSvalNames(tn.Names)
+		if len(names) == 0 {
+			return "", false
+		}
+		return identFromQualified(names, defaultSchema), true
+	case pg_query.ObjectType_OBJECT_TABLE,
+		pg_query.ObjectType_OBJECT_VIEW,
+		pg_query.ObjectType_OBJECT_MATVIEW:
+		items := cs.Object.GetList().GetItems()
+		names := stringSvalNames(items)
+		if len(names) == 0 {
+			return "", false
+		}
+		return identFromQualified(names, defaultSchema), true
+	case pg_query.ObjectType_OBJECT_COLUMN:
+		items := cs.Object.GetList().GetItems()
+		names := stringSvalNames(items)
+		if len(names) < 2 {
+			return "", false
+		}
+		// names: [table, col] or [schema, table, col]
+		return identFromQualified(names[:len(names)-1], defaultSchema), true
+	}
+	return "", false
+}
+
+func stringSvalNames(nodes []*pg_query.Node) []string {
+	out := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		if s := n.GetString_(); s != nil {
+			out = append(out, s.Sval)
+		}
+	}
+	return out
+}
+
+// identFromQualified returns model.Ident(schema, name) given names of length 1
+// (uses defaultSchema) or 2 (schema-qualified).
+func identFromQualified(names []string, defaultSchema string) string {
+	schema := defaultSchema
+	name := names[0]
+	if len(names) >= 2 {
+		schema = names[0]
+		name = names[1]
+	}
+	return model.Ident(schema, name)
+}

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -115,39 +115,30 @@ func isDirectiveComment(text string) bool {
 }
 
 // commentStmtTargetFQN returns the FQN of the entity targeted by a COMMENT ON
-// statement. For COMMENT ON COLUMN/CONSTRAINT, the FQN of the parent table is
-// returned. The second return value is false if the target cannot be determined.
+// statement. For COMMENT ON COLUMN, the FQN of the parent table is returned.
+// The second return value is false if the objtype is not supported.
 func commentStmtTargetFQN(cs *pg_query.CommentStmt, defaultSchema string) (string, bool) {
+	var names []string
 	switch cs.Objtype {
 	case pg_query.ObjectType_OBJECT_TYPE, pg_query.ObjectType_OBJECT_DOMAIN:
-		tn := cs.Object.GetTypeName()
-		if tn == nil {
-			return "", false
-		}
-		names := stringSvalNames(tn.Names)
-		if len(names) == 0 {
-			return "", false
-		}
-		return identFromQualified(names, defaultSchema), true
+		names = stringSvalNames(cs.Object.GetTypeName().GetNames())
 	case pg_query.ObjectType_OBJECT_TABLE,
 		pg_query.ObjectType_OBJECT_VIEW,
 		pg_query.ObjectType_OBJECT_MATVIEW:
-		items := cs.Object.GetList().GetItems()
-		names := stringSvalNames(items)
-		if len(names) == 0 {
-			return "", false
-		}
-		return identFromQualified(names, defaultSchema), true
+		names = stringSvalNames(cs.Object.GetList().GetItems())
 	case pg_query.ObjectType_OBJECT_COLUMN:
-		items := cs.Object.GetList().GetItems()
-		names := stringSvalNames(items)
-		if len(names) < 2 {
-			return "", false
+		// names: [table, col] or [schema, table, col]; drop the column.
+		items := stringSvalNames(cs.Object.GetList().GetItems())
+		if len(items) >= 2 {
+			names = items[:len(items)-1]
 		}
-		// names: [table, col] or [schema, table, col]
-		return identFromQualified(names[:len(names)-1], defaultSchema), true
+	default:
+		return "", false
 	}
-	return "", false
+	if len(names) == 0 {
+		return "", false
+	}
+	return identFromQualified(names, defaultSchema), true
 }
 
 func stringSvalNames(nodes []*pg_query.Node) []string {

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -40,30 +40,36 @@ func CodeStart(sql string, pos int32) int32 {
 // filterTopLevelComments drops comments whose byte range falls inside any
 // parsed statement's actual code region (after leading comments are skipped).
 // Such comments (e.g. inline column comments) cannot be safely relocated.
+//
+// Both comments and spans are in source order, so the scan is a linear
+// two-pointer walk over them.
 func filterTopLevelComments(sql string, comments []Comment, stmts []*pg_query.RawStmt) []Comment {
 	if len(comments) == 0 || len(stmts) == 0 {
 		return comments
 	}
+	sqlLen := int32(len(sql))
 	type span struct{ start, end int32 }
 	spans := make([]span, 0, len(stmts))
 	for _, s := range stmts {
 		if s.StmtLen == 0 {
 			continue
 		}
+		end := s.StmtLocation + s.StmtLen
+		if end > sqlLen {
+			end = sqlLen
+		}
 		spans = append(spans, span{
 			start: CodeStart(sql, s.StmtLocation),
-			end:   s.StmtLocation + s.StmtLen,
+			end:   end,
 		})
 	}
 	out := make([]Comment, 0, len(comments))
+	spanIdx := 0
 	for _, c := range comments {
-		inside := false
-		for _, sp := range spans {
-			if c.Start >= sp.start && c.End <= sp.end {
-				inside = true
-				break
-			}
+		for spanIdx < len(spans) && spans[spanIdx].end < c.Start {
+			spanIdx++
 		}
+		inside := spanIdx < len(spans) && c.Start >= spans[spanIdx].start && c.End <= spans[spanIdx].end
 		if !inside {
 			out = append(out, c)
 		}

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -78,6 +78,22 @@ type Comment struct {
 	Text  string
 }
 
+// ScanTopLevelComments returns SQL comments that appear between (not inside)
+// top-level statements. pist:* directive comments are filtered out. This is a
+// separate pass from the main parser; callers that don't need comments (e.g.
+// plan/apply) should not invoke it.
+func ScanTopLevelComments(sql string) ([]Comment, error) {
+	parsed, err := pg_query.Parse(sql)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SQL: %w", err)
+	}
+	all, err := ScanComments(sql)
+	if err != nil {
+		return nil, err
+	}
+	return filterTopLevelComments(sql, all, parsed.Stmts), nil
+}
+
 // ScanComments returns SQL line comments (--) and C-style block comments (/* */)
 // from sql, in source order, with byte offsets into sql.
 // Comments matching pistachio directives (-- pist:...) are filtered out.

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/pistachio/model"
@@ -113,7 +112,7 @@ func ScanComments(sql string) ([]Comment, error) {
 			continue
 		}
 		text := sql[start:end]
-		if isDirectiveComment(text) {
+		if isPistDirectiveComment(text) {
 			continue
 		}
 		out = append(out, Comment{Start: start, End: end, Text: text})
@@ -121,13 +120,12 @@ func ScanComments(sql string) ([]Comment, error) {
 	return out, nil
 }
 
-func isDirectiveComment(text string) bool {
-	t := strings.TrimSpace(text)
-	if !strings.HasPrefix(t, "--") {
-		return false
-	}
-	t = strings.TrimSpace(strings.TrimPrefix(t, "--"))
-	return strings.HasPrefix(t, "pist:")
+// isPistDirectiveComment reports whether text is a `-- pist:*` directive line.
+// All such directives are re-emitted from the model layer (ExecuteStmts for
+// execute, *ToSQLBare for renamed-from/concurrently), so they are stripped
+// here to avoid duplication or position drift on `pist fmt -w` round-trips.
+func isPistDirectiveComment(text string) bool {
+	return anyDirectivePattern.MatchString(text)
 }
 
 // commentStmtTargetFQN returns the FQN of the entity targeted by a COMMENT ON

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -1,0 +1,92 @@
+package parser
+
+import (
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanComments_lineAndBlock(t *testing.T) {
+	sql := "-- line1\n/* block */\nCREATE TABLE x (id integer);\n"
+	cs, err := ScanComments(sql)
+	require.NoError(t, err)
+	require.Len(t, cs, 2)
+	assert.Equal(t, "-- line1", cs[0].Text)
+	assert.Equal(t, "/* block */", cs[1].Text)
+}
+
+func TestScanComments_filtersDirective(t *testing.T) {
+	sql := "-- pist:execute SELECT 1\n-- regular comment\nCREATE TABLE x (id integer);\n"
+	cs, err := ScanComments(sql)
+	require.NoError(t, err)
+	require.Len(t, cs, 1)
+	assert.Equal(t, "-- regular comment", cs[0].Text)
+}
+
+func TestCodeStart_skipsLeadingCommentsAndWhitespace(t *testing.T) {
+	sql := "-- header\n  /* note */\n\nCREATE TABLE x (id integer);"
+	pos := CodeStart(sql, 0)
+	assert.Equal(t, byte('C'), sql[pos])
+}
+
+func TestCodeStart_alreadyAtCode(t *testing.T) {
+	sql := "CREATE TABLE x (id integer);"
+	pos := CodeStart(sql, 0)
+	assert.Equal(t, int32(0), pos)
+}
+
+func TestFilterTopLevelComments_dropsInline(t *testing.T) {
+	sql := "-- top\nCREATE TABLE x (\n  id integer, -- inline\n  name text\n);\n"
+	cs, err := ScanComments(sql)
+	require.NoError(t, err)
+	require.Len(t, cs, 2)
+
+	parsed, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+	filtered := filterTopLevelComments(sql, cs, parsed.Stmts)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "-- top", filtered[0].Text)
+}
+
+func TestFilterTopLevelComments_keepsBetweenStmts(t *testing.T) {
+	sql := "CREATE TABLE a (id integer);\n-- between\nCREATE TABLE b (id integer);\n"
+	cs, err := ScanComments(sql)
+	require.NoError(t, err)
+	parsed, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+	filtered := filterTopLevelComments(sql, cs, parsed.Stmts)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "-- between", filtered[0].Text)
+}
+
+func TestCommentStmtTargetFQN(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want string
+		ok   bool
+	}{
+		{"table", "COMMENT ON TABLE public.users IS 'x';", "public.users", true},
+		{"table_unqualified", "COMMENT ON TABLE users IS 'x';", "public.users", true},
+		{"view", "COMMENT ON VIEW public.v IS 'x';", "public.v", true},
+		{"matview", "COMMENT ON MATERIALIZED VIEW public.mv IS 'x';", "public.mv", true},
+		{"column", "COMMENT ON COLUMN public.users.name IS 'x';", "public.users", true},
+		{"type", "COMMENT ON TYPE public.status IS 'x';", "public.status", true},
+		{"domain", "COMMENT ON DOMAIN public.pos_int IS 'x';", "public.pos_int", true},
+		{"unsupported_function", "COMMENT ON FUNCTION public.f() IS 'x';", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := pg_query.Parse(tc.sql)
+			require.NoError(t, err)
+			require.NotEmpty(t, parsed.Stmts)
+			cs := parsed.Stmts[0].Stmt.GetCommentStmt()
+			require.NotNil(t, cs)
+			got, ok := commentStmtTargetFQN(cs, "public")
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -36,6 +36,22 @@ func TestScanComments_invalidSQL(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to scan SQL for comments")
 }
 
+func TestScanTopLevelComments(t *testing.T) {
+	sql := "-- top\nCREATE TABLE x (\n  id integer, -- inline\n  name text\n);\n-- after\n"
+	cs, err := ScanTopLevelComments(sql)
+	require.NoError(t, err)
+	got := make([]string, len(cs))
+	for i, c := range cs {
+		got[i] = c.Text
+	}
+	assert.Equal(t, []string{"-- top", "-- after"}, got)
+}
+
+func TestScanTopLevelComments_invalidSQL(t *testing.T) {
+	_, err := ScanTopLevelComments("/* unterminated")
+	require.Error(t, err)
+}
+
 func TestCodeStart_skipsLeadingCommentsAndWhitespace(t *testing.T) {
 	sql := "-- header\n  /* note */\n\nCREATE TABLE x (id integer);"
 	pos := CodeStart(sql, 0)

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -94,6 +94,14 @@ func TestFilterTopLevelComments_keepsBetweenStmts(t *testing.T) {
 	assert.Equal(t, "-- between", filtered[0].Text)
 }
 
+func TestFilterTopLevelComments_emptyInputs(t *testing.T) {
+	parsed, err := pg_query.Parse("CREATE TABLE x (id integer);")
+	require.NoError(t, err)
+	assert.Empty(t, filterTopLevelComments("CREATE TABLE x (id integer);", nil, parsed.Stmts))
+	assert.Equal(t, []Comment{{Start: 0, End: 7, Text: "-- foo"}},
+		filterTopLevelComments("-- foo", []Comment{{Start: 0, End: 7, Text: "-- foo"}}, nil))
+}
+
 func TestCommentStmtTargetFQN(t *testing.T) {
 	cases := []struct {
 		name string

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -17,8 +17,13 @@ func TestScanComments_lineAndBlock(t *testing.T) {
 	assert.Equal(t, "/* block */", cs[1].Text)
 }
 
-func TestScanComments_filtersDirective(t *testing.T) {
-	sql := "-- pist:execute SELECT 1\n-- regular comment\nCREATE TABLE x (id integer);\n"
+func TestScanComments_filtersAllPistDirectives(t *testing.T) {
+	sql := `-- pist:execute SELECT 1
+-- pist:renamed-from old_name
+-- pist:concurrently
+-- regular comment
+CREATE TABLE x (id integer);
+`
 	cs, err := ScanComments(sql)
 	require.NoError(t, err)
 	require.Len(t, cs, 1)

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -25,6 +25,12 @@ func TestScanComments_filtersDirective(t *testing.T) {
 	assert.Equal(t, "-- regular comment", cs[0].Text)
 }
 
+func TestScanComments_invalidSQL(t *testing.T) {
+	_, err := ScanComments("/* unterminated")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to scan SQL for comments")
+}
+
 func TestCodeStart_skipsLeadingCommentsAndWhitespace(t *testing.T) {
 	sql := "-- header\n  /* note */\n\nCREATE TABLE x (id integer);"
 	pos := CodeStart(sql, 0)
@@ -35,6 +41,12 @@ func TestCodeStart_alreadyAtCode(t *testing.T) {
 	sql := "CREATE TABLE x (id integer);"
 	pos := CodeStart(sql, 0)
 	assert.Equal(t, int32(0), pos)
+}
+
+func TestCodeStart_runsToEnd(t *testing.T) {
+	sql := "-- only comments\n  /* and whitespace */\n"
+	pos := CodeStart(sql, 0)
+	assert.Equal(t, int32(len(sql)), pos)
 }
 
 func TestFilterTopLevelComments_dropsInline(t *testing.T) {

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -51,6 +51,8 @@ func ValidateDirectives(rawSQL string) error {
 type ExecuteStmt struct {
 	SQL      string // The SQL statement to execute
 	CheckSQL string // Optional condition check SQL (empty = always execute)
+	Location int32  // Source position of the executed statement's CREATE keyword
+	StmtEnd  int32  // Source position of the executed statement's end
 }
 
 // ExtractExecuteDirectives scans raw SQL for `-- pist:execute [<check SQL>]`
@@ -98,6 +100,8 @@ func ExtractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*Exec
 		executeStmts = append(executeStmts, &ExecuteStmt{
 			SQL:      deparsed,
 			CheckSQL: checkSQL,
+			Location: CodeStart(rawSQL, loc),
+			StmtEnd:  end,
 		})
 		skipLocations[loc] = true
 	}

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -51,7 +51,7 @@ func ValidateDirectives(rawSQL string) error {
 type ExecuteStmt struct {
 	SQL      string // The SQL statement to execute
 	CheckSQL string // Optional condition check SQL (empty = always execute)
-	Location int32  // Source position of the executed statement's CREATE keyword
+	Location int32  // Source position of the executed statement's start, after leading comments
 	StmtEnd  int32  // Source position of the executed statement's end
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11,12 +11,31 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
+type EntityKind string
+
+const (
+	EntityKindEnum   EntityKind = "enum"
+	EntityKindDomain EntityKind = "domain"
+	EntityKindTable  EntityKind = "table"
+	EntityKindView   EntityKind = "view"
+)
+
+type EntityRef struct {
+	Kind         EntityKind
+	FQN          string
+	Location     int32 // start of CREATE keyword (after any leading comments)
+	StmtEnd      int32 // end of own CREATE statement
+	OwnershipEnd int32 // end of last owned statement (CREATE INDEX, ALTER TABLE, COMMENT ON)
+}
+
 type ParseResult struct {
 	Tables       *orderedmap.Map[string, *model.Table]
 	Views        *orderedmap.Map[string, *model.View]
 	Enums        *orderedmap.Map[string, *model.Enum]
 	Domains      *orderedmap.Map[string, *model.Domain]
 	ExecuteStmts []*ExecuteStmt
+	Order        []EntityRef
+	Comments     []Comment
 }
 
 func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error {
@@ -95,6 +114,37 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	views := orderedmap.New[string, *model.View]()
 	enums := orderedmap.New[string, *model.Enum]()
 	domains := orderedmap.New[string, *model.Domain]()
+	var order []EntityRef
+	orderIdx := map[string]int{}
+
+	stmtEnd := func(raw *pg_query.RawStmt) int32 {
+		end := raw.StmtLocation + raw.StmtLen
+		if end > int32(len(sql)) {
+			end = int32(len(sql))
+		}
+		return end
+	}
+	recordEntity := func(kind EntityKind, fqn string, raw *pg_query.RawStmt) {
+		end := stmtEnd(raw)
+		order = append(order, EntityRef{
+			Kind:         kind,
+			FQN:          fqn,
+			Location:     CodeStart(sql, raw.StmtLocation),
+			StmtEnd:      end,
+			OwnershipEnd: end,
+		})
+		orderIdx[fqn] = len(order) - 1
+	}
+	extendOwnership := func(fqn string, raw *pg_query.RawStmt) {
+		i, ok := orderIdx[fqn]
+		if !ok {
+			return
+		}
+		end := stmtEnd(raw)
+		if end > order[i].OwnershipEnd {
+			order[i].OwnershipEnd = end
+		}
+	}
 
 	stmtDirectives := ExtractStmtDirectives(sql, result.Stmts)
 	concurrentlyDirectives := ExtractConcurrentlyDirectives(sql, result.Stmts)
@@ -125,6 +175,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if err := setUnique(enums, enum.FQEN(), "enum", enum); err != nil {
 				return nil, err
 			}
+			recordEntity(EntityKindEnum, enum.FQEN(), rawStmt)
 
 		case node.GetCreateDomainStmt() != nil:
 			domain, err := parseCreateDomainStmt(node.GetCreateDomainStmt(), rawStmt, defaultSchema)
@@ -138,6 +189,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if err := setUnique(domains, domain.FQDN(), "domain", domain); err != nil {
 				return nil, err
 			}
+			recordEntity(EntityKindDomain, domain.FQDN(), rawStmt)
 
 		case node.GetCreateStmt() != nil:
 			table, err := parseCreateStmt(node.GetCreateStmt(), defaultSchema)
@@ -175,6 +227,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if err := setUnique(tables, table.FQTN(), "table", table); err != nil {
 				return nil, err
 			}
+			recordEntity(EntityKindTable, table.FQTN(), rawStmt)
 
 		case node.GetViewStmt() != nil:
 			view, err := parseViewStmt(node.GetViewStmt(), defaultSchema)
@@ -188,6 +241,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if err := setUnique(views, view.FQVN(), "view", view); err != nil {
 				return nil, err
 			}
+			recordEntity(EntityKindView, view.FQVN(), rawStmt)
 
 		case node.GetCreateTableAsStmt() != nil:
 			as := node.GetCreateTableAsStmt()
@@ -203,6 +257,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				if err := setUnique(views, view.FQVN(), "materialized view", view); err != nil {
 					return nil, err
 				}
+				recordEntity(EntityKindView, view.FQVN(), rawStmt)
 			}
 
 		case node.GetIndexStmt() != nil:
@@ -222,10 +277,12 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				if err := setUnique(t.Indexes, idx.Name, "index", idx); err != nil {
 					return nil, err
 				}
+				extendOwnership(fqtn, rawStmt)
 			} else if v, ok := views.GetOk(fqtn); ok && v.Materialized {
 				if err := setUnique(v.Indexes, idx.Name, "index", idx); err != nil {
 					return nil, err
 				}
+				extendOwnership(fqtn, rawStmt)
 			}
 
 		case node.GetAlterTableStmt() != nil:
@@ -252,6 +309,7 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				if err := setUnique(t.ForeignKeys, fk.Name, "foreign key", fk); err != nil {
 					return nil, err
 				}
+				extendOwnership(fqtn, rawStmt)
 			} else if con != nil {
 				if renameFrom != "" {
 					unquoted := normalizeUnqualifiedDirective(renameFrom)
@@ -260,15 +318,33 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				if err := setUnique(t.Constraints, con.Name, "constraint", con); err != nil {
 					return nil, err
 				}
+				extendOwnership(fqtn, rawStmt)
 			}
 
 		case node.GetCommentStmt() != nil:
 			cs := node.GetCommentStmt()
 			parseCommentStmt(cs, defaultSchema, tables, views, enums, domains)
+			if fqn, ok := commentStmtTargetFQN(cs, defaultSchema); ok {
+				extendOwnership(fqn, rawStmt)
+			}
 		}
 	}
 
-	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains, ExecuteStmts: executeStmts}, nil
+	allComments, err := ScanComments(sql)
+	if err != nil {
+		return nil, err
+	}
+	comments := filterTopLevelComments(sql, allComments, result.Stmts)
+
+	return &ParseResult{
+		Tables:       tables,
+		Views:        views,
+		Enums:        enums,
+		Domains:      domains,
+		ExecuteStmts: executeStmts,
+		Order:        order,
+		Comments:     comments,
+	}, nil
 }
 
 func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Table, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -330,12 +330,6 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		}
 	}
 
-	allComments, err := ScanComments(sql)
-	if err != nil {
-		return nil, err
-	}
-	comments := filterTopLevelComments(sql, allComments, result.Stmts)
-
 	return &ParseResult{
 		Tables:       tables,
 		Views:        views,
@@ -343,7 +337,6 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		Domains:      domains,
 		ExecuteStmts: executeStmts,
 		Order:        order,
-		Comments:     comments,
 	}, nil
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -36,6 +36,21 @@ type ParseResult struct {
 	ExecuteStmts []*ExecuteStmt
 	Order        []EntityRef
 	Comments     []Comment
+
+	rawSQL   string
+	rawStmts []*pg_query.RawStmt
+}
+
+// AttachComments scans top-level comments from the SQL that produced r and
+// stores them in r.Comments. It reuses the parse tree captured during the
+// original ParseSQLWithSchema call, so no second pg_query.Parse pass is needed.
+func (r *ParseResult) AttachComments() error {
+	all, err := ScanComments(r.rawSQL)
+	if err != nil {
+		return err
+	}
+	r.Comments = filterTopLevelComments(r.rawSQL, all, r.rawStmts)
+	return nil
 }
 
 func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error {
@@ -337,6 +352,8 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		Domains:      domains,
 		ExecuteStmts: executeStmts,
 		Order:        order,
+		rawSQL:       sql,
+		rawStmts:     result.Stmts,
 	}, nil
 }
 

--- a/test/scenario/testdata/fmt/formatted.sql
+++ b/test/scenario/testdata/fmt/formatted.sql
@@ -1,15 +1,12 @@
--- public.status
 CREATE TYPE public.status AS ENUM (
     'active',
     'inactive',
     'pending'
 );
 
--- public.pos_int
 CREATE DOMAIN public.pos_int AS integer
     CONSTRAINT pos_check CHECK (value > 0);
 
--- public.users
 CREATE TABLE public.users (
     id integer NOT NULL,
     name text NOT NULL,
@@ -19,6 +16,5 @@ CREATE TABLE public.users (
 );
 CREATE INDEX idx_users_name ON public.users USING btree (name);
 
--- public.active_users
 CREATE OR REPLACE VIEW public.active_users AS
 SELECT id, name FROM public.users WHERE status = 'active'::public.status;

--- a/testdata/fmt/comments_around_alter.yml
+++ b/testdata/fmt/comments_around_alter.yml
@@ -1,0 +1,18 @@
+input: |
+  CREATE TABLE public.a (id integer NOT NULL, CONSTRAINT a_pkey PRIMARY KEY (id));
+  CREATE TABLE public.b (id integer NOT NULL, CONSTRAINT b_pkey PRIMARY KEY (id));
+  -- foreign key from b to a
+  ALTER TABLE public.b ADD CONSTRAINT b_a_fk FOREIGN KEY (id) REFERENCES public.a(id);
+expected: |
+  CREATE TABLE public.a (
+      id integer NOT NULL,
+      CONSTRAINT a_pkey PRIMARY KEY (id)
+  );
+
+  CREATE TABLE public.b (
+      id integer NOT NULL,
+      CONSTRAINT b_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE ONLY public.b ADD CONSTRAINT b_a_fk FOREIGN KEY (id) REFERENCES public.a (id);
+  -- foreign key from b to a

--- a/testdata/fmt/comments_around_column_comment.yml
+++ b/testdata/fmt/comments_around_column_comment.yml
@@ -1,0 +1,18 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, name text, CONSTRAINT users_pkey PRIMARY KEY (id));
+  -- describe name column
+  COMMENT ON COLUMN public.users.name IS 'display name';
+  CREATE TABLE public.posts (id integer NOT NULL, CONSTRAINT posts_pkey PRIMARY KEY (id));
+expected: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  COMMENT ON COLUMN public.users.name IS 'display name';
+  -- describe name column
+
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );

--- a/testdata/fmt/comments_around_comment_on.yml
+++ b/testdata/fmt/comments_around_comment_on.yml
@@ -1,0 +1,17 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  -- describe users
+  COMMENT ON TABLE public.users IS 'app users';
+  CREATE TABLE public.posts (id integer NOT NULL, CONSTRAINT posts_pkey PRIMARY KEY (id));
+expected: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  COMMENT ON TABLE public.users IS 'app users';
+  -- describe users
+
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );

--- a/testdata/fmt/comments_around_execute.yml
+++ b/testdata/fmt/comments_around_execute.yml
@@ -1,0 +1,25 @@
+input: |
+  CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  -- describe my_func
+  -- pist:execute SELECT true
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+  -- after my_func
+  CREATE TABLE public.posts (id integer NOT NULL, CONSTRAINT posts_pkey PRIMARY KEY (id));
+  -- end of file
+expected: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- describe my_func
+  -- pist:execute SELECT true
+  CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+
+  -- after my_func
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  -- end of file

--- a/testdata/fmt/comments_around_index.yml
+++ b/testdata/fmt/comments_around_index.yml
@@ -1,0 +1,19 @@
+input: |
+  CREATE TABLE public.a (id integer NOT NULL, CONSTRAINT a_pkey PRIMARY KEY (id));
+  -- index for a
+  CREATE INDEX a_idx ON public.a (id);
+  -- before b
+  CREATE TABLE public.b (id integer NOT NULL, CONSTRAINT b_pkey PRIMARY KEY (id));
+expected: |
+  CREATE TABLE public.a (
+      id integer NOT NULL,
+      CONSTRAINT a_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX a_idx ON public.a USING btree (id);
+  -- index for a
+
+  -- before b
+  CREATE TABLE public.b (
+      id integer NOT NULL,
+      CONSTRAINT b_pkey PRIMARY KEY (id)
+  );

--- a/testdata/fmt/comments_around_matview.yml
+++ b/testdata/fmt/comments_around_matview.yml
@@ -1,0 +1,15 @@
+input: |
+  -- daily summary
+  CREATE MATERIALIZED VIEW public.daily AS SELECT 1 AS n;
+  -- index for daily
+  CREATE INDEX daily_n_idx ON public.daily (n);
+  -- desc
+  COMMENT ON MATERIALIZED VIEW public.daily IS 'rollup';
+expected: |
+  -- daily summary
+  CREATE MATERIALIZED VIEW public.daily AS
+  SELECT 1 AS n;
+  CREATE INDEX daily_n_idx ON public.daily USING btree (n);
+  COMMENT ON MATERIALIZED VIEW public.daily IS 'rollup';
+  -- index for daily
+  -- desc

--- a/testdata/fmt/comments_basic.yml
+++ b/testdata/fmt/comments_basic.yml
@@ -1,0 +1,25 @@
+input: |
+  -- file header
+  -- second line of header
+  -- users table
+  CREATE TABLE public.users (id integer NOT NULL, name text NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  /* posts table */
+  CREATE TABLE public.posts (id integer NOT NULL, CONSTRAINT posts_pkey PRIMARY KEY (id));
+  -- trailing
+expected: |
+  -- file header
+  -- second line of header
+  -- users table
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  /* posts table */
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  -- trailing

--- a/testdata/fmt/comments_block.yml
+++ b/testdata/fmt/comments_block.yml
@@ -1,0 +1,32 @@
+input: |
+  /* file header
+     with multiple
+     lines */
+  CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  /* between table and index */
+  CREATE INDEX users_id_idx ON public.users (id);
+  /* multi-line
+     leading for posts */
+  -- mixed with line comment
+  CREATE TABLE public.posts (id integer NOT NULL, CONSTRAINT posts_pkey PRIMARY KEY (id));
+  /* trailing block */
+expected: |
+  /* file header
+     with multiple
+     lines */
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_id_idx ON public.users USING btree (id);
+  /* between table and index */
+
+  /* multi-line
+     leading for posts */
+  -- mixed with line comment
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  /* trailing block */

--- a/testdata/fmt/comments_each_kind.yml
+++ b/testdata/fmt/comments_each_kind.yml
@@ -1,0 +1,29 @@
+input: |
+  -- enum
+  CREATE TYPE public.status AS ENUM ('on','off');
+  -- domain
+  CREATE DOMAIN public.pos_int AS integer CHECK (VALUE > 0);
+  -- table
+  CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  -- view
+  CREATE VIEW public.active AS SELECT id FROM public.users;
+expected: |
+  -- enum
+  CREATE TYPE public.status AS ENUM (
+      'on',
+      'off'
+  );
+
+  -- domain
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_int_check CHECK (value > 0);
+
+  -- table
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- view
+  CREATE OR REPLACE VIEW public.active AS
+  SELECT id FROM public.users;

--- a/testdata/fmt/comments_inline_dropped.yml
+++ b/testdata/fmt/comments_inline_dropped.yml
@@ -1,5 +1,9 @@
 input: |
-  CREATE TABLE public.users (id integer NOT NULL, name text NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+  CREATE TABLE public.users (
+    id integer NOT NULL, -- inline column comment
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
 expected: |
   CREATE TABLE public.users (
       id integer NOT NULL,

--- a/testdata/fmt/comments_multiple_children.yml
+++ b/testdata/fmt/comments_multiple_children.yml
@@ -1,0 +1,28 @@
+input: |
+  CREATE TABLE public.a (id integer NOT NULL, name text, CONSTRAINT a_pkey PRIMARY KEY (id));
+  -- index 1
+  CREATE INDEX a_id_idx ON public.a (id);
+  -- index 2
+  CREATE INDEX a_name_idx ON public.a (name);
+  -- table comment
+  COMMENT ON TABLE public.a IS 'aaa';
+  -- next
+  CREATE TABLE public.b (id integer NOT NULL, CONSTRAINT b_pkey PRIMARY KEY (id));
+expected: |
+  CREATE TABLE public.a (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT a_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX a_id_idx ON public.a USING btree (id);
+  CREATE INDEX a_name_idx ON public.a USING btree (name);
+  COMMENT ON TABLE public.a IS 'aaa';
+  -- index 1
+  -- index 2
+  -- table comment
+
+  -- next
+  CREATE TABLE public.b (
+      id integer NOT NULL,
+      CONSTRAINT b_pkey PRIMARY KEY (id)
+  );

--- a/testdata/fmt/comments_only.yml
+++ b/testdata/fmt/comments_only.yml
@@ -1,0 +1,6 @@
+input: |
+  -- just a comment
+  -- no entities
+expected: |
+  -- just a comment
+  -- no entities

--- a/testdata/fmt/comments_with_directives.yml
+++ b/testdata/fmt/comments_with_directives.yml
@@ -1,8 +1,10 @@
 input: |
+  -- regular header
   CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
   -- pist:execute SELECT true
   CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
 expected: |
+  -- regular header
   CREATE TABLE public.users (
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)

--- a/testdata/fmt/directives_inline_renamed.yml
+++ b/testdata/fmt/directives_inline_renamed.yml
@@ -1,0 +1,16 @@
+input: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from old_name
+      name text NOT NULL,
+      -- pist:renamed-from old_pkey
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+expected: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from old_name
+      name text NOT NULL,
+      -- pist:renamed-from old_pkey
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/fmt/directives_renamed_concurrently.yml
+++ b/testdata/fmt/directives_renamed_concurrently.yml
@@ -1,0 +1,21 @@
+input: |
+  -- pist:renamed-from old_users
+  CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
+
+  -- pist:concurrently
+  CREATE INDEX users_id_idx ON public.users (id);
+
+  -- pist:renamed-from public.old_view
+  CREATE VIEW public.active AS SELECT id FROM public.users;
+expected: |
+  -- pist:renamed-from public.old_users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pist:concurrently
+  CREATE INDEX users_id_idx ON public.users USING btree (id);
+
+  -- pist:renamed-from public.old_view
+  CREATE OR REPLACE VIEW public.active AS
+  SELECT id FROM public.users;

--- a/testdata/fmt/domain.yml
+++ b/testdata/fmt/domain.yml
@@ -1,6 +1,5 @@
 input: |
   CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
 expected: |
-  -- public.pos_int
   CREATE DOMAIN public.pos_int AS integer
       CONSTRAINT pos_check CHECK (value > 0);

--- a/testdata/fmt/domain_with_enum.yml
+++ b/testdata/fmt/domain_with_enum.yml
@@ -2,12 +2,10 @@ input: |
   CREATE DOMAIN public.user_status AS public.status CONSTRAINT status_check CHECK (VALUE <> 'inactive'::status);
   CREATE TYPE public.status AS ENUM ('active', 'inactive');
 expected: |
-  -- public.status
+  CREATE DOMAIN public.user_status AS public.status
+      CONSTRAINT status_check CHECK (value <> 'inactive'::status);
+
   CREATE TYPE public.status AS ENUM (
       'active',
       'inactive'
   );
-
-  -- public.user_status
-  CREATE DOMAIN public.user_status AS public.status
-      CONSTRAINT status_check CHECK (value <> 'inactive'::status);

--- a/testdata/fmt/enum.yml
+++ b/testdata/fmt/enum.yml
@@ -1,7 +1,6 @@
 input: |
   CREATE TYPE public.status AS ENUM ('active','inactive','pending');
 expected: |
-  -- public.status
   CREATE TYPE public.status AS ENUM (
       'active',
       'inactive',

--- a/testdata/fmt/matview.yml
+++ b/testdata/fmt/matview.yml
@@ -3,13 +3,11 @@ input: |
   CREATE MATERIALIZED VIEW public.user_stats AS SELECT count(*) AS cnt FROM public.users;
   CREATE INDEX idx_user_stats_cnt ON public.user_stats (cnt);
 expected: |
-  -- public.users
   CREATE TABLE public.users (
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 
-  -- public.user_stats
   CREATE MATERIALIZED VIEW public.user_stats AS
   SELECT count(*) AS cnt FROM public.users;
   CREATE INDEX idx_user_stats_cnt ON public.user_stats USING btree (cnt);

--- a/testdata/fmt/mixed.yml
+++ b/testdata/fmt/mixed.yml
@@ -3,19 +3,16 @@ input: |
   CREATE TYPE public.status AS ENUM ('active','inactive');
   CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE name IS NOT NULL;
 expected: |
-  -- public.status
-  CREATE TYPE public.status AS ENUM (
-      'active',
-      'inactive'
-  );
-
-  -- public.users
   CREATE TABLE public.users (
       id integer NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 
-  -- public.active_users
+  CREATE TYPE public.status AS ENUM (
+      'active',
+      'inactive'
+  );
+
   CREATE OR REPLACE VIEW public.active_users AS
   SELECT id, name FROM public.users WHERE name IS NOT NULL;

--- a/testdata/fmt/multiple_enums.yml
+++ b/testdata/fmt/multiple_enums.yml
@@ -2,13 +2,11 @@ input: |
   CREATE TYPE public.status AS ENUM ('active', 'inactive');
   CREATE TYPE public.role AS ENUM ('admin', 'user', 'guest');
 expected: |
-  -- public.status
   CREATE TYPE public.status AS ENUM (
       'active',
       'inactive'
   );
 
-  -- public.role
   CREATE TYPE public.role AS ENUM (
       'admin',
       'user',

--- a/testdata/fmt/multiple_views.yml
+++ b/testdata/fmt/multiple_views.yml
@@ -3,17 +3,14 @@ input: |
   CREATE VIEW public.active_users AS SELECT id, name FROM public.users WHERE name IS NOT NULL;
   CREATE VIEW public.user_ids AS SELECT id FROM public.users;
 expected: |
-  -- public.users
   CREATE TABLE public.users (
       id integer NOT NULL,
       name text NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 
-  -- public.active_users
   CREATE OR REPLACE VIEW public.active_users AS
   SELECT id, name FROM public.users WHERE name IS NOT NULL;
 
-  -- public.user_ids
   CREATE OR REPLACE VIEW public.user_ids AS
   SELECT id FROM public.users;

--- a/testdata/fmt/table_check_unique_default.yml
+++ b/testdata/fmt/table_check_unique_default.yml
@@ -1,7 +1,6 @@
 input: |
   CREATE TABLE public.products (id integer NOT NULL, name text NOT NULL DEFAULT 'unnamed', price integer NOT NULL, CONSTRAINT products_pkey PRIMARY KEY (id), CONSTRAINT products_name_key UNIQUE (name), CONSTRAINT products_price_check CHECK (price > 0));
 expected: |
-  -- public.products
   CREATE TABLE public.products (
       id integer NOT NULL,
       name text DEFAULT 'unnamed' NOT NULL,

--- a/testdata/fmt/view.yml
+++ b/testdata/fmt/view.yml
@@ -2,12 +2,10 @@ input: |
   CREATE TABLE public.users (id integer NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id));
   CREATE VIEW public.active_users AS SELECT id FROM public.users;
 expected: |
-  -- public.users
   CREATE TABLE public.users (
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 
-  -- public.active_users
   CREATE OR REPLACE VIEW public.active_users AS
   SELECT id FROM public.users;

--- a/testdata/fmt/with_index_and_fk.yml
+++ b/testdata/fmt/with_index_and_fk.yml
@@ -4,13 +4,11 @@ input: |
   CREATE INDEX idx_posts_user_id ON public.posts (user_id);
   ALTER TABLE public.posts ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);
 expected: |
-  -- public.users
   CREATE TABLE public.users (
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 
-  -- public.posts
   CREATE TABLE public.posts (
       id integer NOT NULL,
       user_id integer NOT NULL,


### PR DESCRIPTION
## Summary
- `pist fmt` keeps `--` and `/* */` comments that appear between top-level statements.
- Comments are attached to the entity that owns the surrounding region: a comment inside an entity's ownership range (its `CREATE` plus associated `CREATE INDEX` / `ALTER TABLE ADD CONSTRAINT` / `COMMENT ON`) becomes that entity's trailing; otherwise it becomes the next entity's leading.
- The auto-generated `-- public.foo` header is no longer emitted by `fmt` (dump output is unchanged).

## How it works
- `parser.ScanComments` uses `pg_query.Scan` to recover comment tokens (`SQL_COMMENT` / `C_COMMENT`) with byte offsets, since they are not present in the parse tree.
- `EntityRef` now tracks `Location` (start of the `CREATE` keyword), `StmtEnd`, and `OwnershipEnd`. Non-entity stmts (`CREATE INDEX`, `ALTER TABLE ADD ...`, `COMMENT ON ...`) extend their target entity's `OwnershipEnd`.
- `formatWithComments` walks entities in source order, emitting leading + bare SQL + trailing for each, plus any file-trailing comments at the end.
- `model.{Table,View,Enum,Domain}ToSQLBare` are new variants without the `-- FQN` header; `*ToSQL` still produces the header for `dump`.

## Limitations
- Comments inside a `CREATE` body (e.g. inline column comments) are dropped because pg_query discards them before producing the parse tree.
- Within an entity's ownership range, comments are emitted at the end of the entity block rather than at their original position between sub-statements.

## Test plan
- [x] `make test` (parser, model, diff, dump, apply, plan, root, toposort)
- [x] `make lint`
- [x] `bash test/scenario/fmt.test.sh`
- New fixtures: comments_basic, comments_block, comments_inline_dropped, comments_with_directives, comments_around_index, comments_around_alter, comments_around_comment_on, comments_around_column_comment, comments_around_matview, comments_multiple_children, comments_only, comments_each_kind
- New unit tests: ScanComments / CodeStart / filterTopLevelComments / commentStmtTargetFQN

🤖 Generated with [Claude Code](https://claude.com/claude-code)