### PR TITLE
Link PR references in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@ the rename comes out clean):
 
 Resolving these requires cross-object awareness in the diff phase.
 
-Origin: #123.
+Origin: [#123](https://github.com/winebarrel/pistachio/pull/123).
 
 ## Validation of column refs in GENERATED / DEFAULT expressions
 
@@ -31,7 +31,7 @@ A typo or stale rename in these expressions still surfaces only at apply
 time. Adding a walk over `model.Column.Default` for both kinds (gated by
 `Generated`) would close this gap.
 
-Origin: #124.
+Origin: [#124](https://github.com/winebarrel/pistachio/pull/124).
 
 ## INHERITS table plan / apply support
 
@@ -43,7 +43,7 @@ incorrect DDL. The validator already special-cases INHERITS children
 child), but the SQL emitter and diff don't handle the legacy partition
 shape end-to-end.
 
-Origin: #125. Plan / apply fixtures were intentionally not added.
+Origin: [#125](https://github.com/winebarrel/pistachio/pull/125). Plan / apply fixtures were intentionally not added.
 
 ## GENERATED column expression changes
 
@@ -60,7 +60,7 @@ Once expression comparison works, the diff could either error out (as
 the toggle case does) or emit `DROP COLUMN` + `ADD COLUMN` gated by a
 drop policy.
 
-Origin: #125.
+Origin: [#125](https://github.com/winebarrel/pistachio/pull/125).
 
 ## Silent drift on `Table.TableSpace` / `Index.TableSpace` changes
 
@@ -70,7 +70,7 @@ SQL after the object exists has no effect on the generated plan. Should
 emit `ALTER TABLE ... SET TABLESPACE <new>` and
 `ALTER INDEX ... SET TABLESPACE <new>`.
 
-Origin: post-#125 audit.
+Origin: post-[#125](https://github.com/winebarrel/pistachio/pull/125) audit.
 
 ## Silent drift on `Table.Unlogged` toggle
 
@@ -79,7 +79,7 @@ but transitions on existing tables (logged ⇄ unlogged) are not diffed.
 PostgreSQL has `ALTER TABLE ... SET LOGGED` / `SET UNLOGGED`. The current
 `no_diff_unlogged_table.yml` fixture only covers the unchanged case.
 
-Origin: post-#125 audit.
+Origin: post-[#125](https://github.com/winebarrel/pistachio/pull/125) audit.
 
 ## `Column.StorageType` is dead code
 
@@ -88,7 +88,7 @@ parser / catalog / diff. Either implement column storage diffs
 (`ALTER COLUMN ... SET STORAGE PLAIN|EXTERNAL|EXTENDED|MAIN`) or drop
 the field. Today the value is always the zero string.
 
-Origin: post-#125 audit.
+Origin: post-[#125](https://github.com/winebarrel/pistachio/pull/125) audit.
 
 ## Constraint `Deferrable` / `Deferred` granularity
 
@@ -100,7 +100,7 @@ of the constraint. PostgreSQL supports
 `ALTER TABLE ... ALTER CONSTRAINT ... [NOT] DEFERRABLE [INITIALLY ...]`
 for in-place changes; using it would avoid the round-trip.
 
-Origin: post-#125 audit. Optimisation rather than a bug — current
+Origin: post-[#125](https://github.com/winebarrel/pistachio/pull/125) audit. Optimisation rather than a bug — current
 behaviour is correct, just heavier than necessary.
 
 ## Standalone Sequences are not first-class
@@ -112,7 +112,7 @@ sequences in desired SQL therefore round-trip via execute directives
 only. Decide whether sequence is in scope; if yes, add parser/diff
 support; if no, document the limitation.
 
-Origin: post-#125 audit.
+Origin: post-[#125](https://github.com/winebarrel/pistachio/pull/125) audit.
 
 ## Table rename: cross-table dependents
 
@@ -132,11 +132,11 @@ Origin: pre-existing NOTE in `diff/rename.go:detectTableRenames`.
 When desired SQL references the new column name in a dependent
 definition but forgets to add `-- pist:renamed-from` on the column
 itself, current behavior is to produce DDL that fails at apply time.
-The `ValidateColumnRefs` pass added in #124 already catches the
+The `ValidateColumnRefs` pass added in [#124](https://github.com/winebarrel/pistachio/pull/124) already catches the
 inverse case (renamed column with stale dependent reference). The
 forgotten-rename direction could in principle also be caught (e.g. by
 detecting "column X is in current but not desired AND a column with a
 similar name exists in desired") but the heuristic has false positives
 and is not pursued.
 
-Origin: discussion during #124. No current plan to implement.
+Origin: discussion during [#124](https://github.com/winebarrel/pistachio/pull/124). No current plan to implement.


### PR DESCRIPTION
## Summary
- Convert plain `#NNN` PR references in TODO.md into GitHub markdown links so they're directly clickable from rendered markdown.

## Test plan
- [x] Visual diff review — only `#NNN` tokens in `Origin:` / inline references were rewritten; code refs like `diff/rename.go:detectTableRenames` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)