### PR TITLE
Update stale rename NOTE and expand TODO.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Track column comments across `-- pist:renamed-from` renames: comment changes (including drops) on a renamed column are now detected, and unchanged comments no longer emit a redundant `COMMENT ON COLUMN` statement. ([#123](https://github.com/winebarrel/pistachio/pull/123))
 * Validate column references in desired schema at plan time: indexes, constraints (CHECK / UNIQUE / PK / EXCLUDE), and foreign keys (local side) whose definitions reference columns absent from the owning table's desired column set are reported as a single aggregated error before any DDL is executed. Catches the common mistake of renaming a column via `-- pist:renamed-from` while forgetting to update the dependent definition. ([#124](https://github.com/winebarrel/pistachio/pull/124))
 * Fix `GENERATED ALWAYS AS (<expr>) STORED` column handling: parsed desired columns now correctly retain the GENERATED form (previously emitted as `DEFAULT <expr>`), and no-diff plans on generated columns no longer produce a spurious `ALTER COLUMN ... SET DEFAULT` (which PostgreSQL rejects on generated columns). ([#125](https://github.com/winebarrel/pistachio/pull/125))
+* Reject GENERATED toggles at plan time: changing a column between generated and non-generated now errors with `cannot toggle GENERATED — DROP COLUMN + ADD COLUMN is required` instead of silently emitting no DDL. ([#125](https://github.com/winebarrel/pistachio/pull/125))
 
 ## [1.1.0] - 2026-04-28
 

--- a/TODO.md
+++ b/TODO.md
@@ -74,11 +74,10 @@ Origin: post-#125 audit.
 
 ## Silent drift on `Table.Unlogged` toggle
 
-`model.Table.Unlogged` is set on parse and used to emit `CREATE UNLOGGED
-TABLE`, but transitions on existing tables (logged ⇄ unlogged) are not
-diffed. PostgreSQL has `ALTER TABLE ... SET LOGGED` / `SET UNLOGGED`.
-The current `no_diff_unlogged_table.yml` fixture only covers the
-unchanged case.
+`model.Table.Unlogged` is set on parse and used to emit `CREATE UNLOGGED TABLE`,
+but transitions on existing tables (logged ⇄ unlogged) are not diffed.
+PostgreSQL has `ALTER TABLE ... SET LOGGED` / `SET UNLOGGED`. The current
+`no_diff_unlogged_table.yml` fixture only covers the unchanged case.
 
 Origin: post-#125 audit.
 
@@ -97,9 +96,9 @@ Origin: post-#125 audit.
 catalog but not compared directly in the diff. Changes are still
 detected because they end up in the `pg_get_constraintdef` Definition
 string, which means a deferrable toggle currently triggers DROP+ADD
-of the constraint. PostgreSQL supports `ALTER CONSTRAINT ... [NOT]
-DEFERRABLE [INITIALLY ...]` for in-place changes; using it would avoid
-the round-trip.
+of the constraint. PostgreSQL supports
+`ALTER TABLE ... ALTER CONSTRAINT ... [NOT] DEFERRABLE [INITIALLY ...]`
+for in-place changes; using it would avoid the round-trip.
 
 Origin: post-#125 audit. Optimisation rather than a bug — current
 behaviour is correct, just heavier than necessary.
@@ -118,14 +117,13 @@ Origin: post-#125 audit.
 ## Table rename: cross-table dependents
 
 `detectTableRenames` rewrites the renamed table's own indexes and FKs
-in the adjusted current state, but other tables' `FOREIGN KEY ...
-REFERENCES old_table(...)` and view definitions that reference the old
-table name are not rewritten. PostgreSQL auto-updates these on RENAME,
-so a second plan/apply comes out clean, but the first plan can emit
-redundant DROP/CREATE for the dependent objects. The same scope as
-the existing column-rename TODO above ("Auto-rewrite of column
-references in views and cross-table FKs"), extended to table-level
-renames.
+in the adjusted current state, but other tables' `FOREIGN KEY ... REFERENCES old_table(...)`
+and view definitions that reference the old table name are not rewritten.
+PostgreSQL auto-updates these on RENAME, so a second plan/apply comes out
+clean, but the first plan can emit redundant drop/recreate operations for
+the dependent objects. Same scope as the existing column-rename TODO above
+("Auto-rewrite of column references in views and cross-table FKs"),
+extended to table-level renames.
 
 Origin: pre-existing NOTE in `diff/rename.go:detectTableRenames`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -67,8 +67,8 @@ Origin: #125.
 The catalog and parser populate `Table.TableSpace` and `Index.TableSpace`,
 but the diff layer never compares them. Changing a tablespace in desired
 SQL after the object exists has no effect on the generated plan. Should
-emit `ALTER TABLE ... SET TABLESPACE <new>` (and the equivalent
-`ALTER INDEX`).
+emit `ALTER TABLE ... SET TABLESPACE <new>` and
+`ALTER INDEX ... SET TABLESPACE <new>`.
 
 Origin: post-#125 audit.
 

--- a/TODO.md
+++ b/TODO.md
@@ -62,6 +62,73 @@ drop policy.
 
 Origin: #125.
 
+## Silent drift on `Table.TableSpace` / `Index.TableSpace` changes
+
+The catalog and parser populate `Table.TableSpace` and `Index.TableSpace`,
+but the diff layer never compares them. Changing a tablespace in desired
+SQL after the object exists has no effect on the generated plan. Should
+emit `ALTER TABLE ... SET TABLESPACE <new>` (and the equivalent
+`ALTER INDEX`).
+
+Origin: post-#125 audit.
+
+## Silent drift on `Table.Unlogged` toggle
+
+`model.Table.Unlogged` is set on parse and used to emit `CREATE UNLOGGED
+TABLE`, but transitions on existing tables (logged ⇄ unlogged) are not
+diffed. PostgreSQL has `ALTER TABLE ... SET LOGGED` / `SET UNLOGGED`.
+The current `no_diff_unlogged_table.yml` fixture only covers the
+unchanged case.
+
+Origin: post-#125 audit.
+
+## `Column.StorageType` is dead code
+
+`model.Column.StorageType` is declared but never read or written by
+parser / catalog / diff. Either implement column storage diffs
+(`ALTER COLUMN ... SET STORAGE PLAIN|EXTERNAL|EXTENDED|MAIN`) or drop
+the field. Today the value is always the zero string.
+
+Origin: post-#125 audit.
+
+## Constraint `Deferrable` / `Deferred` granularity
+
+`Constraint.Deferrable` / `Constraint.Deferred` are read from the
+catalog but not compared directly in the diff. Changes are still
+detected because they end up in the `pg_get_constraintdef` Definition
+string, which means a deferrable toggle currently triggers DROP+ADD
+of the constraint. PostgreSQL supports `ALTER CONSTRAINT ... [NOT]
+DEFERRABLE [INITIALLY ...]` for in-place changes; using it would avoid
+the round-trip.
+
+Origin: post-#125 audit. Optimisation rather than a bug — current
+behaviour is correct, just heavier than necessary.
+
+## Standalone Sequences are not first-class
+
+`catalog/sequences.go` reads sequences (used for SERIAL/IDENTITY
+metadata), but parser and diff don't handle `CREATE SEQUENCE` /
+`ALTER SEQUENCE` / `DROP SEQUENCE` as schema operations. Standalone
+sequences in desired SQL therefore round-trip via execute directives
+only. Decide whether sequence is in scope; if yes, add parser/diff
+support; if no, document the limitation.
+
+Origin: post-#125 audit.
+
+## Table rename: cross-table dependents
+
+`detectTableRenames` rewrites the renamed table's own indexes and FKs
+in the adjusted current state, but other tables' `FOREIGN KEY ...
+REFERENCES old_table(...)` and view definitions that reference the old
+table name are not rewritten. PostgreSQL auto-updates these on RENAME,
+so a second plan/apply comes out clean, but the first plan can emit
+redundant DROP/CREATE for the dependent objects. The same scope as
+the existing column-rename TODO above ("Auto-rewrite of column
+references in views and cross-table FKs"), extended to table-level
+renames.
+
+Origin: pre-existing NOTE in `diff/rename.go:detectTableRenames`.
+
 ## Plan-time error promotion: forgotten dependent reference
 
 When desired SQL references the new column name in a dependent

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -207,9 +207,9 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 // rewritten in the adjusted current state by `rewriteColumnRefsInIndexes`,
 // `rewriteColumnRefsInConstraints`, and `rewriteColumnRefsInForeignKeys`
 // (called from diffTable), so a plain rename does not produce redundant
-// DROP/ADD on those dependents. View definitions and foreign-key references
-// in *other* tables are still not rewritten — see TODO.md
-// "Auto-rewrite of column references in views and cross-table FKs".
+// drop/recreate operations on those dependents. View definitions and
+// foreign-key references in *other* tables are still not rewritten — see
+// TODO.md "Auto-rewrite of column references in views and cross-table FKs".
 func detectColumnRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Column]) ([]string, *orderedmap.Map[string, *model.Column], error) {
 	var stmts []string
 	adjusted := cloneMap(current)

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -203,12 +203,12 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 }
 
 // detectColumnRenames finds desired columns with RenameFrom that match a current column.
-//
-// NOTE: After a column rename, constraint/index/FK definitions that reference the
-// old column name are not updated in the adjusted current state. PostgreSQL
-// automatically updates these on RENAME COLUMN, so running plan/apply a second
-// time will produce a clean diff. A single plan may emit redundant DROP/ADD for
-// dependent constraints or indexes.
+// Column references in same-table indexes, constraints, and foreign keys are
+// rewritten in the adjusted current state by rewriteColumnRefsInIndexes/
+// Constraints/ForeignKeys (called from diffTable), so a plain rename does not
+// produce redundant DROP/ADD on those dependents. View definitions and
+// foreign-key references in *other* tables are still not rewritten — see
+// TODO.md "Auto-rewrite of column references in views and cross-table FKs".
 func detectColumnRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Column]) ([]string, *orderedmap.Map[string, *model.Column], error) {
 	var stmts []string
 	adjusted := cloneMap(current)

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -204,11 +204,12 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 
 // detectColumnRenames finds desired columns with RenameFrom that match a current column.
 // Column references in same-table indexes, constraints, and foreign keys are
-// rewritten in the adjusted current state by rewriteColumnRefsInIndexes/
-// Constraints/ForeignKeys (called from diffTable), so a plain rename does not
-// produce redundant DROP/ADD on those dependents. View definitions and
-// foreign-key references in *other* tables are still not rewritten — see
-// TODO.md "Auto-rewrite of column references in views and cross-table FKs".
+// rewritten in the adjusted current state by `rewriteColumnRefsInIndexes`,
+// `rewriteColumnRefsInConstraints`, and `rewriteColumnRefsInForeignKeys`
+// (called from diffTable), so a plain rename does not produce redundant
+// DROP/ADD on those dependents. View definitions and foreign-key references
+// in *other* tables are still not rewritten — see TODO.md
+// "Auto-rewrite of column references in views and cross-table FKs".
 func detectColumnRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Column]) ([]string, *orderedmap.Map[string, *model.Column], error) {
 	var stmts []string
 	adjusted := cloneMap(current)


### PR DESCRIPTION
## Summary
- Reword the outdated NOTE on \`detectColumnRenames\` (it claimed dependents weren't updated, which hasn't been true since #123) and point at TODO.md for the genuine remaining gap.
- Add six new deferred items uncovered by a post-#125 audit:
  - \`Table.TableSpace\` / \`Index.TableSpace\` changes are silently dropped
  - \`Table.Unlogged\` toggles are silently dropped
  - \`Column.StorageType\` is declared but never read/written
  - \`Constraint.Deferrable\` / \`Deferred\` go through DROP+ADD instead of \`ALTER CONSTRAINT\`
  - Standalone sequences are not first-class (parser/diff don't handle \`CREATE/ALTER/DROP SEQUENCE\`)
  - Table rename: cross-table dependents (FK \`REFERENCES\` and view definitions in *other* tables)

Documentation only.

## Test plan
- [x] \`make test\`
- [x] \`make lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)