### PR TITLE
Add --concurrently-pre-sql option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2026-04-28
+
+* Add `--concurrently-pre-sql` / `--concurrently-pre-sql-file` option to run SQL (e.g. `SET lock_timeout`) before CONCURRENTLY index DDL. ([#121](https://github.com/winebarrel/pistachio/pull/121))
+
 ## [1.0.0] - 2026-04-28
 
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ CREATE INDEX CONCURRENTLY idx_users_email ON public.users USING btree (email);
 CREATE INDEX idx_users_id ON public.users USING btree (id);
 ```
 
+Use `--concurrently-pre-sql` (or `--concurrently-pre-sql-file`) to run SQL — typically `SET lock_timeout = '...'` — before any `CONCURRENTLY` index DDL. The SQL is only emitted/executed when the plan actually contains `CREATE/DROP INDEX CONCURRENTLY`, so it's safe to set unconditionally. Because `SET` is session-scoped and `CONCURRENTLY` runs outside a transaction, the value carries over to every subsequent `CONCURRENTLY` statement in the same `apply`. Also available as `$PIST_CONCURRENTLY_PRE_SQL` / `$PIST_CONCURRENTLY_PRE_SQL_FILE`.
+
+```bash
+pist apply schema.sql --concurrently-pre-sql "SET lock_timeout = '5s';"
+```
+
 Use `--disable-index-concurrently` to ignore all `CONCURRENTLY` opt-ins (both inline and directive) and emit plain `CREATE INDEX` / `DROP INDEX` instead. Useful when you want to keep the directives / inline `CONCURRENTLY` in your schema files but run a one-off plan/apply inside a transaction. Also available as `$PIST_DISABLE_INDEX_CONCURRENTLY`.
 
 ```bash

--- a/apply.go
+++ b/apply.go
@@ -16,7 +16,7 @@ type ApplyOptions struct {
 	Files                    []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQL                   string   `xor:"pre-sql" env:"PIST_PRE_SQL" help:"SQL to execute before applying changes."`
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PIST_PRE_SQL_FILE" help:"Path to a SQL file to execute before applying changes."`
-	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index operations (e.g. SET lock_timeout). Only run when the plan contains CONCURRENTLY index DDL; runs outside any transaction."`
+	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index operations (e.g. SET lock_timeout). Only run when the diff includes CONCURRENTLY index DDL; runs outside any transaction."`
 	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to execute before CONCURRENTLY index operations."`
 	WithTx                   bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
 	DisableIndexConcurrently bool     `env:"PIST_DISABLE_INDEX_CONCURRENTLY" help:"Ignore all CONCURRENTLY opt-ins (both -- pist:concurrently directives and inline CREATE/DROP INDEX CONCURRENTLY) and emit plain CREATE/DROP INDEX."`

--- a/apply.go
+++ b/apply.go
@@ -16,6 +16,8 @@ type ApplyOptions struct {
 	Files                    []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQL                   string   `xor:"pre-sql" env:"PIST_PRE_SQL" help:"SQL to execute before applying changes."`
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PIST_PRE_SQL_FILE" help:"Path to a SQL file to execute before applying changes."`
+	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index operations (e.g. SET lock_timeout). Only run when the plan contains CONCURRENTLY index DDL; runs outside any transaction."`
+	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to execute before CONCURRENTLY index operations."`
 	WithTx                   bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
 	DisableIndexConcurrently bool     `env:"PIST_DISABLE_INDEX_CONCURRENTLY" help:"Ignore all CONCURRENTLY opt-ins (both -- pist:concurrently directives and inline CREATE/DROP INDEX CONCURRENTLY) and emit plain CREATE/DROP INDEX."`
 }
@@ -39,6 +41,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		Files:                    options.Files,
 		PreSQL:                   options.PreSQL,
 		PreSQLFile:               options.PreSQLFile,
+		ConcurrentlyPreSQL:       options.ConcurrentlyPreSQL,
+		ConcurrentlyPreSQLFile:   options.ConcurrentlyPreSQLFile,
 		DisableIndexConcurrently: options.DisableIndexConcurrently,
 	})
 	if err != nil {
@@ -77,6 +81,16 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		fmt.Fprintln(w, result.PreSQL) //nolint:errcheck
 		if _, err := exec(ctx, result.PreSQL); err != nil {
 			return nil, fmt.Errorf("failed to execute pre-SQL: %w", err)
+		}
+	}
+
+	// concurrently-pre-SQL is gated on HasConcurrentlyIndex so it only runs
+	// when there is CONCURRENTLY index DDL to apply. WithTx + HasConcurrentlyIndex
+	// is rejected above, so this always runs outside a transaction.
+	if result.ConcurrentlyPreSQL != "" && result.HasConcurrentlyIndex {
+		fmt.Fprintln(w, result.ConcurrentlyPreSQL) //nolint:errcheck
+		if _, err := exec(ctx, result.ConcurrentlyPreSQL); err != nil {
+			return nil, fmt.Errorf("failed to execute concurrently-pre-SQL: %w", err)
 		}
 	}
 

--- a/apply_test.go
+++ b/apply_test.go
@@ -767,6 +767,352 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
 	assert.Contains(t, buf.String(), "CREATE INDEX CONCURRENTLY idx_users_name")
 }
 
+func TestApply_WithConcurrentlyPreSQL(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:              []string{desiredFile},
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+	}, &buf)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "SET lock_timeout = '5s';")
+	assert.Contains(t, output, "CREATE INDEX CONCURRENTLY idx_users_name")
+	// concurrently-pre-SQL must be emitted before the CONCURRENTLY DDL.
+	setPos := strings.Index(output, "SET lock_timeout")
+	idxPos := strings.Index(output, "CREATE INDEX CONCURRENTLY")
+	assert.Less(t, setPos, idxPos)
+}
+
+func TestApply_ConcurrentlyPreSQL_SkippedWhenNoConcurrentlyDDL(t *testing.T) {
+	// concurrently-pre-SQL is gated on the diff producing CONCURRENTLY index DDL.
+	// A plain CREATE INDEX must not trigger it.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:              []string{desiredFile},
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+	}, &buf)
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "SET lock_timeout")
+	assert.Contains(t, buf.String(), "CREATE INDEX idx_users_name")
+}
+
+func TestApply_WithConcurrentlyPreSQLFile(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	tmpDir := t.TempDir()
+	desiredFile := filepath.Join(tmpDir, "desired.sql")
+	preSQLFile := filepath.Join(tmpDir, "concurrently-pre.sql")
+
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+	require.NoError(t, os.WriteFile(preSQLFile, []byte(`SET lock_timeout = '5s';`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:                  []string{desiredFile},
+		ConcurrentlyPreSQLFile: preSQLFile,
+	}, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "SET lock_timeout = '5s';")
+	assert.Contains(t, buf.String(), "CREATE INDEX CONCURRENTLY idx_users_name")
+}
+
+func TestApply_ConcurrentlyPreSQL_SkippedWhenDisableIndexConcurrently(t *testing.T) {
+	// --disable-index-concurrently strips CONCURRENTLY from the diff, so
+	// HasConcurrentlyIndex becomes false and concurrently-pre-SQL must not run.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:                    []string{desiredFile},
+		ConcurrentlyPreSQL:       "SET lock_timeout = '5s';",
+		DisableIndexConcurrently: true,
+	}, &buf)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.NotContains(t, output, "SET lock_timeout")
+	assert.NotContains(t, output, "CONCURRENTLY")
+	assert.Contains(t, output, "CREATE INDEX idx_users_name")
+}
+
+func TestApply_ConcurrentlyPreSQL_TriggersOnInlineConcurrently(t *testing.T) {
+	// Inline CREATE INDEX CONCURRENTLY (no directive) must also trigger
+	// concurrently-pre-SQL via HasConcurrentlyIndex.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:              []string{desiredFile},
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+	}, &buf)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "SET lock_timeout = '5s';")
+	assert.Contains(t, output, "CREATE INDEX CONCURRENTLY idx_users_name")
+	setPos := strings.Index(output, "SET lock_timeout")
+	idxPos := strings.Index(output, "CREATE INDEX CONCURRENTLY")
+	assert.Less(t, setPos, idxPos)
+}
+
+func TestApply_ConcurrentlyPreSQL_TriggersOnDropConcurrently(t *testing.T) {
+	// DROP INDEX CONCURRENTLY (driven by --disable-index-concurrently being
+	// off and the desired removing an existing concurrently-flagged index)
+	// must also set HasConcurrentlyIndex.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	// Definition change forces DROP+CREATE; both go through CONCURRENTLY because
+	// the desired index carries the directive.
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING hash (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		DropPolicy:         pistachio.DropPolicy{AllowDrop: []string{"all"}},
+		Files:              []string{desiredFile},
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+	}, &buf)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "SET lock_timeout = '5s';")
+	assert.Contains(t, output, "DROP INDEX CONCURRENTLY public.idx_users_name;")
+	setPos := strings.Index(output, "SET lock_timeout")
+	dropPos := strings.Index(output, "DROP INDEX CONCURRENTLY")
+	assert.Less(t, setPos, dropPos)
+}
+
+func TestApply_PreSQL_And_ConcurrentlyPreSQL_Order(t *testing.T) {
+	// When both --pre-sql and --concurrently-pre-sql are set, order must be:
+	// pre-SQL → concurrently-pre-SQL → schema DDL.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:              []string{desiredFile},
+		PreSQL:             "SET statement_timeout = '10s';",
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+	}, &buf)
+	require.NoError(t, err)
+	output := buf.String()
+	preSQLPos := strings.Index(output, "SET statement_timeout")
+	concPos := strings.Index(output, "SET lock_timeout")
+	idxPos := strings.Index(output, "CREATE INDEX CONCURRENTLY")
+	require.GreaterOrEqual(t, preSQLPos, 0)
+	require.GreaterOrEqual(t, concPos, 0)
+	require.GreaterOrEqual(t, idxPos, 0)
+	assert.Less(t, preSQLPos, concPos)
+	assert.Less(t, concPos, idxPos)
+}
+
+func TestApply_ConcurrentlyPreSQL_ExecError(t *testing.T) {
+	// concurrently-pre-SQL that fails at execution must surface as a
+	// "failed to execute concurrently-pre-SQL" error.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:              []string{desiredFile},
+		ConcurrentlyPreSQL: "SELECT * FROM public.does_not_exist;",
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute concurrently-pre-SQL")
+}
+
+func TestApply_InvalidConcurrentlyPreSQLFile(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:                  []string{desiredFile},
+		ConcurrentlyPreSQLFile: "/nonexistent/file.sql",
+	}, io.Discard)
+	require.Error(t, err)
+}
+
 func TestApply_DisallowedDrops_MultipleTypes(t *testing.T) {
 	// ApplyResult.DisallowedDrops aggregates skipped DROPs across object types
 	// when --allow-drop is empty. The buffer must stay empty (no executable DDL).

--- a/diff_all.go
+++ b/diff_all.go
@@ -22,6 +22,8 @@ type diffAllOptions struct {
 	Files                    []string
 	PreSQL                   string
 	PreSQLFile               string
+	ConcurrentlyPreSQL       string
+	ConcurrentlyPreSQLFile   string
 	DisableIndexConcurrently bool
 }
 
@@ -30,6 +32,7 @@ type diffAllResult struct {
 	Stmts                []string
 	DisallowedDrops      []string
 	PreSQL               string
+	ConcurrentlyPreSQL   string
 	Count                ObjectCount
 	ExecuteStmts         []*parser.ExecuteStmt
 	HasConcurrentlyIndex bool
@@ -123,6 +126,11 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, err
 	}
 
+	concurrentlyPreSQL, err := resolveConcurrentlyPreSQL(options.ConcurrentlyPreSQL, options.ConcurrentlyPreSQLFile)
+	if err != nil {
+		return nil, err
+	}
+
 	var disallowed []string
 	disallowed = append(disallowed, viewDiff.DisallowedDropStmts...)
 	disallowed = append(disallowed, tableDiff.DisallowedDropStmts...)
@@ -133,6 +141,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		Stmts:                stmts,
 		DisallowedDrops:      disallowed,
 		PreSQL:               preSQL,
+		ConcurrentlyPreSQL:   concurrentlyPreSQL,
 		Count:                count,
 		ExecuteStmts:         desired.ExecuteStmts,
 		HasConcurrentlyIndex: tableDiff.HasConcurrently || viewDiff.HasConcurrently,

--- a/export_test.go
+++ b/export_test.go
@@ -1,8 +1,9 @@
 package pistachio
 
 var (
-	ResolvePreSQL     = resolvePreSQL
-	ExtractObjectName = extractObjectName
-	OrderStatements   = orderStatements
-	CompareTaggedPos  = compareTaggedPos
+	ResolvePreSQL             = resolvePreSQL
+	ResolveConcurrentlyPreSQL = resolveConcurrentlyPreSQL
+	ExtractObjectName         = extractObjectName
+	OrderStatements           = orderStatements
+	CompareTaggedPos          = compareTaggedPos
 )

--- a/plan.go
+++ b/plan.go
@@ -86,12 +86,18 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 		stmts = append(stmts, parser.FormatExecuteStmt(es))
 	}
 
-	if result.ConcurrentlyPreSQL != "" && result.HasConcurrentlyIndex && len(stmts) > 0 {
-		stmts = append([]string{result.ConcurrentlyPreSQL}, stmts...)
-	}
-
-	if result.PreSQL != "" && len(stmts) > 0 {
-		stmts = append([]string{result.PreSQL}, stmts...)
+	// Prefix order matches apply: PreSQL → concurrently-pre-SQL → DDL.
+	// Skipped entirely when there is nothing to execute, so an empty plan
+	// stays empty instead of leaking a bare SET / pre-SQL line.
+	if len(stmts) > 0 {
+		var prefix []string
+		if result.PreSQL != "" {
+			prefix = append(prefix, result.PreSQL)
+		}
+		if result.ConcurrentlyPreSQL != "" && result.HasConcurrentlyIndex {
+			prefix = append(prefix, result.ConcurrentlyPreSQL)
+		}
+		stmts = append(prefix, stmts...)
 	}
 
 	return &PlanResult{

--- a/plan.go
+++ b/plan.go
@@ -14,6 +14,8 @@ type PlanOptions struct {
 	Files                    []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQL                   string   `xor:"pre-sql" env:"PIST_PRE_SQL" help:"SQL to prepend to the plan output."`
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PIST_PRE_SQL_FILE" help:"Path to a SQL file to prepend to the plan output."`
+	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL" help:"SQL to run before CONCURRENTLY index operations (e.g. SET lock_timeout). Only emitted when the plan contains CONCURRENTLY index DDL."`
+	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to run before CONCURRENTLY index operations."`
 	DisableIndexConcurrently bool     `env:"PIST_DISABLE_INDEX_CONCURRENTLY" help:"Ignore all CONCURRENTLY opt-ins (both -- pist:concurrently directives and inline CREATE/DROP INDEX CONCURRENTLY) and emit plain CREATE/DROP INDEX."`
 }
 
@@ -69,6 +71,8 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 		Files:                    options.Files,
 		PreSQL:                   options.PreSQL,
 		PreSQLFile:               options.PreSQLFile,
+		ConcurrentlyPreSQL:       options.ConcurrentlyPreSQL,
+		ConcurrentlyPreSQLFile:   options.ConcurrentlyPreSQLFile,
 		DisableIndexConcurrently: options.DisableIndexConcurrently,
 	})
 	if err != nil {
@@ -80,6 +84,10 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	// Append execute statements after schema changes
 	for _, es := range result.ExecuteStmts {
 		stmts = append(stmts, parser.FormatExecuteStmt(es))
+	}
+
+	if result.ConcurrentlyPreSQL != "" && result.HasConcurrentlyIndex && len(stmts) > 0 {
+		stmts = append([]string{result.ConcurrentlyPreSQL}, stmts...)
 	}
 
 	if result.PreSQL != "" && len(stmts) > 0 {

--- a/plan.go
+++ b/plan.go
@@ -14,7 +14,7 @@ type PlanOptions struct {
 	Files                    []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQL                   string   `xor:"pre-sql" env:"PIST_PRE_SQL" help:"SQL to prepend to the plan output."`
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PIST_PRE_SQL_FILE" help:"Path to a SQL file to prepend to the plan output."`
-	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL" help:"SQL to run before CONCURRENTLY index operations (e.g. SET lock_timeout). Only emitted when the plan contains CONCURRENTLY index DDL."`
+	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL" help:"SQL to run before CONCURRENTLY index operations (e.g. SET lock_timeout). Only emitted when the diff includes CONCURRENTLY index DDL."`
 	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PIST_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to run before CONCURRENTLY index operations."`
 	DisableIndexConcurrently bool     `env:"PIST_DISABLE_INDEX_CONCURRENTLY" help:"Ignore all CONCURRENTLY opt-ins (both -- pist:concurrently directives and inline CREATE/DROP INDEX CONCURRENTLY) and emit plain CREATE/DROP INDEX."`
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -194,6 +194,49 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
 	assert.Less(t, setPos, idxPos)
 }
 
+func TestPlan_PreSQL_And_ConcurrentlyPreSQL_Order(t *testing.T) {
+	// When both pre-SQL and concurrently-pre-SQL are set, plan output order
+	// must be: pre-SQL → concurrently-pre-SQL → schema DDL.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files:              []string{desiredFile},
+		PreSQL:             "SET statement_timeout = '10s';",
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+	})
+	require.NoError(t, err)
+	preSQLPos := strings.Index(got.SQL, "SET statement_timeout")
+	concPos := strings.Index(got.SQL, "SET lock_timeout")
+	idxPos := strings.Index(got.SQL, "CREATE INDEX CONCURRENTLY")
+	require.GreaterOrEqual(t, preSQLPos, 0)
+	require.GreaterOrEqual(t, concPos, 0)
+	require.GreaterOrEqual(t, idxPos, 0)
+	assert.Less(t, preSQLPos, concPos)
+	assert.Less(t, concPos, idxPos)
+}
+
 func TestPlan_ConcurrentlyPreSQL_SkippedWhenNoConcurrentlyDDL(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/plan_test.go
+++ b/plan_test.go
@@ -156,6 +156,77 @@ func TestPlan_WithPreSQL(t *testing.T) {
 	assert.Less(t, preSQLPos, diffPos)
 }
 
+func TestPlan_WithConcurrentlyPreSQL(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pist:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files:              []string{desiredFile},
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "SET lock_timeout = '5s';")
+	assert.Contains(t, got.SQL, "CREATE INDEX CONCURRENTLY idx_users_name")
+
+	setPos := strings.Index(got.SQL, "SET lock_timeout")
+	idxPos := strings.Index(got.SQL, "CREATE INDEX CONCURRENTLY")
+	assert.Less(t, setPos, idxPos)
+}
+
+func TestPlan_ConcurrentlyPreSQL_SkippedWhenNoConcurrentlyDDL(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{
+		Files:              []string{desiredFile},
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, got.SQL, "SET lock_timeout")
+	assert.Contains(t, got.SQL, "CREATE INDEX idx_users_name")
+}
+
 func TestPlan_WithPreSQLFile_InvalidFile(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/pre_sql.go
+++ b/pre_sql.go
@@ -8,13 +8,24 @@ import (
 // resolvePreSQL returns the pre-SQL string from either the direct string
 // or the file path. The direct string takes precedence.
 func resolvePreSQL(preSQL, preSQLFile string) (string, error) {
-	if preSQL != "" {
-		return preSQL, nil
+	return resolveSQLOpt(preSQL, preSQLFile, "pre-SQL")
+}
+
+// resolveConcurrentlyPreSQL returns the concurrently-pre-SQL string from
+// either the direct string or the file path. The direct string takes
+// precedence.
+func resolveConcurrentlyPreSQL(preSQL, preSQLFile string) (string, error) {
+	return resolveSQLOpt(preSQL, preSQLFile, "concurrently-pre-SQL")
+}
+
+func resolveSQLOpt(sql, file, label string) (string, error) {
+	if sql != "" {
+		return sql, nil
 	}
-	if preSQLFile != "" {
-		data, err := os.ReadFile(preSQLFile)
+	if file != "" {
+		data, err := os.ReadFile(file)
 		if err != nil {
-			return "", fmt.Errorf("failed to read pre-SQL file: %s: %w", preSQLFile, err)
+			return "", fmt.Errorf("failed to read %s file: %s: %w", label, file, err)
 		}
 		return string(data), nil
 	}

--- a/pre_sql_test.go
+++ b/pre_sql_test.go
@@ -45,3 +45,15 @@ func TestResolvePreSQL_FileNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read pre-SQL file")
 }
+
+func TestResolveConcurrentlyPreSQL_DirectString(t *testing.T) {
+	got, err := pistachio.ResolveConcurrentlyPreSQL("SET lock_timeout = '5s';", "")
+	require.NoError(t, err)
+	assert.Equal(t, "SET lock_timeout = '5s';", got)
+}
+
+func TestResolveConcurrentlyPreSQL_FileNotFound(t *testing.T) {
+	_, err := pistachio.ResolveConcurrentlyPreSQL("", "/nonexistent/pre.sql")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read concurrently-pre-SQL file")
+}


### PR DESCRIPTION
## Summary
- Add `--concurrently-pre-sql` / `--concurrently-pre-sql-file` (env: `PIST_CONCURRENTLY_PRE_SQL` / `PIST_CONCURRENTLY_PRE_SQL_FILE`) to `apply` and `plan`. Typical use case: `SET lock_timeout = '5s'` before long-running CONCURRENTLY index builds.
- Gated on the diff producing `CREATE/DROP INDEX CONCURRENTLY` (`HasConcurrentlyIndex`). Triggered by both the `-- pist:concurrently` directive and inline `CREATE/DROP INDEX CONCURRENTLY`. Suppressed when `--disable-index-concurrently` is set, since that strips the CONCURRENTLY flag from the diff.
- Runs once, after `--pre-sql` and before the schema DDL. `SET` is session-scoped, so the value carries through every subsequent CONCURRENTLY statement. Always runs outside any transaction (`--with-tx` + CONCURRENTLY is already rejected).
- Usage:
  ```bash
  pist apply schema.sql --concurrently-pre-sql "SET lock_timeout = '5s';"
  ```

## Test plan
- [x] `make lint`
- [x] `make test` (root coverage: 98.1%, unchanged from baseline; new code 100% covered)
- [x] Unit: `resolveConcurrentlyPreSQL` direct/file-not-found
- [x] apply: directive trigger, inline `CREATE INDEX CONCURRENTLY` trigger, `DROP INDEX CONCURRENTLY` trigger, file path, file-not-found, exec-error, skipped when no CONCURRENTLY DDL, skipped when `--disable-index-concurrently`, ordering with `--pre-sql`
- [x] plan: emitted before CONCURRENTLY DDL, skipped when no CONCURRENTLY DDL

🤖 Generated with [Claude Code](https://claude.com/claude-code)