### PR TITLE
Validate column references in desired schema at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Validate column references in desired schema at plan time: indexes, constraints (CHECK / UNIQUE / PK / EXCLUDE), and foreign keys (local side) whose definitions reference columns absent from the owning table's desired column set are reported as a single aggregated error before any DDL is executed. Catches the common mistake of renaming a column via `-- pist:renamed-from` while forgetting to update the dependent definition.
+
 ## [1.2.0] - 2026-04-29
 
 * Rewrite column references in same-table indexes, constraints, and foreign keys when a column is renamed via `-- pist:renamed-from`, so a single `ALTER TABLE ... RENAME COLUMN` is emitted without redundant `DROP/CREATE` on dependents. Covers regular / composite / partial / expression / `INCLUDE` / GiST indexes, `UNIQUE` / `PRIMARY KEY` / `CHECK` / `EXCLUDE` constraints, and same-table FKs. ([#123](https://github.com/winebarrel/pistachio/pull/123))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Changelog
 
-## [Unreleased]
-
-* Validate column references in desired schema at plan time: indexes, constraints (CHECK / UNIQUE / PK / EXCLUDE), and foreign keys (local side) whose definitions reference columns absent from the owning table's desired column set are reported as a single aggregated error before any DDL is executed. Catches the common mistake of renaming a column via `-- pist:renamed-from` while forgetting to update the dependent definition.
-
 ## [1.2.0] - 2026-04-29
 
 * Rewrite column references in same-table indexes, constraints, and foreign keys when a column is renamed via `-- pist:renamed-from`, so a single `ALTER TABLE ... RENAME COLUMN` is emitted without redundant `DROP/CREATE` on dependents. Covers regular / composite / partial / expression / `INCLUDE` / GiST indexes, `UNIQUE` / `PRIMARY KEY` / `CHECK` / `EXCLUDE` constraints, and same-table FKs. ([#123](https://github.com/winebarrel/pistachio/pull/123))
 * Track column comments across `-- pist:renamed-from` renames: comment changes (including drops) on a renamed column are now detected, and unchanged comments no longer emit a redundant `COMMENT ON COLUMN` statement. ([#123](https://github.com/winebarrel/pistachio/pull/123))
+* Validate column references in desired schema at plan time: indexes, constraints (CHECK / UNIQUE / PK / EXCLUDE), and foreign keys (local side) whose definitions reference columns absent from the owning table's desired column set are reported as a single aggregated error before any DDL is executed. Catches the common mistake of renaming a column via `-- pist:renamed-from` while forgetting to update the dependent definition. ([#124](https://github.com/winebarrel/pistachio/pull/124))
 
 ## [1.1.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ CREATE TABLE public.users (
 CREATE INDEX idx_users_name ON public.users (display_name);
 ```
 
-If the desired side still references the old name, `pist plan` may emit `DROP/CREATE` for dependent indexes, constraints, or foreign keys that re-reference the missing column, and the subsequent `pist apply` will fail with `column "name" does not exist`.
+If the desired side still references the old name, `pist plan` errors out at parse time with a message like `column "name" referenced in index "idx_users_name" does not exist on table "public.users"`. All such unresolved references are reported in a single error.
 
 The following references are **not** auto-rewritten and may produce a redundant `DROP/CREATE` on the first plan (the second run after applying the rename comes out clean):
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ CREATE TABLE public.users (
 CREATE INDEX idx_users_name ON public.users (display_name);
 ```
 
-If the desired side still references the old name, `pist plan` errors out at parse time with a message like `column "name" referenced in index "idx_users_name" does not exist on table "public.users"`. All such unresolved references are reported in a single error.
+If the desired side still references the old name, `pist plan` errors out at parse time with a message like `column name referenced in index idx_users_name does not exist on table public.users` (identifiers are quoted only when they aren't safe unquoted). All such unresolved references are reported in a single error.
 
 The following references are **not** auto-rewritten and may produce a redundant `DROP/CREATE` on the first plan (the second run after applying the rename comes out clean):
 

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -2,10 +2,10 @@ package diff
 
 import (
 	"fmt"
-	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/internal/pgast"
 	"github.com/winebarrel/pistachio/model"
 )
 
@@ -423,59 +423,13 @@ func collectColumnRenames(desired *orderedmap.Map[string, *model.Column]) map[st
 // unqualified ColumnRef whose name appears in renames to the mapped new
 // name, mutating the tree in place. Each ColumnRef is matched against the
 // original-name set in a single pass, so chained renames (a→b alongside
-// b→c) cannot cascade. Qualified references (table.col) are left untouched
-// because the renamed column belongs to a single table and the diff context
-// is local.
+// b→c) cannot cascade.
 func rewriteColumnRefsInExpr(node *pg_query.Node, renames map[string]string) {
-	if node == nil {
-		return
-	}
-	switch n := node.Node.(type) {
-	case *pg_query.Node_ColumnRef:
-		if len(n.ColumnRef.Fields) == 1 {
-			if s := n.ColumnRef.Fields[0].GetString_(); s != nil {
-				if newName, ok := renames[s.Sval]; ok {
-					s.Sval = newName
-				}
-			}
+	pgast.WalkExprColumnRefs(node, func(s *pg_query.String) {
+		if newName, ok := renames[s.Sval]; ok {
+			s.Sval = newName
 		}
-	case *pg_query.Node_AExpr:
-		rewriteColumnRefsInExpr(n.AExpr.Lexpr, renames)
-		rewriteColumnRefsInExpr(n.AExpr.Rexpr, renames)
-	case *pg_query.Node_BoolExpr:
-		for _, arg := range n.BoolExpr.Args {
-			rewriteColumnRefsInExpr(arg, renames)
-		}
-	case *pg_query.Node_TypeCast:
-		rewriteColumnRefsInExpr(n.TypeCast.Arg, renames)
-	case *pg_query.Node_FuncCall:
-		for _, arg := range n.FuncCall.Args {
-			rewriteColumnRefsInExpr(arg, renames)
-		}
-	case *pg_query.Node_NullTest:
-		rewriteColumnRefsInExpr(n.NullTest.Arg, renames)
-	case *pg_query.Node_AArrayExpr:
-		for _, elem := range n.AArrayExpr.Elements {
-			rewriteColumnRefsInExpr(elem, renames)
-		}
-	case *pg_query.Node_List:
-		for _, item := range n.List.Items {
-			rewriteColumnRefsInExpr(item, renames)
-		}
-	case *pg_query.Node_CoalesceExpr:
-		for _, arg := range n.CoalesceExpr.Args {
-			rewriteColumnRefsInExpr(arg, renames)
-		}
-	case *pg_query.Node_CaseExpr:
-		rewriteColumnRefsInExpr(n.CaseExpr.Arg, renames)
-		rewriteColumnRefsInExpr(n.CaseExpr.Defresult, renames)
-		for _, when := range n.CaseExpr.Args {
-			if w := when.GetCaseWhen(); w != nil {
-				rewriteColumnRefsInExpr(w.Expr, renames)
-				rewriteColumnRefsInExpr(w.Result, renames)
-			}
-		}
-	}
+	})
 }
 
 // rewriteColumnsInIndexDef returns a new index definition with column
@@ -516,8 +470,6 @@ func rewriteColumnsInIndexDef(def string, renames map[string]string) (string, er
 	return pg_query.Deparse(result)
 }
 
-const constraintDefWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
-
 // rewriteColumnsInConstraintDef returns a new constraint definition fragment
 // (e.g. "PRIMARY KEY (id)", "CHECK ((x > 0))", "FOREIGN KEY (a) REFERENCES t(b)")
 // with column references rewritten according to the renames map (old → new).
@@ -527,25 +479,9 @@ const constraintDefWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
 // All renames are applied in a single AST walk so chained renames cannot
 // cascade.
 func rewriteColumnsInConstraintDef(def string, renames map[string]string) (string, error) {
-	sql := constraintDefWrapPrefix + def
-	result, err := pg_query.Parse(sql)
+	result, con, err := pgast.ParseConstraintDefStrict(def)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse constraint definition: %w", err)
-	}
-	if len(result.Stmts) == 0 {
-		return "", fmt.Errorf("empty constraint definition")
-	}
-	as := result.Stmts[0].Stmt.GetAlterTableStmt()
-	if as == nil || len(as.Cmds) == 0 {
-		return "", fmt.Errorf("unexpected parse result for constraint definition")
-	}
-	cmd := as.Cmds[0].GetAlterTableCmd()
-	if cmd == nil || cmd.Def == nil {
-		return "", fmt.Errorf("unexpected parse result for constraint definition")
-	}
-	con := cmd.Def.GetConstraint()
-	if con == nil {
-		return "", fmt.Errorf("unexpected parse result for constraint definition")
+		return "", err
 	}
 
 	rewriteStringList := func(nodes []*pg_query.Node) {
@@ -580,15 +516,7 @@ func rewriteColumnsInConstraintDef(def string, renames map[string]string) (strin
 		}
 	}
 
-	deparsed, err := pg_query.Deparse(result)
-	if err != nil {
-		return "", fmt.Errorf("failed to deparse constraint definition: %w", err)
-	}
-	deparsed = strings.TrimSuffix(deparsed, ";")
-	if !strings.HasPrefix(deparsed, constraintDefWrapPrefix) {
-		return "", fmt.Errorf("unexpected deparsed form: %s", deparsed)
-	}
-	return strings.TrimPrefix(deparsed, constraintDefWrapPrefix), nil
+	return pgast.DeparseConstraintDef(result)
 }
 
 // rewriteColumnRefsInIndexes returns a clone of indexes with each Definition

--- a/internal/pgast/pgast.go
+++ b/internal/pgast/pgast.go
@@ -1,0 +1,123 @@
+// Package pgast provides shared pg_query AST helpers used by both the
+// rename rewriter (diff package) and the column-reference validator
+// (parser package).
+package pgast
+
+import (
+	"fmt"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+// ConstraintWrapPrefix is the wrapper used to parse a constraint definition
+// fragment (e.g. "PRIMARY KEY (id)") as part of a full statement so that
+// pg_query produces a Constraint node we can inspect or mutate.
+const ConstraintWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
+
+// ParseConstraintDef parses a constraint definition fragment and returns
+// the underlying *pg_query.Constraint. Returns nil for unparseable or
+// unexpected input so callers can degrade gracefully.
+func ParseConstraintDef(def string) *pg_query.Constraint {
+	_, con, err := ParseConstraintDefStrict(def)
+	if err != nil {
+		return nil
+	}
+	return con
+}
+
+// ParseConstraintDefStrict is like ParseConstraintDef but also returns the
+// full ParseResult and a typed error, so callers that need to mutate the
+// AST and deparse it back can distinguish failure modes.
+func ParseConstraintDefStrict(def string) (*pg_query.ParseResult, *pg_query.Constraint, error) {
+	result, err := pg_query.Parse(ConstraintWrapPrefix + def)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse constraint definition: %w", err)
+	}
+	if len(result.Stmts) == 0 {
+		return nil, nil, fmt.Errorf("empty constraint definition")
+	}
+	as := result.Stmts[0].Stmt.GetAlterTableStmt()
+	if as == nil || len(as.Cmds) == 0 {
+		return nil, nil, fmt.Errorf("unexpected parse result for constraint definition")
+	}
+	cmd := as.Cmds[0].GetAlterTableCmd()
+	if cmd == nil || cmd.Def == nil {
+		return nil, nil, fmt.Errorf("unexpected parse result for constraint definition")
+	}
+	con := cmd.Def.GetConstraint()
+	if con == nil {
+		return nil, nil, fmt.Errorf("unexpected parse result for constraint definition")
+	}
+	return result, con, nil
+}
+
+// DeparseConstraintDef deparses a ParseResult that came from
+// ParseConstraintDefStrict and strips the wrapper so the caller receives
+// just the constraint fragment.
+func DeparseConstraintDef(result *pg_query.ParseResult) (string, error) {
+	deparsed, err := pg_query.Deparse(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to deparse constraint definition: %w", err)
+	}
+	deparsed = strings.TrimSuffix(deparsed, ";")
+	if !strings.HasPrefix(deparsed, ConstraintWrapPrefix) {
+		return "", fmt.Errorf("unexpected deparsed form: %s", deparsed)
+	}
+	return strings.TrimPrefix(deparsed, ConstraintWrapPrefix), nil
+}
+
+// WalkExprColumnRefs walks an expression tree and invokes visit for each
+// unqualified single-field ColumnRef's underlying String node. Visitors may
+// mutate the String's Sval to rename the column. Qualified references
+// (table.col, schema.table.col) are skipped because they refer outside the
+// local scope.
+func WalkExprColumnRefs(node *pg_query.Node, visit func(*pg_query.String)) {
+	if node == nil {
+		return
+	}
+	switch n := node.Node.(type) {
+	case *pg_query.Node_ColumnRef:
+		if len(n.ColumnRef.Fields) == 1 {
+			if s := n.ColumnRef.Fields[0].GetString_(); s != nil {
+				visit(s)
+			}
+		}
+	case *pg_query.Node_AExpr:
+		WalkExprColumnRefs(n.AExpr.Lexpr, visit)
+		WalkExprColumnRefs(n.AExpr.Rexpr, visit)
+	case *pg_query.Node_BoolExpr:
+		for _, arg := range n.BoolExpr.Args {
+			WalkExprColumnRefs(arg, visit)
+		}
+	case *pg_query.Node_TypeCast:
+		WalkExprColumnRefs(n.TypeCast.Arg, visit)
+	case *pg_query.Node_FuncCall:
+		for _, arg := range n.FuncCall.Args {
+			WalkExprColumnRefs(arg, visit)
+		}
+	case *pg_query.Node_NullTest:
+		WalkExprColumnRefs(n.NullTest.Arg, visit)
+	case *pg_query.Node_AArrayExpr:
+		for _, elem := range n.AArrayExpr.Elements {
+			WalkExprColumnRefs(elem, visit)
+		}
+	case *pg_query.Node_List:
+		for _, item := range n.List.Items {
+			WalkExprColumnRefs(item, visit)
+		}
+	case *pg_query.Node_CoalesceExpr:
+		for _, arg := range n.CoalesceExpr.Args {
+			WalkExprColumnRefs(arg, visit)
+		}
+	case *pg_query.Node_CaseExpr:
+		WalkExprColumnRefs(n.CaseExpr.Arg, visit)
+		WalkExprColumnRefs(n.CaseExpr.Defresult, visit)
+		for _, when := range n.CaseExpr.Args {
+			if w := when.GetCaseWhen(); w != nil {
+				WalkExprColumnRefs(w.Expr, visit)
+				WalkExprColumnRefs(w.Result, visit)
+			}
+		}
+	}
+}

--- a/internal/pgast/pgast_test.go
+++ b/internal/pgast/pgast_test.go
@@ -1,0 +1,75 @@
+package pgast_test
+
+import (
+	"testing"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/internal/pgast"
+)
+
+func TestParseConstraintDef_Unique(t *testing.T) {
+	con := pgast.ParseConstraintDef("UNIQUE (email)")
+	require.NotNil(t, con)
+	require.Len(t, con.Keys, 1)
+	assert.Equal(t, "email", con.Keys[0].GetString_().Sval)
+}
+
+func TestParseConstraintDef_Invalid(t *testing.T) {
+	assert.Nil(t, pgast.ParseConstraintDef("not a valid def"))
+	assert.Nil(t, pgast.ParseConstraintDef(""))
+}
+
+func TestParseConstraintDefStrict_Error(t *testing.T) {
+	_, _, err := pgast.ParseConstraintDefStrict("not a valid def")
+	require.Error(t, err)
+}
+
+func TestDeparseConstraintDef_RoundTrip(t *testing.T) {
+	result, _, err := pgast.ParseConstraintDefStrict("UNIQUE (email)")
+	require.NoError(t, err)
+	got, err := pgast.DeparseConstraintDef(result)
+	require.NoError(t, err)
+	assert.Equal(t, "UNIQUE (email)", got)
+}
+
+func TestWalkExprColumnRefs_CollectsAndMutates(t *testing.T) {
+	con := pgast.ParseConstraintDef("CHECK ((qty > 0 AND qty < 1000))")
+	require.NotNil(t, con)
+
+	var seen []string
+	pgast.WalkExprColumnRefs(con.RawExpr, func(s *pg_query.String) {
+		seen = append(seen, s.Sval)
+	})
+	assert.Equal(t, []string{"qty", "qty"}, seen)
+
+	// Mutate via visitor.
+	pgast.WalkExprColumnRefs(con.RawExpr, func(s *pg_query.String) {
+		if s.Sval == "qty" {
+			s.Sval = "quantity"
+		}
+	})
+	var after []string
+	pgast.WalkExprColumnRefs(con.RawExpr, func(s *pg_query.String) {
+		after = append(after, s.Sval)
+	})
+	assert.Equal(t, []string{"quantity", "quantity"}, after)
+}
+
+func TestWalkExprColumnRefs_NilSafe(t *testing.T) {
+	pgast.WalkExprColumnRefs(nil, func(s *pg_query.String) {
+		t.Fatal("visitor should not be invoked on nil node")
+	})
+}
+
+func TestWalkExprColumnRefs_SkipsQualifiedRefs(t *testing.T) {
+	// `t.col` should not be visited because the diff scope is local.
+	con := pgast.ParseConstraintDef("CHECK ((t.col > 0))")
+	require.NotNil(t, con)
+	called := false
+	pgast.WalkExprColumnRefs(con.RawExpr, func(s *pg_query.String) {
+		called = true
+	})
+	assert.False(t, called)
+}

--- a/internal/pgast/pgast_test.go
+++ b/internal/pgast/pgast_test.go
@@ -57,6 +57,50 @@ func TestWalkExprColumnRefs_CollectsAndMutates(t *testing.T) {
 	assert.Equal(t, []string{"quantity", "quantity"}, after)
 }
 
+// collectRefs is a small helper that returns all unqualified column refs
+// in the RawExpr of a CHECK constraint definition.
+func collectRefs(t *testing.T, def string) []string {
+	t.Helper()
+	con := pgast.ParseConstraintDef(def)
+	require.NotNil(t, con)
+	var refs []string
+	pgast.WalkExprColumnRefs(con.RawExpr, func(s *pg_query.String) {
+		refs = append(refs, s.Sval)
+	})
+	return refs
+}
+
+func TestWalkExprColumnRefs_TypeCast(t *testing.T) {
+	assert.Equal(t, []string{"col"}, collectRefs(t, "CHECK ((col::text = 'x'))"))
+}
+
+func TestWalkExprColumnRefs_FuncCall(t *testing.T) {
+	assert.Equal(t, []string{"col"}, collectRefs(t, "CHECK ((lower(col) = 'x'))"))
+}
+
+func TestWalkExprColumnRefs_NullTest(t *testing.T) {
+	assert.Equal(t, []string{"col"}, collectRefs(t, "CHECK ((col IS NULL))"))
+}
+
+func TestWalkExprColumnRefs_Coalesce(t *testing.T) {
+	assert.Equal(t, []string{"col"}, collectRefs(t, "CHECK ((COALESCE(col, 0) > 0))"))
+}
+
+func TestWalkExprColumnRefs_CaseExpr(t *testing.T) {
+	assert.Equal(t, []string{"col"}, collectRefs(t,
+		"CHECK (((CASE WHEN col > 0 THEN 1 ELSE 0 END) = 1))"))
+}
+
+func TestWalkExprColumnRefs_AnyArray(t *testing.T) {
+	assert.Equal(t, []string{"status"}, collectRefs(t,
+		"CHECK ((status = ANY (ARRAY['a'::text, 'b'::text])))"))
+}
+
+func TestWalkExprColumnRefs_InList(t *testing.T) {
+	assert.Equal(t, []string{"status"}, collectRefs(t,
+		"CHECK ((status IN ('a', 'b')))"))
+}
+
 func TestWalkExprColumnRefs_NilSafe(t *testing.T) {
 	pgast.WalkExprColumnRefs(nil, func(s *pg_query.String) {
 		t.Fatal("visitor should not be invoked on nil node")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -268,6 +268,10 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		}
 	}
 
+	if err := ValidateColumnRefs(tables); err != nil {
+		return nil, err
+	}
+
 	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains, ExecuteStmts: executeStmts}, nil
 }
 

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -1,0 +1,237 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// ValidateColumnRefs returns an error if any index, constraint, or foreign-key
+// definition on a desired table references a column that does not exist in
+// that table's desired column set. All violations across all tables are
+// aggregated via errors.Join so a single plan run reports every problem.
+//
+// Scope: only same-table references are checked. Foreign-key referenced
+// columns (PkAttrs, on the parent table) are out of scope. Partition
+// children that inherit columns from the parent are skipped.
+func ValidateColumnRefs(tables *orderedmap.Map[string, *model.Table]) error {
+	var errs []error
+	for fqtn, t := range tables.All() {
+		if t.PartitionOf != nil && t.PartitionBound != nil {
+			continue
+		}
+
+		cols := make(map[string]bool, t.Columns.Len())
+		for name := range t.Columns.Keys() {
+			cols[name] = true
+		}
+
+		for _, idx := range t.Indexes.CollectValues() {
+			for _, ref := range collectColumnRefsInIndexDef(idx.Definition) {
+				if !cols[ref] {
+					errs = append(errs, fmt.Errorf("column %s referenced in index %s does not exist on table %s",
+						model.Ident(ref), model.Ident(idx.Name), fqtn))
+				}
+			}
+		}
+
+		for _, con := range t.Constraints.CollectValues() {
+			kind := constraintKindLabel(con.Type)
+			for _, ref := range collectColumnRefsInConstraintDef(con.Definition) {
+				if !cols[ref] {
+					errs = append(errs, fmt.Errorf("column %s referenced in %s %s does not exist on table %s",
+						model.Ident(ref), kind, model.Ident(con.Name), fqtn))
+				}
+			}
+		}
+
+		for _, fk := range t.ForeignKeys.CollectValues() {
+			for _, ref := range collectColumnRefsInFKDef(fk.Definition) {
+				if !cols[ref] {
+					errs = append(errs, fmt.Errorf("column %s referenced in foreign key %s does not exist on table %s",
+						model.Ident(ref), model.Ident(fk.Name), fqtn))
+				}
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func constraintKindLabel(ct model.ConstraintType) string {
+	switch {
+	case ct.IsCheckConstraint():
+		return "CHECK constraint"
+	case ct.IsPrimaryKeyConstraint():
+		return "PRIMARY KEY constraint"
+	case ct.IsUniqueConstraint():
+		return "UNIQUE constraint"
+	case ct.IsForeignKeyConstraint():
+		return "FOREIGN KEY constraint"
+	case ct.IsExclusionConstraint():
+		return "EXCLUDE constraint"
+	default:
+		return "constraint"
+	}
+}
+
+// collectColumnRefsInIndexDef returns the unqualified column names referenced
+// by an index definition (IndexParams, IndexIncludingParams, WhereClause).
+// Returns nil on parse errors so validation degrades to a no-op for
+// unparsable definitions.
+func collectColumnRefsInIndexDef(def string) []string {
+	result, err := pg_query.Parse(def)
+	if err != nil || len(result.Stmts) == 0 {
+		return nil
+	}
+	is := result.Stmts[0].Stmt.GetIndexStmt()
+	if is == nil {
+		return nil
+	}
+	var refs []string
+	collect := func(params []*pg_query.Node) {
+		for _, p := range params {
+			ie := p.GetIndexElem()
+			if ie == nil {
+				continue
+			}
+			if ie.Name != "" {
+				refs = append(refs, ie.Name)
+			}
+			refs = append(refs, walkExprColumnRefs(ie.Expr)...)
+		}
+	}
+	collect(is.IndexParams)
+	collect(is.IndexIncludingParams)
+	refs = append(refs, walkExprColumnRefs(is.WhereClause)...)
+	return refs
+}
+
+const constraintWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
+
+// collectColumnRefsInConstraintDef returns the unqualified column names
+// referenced by a constraint definition fragment (Keys, Including, RawExpr,
+// EXCLUDE Exclusions IndexElem).
+func collectColumnRefsInConstraintDef(def string) []string {
+	con := parseConstraint(def)
+	if con == nil {
+		return nil
+	}
+	var refs []string
+	collectStringList := func(nodes []*pg_query.Node) {
+		for _, n := range nodes {
+			if s := n.GetString_(); s != nil && s.Sval != "" {
+				refs = append(refs, s.Sval)
+			}
+		}
+	}
+	collectStringList(con.Keys)
+	collectStringList(con.Including)
+	refs = append(refs, walkExprColumnRefs(con.RawExpr)...)
+	for _, ex := range con.Exclusions {
+		list := ex.GetList()
+		if list == nil {
+			continue
+		}
+		for _, item := range list.Items {
+			ie := item.GetIndexElem()
+			if ie == nil {
+				continue
+			}
+			if ie.Name != "" {
+				refs = append(refs, ie.Name)
+			}
+			refs = append(refs, walkExprColumnRefs(ie.Expr)...)
+		}
+	}
+	return refs
+}
+
+// collectColumnRefsInFKDef returns the local-side column names (FkAttrs)
+// referenced by a foreign-key definition. PkAttrs (parent-table columns) are
+// intentionally excluded; cross-table validation is out of scope.
+func collectColumnRefsInFKDef(def string) []string {
+	con := parseConstraint(def)
+	if con == nil {
+		return nil
+	}
+	var refs []string
+	for _, n := range con.FkAttrs {
+		if s := n.GetString_(); s != nil && s.Sval != "" {
+			refs = append(refs, s.Sval)
+		}
+	}
+	return refs
+}
+
+func parseConstraint(def string) *pg_query.Constraint {
+	result, err := pg_query.Parse(constraintWrapPrefix + def)
+	if err != nil || len(result.Stmts) == 0 {
+		return nil
+	}
+	as := result.Stmts[0].Stmt.GetAlterTableStmt()
+	if as == nil || len(as.Cmds) == 0 {
+		return nil
+	}
+	cmd := as.Cmds[0].GetAlterTableCmd()
+	if cmd == nil || cmd.Def == nil {
+		return nil
+	}
+	return cmd.Def.GetConstraint()
+}
+
+// walkExprColumnRefs returns the unqualified ColumnRef names found in an
+// expression tree. Read-only mirror of diff.rewriteColumnRefsInExpr.
+func walkExprColumnRefs(node *pg_query.Node) []string {
+	if node == nil {
+		return nil
+	}
+	var refs []string
+	switch n := node.Node.(type) {
+	case *pg_query.Node_ColumnRef:
+		if len(n.ColumnRef.Fields) == 1 {
+			if s := n.ColumnRef.Fields[0].GetString_(); s != nil && s.Sval != "" {
+				refs = append(refs, s.Sval)
+			}
+		}
+	case *pg_query.Node_AExpr:
+		refs = append(refs, walkExprColumnRefs(n.AExpr.Lexpr)...)
+		refs = append(refs, walkExprColumnRefs(n.AExpr.Rexpr)...)
+	case *pg_query.Node_BoolExpr:
+		for _, arg := range n.BoolExpr.Args {
+			refs = append(refs, walkExprColumnRefs(arg)...)
+		}
+	case *pg_query.Node_TypeCast:
+		refs = append(refs, walkExprColumnRefs(n.TypeCast.Arg)...)
+	case *pg_query.Node_FuncCall:
+		for _, arg := range n.FuncCall.Args {
+			refs = append(refs, walkExprColumnRefs(arg)...)
+		}
+	case *pg_query.Node_NullTest:
+		refs = append(refs, walkExprColumnRefs(n.NullTest.Arg)...)
+	case *pg_query.Node_AArrayExpr:
+		for _, elem := range n.AArrayExpr.Elements {
+			refs = append(refs, walkExprColumnRefs(elem)...)
+		}
+	case *pg_query.Node_List:
+		for _, item := range n.List.Items {
+			refs = append(refs, walkExprColumnRefs(item)...)
+		}
+	case *pg_query.Node_CoalesceExpr:
+		for _, arg := range n.CoalesceExpr.Args {
+			refs = append(refs, walkExprColumnRefs(arg)...)
+		}
+	case *pg_query.Node_CaseExpr:
+		refs = append(refs, walkExprColumnRefs(n.CaseExpr.Arg)...)
+		refs = append(refs, walkExprColumnRefs(n.CaseExpr.Defresult)...)
+		for _, when := range n.CaseExpr.Args {
+			if w := when.GetCaseWhen(); w != nil {
+				refs = append(refs, walkExprColumnRefs(w.Expr)...)
+				refs = append(refs, walkExprColumnRefs(w.Result)...)
+			}
+		}
+	}
+	return refs
+}

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -14,14 +14,22 @@ import (
 // definition on a desired table references a column that does not exist in
 // that table's desired column set. All violations across all tables are
 // aggregated via errors.Join so a single plan run reports every problem.
+// Within a single object (index / constraint / FK), each missing column
+// name is reported at most once so multiple references to the same name
+// don't produce duplicate error lines.
 //
 // Scope: only same-table references are checked. Foreign-key referenced
-// columns (PkAttrs, on the parent table) are out of scope. Partition
-// children that inherit columns from the parent are skipped.
+// columns (PkAttrs, on the parent table) are out of scope. Tables that
+// inherit columns from a parent (declarative partition children and
+// INHERITS-style children) are skipped.
 func ValidateColumnRefs(tables *orderedmap.Map[string, *model.Table]) error {
 	var errs []error
 	for fqtn, t := range tables.All() {
-		if t.PartitionOf != nil && t.PartitionBound != nil {
+		// Skip both partition children (PartitionOf + PartitionBound set) and
+		// INHERITS-style children (PartitionOf set, PartitionBound nil) — both
+		// inherit their columns from the parent rather than declaring their
+		// own complete column list.
+		if t.PartitionOf != nil {
 			continue
 		}
 
@@ -31,34 +39,41 @@ func ValidateColumnRefs(tables *orderedmap.Map[string, *model.Table]) error {
 		}
 
 		for _, idx := range t.Indexes.CollectValues() {
-			for _, ref := range collectColumnRefsInIndexDef(idx.Definition) {
-				if !cols[ref] {
-					errs = append(errs, fmt.Errorf("column %s referenced in index %s does not exist on table %s",
-						model.Ident(ref), model.Ident(idx.Name), fqtn))
-				}
-			}
+			reportMissing(&errs, cols, collectColumnRefsInIndexDef(idx.Definition), func(ref string) error {
+				return fmt.Errorf("column %s referenced in index %s does not exist on table %s",
+					model.Ident(ref), model.Ident(idx.Name), fqtn)
+			})
 		}
 
 		for _, con := range t.Constraints.CollectValues() {
 			kind := constraintKindLabel(con.Type)
-			for _, ref := range collectColumnRefsInConstraintDef(con.Definition) {
-				if !cols[ref] {
-					errs = append(errs, fmt.Errorf("column %s referenced in %s %s does not exist on table %s",
-						model.Ident(ref), kind, model.Ident(con.Name), fqtn))
-				}
-			}
+			reportMissing(&errs, cols, collectColumnRefsInConstraintDef(con.Definition), func(ref string) error {
+				return fmt.Errorf("column %s referenced in %s %s does not exist on table %s",
+					model.Ident(ref), kind, model.Ident(con.Name), fqtn)
+			})
 		}
 
 		for _, fk := range t.ForeignKeys.CollectValues() {
-			for _, ref := range collectColumnRefsInFKDef(fk.Definition) {
-				if !cols[ref] {
-					errs = append(errs, fmt.Errorf("column %s referenced in foreign key %s does not exist on table %s",
-						model.Ident(ref), model.Ident(fk.Name), fqtn))
-				}
-			}
+			reportMissing(&errs, cols, collectColumnRefsInFKDef(fk.Definition), func(ref string) error {
+				return fmt.Errorf("column %s referenced in foreign key %s does not exist on table %s",
+					model.Ident(ref), model.Ident(fk.Name), fqtn)
+			})
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// reportMissing appends one error per distinct refs[i] that is not in cols,
+// preserving first-encounter order so the aggregated error is deterministic.
+func reportMissing(errs *[]error, cols map[string]bool, refs []string, mkErr func(string) error) {
+	seen := map[string]bool{}
+	for _, ref := range refs {
+		if cols[ref] || seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		*errs = append(*errs, mkErr(ref))
+	}
 }
 
 func constraintKindLabel(ct model.ConstraintType) string {

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -6,6 +6,7 @@ import (
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/internal/pgast"
 	"github.com/winebarrel/pistachio/model"
 )
 
@@ -109,13 +110,11 @@ func collectColumnRefsInIndexDef(def string) []string {
 	return refs
 }
 
-const constraintWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
-
 // collectColumnRefsInConstraintDef returns the unqualified column names
 // referenced by a constraint definition fragment (Keys, Including, RawExpr,
 // EXCLUDE Exclusions IndexElem).
 func collectColumnRefsInConstraintDef(def string) []string {
-	con := parseConstraint(def)
+	con := pgast.ParseConstraintDef(def)
 	if con == nil {
 		return nil
 	}
@@ -153,7 +152,7 @@ func collectColumnRefsInConstraintDef(def string) []string {
 // referenced by a foreign-key definition. PkAttrs (parent-table columns) are
 // intentionally excluded; cross-table validation is out of scope.
 func collectColumnRefsInFKDef(def string) []string {
-	con := parseConstraint(def)
+	con := pgast.ParseConstraintDef(def)
 	if con == nil {
 		return nil
 	}
@@ -166,72 +165,14 @@ func collectColumnRefsInFKDef(def string) []string {
 	return refs
 }
 
-func parseConstraint(def string) *pg_query.Constraint {
-	result, err := pg_query.Parse(constraintWrapPrefix + def)
-	if err != nil || len(result.Stmts) == 0 {
-		return nil
-	}
-	as := result.Stmts[0].Stmt.GetAlterTableStmt()
-	if as == nil || len(as.Cmds) == 0 {
-		return nil
-	}
-	cmd := as.Cmds[0].GetAlterTableCmd()
-	if cmd == nil || cmd.Def == nil {
-		return nil
-	}
-	return cmd.Def.GetConstraint()
-}
-
 // walkExprColumnRefs returns the unqualified ColumnRef names found in an
-// expression tree. Read-only mirror of diff.rewriteColumnRefsInExpr.
+// expression tree.
 func walkExprColumnRefs(node *pg_query.Node) []string {
-	if node == nil {
-		return nil
-	}
 	var refs []string
-	switch n := node.Node.(type) {
-	case *pg_query.Node_ColumnRef:
-		if len(n.ColumnRef.Fields) == 1 {
-			if s := n.ColumnRef.Fields[0].GetString_(); s != nil && s.Sval != "" {
-				refs = append(refs, s.Sval)
-			}
+	pgast.WalkExprColumnRefs(node, func(s *pg_query.String) {
+		if s.Sval != "" {
+			refs = append(refs, s.Sval)
 		}
-	case *pg_query.Node_AExpr:
-		refs = append(refs, walkExprColumnRefs(n.AExpr.Lexpr)...)
-		refs = append(refs, walkExprColumnRefs(n.AExpr.Rexpr)...)
-	case *pg_query.Node_BoolExpr:
-		for _, arg := range n.BoolExpr.Args {
-			refs = append(refs, walkExprColumnRefs(arg)...)
-		}
-	case *pg_query.Node_TypeCast:
-		refs = append(refs, walkExprColumnRefs(n.TypeCast.Arg)...)
-	case *pg_query.Node_FuncCall:
-		for _, arg := range n.FuncCall.Args {
-			refs = append(refs, walkExprColumnRefs(arg)...)
-		}
-	case *pg_query.Node_NullTest:
-		refs = append(refs, walkExprColumnRefs(n.NullTest.Arg)...)
-	case *pg_query.Node_AArrayExpr:
-		for _, elem := range n.AArrayExpr.Elements {
-			refs = append(refs, walkExprColumnRefs(elem)...)
-		}
-	case *pg_query.Node_List:
-		for _, item := range n.List.Items {
-			refs = append(refs, walkExprColumnRefs(item)...)
-		}
-	case *pg_query.Node_CoalesceExpr:
-		for _, arg := range n.CoalesceExpr.Args {
-			refs = append(refs, walkExprColumnRefs(arg)...)
-		}
-	case *pg_query.Node_CaseExpr:
-		refs = append(refs, walkExprColumnRefs(n.CaseExpr.Arg)...)
-		refs = append(refs, walkExprColumnRefs(n.CaseExpr.Defresult)...)
-		for _, when := range n.CaseExpr.Args {
-			if w := when.GetCaseWhen(); w != nil {
-				refs = append(refs, walkExprColumnRefs(w.Expr)...)
-				refs = append(refs, walkExprColumnRefs(w.Result)...)
-			}
-		}
-	}
+	})
 	return refs
 }

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -241,6 +241,43 @@ func TestValidateColumnRefs_CheckAnyArrayChecked(t *testing.T) {
 	assert.Contains(t, err.Error(), "column status referenced")
 }
 
+func TestValidateColumnRefs_MultiTableScoping(t *testing.T) {
+	// One table is valid, another has a missing reference. The error must
+	// name only the offending table.
+	good := newValidatableTable("good", "id", "name")
+	good.Indexes.Set("idx_good", &model.Index{
+		Name:       "idx_good",
+		Definition: "CREATE INDEX idx_good ON public.good (name)",
+	})
+
+	bad := newValidatableTable("bad", "id", "display_name")
+	bad.Indexes.Set("idx_bad", &model.Index{
+		Name:       "idx_bad",
+		Definition: "CREATE INDEX idx_bad ON public.bad (name)",
+	})
+
+	err := ValidateColumnRefs(tablesMap(good, bad))
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "table public.bad")
+	assert.NotContains(t, msg, "table public.good")
+}
+
+func TestValidateColumnRefs_CompositeKeyPartialMiss(t *testing.T) {
+	// In INDEX (a, b) with only b in the desired column set, only "a" must
+	// be reported — not "b".
+	tbl := newValidatableTable("t", "id", "b")
+	tbl.Indexes.Set("idx", &model.Index{
+		Name:       "idx",
+		Definition: "CREATE INDEX idx ON public.t (a, b)",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "column a referenced in index idx")
+	assert.NotContains(t, msg, "column b referenced")
+}
+
 func TestCollectColumnRefsInIndexDef_HandlesUnparseable(t *testing.T) {
 	assert.Nil(t, collectColumnRefsInIndexDef("not valid sql"))
 	assert.Nil(t, collectColumnRefsInIndexDef(""))

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -165,6 +165,49 @@ func TestValidateColumnRefs_PartitionChildSkipped(t *testing.T) {
 	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
 }
 
+func TestValidateColumnRefs_ExpressionIndexMissingColumn(t *testing.T) {
+	// The renamed column reference is inside a function call expression.
+	tbl := newValidatableTable("users", "id", "email_addr")
+	tbl.Indexes.Set("idx_users_email_lower", &model.Index{
+		Name:       "idx_users_email_lower",
+		Definition: "CREATE INDEX idx_users_email_lower ON public.users (lower(email))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column email referenced in index idx_users_email_lower")
+}
+
+func TestValidateColumnRefs_FKCompositeLocalPartialMiss(t *testing.T) {
+	// FK (a, b) REFERENCES ... where a exists but b is missing locally.
+	tbl := newValidatableTable("orders", "id", "tenant_id")
+	tbl.ForeignKeys.Set("fk_buyer", &model.ForeignKey{
+		Constraint: model.Constraint{
+			Name:       "fk_buyer",
+			Type:       model.ConstraintType('f'),
+			Definition: "FOREIGN KEY (tenant_id, user_id) REFERENCES public.users(tenant_id, id)",
+		},
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "column user_id referenced in foreign key fk_buyer")
+	assert.NotContains(t, msg, "column tenant_id referenced")
+}
+
+func TestValidateColumnRefs_SelfReferencingFK(t *testing.T) {
+	// Local-side parent_id resolves to the table's own column set; PkAttrs
+	// (id) are out of scope. Validation must pass.
+	tbl := newValidatableTable("nodes", "id", "parent_id")
+	tbl.ForeignKeys.Set("fk_parent", &model.ForeignKey{
+		Constraint: model.Constraint{
+			Name:       "fk_parent",
+			Type:       model.ConstraintType('f'),
+			Definition: "FOREIGN KEY (parent_id) REFERENCES public.nodes(id)",
+		},
+	})
+	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+}
+
 func TestValidateColumnRefs_ExpressionIndexValid(t *testing.T) {
 	tbl := newValidatableTable("users", "id", "email")
 	tbl.Indexes.Set("idx", &model.Index{

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -1,0 +1,262 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func newValidatableTable(name string, cols ...string) *model.Table {
+	t := &model.Table{
+		Schema:      "public",
+		Name:        name,
+		Columns:     orderedmap.New[string, *model.Column](),
+		Constraints: orderedmap.New[string, *model.Constraint](),
+		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+		Indexes:     orderedmap.New[string, *model.Index](),
+	}
+	for _, c := range cols {
+		t.Columns.Set(c, &model.Column{Name: c})
+	}
+	return t
+}
+
+func tablesMap(ts ...*model.Table) *orderedmap.Map[string, *model.Table] {
+	m := orderedmap.New[string, *model.Table]()
+	for _, t := range ts {
+		m.Set(t.FQTN(), t)
+	}
+	return m
+}
+
+func TestValidateColumnRefs_Valid(t *testing.T) {
+	tbl := newValidatableTable("users", "id", "name")
+	tbl.Indexes.Set("idx", &model.Index{
+		Name:       "idx",
+		Definition: "CREATE INDEX idx ON public.users (name)",
+	})
+	tbl.Constraints.Set("uq", &model.Constraint{
+		Name:       "uq",
+		Type:       model.ConstraintType('u'),
+		Definition: "UNIQUE (name)",
+	})
+	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+}
+
+func TestValidateColumnRefs_IndexMissingColumn(t *testing.T) {
+	tbl := newValidatableTable("users", "id", "display_name")
+	tbl.Indexes.Set("idx_users_name", &model.Index{
+		Name:       "idx_users_name",
+		Definition: "CREATE INDEX idx_users_name ON public.users (name)",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column name referenced in index idx_users_name does not exist on table public.users")
+}
+
+func TestValidateColumnRefs_CheckMissingColumn(t *testing.T) {
+	tbl := newValidatableTable("products", "id", "quantity")
+	tbl.Constraints.Set("products_qty_check", &model.Constraint{
+		Name:       "products_qty_check",
+		Type:       model.ConstraintType('c'),
+		Definition: "CHECK ((qty > 0))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column qty referenced in CHECK constraint products_qty_check does not exist on table public.products")
+}
+
+func TestValidateColumnRefs_FKMissingLocalColumn(t *testing.T) {
+	tbl := newValidatableTable("orders", "id", "buyer_id")
+	tbl.ForeignKeys.Set("fk", &model.ForeignKey{
+		Constraint: model.Constraint{
+			Name:       "fk",
+			Type:       model.ConstraintType('f'),
+			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		},
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column user_id referenced in foreign key fk does not exist on table public.orders")
+}
+
+func TestValidateColumnRefs_FKReferencedColumnNotChecked(t *testing.T) {
+	// PkAttrs (referenced columns) are intentionally not validated. A made-up
+	// referenced column name should not surface as a violation.
+	tbl := newValidatableTable("orders", "id", "user_id")
+	tbl.ForeignKeys.Set("fk", &model.ForeignKey{
+		Constraint: model.Constraint{
+			Name:       "fk",
+			Type:       model.ConstraintType('f'),
+			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(nonexistent_pk)",
+		},
+	})
+	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+}
+
+func TestValidateColumnRefs_AggregatesMultiple(t *testing.T) {
+	tbl := newValidatableTable("t", "id")
+	tbl.Indexes.Set("idx_a", &model.Index{Name: "idx_a", Definition: "CREATE INDEX idx_a ON public.t (a)"})
+	tbl.Constraints.Set("c_b", &model.Constraint{Name: "c_b", Type: model.ConstraintType('c'), Definition: "CHECK ((b > 0))"})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "column a referenced in index idx_a")
+	assert.Contains(t, msg, "column b referenced in CHECK constraint c_b")
+}
+
+func TestValidateColumnRefs_PartitionChildSkipped(t *testing.T) {
+	parent := "public.events"
+	bound := "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')"
+	tbl := &model.Table{
+		Schema:         "public",
+		Name:           "events_2024",
+		PartitionOf:    &parent,
+		PartitionBound: &bound,
+		Columns:        orderedmap.New[string, *model.Column](),
+		Constraints:    orderedmap.New[string, *model.Constraint](),
+		ForeignKeys:    orderedmap.New[string, *model.ForeignKey](),
+		Indexes:        orderedmap.New[string, *model.Index](),
+	}
+	// Index references a column not in the (empty) inherited child column set.
+	tbl.Indexes.Set("idx", &model.Index{Name: "idx", Definition: "CREATE INDEX idx ON public.events_2024 (id)"})
+	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+}
+
+func TestValidateColumnRefs_ExpressionIndexValid(t *testing.T) {
+	tbl := newValidatableTable("users", "id", "email")
+	tbl.Indexes.Set("idx", &model.Index{
+		Name:       "idx",
+		Definition: "CREATE INDEX idx ON public.users (lower(email))",
+	})
+	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+}
+
+func TestValidateColumnRefs_PartialIndexWhereChecked(t *testing.T) {
+	tbl := newValidatableTable("users", "id", "active")
+	tbl.Indexes.Set("idx", &model.Index{
+		Name:       "idx",
+		Definition: "CREATE INDEX idx ON public.users (id) WHERE deleted_at IS NULL",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column deleted_at referenced in index idx")
+}
+
+func TestValidateColumnRefs_ExclusionChecked(t *testing.T) {
+	tbl := newValidatableTable("reservations", "id", "room", "time_range")
+	tbl.Constraints.Set("no_overlap", &model.Constraint{
+		Name:       "no_overlap",
+		Type:       model.ConstraintType('x'),
+		Definition: "EXCLUDE USING gist (room WITH =, during WITH &&)",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column during referenced in EXCLUDE constraint no_overlap")
+}
+
+func TestValidateColumnRefs_QuotedIdentifier(t *testing.T) {
+	tbl := newValidatableTable("t", "id", "MyName")
+	tbl.Indexes.Set("idx", &model.Index{
+		Name:       "idx",
+		Definition: `CREATE INDEX idx ON public.t ("MyName")`,
+	})
+	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+}
+
+func TestValidateColumnRefs_CheckBoolExprChecked(t *testing.T) {
+	tbl := newValidatableTable("t", "id")
+	tbl.Constraints.Set("c", &model.Constraint{
+		Name:       "c",
+		Type:       model.ConstraintType('c'),
+		Definition: "CHECK ((a > 0 AND b < 100))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "column a referenced")
+	assert.Contains(t, msg, "column b referenced")
+}
+
+func TestValidateColumnRefs_CheckTypeCastChecked(t *testing.T) {
+	tbl := newValidatableTable("t", "id")
+	tbl.Constraints.Set("c", &model.Constraint{
+		Name:       "c",
+		Type:       model.ConstraintType('c'),
+		Definition: "CHECK ((status::text = 'a'))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column status referenced")
+}
+
+func TestValidateColumnRefs_CheckCoalesceChecked(t *testing.T) {
+	tbl := newValidatableTable("t", "id")
+	tbl.Constraints.Set("c", &model.Constraint{
+		Name:       "c",
+		Type:       model.ConstraintType('c'),
+		Definition: "CHECK ((COALESCE(qty, 0) > 0))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column qty referenced")
+}
+
+func TestValidateColumnRefs_CheckCaseChecked(t *testing.T) {
+	tbl := newValidatableTable("t", "id")
+	tbl.Constraints.Set("c", &model.Constraint{
+		Name:       "c",
+		Type:       model.ConstraintType('c'),
+		Definition: "CHECK (((CASE WHEN flag THEN 1 ELSE 0 END) = 1))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column flag referenced")
+}
+
+func TestValidateColumnRefs_CheckInListChecked(t *testing.T) {
+	tbl := newValidatableTable("t", "id")
+	tbl.Constraints.Set("c", &model.Constraint{
+		Name:       "c",
+		Type:       model.ConstraintType('c'),
+		Definition: "CHECK ((status IN ('a', 'b')))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column status referenced")
+}
+
+func TestValidateColumnRefs_CheckAnyArrayChecked(t *testing.T) {
+	tbl := newValidatableTable("t", "id")
+	tbl.Constraints.Set("c", &model.Constraint{
+		Name:       "c",
+		Type:       model.ConstraintType('c'),
+		Definition: "CHECK ((status = ANY (ARRAY['a'::text, 'b'::text])))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column status referenced")
+}
+
+func TestCollectColumnRefsInIndexDef_HandlesUnparseable(t *testing.T) {
+	assert.Nil(t, collectColumnRefsInIndexDef("not valid sql"))
+	assert.Nil(t, collectColumnRefsInIndexDef(""))
+	assert.Nil(t, collectColumnRefsInIndexDef("SELECT 1"))
+}
+
+func TestCollectColumnRefsInConstraintDef_HandlesUnparseable(t *testing.T) {
+	assert.Nil(t, collectColumnRefsInConstraintDef("not a constraint"))
+	assert.Nil(t, collectColumnRefsInConstraintDef(""))
+}
+
+func TestConstraintKindLabel(t *testing.T) {
+	assert.Equal(t, "CHECK constraint", constraintKindLabel(model.ConstraintType('c')))
+	assert.Equal(t, "PRIMARY KEY constraint", constraintKindLabel(model.ConstraintType('p')))
+	assert.Equal(t, "UNIQUE constraint", constraintKindLabel(model.ConstraintType('u')))
+	assert.Equal(t, "FOREIGN KEY constraint", constraintKindLabel(model.ConstraintType('f')))
+	assert.Equal(t, "EXCLUDE constraint", constraintKindLabel(model.ConstraintType('x')))
+	assert.Equal(t, "constraint", constraintKindLabel(model.ConstraintType('?')))
+}

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,6 +107,44 @@ func TestValidateColumnRefs_AggregatesMultiple(t *testing.T) {
 	msg := err.Error()
 	assert.Contains(t, msg, "column a referenced in index idx_a")
 	assert.Contains(t, msg, "column b referenced in CHECK constraint c_b")
+}
+
+func TestValidateColumnRefs_InheritsChildSkipped(t *testing.T) {
+	// INHERITS-style children are represented with PartitionOf set and
+	// PartitionBound nil. Their column list is inherited from the parent,
+	// so validating their definitions against an empty Columns map would
+	// produce false positives.
+	parent := "public.events"
+	tbl := &model.Table{
+		Schema:      "public",
+		Name:        "events_v2",
+		PartitionOf: &parent,
+		Columns:     orderedmap.New[string, *model.Column](),
+		Constraints: orderedmap.New[string, *model.Constraint](),
+		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+		Indexes:     orderedmap.New[string, *model.Index](),
+	}
+	tbl.Constraints.Set("pk", &model.Constraint{
+		Name:       "pk",
+		Type:       model.ConstraintType('p'),
+		Definition: "PRIMARY KEY (id)",
+	})
+	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+}
+
+func TestValidateColumnRefs_DeduplicatesPerObject(t *testing.T) {
+	// CHECK with multiple references to the same missing column must report
+	// the column only once.
+	tbl := newValidatableTable("t", "id")
+	tbl.Constraints.Set("c", &model.Constraint{
+		Name:       "c",
+		Type:       model.ConstraintType('c'),
+		Definition: "CHECK ((qty > 0 AND qty < 100))",
+	})
+	err := ValidateColumnRefs(tablesMap(tbl))
+	require.Error(t, err)
+	count := strings.Count(err.Error(), "column qty referenced")
+	assert.Equal(t, 1, count)
 }
 
 func TestValidateColumnRefs_PartitionChildSkipped(t *testing.T) {

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -289,6 +289,33 @@ func TestCollectColumnRefsInConstraintDef_HandlesUnparseable(t *testing.T) {
 	assert.Nil(t, collectColumnRefsInConstraintDef(""))
 }
 
+func TestParseSQLWithSchema_RejectsUnresolvedColumnRef(t *testing.T) {
+	// End-to-end through ParseSQLWithSchema so the validation call site in
+	// parser.go is exercised by the parser package's own tests.
+	sql := `CREATE TABLE users (
+    id integer NOT NULL,
+    display_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON users (name);`
+
+	_, err := ParseSQLWithSchema(sql, "public")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "column name referenced in index idx_users_name does not exist on table public.users")
+}
+
+func TestParseSQLWithSchema_AcceptsResolvedColumnRefs(t *testing.T) {
+	sql := `CREATE TABLE users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON users (name);`
+
+	_, err := ParseSQLWithSchema(sql, "public")
+	require.NoError(t, err)
+}
+
 func TestConstraintKindLabel(t *testing.T) {
 	assert.Equal(t, "CHECK constraint", constraintKindLabel(model.ConstraintType('c')))
 	assert.Equal(t, "PRIMARY KEY constraint", constraintKindLabel(model.ConstraintType('p')))

--- a/testdata/plan/error_check_missing_column.yml
+++ b/testdata/plan/error_check_missing_column.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      -- pist:renamed-from qty
+      quantity integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id),
+      CONSTRAINT products_qty_check CHECK (qty > 0)
+  );
+error: 'column qty referenced in CHECK constraint products_qty_check does not exist on table public.products'

--- a/testdata/plan/error_exclusion_missing_column.yml
+++ b/testdata/plan/error_exclusion_missing_column.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE EXTENSION IF NOT EXISTS btree_gist;
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      during tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.reservations (
+      id integer NOT NULL,
+      room integer NOT NULL,
+      -- pist:renamed-from during
+      time_range tsrange NOT NULL,
+      CONSTRAINT reservations_pkey PRIMARY KEY (id),
+      CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, during WITH &&)
+  );
+error: 'column during referenced in EXCLUDE constraint no_overlap does not exist on table public.reservations'

--- a/testdata/plan/error_fk_missing_column.yml
+++ b/testdata/plan/error_fk_missing_column.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      -- pist:renamed-from user_id
+      buyer_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+error: 'column user_id referenced in foreign key orders_user_id_fkey does not exist on table public.orders'

--- a/testdata/plan/error_index_include_missing_column.yml
+++ b/testdata/plan/error_index_include_missing_column.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      sku text NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      sku text NOT NULL,
+      -- pist:renamed-from name
+      product_name text NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_products_sku ON public.products (sku) INCLUDE (name);
+error: 'column name referenced in index idx_products_sku does not exist on table public.products'

--- a/testdata/plan/error_index_missing_column.yml
+++ b/testdata/plan/error_index_missing_column.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+error: 'column name referenced in index idx_users_name does not exist on table public.users'

--- a/testdata/plan/error_pk_missing_column.yml
+++ b/testdata/plan/error_pk_missing_column.yml
@@ -1,0 +1,12 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      -- pist:renamed-from id
+      user_id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+error: 'column id referenced in PRIMARY KEY constraint users_pkey does not exist on table public.users'

--- a/testdata/plan/error_unique_include_missing_column.yml
+++ b/testdata/plan/error_unique_include_missing_column.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      -- pist:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email) INCLUDE (name)
+  );
+error: 'column name referenced in UNIQUE constraint users_email_key does not exist on table public.users'

--- a/testdata/plan/error_unique_missing_column.yml
+++ b/testdata/plan/error_unique_missing_column.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pist:renamed-from email
+      email_addr text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );
+error: 'column email referenced in UNIQUE constraint users_email_key does not exist on table public.users'


### PR DESCRIPTION
## Summary
- Resolve unqualified column references in each table's index, constraint, and foreign-key definitions against the table's desired column set; report unresolved references as a single aggregated error (`errors.Join`) before any DDL runs.
- Catches the common mistake of renaming a column via `-- pist:renamed-from` while forgetting to update a dependent definition (previously surfaced only at apply time as `column "X" does not exist`).
- Scope intentionally limited to same-table references — FK `PkAttrs` (parent-table columns) and partition children are skipped, mirroring the rename-rewrite policy.

## Test plan
- [x] `make test` (parser unit tests + new error YAML fixtures across index / CHECK / UNIQUE / FK / EXCLUDE)
- [x] `make lint`
- [x] Coverage check — `walkExprColumnRefs` 100%, `ValidateColumnRefs` 100%; remaining sub-100% lines in helpers are paranoid pg_query AST guards skipped per CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)