### PR TITLE
Move pure SQL-input/output tests to YAML fixtures

### DIFF
--- a/apply_test.go
+++ b/apply_test.go
@@ -496,60 +496,6 @@ $$ LANGUAGE sql;
 	assert.Equal(t, "public", schema)
 }
 
-func TestApply_NoDiff(t *testing.T) {
-	ctx := context.Background()
-	conn := testutil.ConnectDB(t)
-	defer conn.Close(ctx)
-
-	initSQL := `CREATE TABLE public.users (
-    id integer NOT NULL,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`
-	testutil.SetupDB(t, ctx, conn, initSQL)
-
-	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
-	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL), 0o644))
-
-	client := pistachio.NewClient(&pistachio.Options{
-		ConnString: conn.Config().ConnString(),
-		Schemas:    []string{"public"},
-	})
-
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
-	require.NoError(t, err)
-}
-
-func TestApply_SchemalessDesired(t *testing.T) {
-	ctx := context.Background()
-	conn := testutil.ConnectDB(t)
-	defer conn.Close(ctx)
-
-	testutil.SetupDB(t, ctx, conn, `
-CREATE TABLE public.users (
-    id integer NOT NULL,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`)
-
-	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
-	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
-    id integer NOT NULL,
-    name text,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`), 0o644))
-
-	client := pistachio.NewClient(&pistachio.Options{
-		ConnString: conn.Config().ConnString(),
-		Schemas:    []string{"public"},
-	})
-
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
-	require.NoError(t, err)
-
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
-	require.NoError(t, err)
-	assert.Contains(t, got.String(), "name text")
-}
-
 func TestApply_ExecuteCheckSQLError(t *testing.T) {
 	// User-supplied check SQL that itself errors (e.g., references a missing
 	// table) must surface as a "failed to evaluate check SQL" error.

--- a/dump_test.go
+++ b/dump_test.go
@@ -77,23 +77,6 @@ func TestDump_CanceledContext(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to fetch tables")
 }
 
-func TestDumpResult_String_Empty(t *testing.T) {
-	ctx := context.Background()
-	conn := testutil.ConnectDB(t)
-	defer conn.Close(ctx)
-
-	testutil.SetupDB(t, ctx, conn, "")
-
-	client := pistachio.NewClient(&pistachio.Options{
-		ConnString: conn.Config().ConnString(),
-		Schemas:    []string{"public"},
-	})
-
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
-	require.NoError(t, err)
-	assert.Equal(t, "", got.String())
-}
-
 func TestDump_Count(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
@@ -451,27 +434,6 @@ CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);`
 	s := got.String()
 	assert.Contains(t, s, "CREATE DOMAIN pos_int AS integer")
 	assert.NotContains(t, s, "public.pos_int")
-}
-
-func TestDump_Domain_DefaultCollationExcluded(t *testing.T) {
-	ctx := context.Background()
-	conn := testutil.ConnectDB(t)
-	defer conn.Close(ctx)
-
-	testutil.SetupDB(t, ctx, conn, `
-CREATE DOMAIN public.email AS varchar(255) NOT NULL DEFAULT ''::varchar;`)
-
-	client := pistachio.NewClient(&pistachio.Options{
-		ConnString: conn.Config().ConnString(),
-		Schemas:    []string{"public"},
-	})
-
-	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
-	require.NoError(t, err)
-	s := got.String()
-	assert.Contains(t, s, "CREATE DOMAIN public.email")
-	assert.NotContains(t, s, "COLLATE")
-	assert.NotContains(t, s, "default")
 }
 
 func TestDump_Domain_OmitSchema_PlanNoDiff(t *testing.T) {

--- a/plan_test.go
+++ b/plan_test.go
@@ -392,62 +392,6 @@ func TestPlan_WithPreSQLFile_NoDiff(t *testing.T) {
 	assert.Empty(t, got.SQL)
 }
 
-func TestPlan_SchemalessDesired(t *testing.T) {
-	ctx := context.Background()
-	conn := testutil.ConnectDB(t)
-	defer conn.Close(ctx)
-
-	testutil.SetupDB(t, ctx, conn, `
-CREATE TABLE public.users (
-    id integer NOT NULL,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`)
-
-	// Desired SQL without schema qualification
-	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
-	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
-    id integer NOT NULL,
-    name text,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`), 0o644))
-
-	client := pistachio.NewClient(&pistachio.Options{
-		ConnString: conn.Config().ConnString(),
-		Schemas:    []string{"public"},
-	})
-
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
-	require.NoError(t, err)
-	assert.Contains(t, got.SQL, "ALTER TABLE public.users ADD COLUMN name text;")
-}
-
-func TestPlan_SchemalessDesired_NoDiff(t *testing.T) {
-	ctx := context.Background()
-	conn := testutil.ConnectDB(t)
-	defer conn.Close(ctx)
-
-	testutil.SetupDB(t, ctx, conn, `
-CREATE TABLE public.users (
-    id integer NOT NULL,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`)
-
-	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
-	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE users (
-    id integer NOT NULL,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`), 0o644))
-
-	client := pistachio.NewClient(&pistachio.Options{
-		ConnString: conn.Config().ConnString(),
-		Schemas:    []string{"public"},
-	})
-
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
-	require.NoError(t, err)
-	assert.Empty(t, got.SQL)
-}
-
 func TestPlan_RenameColumn_NonPublicSchema(t *testing.T) {
 	ctx := context.Background()
 

--- a/testdata/apply/schemaless_desired.yml
+++ b/testdata/apply/schemaless_desired.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/dump/domain_no_collation.yml
+++ b/testdata/dump/domain_no_collation.yml
@@ -1,0 +1,5 @@
+init: |
+  CREATE DOMAIN public.email AS varchar(255) NOT NULL DEFAULT ''::varchar;
+dump: |
+  -- public.email
+  CREATE DOMAIN public.email AS character varying(255) DEFAULT ''::character varying NOT NULL;

--- a/testdata/plan/schemaless_desired.yml
+++ b/testdata/plan/schemaless_desired.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users ADD COLUMN name text;

--- a/testdata/plan/schemaless_desired_no_diff.yml
+++ b/testdata/plan/schemaless_desired_no_diff.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: ""


### PR DESCRIPTION
Convert Go tests that only verify init SQL -> diff/applied SQL to the
existing YAML harness, mirroring the approach in dd172f2:

- TestDump_Domain_DefaultCollationExcluded -> testdata/dump/domain_no_collation.yml
- TestPlan_SchemalessDesired -> testdata/plan/schemaless_desired.yml
- TestPlan_SchemalessDesired_NoDiff -> testdata/plan/schemaless_desired_no_diff.yml
- TestApply_SchemalessDesired -> testdata/apply/schemaless_desired.yml

Also remove TestDumpResult_String_Empty (already covered by
testdata/dump/empty.yml) and TestApply_NoDiff (already covered by
testdata/apply/no_diff.yml).

Coverage on the pistachio package is unchanged (78.7% before and after,
identical at the function level).