### PR TITLE
Rewrite column refs in dependents on column rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.0] - 2026-04-29
+
+* Rewrite column references in same-table indexes, constraints, and foreign keys when a column is renamed via `-- pist:renamed-from`, so a single `ALTER TABLE ... RENAME COLUMN` is emitted without redundant `DROP/CREATE` on dependents. Covers regular / composite / partial / expression / `INCLUDE` / GiST indexes, `UNIQUE` / `PRIMARY KEY` / `CHECK` / `EXCLUDE` constraints, and same-table FKs. ([#123](https://github.com/winebarrel/pistachio/pull/123))
+
 ## [1.1.0] - 2026-04-28
 
 * Add `--concurrently-pre-sql` / `--concurrently-pre-sql-file` option to run SQL (e.g. `SET lock_timeout`) before CONCURRENTLY index DDL. ([#121](https://github.com/winebarrel/pistachio/pull/121))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.2.0] - 2026-04-29
 
 * Rewrite column references in same-table indexes, constraints, and foreign keys when a column is renamed via `-- pist:renamed-from`, so a single `ALTER TABLE ... RENAME COLUMN` is emitted without redundant `DROP/CREATE` on dependents. Covers regular / composite / partial / expression / `INCLUDE` / GiST indexes, `UNIQUE` / `PRIMARY KEY` / `CHECK` / `EXCLUDE` constraints, and same-table FKs. ([#123](https://github.com/winebarrel/pistachio/pull/123))
+* Track column comments across `-- pist:renamed-from` renames: comment changes (including drops) on a renamed column are now detected, and unchanged comments no longer emit a redundant `COMMENT ON COLUMN` statement. ([#123](https://github.com/winebarrel/pistachio/pull/123))
 
 ## [1.1.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,30 @@ ALTER TABLE public.orders ADD CONSTRAINT fk_new_name FOREIGN KEY (user_id) REFER
 > [!TIP]
 > Rename directives that have already been applied are silently skipped, so you can safely leave them in your schema files until cleanup.
 
+#### Column rename caveats
+
+When a column is renamed, pistachio rewrites column references in **same-table** indexes, constraints, and foreign keys (including `EXCLUDE`, partial / expression / `INCLUDE` indexes) on the current side, so a single `ALTER TABLE ... RENAME COLUMN` is emitted without redundant `DROP/CREATE` on the dependents.
+
+The desired-side SQL must use the **new** column name in those dependent definitions:
+
+```sql
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    -- pist:renamed-from name
+    display_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- Reference the new column name here:
+CREATE INDEX idx_users_name ON public.users (display_name);
+```
+
+If the desired side still references the old name, `pist plan` will emit a `DROP/CREATE INDEX` that re-references the missing column and the subsequent `pist apply` will fail with `column "name" does not exist`.
+
+The following references are **not** auto-rewritten and may produce a redundant `DROP/CREATE` on the first plan (the second run after applying the rename comes out clean):
+
+- View / materialized view definitions that `SELECT` the renamed column
+- Foreign keys in *other* tables whose `REFERENCES this_table(renamed_col)` points at the renamed column
+
 ### Split dump
 
 Use `--split` to output each table/view/enum as a separate file in the specified directory.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ CREATE TABLE public.users (
 CREATE INDEX idx_users_name ON public.users (display_name);
 ```
 
-If the desired side still references the old name, `pist plan` will emit a `DROP/CREATE INDEX` that re-references the missing column and the subsequent `pist apply` will fail with `column "name" does not exist`.
+If the desired side still references the old name, `pist plan` may emit `DROP/CREATE` for dependent indexes, constraints, or foreign keys that re-reference the missing column, and the subsequent `pist apply` will fail with `column "name" does not exist`.
 
 The following references are **not** auto-rewritten and may produce a redundant `DROP/CREATE` on the first plan (the second run after applying the rename comes out clean):
 

--- a/apply_test.go
+++ b/apply_test.go
@@ -54,6 +54,47 @@ func TestApply(t *testing.T) {
 	}
 }
 
+func TestApply_RenameColumn_NonPublicSchema(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.events (
+    id integer NOT NULL,
+    occurred_at timestamp NOT NULL,
+    CONSTRAINT events_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_events_time ON myschema.events (occurred_at);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE myschema.events (
+    id integer NOT NULL,
+    -- pist:renamed-from occurred_at
+    event_time timestamp NOT NULL,
+    CONSTRAINT events_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_events_time ON myschema.events (event_time);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
+	require.NoError(t, err)
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	expected := `-- myschema.events
+CREATE TABLE myschema.events (
+    id integer NOT NULL,
+    event_time timestamp without time zone NOT NULL,
+    CONSTRAINT events_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_events_time ON myschema.events USING btree (event_time);`
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(got.String()))
+}
+
 func TestApply_WithPreSQL(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -546,6 +546,24 @@ func rewriteColumnInConstraintDef(def, oldName, newName string) (string, error) 
 	rewriteStringList(con.Including)
 	rewriteStringList(con.FkAttrs)
 	rewriteColumnRefInExpr(con.RawExpr, oldName, newName)
+	// EXCLUDE constraints encode each (column, operator) pair as a List node
+	// with an IndexElem followed by an operator. Walk the IndexElem side.
+	for _, ex := range con.Exclusions {
+		list := ex.GetList()
+		if list == nil {
+			continue
+		}
+		for _, item := range list.Items {
+			ie := item.GetIndexElem()
+			if ie == nil {
+				continue
+			}
+			if ie.Name == oldName {
+				ie.Name = newName
+			}
+			rewriteColumnRefInExpr(ie.Expr, oldName, newName)
+		}
+	}
 
 	deparsed, err := pg_query.Deparse(result)
 	if err != nil {

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"fmt"
+	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
@@ -404,4 +405,209 @@ func cloneMap[K comparable, V any](m *orderedmap.Map[K, V]) *orderedmap.Map[K, V
 		clone.Set(k, v)
 	}
 	return clone
+}
+
+// collectColumnRenames returns a map of old column name → new column name
+// for desired columns annotated with -- pist:renamed-from.
+func collectColumnRenames(desired *orderedmap.Map[string, *model.Column]) map[string]string {
+	renames := make(map[string]string)
+	for name, col := range desired.All() {
+		if col.RenameFrom != nil && *col.RenameFrom != name {
+			renames[*col.RenameFrom] = name
+		}
+	}
+	return renames
+}
+
+// rewriteColumnRefInExpr walks an expression tree and rewrites unqualified
+// ColumnRef nodes whose name matches oldName to newName, mutating the tree
+// in place. Qualified references (table.col) are left untouched because the
+// renamed column belongs to a single table and its diff context is local.
+func rewriteColumnRefInExpr(node *pg_query.Node, oldName, newName string) {
+	if node == nil {
+		return
+	}
+	switch n := node.Node.(type) {
+	case *pg_query.Node_ColumnRef:
+		if len(n.ColumnRef.Fields) == 1 {
+			if s := n.ColumnRef.Fields[0].GetString_(); s != nil && s.Sval == oldName {
+				s.Sval = newName
+			}
+		}
+	case *pg_query.Node_AExpr:
+		rewriteColumnRefInExpr(n.AExpr.Lexpr, oldName, newName)
+		rewriteColumnRefInExpr(n.AExpr.Rexpr, oldName, newName)
+	case *pg_query.Node_BoolExpr:
+		for _, arg := range n.BoolExpr.Args {
+			rewriteColumnRefInExpr(arg, oldName, newName)
+		}
+	case *pg_query.Node_TypeCast:
+		rewriteColumnRefInExpr(n.TypeCast.Arg, oldName, newName)
+	case *pg_query.Node_FuncCall:
+		for _, arg := range n.FuncCall.Args {
+			rewriteColumnRefInExpr(arg, oldName, newName)
+		}
+	case *pg_query.Node_NullTest:
+		rewriteColumnRefInExpr(n.NullTest.Arg, oldName, newName)
+	case *pg_query.Node_AArrayExpr:
+		for _, elem := range n.AArrayExpr.Elements {
+			rewriteColumnRefInExpr(elem, oldName, newName)
+		}
+	case *pg_query.Node_List:
+		for _, item := range n.List.Items {
+			rewriteColumnRefInExpr(item, oldName, newName)
+		}
+	case *pg_query.Node_CoalesceExpr:
+		for _, arg := range n.CoalesceExpr.Args {
+			rewriteColumnRefInExpr(arg, oldName, newName)
+		}
+	case *pg_query.Node_CaseExpr:
+		rewriteColumnRefInExpr(n.CaseExpr.Arg, oldName, newName)
+		rewriteColumnRefInExpr(n.CaseExpr.Defresult, oldName, newName)
+		for _, when := range n.CaseExpr.Args {
+			if w := when.GetCaseWhen(); w != nil {
+				rewriteColumnRefInExpr(w.Expr, oldName, newName)
+				rewriteColumnRefInExpr(w.Result, oldName, newName)
+			}
+		}
+	}
+}
+
+// rewriteColumnInIndexDef returns a new index definition with column references
+// to oldName replaced by newName. Returns the original definition unchanged
+// if pg_query parse/deparse fails.
+func rewriteColumnInIndexDef(def, oldName, newName string) (string, error) {
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse index definition: %w", err)
+	}
+	if len(result.Stmts) == 0 {
+		return "", fmt.Errorf("empty index definition")
+	}
+	is := result.Stmts[0].Stmt.GetIndexStmt()
+	if is == nil {
+		return "", fmt.Errorf("expected IndexStmt in index definition")
+	}
+	rewriteIndexElems := func(params []*pg_query.Node) {
+		for _, p := range params {
+			ie := p.GetIndexElem()
+			if ie == nil {
+				continue
+			}
+			if ie.Name == oldName {
+				ie.Name = newName
+			}
+			rewriteColumnRefInExpr(ie.Expr, oldName, newName)
+		}
+	}
+	rewriteIndexElems(is.IndexParams)
+	rewriteIndexElems(is.IndexIncludingParams)
+	rewriteColumnRefInExpr(is.WhereClause, oldName, newName)
+	return pg_query.Deparse(result)
+}
+
+const constraintDefWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
+
+// rewriteColumnInConstraintDef returns a new constraint definition fragment
+// (e.g. "PRIMARY KEY (id)", "CHECK ((x > 0))", "FOREIGN KEY (a) REFERENCES t(b)")
+// with column references to oldName replaced by newName. PkAttrs (referenced
+// columns on the foreign side) are intentionally NOT rewritten because they
+// refer to a different table.
+func rewriteColumnInConstraintDef(def, oldName, newName string) (string, error) {
+	sql := constraintDefWrapPrefix + def
+	result, err := pg_query.Parse(sql)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse constraint definition: %w", err)
+	}
+	if len(result.Stmts) == 0 {
+		return "", fmt.Errorf("empty constraint definition")
+	}
+	as := result.Stmts[0].Stmt.GetAlterTableStmt()
+	if as == nil || len(as.Cmds) == 0 {
+		return "", fmt.Errorf("unexpected parse result for constraint definition")
+	}
+	cmd := as.Cmds[0].GetAlterTableCmd()
+	if cmd == nil || cmd.Def == nil {
+		return "", fmt.Errorf("unexpected parse result for constraint definition")
+	}
+	con := cmd.Def.GetConstraint()
+	if con == nil {
+		return "", fmt.Errorf("unexpected parse result for constraint definition")
+	}
+
+	rewriteStringList := func(nodes []*pg_query.Node) {
+		for _, n := range nodes {
+			if s := n.GetString_(); s != nil && s.Sval == oldName {
+				s.Sval = newName
+			}
+		}
+	}
+	rewriteStringList(con.Keys)
+	rewriteStringList(con.Including)
+	rewriteStringList(con.FkAttrs)
+	rewriteColumnRefInExpr(con.RawExpr, oldName, newName)
+
+	deparsed, err := pg_query.Deparse(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to deparse constraint definition: %w", err)
+	}
+	deparsed = strings.TrimSuffix(deparsed, ";")
+	if !strings.HasPrefix(deparsed, constraintDefWrapPrefix) {
+		return "", fmt.Errorf("unexpected deparsed form: %s", deparsed)
+	}
+	return strings.TrimPrefix(deparsed, constraintDefWrapPrefix), nil
+}
+
+// rewriteColumnRefsInIndexes returns a clone of indexes with each Definition
+// updated to reflect the column renames. Definitions that fail to parse/deparse
+// are left unchanged so downstream comparison still functions (will fall back
+// to redundant DROP/CREATE in that case).
+func rewriteColumnRefsInIndexes(indexes *orderedmap.Map[string, *model.Index], renames map[string]string) *orderedmap.Map[string, *model.Index] {
+	out := orderedmap.New[string, *model.Index]()
+	for name, idx := range indexes.All() {
+		clone := *idx
+		for old, n := range renames {
+			updated, err := rewriteColumnInIndexDef(clone.Definition, old, n)
+			if err == nil {
+				clone.Definition = updated
+			}
+		}
+		out.Set(name, &clone)
+	}
+	return out
+}
+
+// rewriteColumnRefsInConstraints returns a clone of constraints with each
+// Definition updated to reflect column renames.
+func rewriteColumnRefsInConstraints(cons *orderedmap.Map[string, *model.Constraint], renames map[string]string) *orderedmap.Map[string, *model.Constraint] {
+	out := orderedmap.New[string, *model.Constraint]()
+	for name, con := range cons.All() {
+		clone := *con
+		for old, n := range renames {
+			updated, err := rewriteColumnInConstraintDef(clone.Definition, old, n)
+			if err == nil {
+				clone.Definition = updated
+			}
+		}
+		out.Set(name, &clone)
+	}
+	return out
+}
+
+// rewriteColumnRefsInForeignKeys returns a clone of FKs with each Definition
+// updated to reflect column renames on the local side (FkAttrs). Referenced
+// columns are not touched.
+func rewriteColumnRefsInForeignKeys(fks *orderedmap.Map[string, *model.ForeignKey], renames map[string]string) *orderedmap.Map[string, *model.ForeignKey] {
+	out := orderedmap.New[string, *model.ForeignKey]()
+	for name, fk := range fks.All() {
+		clone := *fk
+		for old, n := range renames {
+			updated, err := rewriteColumnInConstraintDef(clone.Definition, old, n)
+			if err == nil {
+				clone.Definition = updated
+			}
+		}
+		out.Set(name, &clone)
+	}
+	return out
 }

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -621,6 +621,22 @@ func rewriteColumnRefsInConstraints(cons *orderedmap.Map[string, *model.Constrai
 	return out
 }
 
+// renameColumnKeys returns a clone of the columns map where each key in
+// renames is replaced by its mapped new name. Iteration is single-pass
+// (each existing key is matched once against the renames map) so chained
+// renames such as a→b alongside b→c do not cascade. Order is preserved.
+func renameColumnKeys(cols *orderedmap.Map[string, *model.Column], renames map[string]string) *orderedmap.Map[string, *model.Column] {
+	out := orderedmap.New[string, *model.Column]()
+	for name, col := range cols.All() {
+		if newName, ok := renames[name]; ok {
+			out.Set(newName, col)
+		} else {
+			out.Set(name, col)
+		}
+	}
+	return out
+}
+
 // rewriteColumnRefsInForeignKeys returns a clone of FKs with each Definition
 // updated to reflect column renames on the local side (FkAttrs). Referenced
 // columns are not touched.

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -419,64 +419,74 @@ func collectColumnRenames(desired *orderedmap.Map[string, *model.Column]) map[st
 	return renames
 }
 
-// rewriteColumnRefInExpr walks an expression tree and rewrites unqualified
-// ColumnRef nodes whose name matches oldName to newName, mutating the tree
-// in place. Qualified references (table.col) are left untouched because the
-// renamed column belongs to a single table and its diff context is local.
-func rewriteColumnRefInExpr(node *pg_query.Node, oldName, newName string) {
+// rewriteColumnRefsInExpr walks an expression tree and rewrites each
+// unqualified ColumnRef whose name appears in renames to the mapped new
+// name, mutating the tree in place. Each ColumnRef is matched against the
+// original-name set in a single pass, so chained renames (a→b alongside
+// b→c) cannot cascade. Qualified references (table.col) are left untouched
+// because the renamed column belongs to a single table and the diff context
+// is local.
+func rewriteColumnRefsInExpr(node *pg_query.Node, renames map[string]string) {
 	if node == nil {
 		return
 	}
 	switch n := node.Node.(type) {
 	case *pg_query.Node_ColumnRef:
 		if len(n.ColumnRef.Fields) == 1 {
-			if s := n.ColumnRef.Fields[0].GetString_(); s != nil && s.Sval == oldName {
-				s.Sval = newName
+			if s := n.ColumnRef.Fields[0].GetString_(); s != nil {
+				if newName, ok := renames[s.Sval]; ok {
+					s.Sval = newName
+				}
 			}
 		}
 	case *pg_query.Node_AExpr:
-		rewriteColumnRefInExpr(n.AExpr.Lexpr, oldName, newName)
-		rewriteColumnRefInExpr(n.AExpr.Rexpr, oldName, newName)
+		rewriteColumnRefsInExpr(n.AExpr.Lexpr, renames)
+		rewriteColumnRefsInExpr(n.AExpr.Rexpr, renames)
 	case *pg_query.Node_BoolExpr:
 		for _, arg := range n.BoolExpr.Args {
-			rewriteColumnRefInExpr(arg, oldName, newName)
+			rewriteColumnRefsInExpr(arg, renames)
 		}
 	case *pg_query.Node_TypeCast:
-		rewriteColumnRefInExpr(n.TypeCast.Arg, oldName, newName)
+		rewriteColumnRefsInExpr(n.TypeCast.Arg, renames)
 	case *pg_query.Node_FuncCall:
 		for _, arg := range n.FuncCall.Args {
-			rewriteColumnRefInExpr(arg, oldName, newName)
+			rewriteColumnRefsInExpr(arg, renames)
 		}
 	case *pg_query.Node_NullTest:
-		rewriteColumnRefInExpr(n.NullTest.Arg, oldName, newName)
+		rewriteColumnRefsInExpr(n.NullTest.Arg, renames)
 	case *pg_query.Node_AArrayExpr:
 		for _, elem := range n.AArrayExpr.Elements {
-			rewriteColumnRefInExpr(elem, oldName, newName)
+			rewriteColumnRefsInExpr(elem, renames)
 		}
 	case *pg_query.Node_List:
 		for _, item := range n.List.Items {
-			rewriteColumnRefInExpr(item, oldName, newName)
+			rewriteColumnRefsInExpr(item, renames)
 		}
 	case *pg_query.Node_CoalesceExpr:
 		for _, arg := range n.CoalesceExpr.Args {
-			rewriteColumnRefInExpr(arg, oldName, newName)
+			rewriteColumnRefsInExpr(arg, renames)
 		}
 	case *pg_query.Node_CaseExpr:
-		rewriteColumnRefInExpr(n.CaseExpr.Arg, oldName, newName)
-		rewriteColumnRefInExpr(n.CaseExpr.Defresult, oldName, newName)
+		rewriteColumnRefsInExpr(n.CaseExpr.Arg, renames)
+		rewriteColumnRefsInExpr(n.CaseExpr.Defresult, renames)
 		for _, when := range n.CaseExpr.Args {
 			if w := when.GetCaseWhen(); w != nil {
-				rewriteColumnRefInExpr(w.Expr, oldName, newName)
-				rewriteColumnRefInExpr(w.Result, oldName, newName)
+				rewriteColumnRefsInExpr(w.Expr, renames)
+				rewriteColumnRefsInExpr(w.Result, renames)
 			}
 		}
 	}
 }
 
-// rewriteColumnInIndexDef returns a new index definition with column references
-// to oldName replaced by newName. Returns an error (and an empty string) if
-// pg_query parse/deparse fails; callers fall back to the original definition.
-func rewriteColumnInIndexDef(def, oldName, newName string) (string, error) {
+// rewriteColumnsInIndexDef returns a new index definition with column
+// references rewritten according to the renames map (old → new). Returns an
+// error (and an empty string) if pg_query parse/deparse fails; callers fall
+// back to the original definition.
+//
+// All renames are applied in a single AST walk, so chained renames (a→b and
+// b→c) do not cascade — each original column name is matched once against
+// the renames map.
+func rewriteColumnsInIndexDef(def string, renames map[string]string) (string, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse index definition: %w", err)
@@ -494,26 +504,29 @@ func rewriteColumnInIndexDef(def, oldName, newName string) (string, error) {
 			if ie == nil {
 				continue
 			}
-			if ie.Name == oldName {
+			if newName, ok := renames[ie.Name]; ok {
 				ie.Name = newName
 			}
-			rewriteColumnRefInExpr(ie.Expr, oldName, newName)
+			rewriteColumnRefsInExpr(ie.Expr, renames)
 		}
 	}
 	rewriteIndexElems(is.IndexParams)
 	rewriteIndexElems(is.IndexIncludingParams)
-	rewriteColumnRefInExpr(is.WhereClause, oldName, newName)
+	rewriteColumnRefsInExpr(is.WhereClause, renames)
 	return pg_query.Deparse(result)
 }
 
 const constraintDefWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
 
-// rewriteColumnInConstraintDef returns a new constraint definition fragment
+// rewriteColumnsInConstraintDef returns a new constraint definition fragment
 // (e.g. "PRIMARY KEY (id)", "CHECK ((x > 0))", "FOREIGN KEY (a) REFERENCES t(b)")
-// with column references to oldName replaced by newName. PkAttrs (referenced
-// columns on the foreign side) are intentionally NOT rewritten because they
-// refer to a different table.
-func rewriteColumnInConstraintDef(def, oldName, newName string) (string, error) {
+// with column references rewritten according to the renames map (old → new).
+// PkAttrs (referenced columns on the foreign side) are intentionally NOT
+// rewritten because they refer to a different table.
+//
+// All renames are applied in a single AST walk so chained renames cannot
+// cascade.
+func rewriteColumnsInConstraintDef(def string, renames map[string]string) (string, error) {
 	sql := constraintDefWrapPrefix + def
 	result, err := pg_query.Parse(sql)
 	if err != nil {
@@ -537,15 +550,17 @@ func rewriteColumnInConstraintDef(def, oldName, newName string) (string, error) 
 
 	rewriteStringList := func(nodes []*pg_query.Node) {
 		for _, n := range nodes {
-			if s := n.GetString_(); s != nil && s.Sval == oldName {
-				s.Sval = newName
+			if s := n.GetString_(); s != nil {
+				if newName, ok := renames[s.Sval]; ok {
+					s.Sval = newName
+				}
 			}
 		}
 	}
 	rewriteStringList(con.Keys)
 	rewriteStringList(con.Including)
 	rewriteStringList(con.FkAttrs)
-	rewriteColumnRefInExpr(con.RawExpr, oldName, newName)
+	rewriteColumnRefsInExpr(con.RawExpr, renames)
 	// EXCLUDE constraints encode each (column, operator) pair as a List node
 	// with an IndexElem followed by an operator. Walk the IndexElem side.
 	for _, ex := range con.Exclusions {
@@ -558,10 +573,10 @@ func rewriteColumnInConstraintDef(def, oldName, newName string) (string, error) 
 			if ie == nil {
 				continue
 			}
-			if ie.Name == oldName {
+			if newName, ok := renames[ie.Name]; ok {
 				ie.Name = newName
 			}
-			rewriteColumnRefInExpr(ie.Expr, oldName, newName)
+			rewriteColumnRefsInExpr(ie.Expr, renames)
 		}
 	}
 
@@ -584,11 +599,8 @@ func rewriteColumnRefsInIndexes(indexes *orderedmap.Map[string, *model.Index], r
 	out := orderedmap.New[string, *model.Index]()
 	for name, idx := range indexes.All() {
 		clone := *idx
-		for old, n := range renames {
-			updated, err := rewriteColumnInIndexDef(clone.Definition, old, n)
-			if err == nil {
-				clone.Definition = updated
-			}
+		if updated, err := rewriteColumnsInIndexDef(clone.Definition, renames); err == nil {
+			clone.Definition = updated
 		}
 		out.Set(name, &clone)
 	}
@@ -601,11 +613,8 @@ func rewriteColumnRefsInConstraints(cons *orderedmap.Map[string, *model.Constrai
 	out := orderedmap.New[string, *model.Constraint]()
 	for name, con := range cons.All() {
 		clone := *con
-		for old, n := range renames {
-			updated, err := rewriteColumnInConstraintDef(clone.Definition, old, n)
-			if err == nil {
-				clone.Definition = updated
-			}
+		if updated, err := rewriteColumnsInConstraintDef(clone.Definition, renames); err == nil {
+			clone.Definition = updated
 		}
 		out.Set(name, &clone)
 	}
@@ -619,11 +628,8 @@ func rewriteColumnRefsInForeignKeys(fks *orderedmap.Map[string, *model.ForeignKe
 	out := orderedmap.New[string, *model.ForeignKey]()
 	for name, fk := range fks.All() {
 		clone := *fk
-		for old, n := range renames {
-			updated, err := rewriteColumnInConstraintDef(clone.Definition, old, n)
-			if err == nil {
-				clone.Definition = updated
-			}
+		if updated, err := rewriteColumnsInConstraintDef(clone.Definition, renames); err == nil {
+			clone.Definition = updated
 		}
 		out.Set(name, &clone)
 	}

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -474,8 +474,8 @@ func rewriteColumnRefInExpr(node *pg_query.Node, oldName, newName string) {
 }
 
 // rewriteColumnInIndexDef returns a new index definition with column references
-// to oldName replaced by newName. Returns the original definition unchanged
-// if pg_query parse/deparse fails.
+// to oldName replaced by newName. Returns an error (and an empty string) if
+// pg_query parse/deparse fails; callers fall back to the original definition.
 func rewriteColumnInIndexDef(def, oldName, newName string) (string, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {

--- a/diff/rename_test.go
+++ b/diff/rename_test.go
@@ -1,0 +1,211 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestCollectColumnRenames(t *testing.T) {
+	cols := orderedmap.New[string, *model.Column]()
+	cols.Set("display_name", &model.Column{Name: "display_name", RenameFrom: ptr("name")})
+	cols.Set("id", &model.Column{Name: "id"})
+	cols.Set("self", &model.Column{Name: "self", RenameFrom: ptr("self")}) // no-op same-name rename
+
+	renames := collectColumnRenames(cols)
+	assert.Equal(t, map[string]string{"name": "display_name"}, renames)
+}
+
+func TestRewriteColumnInIndexDef_PlainColumn(t *testing.T) {
+	got, err := rewriteColumnInIndexDef(
+		"CREATE INDEX idx ON public.t USING btree (name)",
+		"name", "display_name",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "(display_name)")
+	assert.NotContains(t, got, "(name)")
+}
+
+func TestRewriteColumnInIndexDef_LeavesOtherColumns(t *testing.T) {
+	got, err := rewriteColumnInIndexDef(
+		"CREATE INDEX idx ON public.t USING btree (a, b)",
+		"a", "x",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "(x, b)")
+}
+
+func TestRewriteColumnInIndexDef_ExpressionIndex(t *testing.T) {
+	got, err := rewriteColumnInIndexDef(
+		"CREATE INDEX idx ON public.t USING btree (lower(email))",
+		"email", "email_addr",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "lower(email_addr)")
+}
+
+func TestRewriteColumnInIndexDef_PartialWhere(t *testing.T) {
+	got, err := rewriteColumnInIndexDef(
+		"CREATE INDEX idx ON public.t USING btree (id) WHERE deleted_at IS NULL",
+		"deleted_at", "removed_at",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "removed_at IS NULL")
+}
+
+func TestRewriteColumnInIndexDef_IncludeClause(t *testing.T) {
+	got, err := rewriteColumnInIndexDef(
+		"CREATE INDEX idx ON public.t USING btree (sku) INCLUDE (name)",
+		"name", "product_name",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "INCLUDE (product_name)")
+}
+
+func TestRewriteColumnInIndexDef_ParseError(t *testing.T) {
+	_, err := rewriteColumnInIndexDef("not a valid sql", "a", "b")
+	require.Error(t, err)
+}
+
+func TestRewriteColumnInConstraintDef_Unique(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef("UNIQUE (email)", "email", "email_addr")
+	require.NoError(t, err)
+	assert.Contains(t, got, "(email_addr)")
+}
+
+func TestRewriteColumnInConstraintDef_PrimaryKey(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef("PRIMARY KEY (id)", "id", "user_id")
+	require.NoError(t, err)
+	assert.Contains(t, got, "(user_id)")
+}
+
+func TestRewriteColumnInConstraintDef_Check(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef("CHECK ((qty > 0))", "qty", "quantity")
+	require.NoError(t, err)
+	assert.Contains(t, got, "quantity > 0")
+}
+
+func TestRewriteColumnInConstraintDef_CheckBoolExpr(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef(
+		"CHECK ((qty > 0 AND qty < 1000))",
+		"qty", "quantity",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "quantity > 0")
+	assert.Contains(t, got, "quantity < 1000")
+}
+
+func TestRewriteColumnInConstraintDef_CheckNullTest(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef("CHECK ((deleted_at IS NULL))", "deleted_at", "removed_at")
+	require.NoError(t, err)
+	assert.Contains(t, got, "removed_at IS NULL")
+}
+
+func TestRewriteColumnInConstraintDef_FKLocalAttrs(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef(
+		"FOREIGN KEY (user_id) REFERENCES users(id)",
+		"user_id", "buyer_id",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "(buyer_id)")
+	// PkAttrs (referenced columns) must NOT be rewritten
+	assert.Contains(t, got, "users (id)")
+}
+
+func TestRewriteColumnInConstraintDef_FKReferencedNotRewritten(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef(
+		"FOREIGN KEY (user_id) REFERENCES users(id)",
+		"id", "user_pk",
+	)
+	require.NoError(t, err)
+	// PkAttrs side: "id" should stay as-is even though it matches oldName
+	assert.Contains(t, got, "users (id)")
+}
+
+func TestRewriteColumnInConstraintDef_Exclusion(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef(
+		"EXCLUDE USING gist (room WITH =, during WITH &&)",
+		"during", "time_range",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "time_range WITH")
+}
+
+func TestRewriteColumnInConstraintDef_UniqueInclude(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef(
+		"UNIQUE (email) INCLUDE (name)",
+		"name", "display_name",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "INCLUDE (display_name)")
+}
+
+func TestRewriteColumnInConstraintDef_ParseError(t *testing.T) {
+	_, err := rewriteColumnInConstraintDef("not a valid def", "a", "b")
+	require.Error(t, err)
+}
+
+func TestRewriteColumnRefsInIndexes_RewritesAndClones(t *testing.T) {
+	in := orderedmap.New[string, *model.Index]()
+	original := &model.Index{
+		Schema:     "public",
+		Name:       "idx",
+		Table:      "t",
+		Definition: "CREATE INDEX idx ON public.t USING btree (name)",
+	}
+	in.Set("idx", original)
+
+	out := rewriteColumnRefsInIndexes(in, map[string]string{"name": "display_name"})
+	got, ok := out.GetOk("idx")
+	require.True(t, ok)
+	assert.Contains(t, got.Definition, "(display_name)")
+	// The original input must not be mutated.
+	assert.Contains(t, original.Definition, "(name)")
+}
+
+func TestRewriteColumnRefsInIndexes_FallbackOnParseError(t *testing.T) {
+	in := orderedmap.New[string, *model.Index]()
+	in.Set("idx", &model.Index{
+		Schema:     "public",
+		Name:       "idx",
+		Table:      "t",
+		Definition: "not a valid CREATE INDEX",
+	})
+
+	out := rewriteColumnRefsInIndexes(in, map[string]string{"name": "display_name"})
+	got, ok := out.GetOk("idx")
+	require.True(t, ok)
+	// Unparseable definitions are kept intact so downstream comparison still works.
+	assert.Equal(t, "not a valid CREATE INDEX", got.Definition)
+}
+
+func TestRewriteColumnRefsInConstraints_RewritesAndClones(t *testing.T) {
+	in := orderedmap.New[string, *model.Constraint]()
+	original := &model.Constraint{Name: "u", Definition: "UNIQUE (email)"}
+	in.Set("u", original)
+
+	out := rewriteColumnRefsInConstraints(in, map[string]string{"email": "email_addr"})
+	got, ok := out.GetOk("u")
+	require.True(t, ok)
+	assert.Contains(t, got.Definition, "(email_addr)")
+	assert.Contains(t, original.Definition, "(email)")
+}
+
+func TestRewriteColumnRefsInForeignKeys_RewritesLocalAttrs(t *testing.T) {
+	in := orderedmap.New[string, *model.ForeignKey]()
+	in.Set("fk", &model.ForeignKey{
+		Constraint: model.Constraint{
+			Name:       "fk",
+			Definition: "FOREIGN KEY (user_id) REFERENCES users(id)",
+		},
+	})
+
+	out := rewriteColumnRefsInForeignKeys(in, map[string]string{"user_id": "buyer_id"})
+	got, ok := out.GetOk("fk")
+	require.True(t, ok)
+	assert.Contains(t, got.Definition, "(buyer_id)")
+	assert.Contains(t, got.Definition, "users (id)")
+}

--- a/diff/rename_test.go
+++ b/diff/rename_test.go
@@ -276,6 +276,34 @@ func TestRewriteColumnRefsInConstraints_RewritesAndClones(t *testing.T) {
 	assert.Contains(t, original.Definition, "(email)")
 }
 
+func TestRenameColumnKeys_RemapsAndPreservesOrder(t *testing.T) {
+	in := orderedmap.New[string, *model.Column]()
+	in.Set("a", &model.Column{Name: "a"})
+	in.Set("b", &model.Column{Name: "b"})
+	in.Set("c", &model.Column{Name: "c"})
+
+	out := renameColumnKeys(in, map[string]string{"b": "d"})
+	keys := []string{}
+	for k := range out.All() {
+		keys = append(keys, k)
+	}
+	assert.Equal(t, []string{"a", "d", "c"}, keys)
+}
+
+func TestRenameColumnKeys_NoCascadeOnChain(t *testing.T) {
+	// a→b alongside b→c must not cascade through a single column to c.
+	in := orderedmap.New[string, *model.Column]()
+	in.Set("a", &model.Column{Name: "a"})
+	in.Set("b", &model.Column{Name: "b"})
+
+	out := renameColumnKeys(in, map[string]string{"a": "b", "b": "c"})
+	keys := []string{}
+	for k := range out.All() {
+		keys = append(keys, k)
+	}
+	assert.Equal(t, []string{"b", "c"}, keys)
+}
+
 func TestRewriteColumnRefsInForeignKeys_RewritesLocalAttrs(t *testing.T) {
 	in := orderedmap.New[string, *model.ForeignKey]()
 	in.Set("fk", &model.ForeignKey{

--- a/diff/rename_test.go
+++ b/diff/rename_test.go
@@ -148,6 +148,61 @@ func TestRewriteColumnInConstraintDef_ParseError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRewriteColumnInConstraintDef_CheckTypeCast(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef("CHECK ((col::text = 'x'))", "col", "value")
+	require.NoError(t, err)
+	assert.Contains(t, got, "value")
+	assert.NotContains(t, got, "(col")
+}
+
+func TestRewriteColumnInConstraintDef_CheckCoalesce(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef("CHECK ((COALESCE(col, 0) > 0))", "col", "value")
+	require.NoError(t, err)
+	assert.Contains(t, got, "COALESCE(value")
+}
+
+func TestRewriteColumnInConstraintDef_CheckCase(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef(
+		"CHECK (((CASE WHEN col > 0 THEN 1 ELSE 0 END) = 1))",
+		"col", "value",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "value")
+}
+
+func TestRewriteColumnInConstraintDef_CheckAnyArray(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef(
+		"CHECK ((status = ANY (ARRAY['a'::text, 'b'::text])))",
+		"status", "state",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "state")
+}
+
+func TestRewriteColumnInConstraintDef_CheckInList(t *testing.T) {
+	got, err := rewriteColumnInConstraintDef(
+		"CHECK ((status IN ('a', 'b')))",
+		"status", "state",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "state")
+}
+
+func TestRewriteColumnInIndexDef_EmptyInput(t *testing.T) {
+	_, err := rewriteColumnInIndexDef("", "a", "b")
+	require.Error(t, err)
+}
+
+func TestRewriteColumnInIndexDef_NotIndexStmt(t *testing.T) {
+	_, err := rewriteColumnInIndexDef("SELECT 1", "a", "b")
+	require.Error(t, err)
+}
+
+func TestRewriteColumnInConstraintDef_EmptyInput(t *testing.T) {
+	_, err := rewriteColumnInConstraintDef("", "a", "b")
+	require.Error(t, err)
+}
+
 func TestRewriteColumnRefsInIndexes_RewritesAndClones(t *testing.T) {
 	in := orderedmap.New[string, *model.Index]()
 	original := &model.Index{

--- a/diff/rename_test.go
+++ b/diff/rename_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
+func one(old, n string) map[string]string {
+	return map[string]string{old: n}
+}
+
 func TestCollectColumnRenames(t *testing.T) {
 	cols := orderedmap.New[string, *model.Column]()
 	cols.Set("display_name", &model.Column{Name: "display_name", RenameFrom: ptr("name")})
@@ -19,95 +23,117 @@ func TestCollectColumnRenames(t *testing.T) {
 	assert.Equal(t, map[string]string{"name": "display_name"}, renames)
 }
 
-func TestRewriteColumnInIndexDef_PlainColumn(t *testing.T) {
-	got, err := rewriteColumnInIndexDef(
+func TestRewriteColumnsInIndexDef_PlainColumn(t *testing.T) {
+	got, err := rewriteColumnsInIndexDef(
 		"CREATE INDEX idx ON public.t USING btree (name)",
-		"name", "display_name",
+		one("name", "display_name"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "(display_name)")
 	assert.NotContains(t, got, "(name)")
 }
 
-func TestRewriteColumnInIndexDef_LeavesOtherColumns(t *testing.T) {
-	got, err := rewriteColumnInIndexDef(
+func TestRewriteColumnsInIndexDef_LeavesOtherColumns(t *testing.T) {
+	got, err := rewriteColumnsInIndexDef(
 		"CREATE INDEX idx ON public.t USING btree (a, b)",
-		"a", "x",
+		one("a", "x"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "(x, b)")
 }
 
-func TestRewriteColumnInIndexDef_ExpressionIndex(t *testing.T) {
-	got, err := rewriteColumnInIndexDef(
+func TestRewriteColumnsInIndexDef_ExpressionIndex(t *testing.T) {
+	got, err := rewriteColumnsInIndexDef(
 		"CREATE INDEX idx ON public.t USING btree (lower(email))",
-		"email", "email_addr",
+		one("email", "email_addr"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "lower(email_addr)")
 }
 
-func TestRewriteColumnInIndexDef_PartialWhere(t *testing.T) {
-	got, err := rewriteColumnInIndexDef(
+func TestRewriteColumnsInIndexDef_PartialWhere(t *testing.T) {
+	got, err := rewriteColumnsInIndexDef(
 		"CREATE INDEX idx ON public.t USING btree (id) WHERE deleted_at IS NULL",
-		"deleted_at", "removed_at",
+		one("deleted_at", "removed_at"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "removed_at IS NULL")
 }
 
-func TestRewriteColumnInIndexDef_IncludeClause(t *testing.T) {
-	got, err := rewriteColumnInIndexDef(
+func TestRewriteColumnsInIndexDef_IncludeClause(t *testing.T) {
+	got, err := rewriteColumnsInIndexDef(
 		"CREATE INDEX idx ON public.t USING btree (sku) INCLUDE (name)",
-		"name", "product_name",
+		one("name", "product_name"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "INCLUDE (product_name)")
 }
 
-func TestRewriteColumnInIndexDef_ParseError(t *testing.T) {
-	_, err := rewriteColumnInIndexDef("not a valid sql", "a", "b")
+func TestRewriteColumnsInIndexDef_NoCascadeOnChain(t *testing.T) {
+	// Renames a→b alongside b→c must rewrite the index's reference to a (the
+	// original) into b — NOT cascade through b→c into c.
+	got, err := rewriteColumnsInIndexDef(
+		"CREATE INDEX idx ON public.t USING btree (a, b)",
+		map[string]string{"a": "b", "b": "c"},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "(b, c)")
+	assert.NotContains(t, got, "(c, c)")
+}
+
+func TestRewriteColumnsInIndexDef_ParseError(t *testing.T) {
+	_, err := rewriteColumnsInIndexDef("not a valid sql", one("a", "b"))
 	require.Error(t, err)
 }
 
-func TestRewriteColumnInConstraintDef_Unique(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef("UNIQUE (email)", "email", "email_addr")
+func TestRewriteColumnsInIndexDef_EmptyInput(t *testing.T) {
+	_, err := rewriteColumnsInIndexDef("", one("a", "b"))
+	require.Error(t, err)
+}
+
+func TestRewriteColumnsInIndexDef_NotIndexStmt(t *testing.T) {
+	_, err := rewriteColumnsInIndexDef("SELECT 1", one("a", "b"))
+	require.Error(t, err)
+}
+
+func TestRewriteColumnsInConstraintDef_Unique(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef("UNIQUE (email)", one("email", "email_addr"))
 	require.NoError(t, err)
 	assert.Contains(t, got, "(email_addr)")
 }
 
-func TestRewriteColumnInConstraintDef_PrimaryKey(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef("PRIMARY KEY (id)", "id", "user_id")
+func TestRewriteColumnsInConstraintDef_PrimaryKey(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef("PRIMARY KEY (id)", one("id", "user_id"))
 	require.NoError(t, err)
 	assert.Contains(t, got, "(user_id)")
 }
 
-func TestRewriteColumnInConstraintDef_Check(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef("CHECK ((qty > 0))", "qty", "quantity")
+func TestRewriteColumnsInConstraintDef_Check(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef("CHECK ((qty > 0))", one("qty", "quantity"))
 	require.NoError(t, err)
 	assert.Contains(t, got, "quantity > 0")
 }
 
-func TestRewriteColumnInConstraintDef_CheckBoolExpr(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef(
+func TestRewriteColumnsInConstraintDef_CheckBoolExpr(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef(
 		"CHECK ((qty > 0 AND qty < 1000))",
-		"qty", "quantity",
+		one("qty", "quantity"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "quantity > 0")
 	assert.Contains(t, got, "quantity < 1000")
 }
 
-func TestRewriteColumnInConstraintDef_CheckNullTest(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef("CHECK ((deleted_at IS NULL))", "deleted_at", "removed_at")
+func TestRewriteColumnsInConstraintDef_CheckNullTest(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef("CHECK ((deleted_at IS NULL))", one("deleted_at", "removed_at"))
 	require.NoError(t, err)
 	assert.Contains(t, got, "removed_at IS NULL")
 }
 
-func TestRewriteColumnInConstraintDef_FKLocalAttrs(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef(
+func TestRewriteColumnsInConstraintDef_FKLocalAttrs(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef(
 		"FOREIGN KEY (user_id) REFERENCES users(id)",
-		"user_id", "buyer_id",
+		one("user_id", "buyer_id"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "(buyer_id)")
@@ -115,92 +141,93 @@ func TestRewriteColumnInConstraintDef_FKLocalAttrs(t *testing.T) {
 	assert.Contains(t, got, "users (id)")
 }
 
-func TestRewriteColumnInConstraintDef_FKReferencedNotRewritten(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef(
+func TestRewriteColumnsInConstraintDef_FKReferencedNotRewritten(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef(
 		"FOREIGN KEY (user_id) REFERENCES users(id)",
-		"id", "user_pk",
+		one("id", "user_pk"),
 	)
 	require.NoError(t, err)
 	// PkAttrs side: "id" should stay as-is even though it matches oldName
 	assert.Contains(t, got, "users (id)")
 }
 
-func TestRewriteColumnInConstraintDef_Exclusion(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef(
+func TestRewriteColumnsInConstraintDef_Exclusion(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef(
 		"EXCLUDE USING gist (room WITH =, during WITH &&)",
-		"during", "time_range",
+		one("during", "time_range"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "time_range WITH")
 }
 
-func TestRewriteColumnInConstraintDef_UniqueInclude(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef(
+func TestRewriteColumnsInConstraintDef_UniqueInclude(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef(
 		"UNIQUE (email) INCLUDE (name)",
-		"name", "display_name",
+		one("name", "display_name"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "INCLUDE (display_name)")
 }
 
-func TestRewriteColumnInConstraintDef_ParseError(t *testing.T) {
-	_, err := rewriteColumnInConstraintDef("not a valid def", "a", "b")
+func TestRewriteColumnsInConstraintDef_ParseError(t *testing.T) {
+	_, err := rewriteColumnsInConstraintDef("not a valid def", one("a", "b"))
 	require.Error(t, err)
 }
 
-func TestRewriteColumnInConstraintDef_CheckTypeCast(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef("CHECK ((col::text = 'x'))", "col", "value")
+func TestRewriteColumnsInConstraintDef_EmptyInput(t *testing.T) {
+	_, err := rewriteColumnsInConstraintDef("", one("a", "b"))
+	require.Error(t, err)
+}
+
+func TestRewriteColumnsInConstraintDef_CheckTypeCast(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef("CHECK ((col::text = 'x'))", one("col", "value"))
 	require.NoError(t, err)
 	assert.Contains(t, got, "value")
 	assert.NotContains(t, got, "(col")
 }
 
-func TestRewriteColumnInConstraintDef_CheckCoalesce(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef("CHECK ((COALESCE(col, 0) > 0))", "col", "value")
+func TestRewriteColumnsInConstraintDef_CheckCoalesce(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef("CHECK ((COALESCE(col, 0) > 0))", one("col", "value"))
 	require.NoError(t, err)
 	assert.Contains(t, got, "COALESCE(value")
 }
 
-func TestRewriteColumnInConstraintDef_CheckCase(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef(
+func TestRewriteColumnsInConstraintDef_CheckCase(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef(
 		"CHECK (((CASE WHEN col > 0 THEN 1 ELSE 0 END) = 1))",
-		"col", "value",
+		one("col", "value"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "value")
 }
 
-func TestRewriteColumnInConstraintDef_CheckAnyArray(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef(
+func TestRewriteColumnsInConstraintDef_CheckAnyArray(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef(
 		"CHECK ((status = ANY (ARRAY['a'::text, 'b'::text])))",
-		"status", "state",
+		one("status", "state"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "state")
 }
 
-func TestRewriteColumnInConstraintDef_CheckInList(t *testing.T) {
-	got, err := rewriteColumnInConstraintDef(
+func TestRewriteColumnsInConstraintDef_CheckInList(t *testing.T) {
+	got, err := rewriteColumnsInConstraintDef(
 		"CHECK ((status IN ('a', 'b')))",
-		"status", "state",
+		one("status", "state"),
 	)
 	require.NoError(t, err)
 	assert.Contains(t, got, "state")
 }
 
-func TestRewriteColumnInIndexDef_EmptyInput(t *testing.T) {
-	_, err := rewriteColumnInIndexDef("", "a", "b")
-	require.Error(t, err)
-}
-
-func TestRewriteColumnInIndexDef_NotIndexStmt(t *testing.T) {
-	_, err := rewriteColumnInIndexDef("SELECT 1", "a", "b")
-	require.Error(t, err)
-}
-
-func TestRewriteColumnInConstraintDef_EmptyInput(t *testing.T) {
-	_, err := rewriteColumnInConstraintDef("", "a", "b")
-	require.Error(t, err)
+func TestRewriteColumnsInConstraintDef_NoCascadeOnChain(t *testing.T) {
+	// Renames a→b and b→c must not cascade.
+	got, err := rewriteColumnsInConstraintDef(
+		"UNIQUE (a, b)",
+		map[string]string{"a": "b", "b": "c"},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, got, "(b, c)")
+	assert.NotContains(t, got, "(c, c)")
 }
 
 func TestRewriteColumnRefsInIndexes_RewritesAndClones(t *testing.T) {
@@ -213,7 +240,7 @@ func TestRewriteColumnRefsInIndexes_RewritesAndClones(t *testing.T) {
 	}
 	in.Set("idx", original)
 
-	out := rewriteColumnRefsInIndexes(in, map[string]string{"name": "display_name"})
+	out := rewriteColumnRefsInIndexes(in, one("name", "display_name"))
 	got, ok := out.GetOk("idx")
 	require.True(t, ok)
 	assert.Contains(t, got.Definition, "(display_name)")
@@ -230,7 +257,7 @@ func TestRewriteColumnRefsInIndexes_FallbackOnParseError(t *testing.T) {
 		Definition: "not a valid CREATE INDEX",
 	})
 
-	out := rewriteColumnRefsInIndexes(in, map[string]string{"name": "display_name"})
+	out := rewriteColumnRefsInIndexes(in, one("name", "display_name"))
 	got, ok := out.GetOk("idx")
 	require.True(t, ok)
 	// Unparseable definitions are kept intact so downstream comparison still works.
@@ -242,7 +269,7 @@ func TestRewriteColumnRefsInConstraints_RewritesAndClones(t *testing.T) {
 	original := &model.Constraint{Name: "u", Definition: "UNIQUE (email)"}
 	in.Set("u", original)
 
-	out := rewriteColumnRefsInConstraints(in, map[string]string{"email": "email_addr"})
+	out := rewriteColumnRefsInConstraints(in, one("email", "email_addr"))
 	got, ok := out.GetOk("u")
 	require.True(t, ok)
 	assert.Contains(t, got.Definition, "(email_addr)")
@@ -258,7 +285,7 @@ func TestRewriteColumnRefsInForeignKeys_RewritesLocalAttrs(t *testing.T) {
 		},
 	})
 
-	out := rewriteColumnRefsInForeignKeys(in, map[string]string{"user_id": "buyer_id"})
+	out := rewriteColumnRefsInForeignKeys(in, one("user_id", "buyer_id"))
 	got, ok := out.GetOk("fk")
 	require.True(t, ok)
 	assert.Contains(t, got.Definition, "(buyer_id)")

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -154,11 +154,14 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	// Rewrite column references in dependent objects so that subsequent diffs
 	// don't see the renamed column as a definition change. PostgreSQL applies
 	// RENAME COLUMN transparently to indexes/constraints/FKs on the same table.
+	// Also rekey current.Columns so diffComments looks up the right entry by
+	// the new column name.
 	if columnRenames := collectColumnRenames(desired.Columns); len(columnRenames) > 0 {
 		clone := *current
 		clone.Indexes = rewriteColumnRefsInIndexes(current.Indexes, columnRenames)
 		clone.Constraints = rewriteColumnRefsInConstraints(current.Constraints, columnRenames)
 		clone.ForeignKeys = rewriteColumnRefsInForeignKeys(current.ForeignKeys, columnRenames)
+		clone.Columns = renameColumnKeys(current.Columns, columnRenames)
 		current = &clone
 	}
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -151,6 +151,17 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	result.Stmts = append(result.Stmts, colStmts...)
 	result.DisallowedDropStmts = append(result.DisallowedDropStmts, colDisallowed...)
 
+	// Rewrite column references in dependent objects so that subsequent diffs
+	// don't see the renamed column as a definition change. PostgreSQL applies
+	// RENAME COLUMN transparently to indexes/constraints/FKs on the same table.
+	if columnRenames := collectColumnRenames(desired.Columns); len(columnRenames) > 0 {
+		clone := *current
+		clone.Indexes = rewriteColumnRefsInIndexes(current.Indexes, columnRenames)
+		clone.Constraints = rewriteColumnRefsInConstraints(current.Constraints, columnRenames)
+		clone.ForeignKeys = rewriteColumnRefsInForeignKeys(current.ForeignKeys, columnRenames)
+		current = &clone
+	}
+
 	conStmts, conDisallowed, err := diffConstraints(fqtn, current.Constraints, desired.Constraints, dc)
 	if err != nil {
 		return nil, err

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1400,6 +1400,44 @@ func TestDiffTable_fkRenameError(t *testing.T) {
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
 
+func TestDiffTable_columnRenameRewritesDependents(t *testing.T) {
+	current := newTable("public", "users")
+	current.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	current.Columns.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, Comment: ptr("legacy")})
+	current.Indexes.Set("idx_users_name", &model.Index{
+		Schema:     "public",
+		Name:       "idx_users_name",
+		Table:      "users",
+		Definition: "CREATE INDEX idx_users_name ON public.users USING btree (name)",
+	})
+
+	desired := newTable("public", "users")
+	desired.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	oldName := "name"
+	desired.Columns.Set("display_name", &model.Column{
+		Name:       "display_name",
+		TypeName:   "text",
+		NotNull:    true,
+		RenameFrom: &oldName,
+		Comment:    ptr("legacy"),
+	})
+	desired.Indexes.Set("idx_users_name", &model.Index{
+		Schema:     "public",
+		Name:       "idx_users_name",
+		Table:      "users",
+		Definition: "CREATE INDEX idx_users_name ON public.users USING btree (display_name)",
+	})
+
+	tableResult, err := diffTable(current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+
+	// Only the RENAME COLUMN should be emitted; no redundant DROP/CREATE
+	// INDEX, and no comment statement (the comment is preserved through
+	// RENAME).
+	require.Len(t, tableResult.Stmts, 1)
+	assert.Equal(t, "ALTER TABLE public.users RENAME COLUMN name TO display_name;", tableResult.Stmts[0])
+}
+
 func TestEqualConstraintDef_same(t *testing.T) {
 	assert.True(t, equalConstraintDef(
 		"PRIMARY KEY (id)",

--- a/plan_test.go
+++ b/plan_test.go
@@ -448,6 +448,37 @@ CREATE TABLE public.users (
 	assert.Empty(t, got.SQL)
 }
 
+func TestPlan_RenameColumn_NonPublicSchema(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.events (
+    id integer NOT NULL,
+    occurred_at timestamp NOT NULL,
+    CONSTRAINT events_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_events_time ON myschema.events (occurred_at);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE myschema.events (
+    id integer NOT NULL,
+    -- pist:renamed-from occurred_at
+    event_time timestamp NOT NULL,
+    CONSTRAINT events_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_events_time ON myschema.events (event_time);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Equal(t, "ALTER TABLE myschema.events RENAME COLUMN occurred_at TO event_time;", strings.TrimSpace(got.SQL))
+}
+
 func TestPlan(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/testdata/apply/rename_column_with_check.yml
+++ b/testdata/apply/rename_column_with_check.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_qty_check CHECK (qty > 0)
+  );
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      -- pist:renamed-from qty
+      quantity integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_qty_check CHECK (quantity > 0)
+  );
+applied: |
+  -- public.products
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      quantity integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_qty_check CHECK (quantity > 0)
+  );

--- a/testdata/apply/rename_column_with_exclusion.yml
+++ b/testdata/apply/rename_column_with_exclusion.yml
@@ -1,0 +1,27 @@
+init: |
+  CREATE EXTENSION IF NOT EXISTS btree_gist;
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, during WITH &&)
+  );
+desired: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      -- pist:renamed-from during
+      time_range tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, time_range WITH &&)
+  );
+applied: |
+  -- public.reservations
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      time_range tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, time_range WITH &&)
+  );

--- a/testdata/apply/rename_column_with_fk.yml
+++ b/testdata/apply/rename_column_with_fk.yml
@@ -1,0 +1,38 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      -- pist:renamed-from user_id
+      buyer_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT orders_user_id_fkey FOREIGN KEY (buyer_id) REFERENCES public.users(id)
+  );
+applied: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      buyer_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_user_id_fkey FOREIGN KEY (buyer_id) REFERENCES users(id);
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/rename_column_with_gist_index.yml
+++ b/testdata/apply/rename_column_with_gist_index.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_reservations_during ON public.reservations USING gist (during);
+desired: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      -- pist:renamed-from during
+      time_range tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_reservations_during ON public.reservations USING gist (time_range);
+applied: |
+  -- public.reservations
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      time_range tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_reservations_during ON public.reservations USING gist (time_range);

--- a/testdata/apply/rename_column_with_index.yml
+++ b/testdata/apply/rename_column_with_index.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (display_name);
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users USING btree (display_name);

--- a/testdata/apply/rename_column_with_unique.yml
+++ b/testdata/apply/rename_column_with_unique.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from email
+      email_address text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email_address)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email_address text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email_address)
+  );

--- a/testdata/apply/rename_quoted_column_with_index.yml
+++ b/testdata/apply/rename_quoted_column_with_index.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      "MyName" text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_myname ON public.users ("MyName");
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from "MyName"
+      "DisplayName" text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_myname ON public.users ("DisplayName");
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      "DisplayName" text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_myname ON public.users USING btree ("DisplayName");

--- a/testdata/plan/rename_column_drops_comment.yml
+++ b/testdata/plan/rename_column_drops_comment.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  COMMENT ON COLUMN public.users.name IS 'old comment';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users RENAME COLUMN name TO display_name;
+  COMMENT ON COLUMN public.users.display_name IS NULL;

--- a/testdata/plan/rename_column_in_composite_index.yml
+++ b/testdata/plan/rename_column_in_composite_index.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      occurred_at timestamp NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_events_user_time ON public.events (user_id, occurred_at);
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      -- pist:renamed-from occurred_at
+      event_time timestamp NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_events_user_time ON public.events (user_id, event_time);
+plan: |
+  ALTER TABLE public.events RENAME COLUMN occurred_at TO event_time;

--- a/testdata/plan/rename_column_in_composite_unique.yml
+++ b/testdata/plan/rename_column_in_composite_unique.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      tenant_id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_tenant_email_key UNIQUE (tenant_id, email)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      tenant_id integer NOT NULL,
+      -- pist:renamed-from email
+      email_address text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_tenant_email_key UNIQUE (tenant_id, email_address)
+  );
+plan: |
+  ALTER TABLE public.users RENAME COLUMN email TO email_address;

--- a/testdata/plan/rename_column_keeps_comment.yml
+++ b/testdata/plan/rename_column_keeps_comment.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  COMMENT ON COLUMN public.users.name IS 'user display name';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  COMMENT ON COLUMN public.users.display_name IS 'user display name';
+plan: |
+  ALTER TABLE public.users RENAME COLUMN name TO display_name;

--- a/testdata/plan/rename_column_pk.yml
+++ b/testdata/plan/rename_column_pk.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      -- pist:renamed-from id
+      user_id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (user_id)
+  );
+plan: |
+  ALTER TABLE public.users RENAME COLUMN id TO user_id;

--- a/testdata/plan/rename_column_with_check.yml
+++ b/testdata/plan/rename_column_with_check.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_qty_check CHECK (qty > 0)
+  );
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      -- pist:renamed-from qty
+      quantity integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_qty_check CHECK (quantity > 0)
+  );
+plan: |
+  ALTER TABLE public.products RENAME COLUMN qty TO quantity;

--- a/testdata/plan/rename_column_with_exclusion.yml
+++ b/testdata/plan/rename_column_with_exclusion.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE EXTENSION IF NOT EXISTS btree_gist;
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, during WITH &&)
+  );
+desired: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      -- pist:renamed-from during
+      time_range tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, time_range WITH &&)
+  );
+plan: |
+  ALTER TABLE public.reservations RENAME COLUMN during TO time_range;

--- a/testdata/plan/rename_column_with_expr_index.yml
+++ b/testdata/plan/rename_column_with_expr_index.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email_lower ON public.users (lower(email));
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from email
+      email_addr text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email_lower ON public.users (lower(email_addr));
+plan: |
+  ALTER TABLE public.users RENAME COLUMN email TO email_addr;

--- a/testdata/plan/rename_column_with_fk.yml
+++ b/testdata/plan/rename_column_with_fk.yml
@@ -1,0 +1,25 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      -- pist:renamed-from user_id
+      buyer_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT orders_user_id_fkey FOREIGN KEY (buyer_id) REFERENCES public.users(id)
+  );
+plan: |
+  ALTER TABLE public.orders RENAME COLUMN user_id TO buyer_id;

--- a/testdata/plan/rename_column_with_gist_index.yml
+++ b/testdata/plan/rename_column_with_gist_index.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_reservations_during ON public.reservations USING gist (during);
+desired: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      -- pist:renamed-from during
+      time_range tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_reservations_during ON public.reservations USING gist (time_range);
+plan: |
+  ALTER TABLE public.reservations RENAME COLUMN during TO time_range;

--- a/testdata/plan/rename_column_with_include_index.yml
+++ b/testdata/plan/rename_column_with_include_index.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      sku text NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_products_sku ON public.products (sku) INCLUDE (name);
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      sku text NOT NULL,
+      -- pist:renamed-from name
+      product_name text NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_products_sku ON public.products (sku) INCLUDE (product_name);
+plan: |
+  ALTER TABLE public.products RENAME COLUMN name TO product_name;

--- a/testdata/plan/rename_column_with_index.yml
+++ b/testdata/plan/rename_column_with_index.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (display_name);
+plan: |
+  ALTER TABLE public.users RENAME COLUMN name TO display_name;

--- a/testdata/plan/rename_column_with_isnull_partial_index.yml
+++ b/testdata/plan/rename_column_with_isnull_partial_index.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      deleted_at timestamp,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_active ON public.users (id) WHERE deleted_at IS NULL;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from deleted_at
+      removed_at timestamp,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_active ON public.users (id) WHERE removed_at IS NULL;
+plan: |
+  ALTER TABLE public.users RENAME COLUMN deleted_at TO removed_at;

--- a/testdata/plan/rename_column_with_partial_index.yml
+++ b/testdata/plan/rename_column_with_partial_index.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_products_qty ON public.products (qty) WHERE qty > 0;
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      -- pist:renamed-from qty
+      quantity integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_products_qty ON public.products (quantity) WHERE quantity > 0;
+plan: |
+  ALTER TABLE public.products RENAME COLUMN qty TO quantity;

--- a/testdata/plan/rename_column_with_range_check.yml
+++ b/testdata/plan/rename_column_with_range_check.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_qty_check CHECK (qty > 0 AND qty < 1000)
+  );
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      -- pist:renamed-from qty
+      quantity integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_qty_check CHECK (quantity > 0 AND quantity < 1000)
+  );
+plan: |
+  ALTER TABLE public.products RENAME COLUMN qty TO quantity;

--- a/testdata/plan/rename_column_with_unique.yml
+++ b/testdata/plan/rename_column_with_unique.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from email
+      email_address text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email_address)
+  );
+plan: |
+  ALTER TABLE public.users RENAME COLUMN email TO email_address;

--- a/testdata/plan/rename_column_with_unique_include.yml
+++ b/testdata/plan/rename_column_with_unique_include.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email) INCLUDE (name)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      -- pist:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email) INCLUDE (display_name)
+  );
+plan: |
+  ALTER TABLE public.users RENAME COLUMN name TO display_name;

--- a/testdata/plan/rename_multiple_columns_with_index.yml
+++ b/testdata/plan/rename_multiple_columns_with_index.yml
@@ -1,0 +1,21 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      first_name text NOT NULL,
+      last_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (first_name, last_name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from first_name
+      given_name text NOT NULL,
+      -- pist:renamed-from last_name
+      family_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (given_name, family_name);
+plan: |
+  ALTER TABLE public.users RENAME COLUMN first_name TO given_name;
+  ALTER TABLE public.users RENAME COLUMN last_name TO family_name;

--- a/testdata/plan/rename_quoted_column_with_index.yml
+++ b/testdata/plan/rename_quoted_column_with_index.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      "MyName" text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_myname ON public.users ("MyName");
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from "MyName"
+      "DisplayName" text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_myname ON public.users ("DisplayName");
+plan: |
+  ALTER TABLE public.users RENAME COLUMN "MyName" TO "DisplayName";


### PR DESCRIPTION
## Summary
- Walk the table's indexes / constraints / foreign keys after a `-- pist:renamed-from` column rename and rewrite the column references in their definitions on the current side, so subsequent diffs no longer emit redundant `DROP/CREATE` for dependents that PostgreSQL's `RENAME COLUMN` already updates transparently.
- Coverage spans regular indexes, composite / partial / expression / `INCLUDE` / GiST indexes, `UNIQUE` / `PRIMARY KEY` / `CHECK` / `EXCLUDE` constraints, and same-table FKs (the FK's local columns).
- Document the caveats in README: desired-side dependents must use the new column name, and cross-table references (views, FKs in other tables) are still subject to redundant `DROP/CREATE` on the first plan.

## Test plan
- [x] `make test` (full integration suite, including the 16 new plan / 7 new apply YAML fixtures and 2 new Go tests)
- [x] `make lint`
- [x] Coverage check — package-level coverage unchanged (75.3% → 75.4%); naturally-reachable branches in the new rewriter exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)