### PR TITLE
Add row-level security (RLS) and policy support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ make fix            # golangci-lint run --fix (auto-fix lint errors)
 - `cmd/command/` - CLI command implementations
 - `parser/` - SQL parser (uses pg_query_go to parse and deparse PostgreSQL SQL)
 - `catalog/` - Reads current schema state from PostgreSQL system catalogs (`pg_catalog`)
-- `model/` - Data model structs (Table, Column, Constraint, ForeignKey, Index, View, Enum, Domain)
+- `model/` - Data model structs (Table, Column, Constraint, ForeignKey, Index, Policy, View, Enum, Domain)
 - `diff/` - Generates DDL diff between current and desired schemas
 - `internal/testutil/` - Test helpers (DB connection, setup)
 - `testdata/` - YAML-based test fixtures for multiple test suites, including integration and unit tests

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ pist apply ./schema/*.sql         # apply it
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
 - Comments (on tables, columns, views, types, domains)
+- Row-level security (`ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY`, policies via `CREATE POLICY` / `ALTER POLICY` / `DROP POLICY`)
 - Renaming (tables, views, enums, domains, columns, constraints, foreign keys, indexes via `-- pist:renamed-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ pist apply ./schema/*.sql         # apply it
 - Indexes (unique, partial, expression, hash, multi-column)
 - Comments (on tables, columns, views, types, domains)
 - Row-level security (`ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY`, policies via `CREATE POLICY` / `ALTER POLICY` / `DROP POLICY`)
-- Renaming (tables, views, enums, domains, columns, constraints, foreign keys, indexes via `-- pist:renamed-from` directive)
+- Renaming (tables, views, enums, domains, columns, constraints, foreign keys, indexes, policies via `-- pist:renamed-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 

--- a/TODO.md
+++ b/TODO.md
@@ -127,6 +127,42 @@ extended to table-level renames.
 
 Origin: pre-existing NOTE in `diff/rename.go:detectTableRenames`.
 
+## Policy USING / WITH CHECK normalization for subquery column refs
+
+`pg_get_expr` qualifies column references inside subqueries (e.g. emits
+`SELECT allowed.id FROM myschema.allowed` for a USING that the user wrote
+as `SELECT id FROM myschema.allowed`). The desired-side parser deparses
+without that qualification, so even semantically-identical USING /
+WITH CHECK expressions produce a spurious `ALTER POLICY` when subqueries
+are involved.
+
+`equalPolicyExpr` reuses `normalizeCheckExpr` from constraint diffs, which
+strips text-like casts and canonicalises `= ANY(ARRAY[...])` → `IN (...)`,
+but does not walk into subqueries and rewrite ColumnRef qualifications.
+
+Fix would be to walk `SubLink` / `RangeSubselect` nodes and strip column
+qualifiers that match the FROM-clause table alias. The same approach
+would also benefit constraint CHECK expressions if they ever contain
+subqueries (uncommon — PostgreSQL discourages them).
+
+Origin: post-RLS-support audit. Workaround: avoid subqueries in policy
+expressions, or use a function that wraps the subquery.
+
+## TO CURRENT_USER / SESSION_USER / CURRENT_ROLE in CREATE POLICY
+
+PostgreSQL resolves these reserved role specs at policy creation time
+and stores the resolved role OID in `pg_policy.polroles`. As a result,
+desired SQL written as `TO current_user` cannot round-trip through the
+catalog: subsequent plans see the resolved role name (e.g. `postgres`)
+and emit a spurious `ALTER POLICY ... TO`.
+
+Recommendation is to use literal role names in desired SQL. The parser
+accepts the reserved specs for convenience but the limitation should be
+documented prominently.
+
+Origin: post-RLS-support audit. No fix planned — this is a PostgreSQL
+behavior that affects the catalog round-trip, not a pistachio bug.
+
 ## Plan-time error promotion: forgotten dependent reference
 
 When desired SQL references the new column name in a dependent

--- a/catalog/policies.go
+++ b/catalog/policies.go
@@ -11,6 +11,11 @@ import (
 // ListPoliciesByTable returns row-level security policies attached to the
 // given table, in pg_policy.polname order.
 func (c *Catalog) ListPoliciesByTable(ctx context.Context, table *model.Table) ([]*model.Policy, error) {
+	// pg_policy.polroles uses OID 0 to represent PUBLIC. pg_roles does not
+	// contain a row for OID 0, so a join would silently drop PUBLIC when it
+	// appears alongside named roles (e.g. TO PUBLIC, app_user). UNION the
+	// synthetic "public" entry with the named-role rows so all elements are
+	// preserved and sorted together.
 	q := `
 		SELECT
 			pol.polname,
@@ -18,14 +23,17 @@ func (c *Catalog) ListPoliciesByTable(ctx context.Context, table *model.Table) (
 			pol.polcmd,
 			COALESCE(
 				(
-					SELECT
-						array_agg(rolname ORDER BY rolname)
-					FROM
-						pg_catalog.pg_roles r
-					WHERE
-						r.oid = ANY(pol.polroles)
+					SELECT array_agg(rolname ORDER BY rolname)
+					FROM (
+						SELECT 'public'::name AS rolname
+						WHERE 0 = ANY(pol.polroles)
+						UNION
+						SELECT r.rolname
+						FROM pg_catalog.pg_roles r
+						WHERE r.oid = ANY(pol.polroles)
+					) AS roles
 				),
-				CASE WHEN 0 = ANY(pol.polroles) THEN ARRAY['public']::name[] ELSE ARRAY[]::name[] END
+				ARRAY[]::name[]
 			) AS roles,
 			pg_catalog.pg_get_expr(pol.polqual, pol.polrelid) AS using_expr,
 			pg_catalog.pg_get_expr(pol.polwithcheck, pol.polrelid) AS with_check

--- a/catalog/policies.go
+++ b/catalog/policies.go
@@ -1,0 +1,72 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// ListPoliciesByTable returns row-level security policies attached to the
+// given table, in pg_policy.polname order.
+func (c *Catalog) ListPoliciesByTable(ctx context.Context, table *model.Table) ([]*model.Policy, error) {
+	q := `
+		SELECT
+			pol.polname,
+			pol.polpermissive,
+			pol.polcmd,
+			COALESCE(
+				(
+					SELECT
+						array_agg(rolname ORDER BY rolname)
+					FROM
+						pg_catalog.pg_roles r
+					WHERE
+						r.oid = ANY(pol.polroles)
+				),
+				CASE WHEN 0 = ANY(pol.polroles) THEN ARRAY['public']::name[] ELSE ARRAY[]::name[] END
+			) AS roles,
+			pg_catalog.pg_get_expr(pol.polqual, pol.polrelid) AS using_expr,
+			pg_catalog.pg_get_expr(pol.polwithcheck, pol.polrelid) AS with_check
+		FROM
+			-- https://www.postgresql.org/docs/current/catalog-pg-policy.html
+			pg_catalog.pg_policy pol
+		WHERE
+			pol.polrelid = @table_oid
+		ORDER BY
+			pol.polname
+	`
+	args := pgx.NamedArgs{"table_oid": table.OID}
+
+	rows, err := c.conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get policy info: %w", err)
+	}
+	defer rows.Close()
+
+	var policies []*model.Policy
+	for rows.Next() {
+		p := &model.Policy{
+			Schema: table.Schema,
+			Table:  table.Name,
+		}
+		err := rows.Scan(
+			&p.Name,
+			&p.Permissive,
+			&p.Command,
+			&p.Roles,
+			&p.Using,
+			&p.WithCheck,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("catalog: failed to scan policy info: %w", err)
+		}
+		policies = append(policies, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: failed to scan policy info rows: %w", err)
+	}
+
+	return policies, nil
+}

--- a/catalog/policies_test.go
+++ b/catalog/policies_test.go
@@ -107,6 +107,33 @@ func TestListPoliciesByTable(t *testing.T) {
 		assert.Contains(t, *pol.WithCheck, "owner")
 	})
 
+	// pg_policy.polroles uses OID 0 to represent PUBLIC. The catalog query
+	// must merge OID 0 with named-role rows from pg_roles (which has no row
+	// for OID 0), and sort the result. Multiple named roles exercise the
+	// array_agg ORDER BY path. Note: PostgreSQL itself collapses
+	// "TO PUBLIC, named_role" to "TO PUBLIC" with a WARNING ("ignoring
+	// specified roles other than PUBLIC"), so the mixed-PUBLIC case is not
+	// reachable from real input.
+	t.Run("policy with multiple named roles", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.documents (
+				id bigint NOT NULL,
+				owner text NOT NULL,
+				CONSTRAINT documents_pkey PRIMARY KEY (id)
+			);
+			ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+			CREATE POLICY p ON public.documents FOR SELECT TO postgres, pg_read_all_data USING (owner = current_user);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		pol, _ := tables.Get("public.documents").Policies.GetOk("p")
+		assert.Equal(t, []string{"pg_read_all_data", "postgres"}, pol.Roles,
+			"named roles should be preserved and sorted alphabetically")
+	})
+
 	t.Run("policy with named role", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE TABLE public.documents (

--- a/catalog/policies_test.go
+++ b/catalog/policies_test.go
@@ -1,0 +1,169 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/catalog"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+func TestListPoliciesByTable(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	t.Run("simple SELECT policy", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.documents (
+				id bigint NOT NULL,
+				owner text NOT NULL,
+				CONSTRAINT documents_pkey PRIMARY KEY (id)
+			);
+			ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+			CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.documents")
+		require.True(t, tbl.RowSecurity)
+		assert.False(t, tbl.ForceRowSecurity)
+		assert.Equal(t, 1, tbl.Policies.Len())
+
+		pol, ok := tbl.Policies.GetOk("owner_select")
+		require.True(t, ok)
+		assert.True(t, pol.Permissive)
+		assert.Equal(t, "SELECT", pol.Command.String())
+		assert.Equal(t, []string{"public"}, pol.Roles)
+		require.NotNil(t, pol.Using)
+		assert.Contains(t, *pol.Using, "owner")
+		assert.Nil(t, pol.WithCheck)
+	})
+
+	t.Run("FORCE row security", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.documents (
+				id bigint NOT NULL,
+				CONSTRAINT documents_pkey PRIMARY KEY (id)
+			);
+			ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.documents")
+		assert.True(t, tbl.RowSecurity)
+		assert.True(t, tbl.ForceRowSecurity)
+		assert.Equal(t, 0, tbl.Policies.Len())
+	})
+
+	t.Run("RESTRICTIVE policy", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.documents (
+				id bigint NOT NULL,
+				owner text NOT NULL,
+				CONSTRAINT documents_pkey PRIMARY KEY (id)
+			);
+			ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+			CREATE POLICY p ON public.documents AS RESTRICTIVE FOR ALL USING (owner = current_user);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		pol, _ := tables.Get("public.documents").Policies.GetOk("p")
+		assert.False(t, pol.Permissive)
+		assert.True(t, pol.Command.IsAll())
+	})
+
+	t.Run("INSERT policy with WITH CHECK", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.documents (
+				id bigint NOT NULL,
+				owner text NOT NULL,
+				CONSTRAINT documents_pkey PRIMARY KEY (id)
+			);
+			ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+			CREATE POLICY p ON public.documents FOR INSERT WITH CHECK (owner = current_user);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		pol, _ := tables.Get("public.documents").Policies.GetOk("p")
+		assert.Equal(t, "INSERT", pol.Command.String())
+		assert.Nil(t, pol.Using)
+		require.NotNil(t, pol.WithCheck)
+		assert.Contains(t, *pol.WithCheck, "owner")
+	})
+
+	t.Run("policy with named role", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.documents (
+				id bigint NOT NULL,
+				owner text NOT NULL,
+				CONSTRAINT documents_pkey PRIMARY KEY (id)
+			);
+			ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+			CREATE POLICY p ON public.documents FOR SELECT TO postgres USING (owner = current_user);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		pol, _ := tables.Get("public.documents").Policies.GetOk("p")
+		assert.Equal(t, []string{"postgres"}, pol.Roles)
+	})
+
+	t.Run("multiple policies sorted by name", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.documents (
+				id bigint NOT NULL,
+				owner text NOT NULL,
+				CONSTRAINT documents_pkey PRIMARY KEY (id)
+			);
+			ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+			CREATE POLICY zeta ON public.documents FOR DELETE USING (owner = current_user);
+			CREATE POLICY alpha ON public.documents FOR SELECT USING (owner = current_user);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.documents")
+		var names []string
+		for name := range tbl.Policies.Keys() {
+			names = append(names, name)
+		}
+		assert.Equal(t, []string{"alpha", "zeta"}, names)
+	})
+
+	t.Run("table without policies", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.users (
+				id integer NOT NULL,
+				CONSTRAINT users_pkey PRIMARY KEY (id)
+			);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.users")
+		assert.False(t, tbl.RowSecurity)
+		assert.Equal(t, 0, tbl.Policies.Len())
+	})
+}

--- a/catalog/tables.go
+++ b/catalog/tables.go
@@ -68,6 +68,8 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 			pg_catalog.pg_get_partkeydef(c.oid) AS partition_def,
 			p.relname AS partition_of,
 			pg_catalog.pg_get_expr(c.relpartbound, c.oid) AS partition_bound,
+			c.relrowsecurity,
+			c.relforcerowsecurity,
 			d.description
 		FROM
 			-- https://www.postgresql.org/docs/current/catalog-pg-class.html
@@ -111,6 +113,8 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 			&t.PartitionDef,
 			&t.PartitionOf,
 			&t.PartitionBound,
+			&t.RowSecurity,
+			&t.ForceRowSecurity,
 			&t.Comment,
 		)
 		if err != nil {
@@ -120,6 +124,7 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 		t.Indexes = orderedmap.New[string, *model.Index]()
 		t.Constraints = orderedmap.New[string, *model.Constraint]()
 		t.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		t.Policies = orderedmap.New[string, *model.Policy]()
 		tables = append(tables, &t)
 	}
 	if err := rows.Err(); err != nil {
@@ -144,6 +149,14 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 		}
 		for _, fk := range fks {
 			t.ForeignKeys.Set(fk.Name, fk)
+		}
+
+		policies, err := c.ListPoliciesByTable(ctx, t)
+		if err != nil {
+			return nil, fmt.Errorf("catalog: failed to get policies for %s.%s: %w", t.Schema, t.Name, err)
+		}
+		for _, p := range policies {
+			t.Policies.Set(p.Name, p)
 		}
 	}
 

--- a/diff/policies.go
+++ b/diff/policies.go
@@ -1,0 +1,266 @@
+package diff
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// diffRLS emits ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL
+// SECURITY statements for changes to the table-level RLS flags.
+func diffRLS(fqtn string, current, desired *model.Table) []string {
+	var stmts []string
+	if current.RowSecurity != desired.RowSecurity {
+		if desired.RowSecurity {
+			stmts = append(stmts, "ALTER TABLE "+fqtn+" ENABLE ROW LEVEL SECURITY;")
+		} else {
+			stmts = append(stmts, "ALTER TABLE "+fqtn+" DISABLE ROW LEVEL SECURITY;")
+		}
+	}
+	if current.ForceRowSecurity != desired.ForceRowSecurity {
+		if desired.ForceRowSecurity {
+			stmts = append(stmts, "ALTER TABLE "+fqtn+" FORCE ROW LEVEL SECURITY;")
+		} else {
+			stmts = append(stmts, "ALTER TABLE "+fqtn+" NO FORCE ROW LEVEL SECURITY;")
+		}
+	}
+	return stmts
+}
+
+// diffPolicies emits CREATE POLICY / ALTER POLICY / DROP POLICY statements for
+// changes between current and desired policies on the same table.
+//
+// Pure removals (policy absent from desired) honor the policy-drop policy via
+// dc; definition changes still run as DROP+CREATE when a property that cannot
+// be modified in place (Command / Permissive) changes. USING / WITH CHECK /
+// roles changes use ALTER POLICY for an in-place update.
+func diffPolicies(
+	fqtn string,
+	current, desired *orderedmap.Map[string, *model.Policy],
+	dc DropChecker,
+) (stmts []string, disallowed []string, err error) {
+	dc = NormalizeDropChecker(dc)
+
+	// Callers (diffTable) always pass initialized maps from parser/catalog,
+	// so no nil-guard is needed here.
+
+	// Detect renames first so subsequent diff steps see the renamed policy
+	// under its new name in the adjusted current map.
+	renameStmts, current, renamedFrom, err := detectPolicyRenames(fqtn, current, desired)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Renamed policies whose definition also requires DROP+CREATE: skip the
+	// RENAME and let the recreate-with-new-name cover the change.
+	needsRecreateRenamed := map[string]bool{}
+	for newName, oldName := range renamedFrom {
+		cur, ok := current.GetOk(newName)
+		des, dok := desired.GetOk(newName)
+		if !ok || !dok {
+			continue
+		}
+		if needsRecreate(cur, des) {
+			needsRecreateRenamed[oldName+"->"+newName] = true
+		}
+	}
+	for newName, oldName := range renamedFrom {
+		if needsRecreateRenamed[oldName+"->"+newName] {
+			continue
+		}
+		// Find the matching rename statement (ordering preserved from desired).
+		needle := "ALTER POLICY " + model.Ident(oldName) + " ON " + fqtn + " RENAME TO " + model.Ident(newName) + ";"
+		for _, stmt := range renameStmts {
+			if stmt == needle {
+				stmts = append(stmts, stmt)
+				break
+			}
+		}
+	}
+
+	policyAllowed := dc.IsDropAllowed("policy")
+
+	// Drop removed or recreate-required policies first so a CREATE for the same
+	// name later does not conflict. When a policy was both renamed and needs
+	// recreation, the DROP must reference the old name because the RENAME was
+	// suppressed above.
+	for name, cur := range current.All() {
+		des, ok := desired.GetOk(name)
+		if !ok {
+			drop := dropPolicySQL(fqtn, name)
+			if !policyAllowed {
+				disallowed = append(disallowed, "-- skipped: "+drop)
+				continue
+			}
+			stmts = append(stmts, drop)
+			continue
+		}
+		if needsRecreate(cur, des) {
+			dropName := name
+			if oldName, renamed := renamedFrom[name]; renamed {
+				dropName = oldName
+			}
+			stmts = append(stmts, dropPolicySQL(fqtn, dropName))
+		}
+	}
+
+	// Add new or recreated policies, then ALTER for in-place changes.
+	for name, des := range desired.All() {
+		cur, ok := current.GetOk(name)
+		if !ok {
+			stmts = append(stmts, des.SQL())
+			continue
+		}
+		if needsRecreate(cur, des) {
+			stmts = append(stmts, des.SQL())
+			continue
+		}
+		if alterStmt := alterPolicySQL(fqtn, cur, des); alterStmt != "" {
+			stmts = append(stmts, alterStmt)
+		}
+	}
+
+	return stmts, disallowed, nil
+}
+
+// needsRecreate reports whether two policies differ in a way that cannot be
+// expressed via ALTER POLICY. PostgreSQL's ALTER POLICY can only set clauses;
+// it cannot remove a clause that was previously set, and Command / Permissive
+// are immutable in place.
+func needsRecreate(a, b *model.Policy) bool {
+	return a.Command != b.Command ||
+		a.Permissive != b.Permissive ||
+		(a.Using != nil && b.Using == nil) ||
+		(a.WithCheck != nil && b.WithCheck == nil)
+}
+
+func dropPolicySQL(fqtn, name string) string {
+	return "DROP POLICY " + model.Ident(name) + " ON " + fqtn + ";"
+}
+
+// alterPolicySQL returns a single ALTER POLICY statement covering the
+// in-place modifiable attributes (TO, USING, WITH CHECK). Returns "" if no
+// in-place change is needed. The caller must have already routed clause
+// removals (current set, desired nil) to DROP+CREATE via needsRecreate.
+func alterPolicySQL(fqtn string, current, desired *model.Policy) string {
+	rolesChanged := !equalRoles(current.Roles, desired.Roles)
+	usingChanged := exprChanged(current.Using, desired.Using)
+	withCheckChanged := exprChanged(current.WithCheck, desired.WithCheck)
+	if !rolesChanged && !usingChanged && !withCheckChanged {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("ALTER POLICY ")
+	b.WriteString(model.Ident(desired.Name))
+	b.WriteString(" ON ")
+	b.WriteString(fqtn)
+	if rolesChanged {
+		// Treat empty desired roles as PUBLIC so ALTER POLICY ... TO is always
+		// well-formed; PostgreSQL stores no-roles policies as PUBLIC anyway.
+		roles := desired.Roles
+		if len(roles) == 0 {
+			roles = []string{"public"}
+		}
+		b.WriteString(" TO ")
+		b.WriteString(strings.Join(formatRoles(roles), ", "))
+	}
+	if usingChanged && desired.Using != nil {
+		b.WriteString(" USING (")
+		b.WriteString(*desired.Using)
+		b.WriteString(")")
+	}
+	if withCheckChanged && desired.WithCheck != nil {
+		b.WriteString(" WITH CHECK (")
+		b.WriteString(*desired.WithCheck)
+		b.WriteString(")")
+	}
+	b.WriteString(";")
+	return b.String()
+}
+
+// equalRoles compares two role lists, treating an empty list as equivalent to
+// ["public"] (PostgreSQL stores both the same way).
+func equalRoles(a, b []string) bool {
+	na := normalizeRoles(a)
+	nb := normalizeRoles(b)
+	return slices.Equal(na, nb)
+}
+
+func normalizeRoles(r []string) []string {
+	if len(r) == 0 {
+		return []string{"public"}
+	}
+	out := slices.Clone(r)
+	slices.Sort(out)
+	return out
+}
+
+func formatRoles(roles []string) []string {
+	out := make([]string, len(roles))
+	for i, r := range roles {
+		switch r {
+		case "public", "current_user", "current_role", "session_user":
+			out[i] = r
+		default:
+			out[i] = model.Ident(r)
+		}
+	}
+	return out
+}
+
+// exprChanged compares two optional expression strings by parsing them as
+// SELECT expressions so that pg_get_expr-added casts and formatting noise do
+// not cause false diffs.
+func exprChanged(a, b *string) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil || b == nil {
+		return true
+	}
+	return !equalPolicyExpr(*a, *b)
+}
+
+// equalPolicyExpr returns true if two expressions are semantically equal,
+// using the same normalization as constraint expressions (strips text-like
+// casts, canonicalises = ANY(ARRAY[...]) → IN (...)).
+//
+// Comparison goes through parse → normalize → deparse → string compare so that
+// pg_get_expr-added casts, parentheses, and AST `location` field differences
+// don't cause false diffs.
+func equalPolicyExpr(a, b string) bool {
+	if a == b {
+		return true
+	}
+	normA, errA := normalizePolicyExpr(a)
+	normB, errB := normalizePolicyExpr(b)
+	if errA != nil || errB != nil {
+		return a == b
+	}
+	return normA == normB
+}
+
+func normalizePolicyExpr(expr string) (string, error) {
+	result, err := pg_query.Parse("SELECT " + expr)
+	if err != nil {
+		return "", err
+	}
+	if len(result.Stmts) == 0 {
+		return "", fmt.Errorf("unexpected parse result for expression: %s", expr)
+	}
+	stmt := result.Stmts[0].Stmt.GetSelectStmt()
+	if stmt == nil || len(stmt.TargetList) == 0 {
+		return "", fmt.Errorf("unexpected parse result for expression: %s", expr)
+	}
+	target := stmt.TargetList[0].GetResTarget()
+	if target == nil {
+		return "", fmt.Errorf("unexpected parse result for expression: %s", expr)
+	}
+	target.Val = normalizeCheckExpr(target.Val)
+	return pg_query.Deparse(result)
+}

--- a/diff/policies.go
+++ b/diff/policies.go
@@ -56,20 +56,23 @@ func diffPolicies(
 	}
 
 	// Renamed policies whose definition also requires DROP+CREATE: skip the
-	// RENAME and let the recreate-with-new-name cover the change.
+	// RENAME and let the recreate-with-new-name cover the change. Keyed by
+	// newName because renamedFrom is keyed by newName (unique in desired) —
+	// concatenated keys could collide on quoted identifiers containing the
+	// separator.
 	needsRecreateRenamed := map[string]bool{}
-	for newName, oldName := range renamedFrom {
+	for newName := range renamedFrom {
 		cur, ok := current.GetOk(newName)
 		des, dok := desired.GetOk(newName)
 		if !ok || !dok {
 			continue
 		}
 		if needsRecreate(cur, des) {
-			needsRecreateRenamed[oldName+"->"+newName] = true
+			needsRecreateRenamed[newName] = true
 		}
 	}
 	for newName, oldName := range renamedFrom {
-		if needsRecreateRenamed[oldName+"->"+newName] {
+		if needsRecreateRenamed[newName] {
 			continue
 		}
 		// Find the matching rename statement (ordering preserved from desired).

--- a/diff/policies_test.go
+++ b/diff/policies_test.go
@@ -202,3 +202,78 @@ func TestEqualPolicyExpr_NormalizesParens(t *testing.T) {
 	// treat both forms as equal.
 	assert.True(t, equalPolicyExpr("(owner = current_user)", "owner = current_user"))
 }
+
+// equalPolicyExpr falls back to raw string comparison when either side
+// fails to parse, to avoid losing diffs on malformed input.
+func TestEqualPolicyExpr_ParseErrorFallback(t *testing.T) {
+	assert.False(t, equalPolicyExpr("not a valid expr )", "valid"))
+	assert.True(t, equalPolicyExpr("not a valid expr )", "not a valid expr )"))
+}
+
+func TestNormalizeRoles(t *testing.T) {
+	assert.Equal(t, []string{"public"}, normalizeRoles(nil), "empty → [public]")
+	assert.Equal(t, []string{"a", "b"}, normalizeRoles([]string{"b", "a"}), "sorted")
+}
+
+func TestFormatRoles(t *testing.T) {
+	assert.Equal(t, []string{"public"}, formatRoles([]string{"public"}))
+	assert.Equal(t, []string{"current_user"}, formatRoles([]string{"current_user"}))
+	assert.Equal(t, []string{"current_role"}, formatRoles([]string{"current_role"}))
+	assert.Equal(t, []string{"session_user"}, formatRoles([]string{"session_user"}))
+	assert.Equal(t, []string{"app_user"}, formatRoles([]string{"app_user"}), "named role unquoted")
+	assert.Equal(t, []string{`"User"`}, formatRoles([]string{"User"}), "quoted when needed")
+}
+
+// ALTER POLICY ... TO <roles> covers the rolesChanged branch in alterPolicySQL.
+func TestDiffPolicies_AlterRoles(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", 'r', withUsing("true"), func(p *model.Policy) { p.Roles = []string{"public"} }))
+	des.Set("p", newPolicy("p", 'r', withUsing("true"), func(p *model.Policy) { p.Roles = []string{"app_user"} }))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER POLICY p ON public.documents TO app_user;"}, stmts)
+}
+
+// ALTER POLICY desired.Roles=nil should normalize to TO public.
+func TestDiffPolicies_AlterRoles_EmptyToPublic(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", 'r', withUsing("true"), func(p *model.Policy) { p.Roles = []string{"app_user"} }))
+	des.Set("p", newPolicy("p", 'r', withUsing("true")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER POLICY p ON public.documents TO public;"}, stmts)
+}
+
+// ALTER POLICY adding WITH CHECK in place (current has none, desired adds one).
+func TestDiffPolicies_AddWithCheckInPlace(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", '*', withUsing("a")))
+	des.Set("p", newPolicy("p", '*', withUsing("a"), withWithCheck("b")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER POLICY p ON public.documents WITH CHECK (b);"}, stmts)
+}
+
+// Combined rename + recreate path: when the renamed policy also has a
+// definition change requiring DROP+CREATE, the RENAME must be suppressed
+// and the DROP must reference the old name (line 104-106 branch).
+func TestDiffPolicies_RenameAndRecreate(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("old", newPolicy("old", 'r', withUsing("true")))
+	// Rename old → new AND change command from SELECT to ALL.
+	des.Set("new", newPolicy("new", '*', withUsing("true"), renameFrom("old")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DROP POLICY old ON public.documents;",
+		"CREATE POLICY new ON public.documents USING (true);",
+	}, stmts)
+}

--- a/diff/policies_test.go
+++ b/diff/policies_test.go
@@ -1,0 +1,204 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func newPolicy(name string, command model.PolicyCommand, opts ...func(*model.Policy)) *model.Policy {
+	p := &model.Policy{
+		Name:       name,
+		Schema:     "public",
+		Table:      "documents",
+		Permissive: true,
+		Command:    command,
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+func withUsing(s string) func(*model.Policy)     { return func(p *model.Policy) { p.Using = &s } }
+func withWithCheck(s string) func(*model.Policy) { return func(p *model.Policy) { p.WithCheck = &s } }
+func restrictive() func(*model.Policy)           { return func(p *model.Policy) { p.Permissive = false } }
+func renameFrom(s string) func(*model.Policy)    { return func(p *model.Policy) { p.RenameFrom = &s } }
+
+func TestDiffRLS_NoChange(t *testing.T) {
+	cur := &model.Table{RowSecurity: true, ForceRowSecurity: true}
+	des := &model.Table{RowSecurity: true, ForceRowSecurity: true}
+	assert.Empty(t, diffRLS("public.documents", cur, des))
+}
+
+func TestDiffRLS_EnableDisable(t *testing.T) {
+	cur := &model.Table{}
+	des := &model.Table{RowSecurity: true}
+	assert.Equal(t,
+		[]string{"ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;"},
+		diffRLS("public.documents", cur, des))
+
+	cur, des = &model.Table{RowSecurity: true}, &model.Table{}
+	assert.Equal(t,
+		[]string{"ALTER TABLE public.documents DISABLE ROW LEVEL SECURITY;"},
+		diffRLS("public.documents", cur, des))
+}
+
+func TestDiffRLS_ForceNoForce(t *testing.T) {
+	cur := &model.Table{}
+	des := &model.Table{ForceRowSecurity: true}
+	assert.Equal(t,
+		[]string{"ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;"},
+		diffRLS("public.documents", cur, des))
+
+	cur, des = &model.Table{ForceRowSecurity: true}, &model.Table{}
+	assert.Equal(t,
+		[]string{"ALTER TABLE public.documents NO FORCE ROW LEVEL SECURITY;"},
+		diffRLS("public.documents", cur, des))
+}
+
+func TestDiffPolicies_NoChange(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
+	des.Set("p", newPolicy("p", 'r', withUsing("true")))
+
+	stmts, disallowed, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+	assert.Empty(t, disallowed)
+}
+
+func TestDiffPolicies_AddPolicy(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	des.Set("p", newPolicy("p", 'r', withUsing("true")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CREATE POLICY p ON public.documents FOR SELECT USING (true);"}, stmts)
+}
+
+func TestDiffPolicies_DropPolicy_Allowed(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
+	des := orderedmap.New[string, *model.Policy]()
+
+	stmts, disallowed, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DROP POLICY p ON public.documents;"}, stmts)
+	assert.Empty(t, disallowed)
+}
+
+func TestDiffPolicies_DropPolicy_Disallowed(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
+	des := orderedmap.New[string, *model.Policy]()
+
+	stmts, disallowed, err := diffPolicies("public.documents", cur, des, DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+	assert.Equal(t, []string{"-- skipped: DROP POLICY p ON public.documents;"}, disallowed)
+}
+
+func TestDiffPolicies_AlterUsing(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", 'r', withUsing("a")))
+	des.Set("p", newPolicy("p", 'r', withUsing("b")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER POLICY p ON public.documents USING (b);"}, stmts)
+}
+
+func TestDiffPolicies_RecreateOnCommandChange(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
+	des.Set("p", newPolicy("p", '*', withUsing("true")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DROP POLICY p ON public.documents;",
+		"CREATE POLICY p ON public.documents USING (true);",
+	}, stmts)
+}
+
+func TestDiffPolicies_RecreateOnPermissiveChange(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", '*', withUsing("true")))
+	des.Set("p", newPolicy("p", '*', withUsing("true"), restrictive()))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DROP POLICY p ON public.documents;",
+		"CREATE POLICY p ON public.documents AS RESTRICTIVE USING (true);",
+	}, stmts)
+}
+
+func TestDiffPolicies_RecreateOnUsingRemoval(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", '*', withUsing("a"), withWithCheck("b")))
+	des.Set("p", newPolicy("p", '*', withWithCheck("b")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DROP POLICY p ON public.documents;",
+		"CREATE POLICY p ON public.documents WITH CHECK (b);",
+	}, stmts)
+}
+
+func TestDiffPolicies_Rename(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("old", newPolicy("old", 'r', withUsing("true")))
+	des.Set("new", newPolicy("new", 'r', withUsing("true"), renameFrom("old")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER POLICY old ON public.documents RENAME TO new;"}, stmts)
+}
+
+func TestDiffPolicies_RenameSourceMissing(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	des.Set("new", newPolicy("new", 'r', withUsing("true"), renameFrom("nonexistent")))
+
+	_, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source policy nonexistent not found")
+}
+
+func TestEqualRoles(t *testing.T) {
+	assert.True(t, equalRoles(nil, nil))
+	assert.True(t, equalRoles([]string{"public"}, nil), "empty == [public]")
+	assert.True(t, equalRoles([]string{"a", "b"}, []string{"b", "a"}), "order-insensitive")
+	assert.False(t, equalRoles([]string{"a"}, []string{"b"}))
+}
+
+func TestExprChanged(t *testing.T) {
+	a := "owner = current_user"
+	b := "owner = current_user"
+	c := "owner = session_user"
+	assert.False(t, exprChanged(nil, nil))
+	assert.True(t, exprChanged(&a, nil))
+	assert.True(t, exprChanged(nil, &a))
+	assert.False(t, exprChanged(&a, &b), "same expression")
+	assert.True(t, exprChanged(&a, &c), "different expression")
+}
+
+func TestEqualPolicyExpr_NormalizesParens(t *testing.T) {
+	// pg_get_expr wraps the top-level boolean in parentheses; the parser
+	// deparses without them. Normalization through parse/deparse should
+	// treat both forms as equal.
+	assert.True(t, equalPolicyExpr("(owner = current_user)", "owner = current_user"))
+}

--- a/diff/policies_test.go
+++ b/diff/policies_test.go
@@ -277,3 +277,18 @@ func TestDiffPolicies_RenameAndRecreate(t *testing.T) {
 		"CREATE POLICY new ON public.documents USING (true);",
 	}, stmts)
 }
+
+// Quoted policy identifiers may contain arbitrary characters including the
+// "->" sequence. The rename-suppression bookkeeping must key on the new
+// name alone (which is unique in renamedFrom) so such identifiers don't
+// collide with concatenated keys.
+func TestDiffPolicies_Rename_QuotedIdentifierWithArrow(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set(`a->b`, newPolicy(`a->b`, 'r', withUsing("true")))
+	des.Set(`c`, newPolicy(`c`, 'r', withUsing("true"), renameFrom(`a->b`)))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{`ALTER POLICY "a->b" ON public.documents RENAME TO c;`}, stmts)
+}

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -399,6 +399,49 @@ func detectForeignKeyRenames(fqtn string, current, desired *orderedmap.Map[strin
 	return stmts, adjusted, renamedFrom, nil
 }
 
+// detectPolicyRenames finds desired policies with RenameFrom that match a
+// current policy on the same table. Returns the rename statements, the
+// adjusted current map keyed by new names, and a renamedFrom[newName] = oldName
+// map so the caller can suppress the RENAME when the policy needs DROP+CREATE.
+func detectPolicyRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Policy]) ([]string, *orderedmap.Map[string, *model.Policy], map[string]string, error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+	renamedFrom := map[string]string{}
+
+	for newName, desiredPol := range desired.All() {
+		if desiredPol.RenameFrom == nil {
+			continue
+		}
+		oldName := *desiredPol.RenameFrom
+
+		if oldName == newName {
+			continue
+		}
+
+		oldPol, ok := adjusted.GetOk(oldName)
+		if !ok {
+			if _, exists := adjusted.GetOk(newName); exists {
+				continue
+			}
+			return nil, nil, nil, fmt.Errorf("rename source policy %s not found on %s", model.Ident(oldName), fqtn)
+		}
+
+		if _, exists := adjusted.GetOk(newName); exists {
+			return nil, nil, nil, fmt.Errorf("cannot rename policy %s to %s on %s: destination already exists", model.Ident(oldName), model.Ident(newName), fqtn)
+		}
+
+		stmts = append(stmts, "ALTER POLICY "+model.Ident(oldName)+" ON "+fqtn+" RENAME TO "+model.Ident(newName)+";")
+		renamedFrom[newName] = oldName
+
+		adjusted.Delete(oldName)
+		renamed := *oldPol
+		renamed.Name = newName
+		adjusted.Set(newName, &renamed)
+	}
+
+	return stmts, adjusted, renamedFrom, nil
+}
+
 // cloneMap creates a shallow copy of an orderedmap.
 func cloneMap[K comparable, V any](m *orderedmap.Map[K, V]) *orderedmap.Map[K, V] {
 	clone := orderedmap.New[K, V]()

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -103,6 +103,9 @@ func newTableExtras(t *model.Table) (stmts []string, fkStmts []string, hasConcur
 	for _, fk := range t.ForeignKeys.CollectValues() {
 		fkStmts = append(fkStmts, fk.SQL())
 	}
+	if rlsSQL := t.RLSSQL(); rlsSQL != "" {
+		stmts = append(stmts, strings.Split(rlsSQL, "\n")...)
+	}
 	if commentSQL := t.CommentSQL(); commentSQL != "" {
 		stmts = append(stmts, strings.Split(commentSQL, "\n")...)
 	}
@@ -123,7 +126,9 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	fqtn := desired.FQTN()
 
 	// Partition children inherit columns and constraints from the parent,
-	// so skip diffing them to avoid false DROP statements.
+	// so skip diffing them to avoid false DROP statements. RLS flags and
+	// policies are owned per-relation (children do not auto-inherit them),
+	// so they're still diffed here, mirroring how indexes and FKs work.
 	if desired.PartitionOf != nil && desired.PartitionBound != nil {
 		idxResult, err := diffIndexes(current.Indexes, desired.Indexes, dc)
 		if err != nil {
@@ -141,6 +146,15 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		result.FKDropStmts = append(result.FKDropStmts, fkDrops...)
 		result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
 		result.DisallowedDropStmts = append(result.DisallowedDropStmts, fkDisallowed...)
+
+		result.Stmts = append(result.Stmts, diffRLS(fqtn, current, desired)...)
+		polStmts, polDisallowed, err := diffPolicies(fqtn, current.Policies, desired.Policies, dc)
+		if err != nil {
+			return nil, err
+		}
+		result.Stmts = append(result.Stmts, polStmts...)
+		result.DisallowedDropStmts = append(result.DisallowedDropStmts, polDisallowed...)
+
 		return result, nil
 	}
 
@@ -189,6 +203,18 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	result.FKDropStmts = append(result.FKDropStmts, fkDrops...)
 	result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
 	result.DisallowedDropStmts = append(result.DisallowedDropStmts, fkDisallowed...)
+
+	// RLS toggles run before CREATE POLICY so a newly enabled table has its
+	// flag set when policies attach. Disabling RLS likewise comes before any
+	// policy DROP that the user may have stacked alongside.
+	result.Stmts = append(result.Stmts, diffRLS(fqtn, current, desired)...)
+
+	polStmts, polDisallowed, err := diffPolicies(fqtn, current.Policies, desired.Policies, dc)
+	if err != nil {
+		return nil, err
+	}
+	result.Stmts = append(result.Stmts, polStmts...)
+	result.DisallowedDropStmts = append(result.DisallowedDropStmts, polDisallowed...)
 
 	result.Stmts = append(result.Stmts, diffComments(current, desired)...)
 

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -17,6 +17,7 @@ func newTable(schema, name string) *model.Table {
 		Constraints: orderedmap.New[string, *model.Constraint](),
 		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
 		Indexes:     orderedmap.New[string, *model.Index](),
+		Policies:    orderedmap.New[string, *model.Policy](),
 	}
 }
 

--- a/diff_all.go
+++ b/diff_all.go
@@ -367,6 +367,9 @@ func extractObjectName(sql string) string {
 		{"ALTER INDEX "},
 		{"DROP INDEX CONCURRENTLY "},
 		{"DROP INDEX "},
+		{"CREATE POLICY "},
+		{"ALTER POLICY "},
+		{"DROP POLICY "},
 		{"ALTER TABLE ONLY "},
 		{"ALTER TABLE "},
 		{"ALTER TYPE "},
@@ -408,6 +411,13 @@ func extractObjectName(sql string) string {
 			// Index statements belong to the table they're on, but ALTER INDEX
 			// doesn't contain the table name directly. Return "" to use pos=-1.
 			return ""
+		}
+
+		if strings.HasPrefix(upper, "CREATE POLICY ") ||
+			strings.HasPrefix(upper, "ALTER POLICY ") ||
+			strings.HasPrefix(upper, "DROP POLICY ") {
+			// {CREATE,ALTER,DROP} POLICY name ON schema.table ...
+			return extractIndexTable(sql)
 		}
 
 		rest := sql[len(p.prefix):]

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -7,7 +7,7 @@ import "slices"
 // If AllowDrop contains "all", all drops are allowed.
 // Otherwise, only the listed object types are allowed to be dropped.
 type DropPolicy struct {
-	AllowDrop []string `enum:"all,table,view,enum,domain,column,constraint,foreign_key,index" env:"PIST_ALLOW_DROP" help:"Allow dropping specified object types (can be repeated). Use 'all' to allow all drops."`
+	AllowDrop []string `enum:"all,table,view,enum,domain,column,constraint,foreign_key,index,policy" env:"PIST_ALLOW_DROP" help:"Allow dropping specified object types (can be repeated). Use 'all' to allow all drops."`
 }
 
 func (p *DropPolicy) IsDropAllowed(objectType string) bool {

--- a/dump.go
+++ b/dump.go
@@ -54,6 +54,15 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 			}
 			copied.Indexes = idxs
 		}
+		if copied.Policies != nil && copied.Policies.Len() > 0 {
+			policies := orderedmap.New[string, *model.Policy]()
+			for _, p := range copied.Policies.CollectValues() {
+				pCopied := *p
+				pCopied.Schema = ""
+				policies.Set(p.Name, &pCopied)
+			}
+			copied.Policies = policies
+		}
 		tables.Set(fqtn, &copied)
 	}
 	return tables

--- a/model/policy.go
+++ b/model/policy.go
@@ -1,0 +1,93 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PolicyCommand mirrors pg_policy.polcmd:
+//
+//	'*' ALL, 'r' SELECT, 'a' INSERT, 'w' UPDATE, 'd' DELETE
+type PolicyCommand byte
+
+func (c PolicyCommand) String() string {
+	switch c {
+	case '*':
+		return "ALL"
+	case 'r':
+		return "SELECT"
+	case 'a':
+		return "INSERT"
+	case 'w':
+		return "UPDATE"
+	case 'd':
+		return "DELETE"
+	default:
+		return ""
+	}
+}
+
+func (c PolicyCommand) IsAll() bool { return c == '*' }
+
+type Policy struct {
+	Name       string
+	RenameFrom *string
+	Schema     string
+	Table      string
+	Permissive bool
+	Command    PolicyCommand
+	Roles      []string
+	Using      *string
+	WithCheck  *string
+}
+
+func (p *Policy) String() string {
+	return fmt.Sprintf("%#v", *p)
+}
+
+// SQL renders a CREATE POLICY statement.
+func (p Policy) SQL() string {
+	var b strings.Builder
+	b.WriteString("CREATE POLICY ")
+	b.WriteString(Ident(p.Name))
+	b.WriteString(" ON ")
+	b.WriteString(Ident(p.Schema, p.Table))
+	if !p.Permissive {
+		b.WriteString(" AS RESTRICTIVE")
+	}
+	if !p.Command.IsAll() {
+		b.WriteString(" FOR ")
+		b.WriteString(p.Command.String())
+	}
+	b.WriteString(p.rolesClause())
+	if p.Using != nil {
+		b.WriteString(" USING (")
+		b.WriteString(*p.Using)
+		b.WriteString(")")
+	}
+	if p.WithCheck != nil {
+		b.WriteString(" WITH CHECK (")
+		b.WriteString(*p.WithCheck)
+		b.WriteString(")")
+	}
+	b.WriteString(";")
+	return b.String()
+}
+
+func (p Policy) rolesClause() string {
+	if len(p.Roles) == 0 {
+		return ""
+	}
+	if len(p.Roles) == 1 && p.Roles[0] == "public" {
+		return ""
+	}
+	parts := make([]string, len(p.Roles))
+	for i, r := range p.Roles {
+		if r == "public" || r == "current_user" || r == "current_role" || r == "session_user" {
+			parts[i] = r
+			continue
+		}
+		parts[i] = Ident(r)
+	}
+	return " TO " + strings.Join(parts, ", ")
+}

--- a/model/policy_test.go
+++ b/model/policy_test.go
@@ -1,0 +1,114 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyCommand_String(t *testing.T) {
+	assert.Equal(t, "ALL", PolicyCommand('*').String())
+	assert.Equal(t, "SELECT", PolicyCommand('r').String())
+	assert.Equal(t, "INSERT", PolicyCommand('a').String())
+	assert.Equal(t, "UPDATE", PolicyCommand('w').String())
+	assert.Equal(t, "DELETE", PolicyCommand('d').String())
+	assert.Equal(t, "", PolicyCommand(0).String())
+}
+
+func TestPolicyCommand_IsAll(t *testing.T) {
+	assert.True(t, PolicyCommand('*').IsAll())
+	assert.False(t, PolicyCommand('r').IsAll())
+}
+
+func TestPolicy_String(t *testing.T) {
+	p := &Policy{Name: "p", Schema: "public", Table: "t", Command: '*', Permissive: true}
+	s := p.String()
+	assert.Contains(t, s, "p")
+}
+
+func TestPolicy_SQL_minimal(t *testing.T) {
+	using := "true"
+	p := Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*', Using: &using}
+	assert.Equal(t, "CREATE POLICY p ON public.t USING (true);", p.SQL())
+}
+
+func TestPolicy_SQL_restrictive(t *testing.T) {
+	using := "owner = current_user"
+	p := Policy{Name: "p", Schema: "public", Table: "t", Permissive: false, Command: '*', Using: &using}
+	assert.Equal(t, "CREATE POLICY p ON public.t AS RESTRICTIVE USING (owner = current_user);", p.SQL())
+}
+
+func TestPolicy_SQL_specific_command(t *testing.T) {
+	using := "true"
+	p := Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: 'r', Using: &using}
+	assert.Equal(t, "CREATE POLICY p ON public.t FOR SELECT USING (true);", p.SQL())
+}
+
+func TestPolicy_SQL_with_check(t *testing.T) {
+	using := "true"
+	wc := "owner = current_user"
+	p := Policy{
+		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
+		Using: &using, WithCheck: &wc,
+	}
+	assert.Equal(t,
+		"CREATE POLICY p ON public.t USING (true) WITH CHECK (owner = current_user);",
+		p.SQL())
+}
+
+func TestPolicy_SQL_with_check_only(t *testing.T) {
+	wc := "owner = current_user"
+	p := Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: 'a', WithCheck: &wc}
+	assert.Equal(t, "CREATE POLICY p ON public.t FOR INSERT WITH CHECK (owner = current_user);", p.SQL())
+}
+
+func TestPolicy_SQL_role_named(t *testing.T) {
+	using := "true"
+	p := Policy{
+		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
+		Roles: []string{"app_user"}, Using: &using,
+	}
+	assert.Equal(t, "CREATE POLICY p ON public.t TO app_user USING (true);", p.SQL())
+}
+
+func TestPolicy_SQL_role_reserved(t *testing.T) {
+	using := "true"
+	p := Policy{
+		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
+		Roles: []string{"current_user"}, Using: &using,
+	}
+	assert.Equal(t, "CREATE POLICY p ON public.t TO current_user USING (true);", p.SQL())
+}
+
+func TestPolicy_SQL_role_multiple(t *testing.T) {
+	using := "true"
+	p := Policy{
+		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
+		Roles: []string{"a", "b"}, Using: &using,
+	}
+	assert.Equal(t, "CREATE POLICY p ON public.t TO a, b USING (true);", p.SQL())
+}
+
+// rolesClause returns "" when only PUBLIC is in the role list (catalog +
+// parser both normalize the omitted-TO case to ["public"]), so emit must
+// drop the TO clause entirely.
+func TestPolicy_SQL_role_public_only(t *testing.T) {
+	using := "true"
+	p := Policy{
+		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
+		Roles: []string{"public"}, Using: &using,
+	}
+	assert.Equal(t, "CREATE POLICY p ON public.t USING (true);", p.SQL())
+}
+
+// Empty Roles list: should also collapse to no TO clause. This branch is
+// dead code from the parser/catalog paths (both inject PUBLIC) but is
+// reachable from direct construction and worth covering.
+func TestPolicy_SQL_role_empty(t *testing.T) {
+	using := "true"
+	p := Policy{
+		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
+		Using: &using,
+	}
+	assert.Equal(t, "CREATE POLICY p ON public.t USING (true);", p.SQL())
+}

--- a/model/policy_test.go
+++ b/model/policy_test.go
@@ -89,9 +89,11 @@ func TestPolicy_SQL_role_multiple(t *testing.T) {
 	assert.Equal(t, "CREATE POLICY p ON public.t TO a, b USING (true);", p.SQL())
 }
 
-// rolesClause returns "" when only PUBLIC is in the role list (catalog +
-// parser both normalize the omitted-TO case to ["public"]), so emit must
-// drop the TO clause entirely.
+// rolesClause returns "" when the role list is exactly ["public"]. The
+// catalog COALESCE normalizes empty polroles to ["public"], and pg_query
+// injects ROLESPEC_PUBLIC into cps.Roles for an omitted TO clause (which
+// parsePolicyRoles maps to "public"), so this is the form Policy.Roles
+// takes in practice when no TO is specified.
 func TestPolicy_SQL_role_public_only(t *testing.T) {
 	using := "true"
 	p := Policy{
@@ -101,9 +103,11 @@ func TestPolicy_SQL_role_public_only(t *testing.T) {
 	assert.Equal(t, "CREATE POLICY p ON public.t USING (true);", p.SQL())
 }
 
-// Empty Roles list: should also collapse to no TO clause. This branch is
-// dead code from the parser/catalog paths (both inject PUBLIC) but is
-// reachable from direct construction and worth covering.
+// Empty Roles list: the SQL emitter must also collapse to no TO clause.
+// This is a defensive path: parsePolicyRoles returns nil only when invoked
+// with an empty node list, which pg_query never produces (it injects
+// ROLESPEC_PUBLIC for omitted TO), and the catalog coalesces to ["public"]
+// instead. Reachable only via direct construction.
 func TestPolicy_SQL_role_empty(t *testing.T) {
 	using := "true"
 	p := Policy{

--- a/model/table.go
+++ b/model/table.go
@@ -8,21 +8,24 @@ import (
 )
 
 type Table struct {
-	OID            uint32
-	Schema         string
-	Name           string
-	RenameFrom     *string
-	TableSpace     *string
-	Unlogged       bool
-	Partitioned    bool
-	PartitionDef   *string
-	PartitionOf    *string
-	PartitionBound *string
-	Columns        *orderedmap.Map[string, *Column]
-	Constraints    *orderedmap.Map[string, *Constraint]
-	ForeignKeys    *orderedmap.Map[string, *ForeignKey]
-	Indexes        *orderedmap.Map[string, *Index]
-	Comment        *string
+	OID              uint32
+	Schema           string
+	Name             string
+	RenameFrom       *string
+	TableSpace       *string
+	Unlogged         bool
+	Partitioned      bool
+	PartitionDef     *string
+	PartitionOf      *string
+	PartitionBound   *string
+	RowSecurity      bool
+	ForceRowSecurity bool
+	Columns          *orderedmap.Map[string, *Column]
+	Constraints      *orderedmap.Map[string, *Constraint]
+	ForeignKeys      *orderedmap.Map[string, *ForeignKey]
+	Indexes          *orderedmap.Map[string, *Index]
+	Policies         *orderedmap.Map[string, *Policy]
+	Comment          *string
 }
 
 func (t Table) FQTN() string {
@@ -114,6 +117,22 @@ func (t Table) FkSQL() string {
 	)
 }
 
+func (t Table) RLSSQL() string {
+	var stmts []string
+	if t.RowSecurity {
+		stmts = append(stmts, "ALTER TABLE "+t.FQTN()+" ENABLE ROW LEVEL SECURITY;")
+	}
+	if t.ForceRowSecurity {
+		stmts = append(stmts, "ALTER TABLE "+t.FQTN()+" FORCE ROW LEVEL SECURITY;")
+	}
+	if t.Policies != nil {
+		for _, p := range t.Policies.CollectValues() {
+			stmts = append(stmts, p.SQL())
+		}
+	}
+	return strings.Join(stmts, "\n")
+}
+
 func (t Table) CommentSQL() string {
 	var stmts []string
 	if t.Comment != nil {
@@ -133,6 +152,9 @@ func TableToSQL(t *Table) string {
 		parts = append(parts, s)
 	}
 	if s := t.FkSQL(); s != "" {
+		parts = append(parts, "\n"+s)
+	}
+	if s := t.RLSSQL(); s != "" {
 		parts = append(parts, "\n"+s)
 	}
 	if s := t.CommentSQL(); s != "" {

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -15,7 +15,58 @@ func newTable(schema, name string) *Table {
 		Constraints: orderedmap.New[string, *Constraint](),
 		ForeignKeys: orderedmap.New[string, *ForeignKey](),
 		Indexes:     orderedmap.New[string, *Index](),
+		Policies:    orderedmap.New[string, *Policy](),
 	}
+}
+
+func TestTable_RLSSQL_Empty(t *testing.T) {
+	tbl := newTable("public", "users")
+	assert.Empty(t, tbl.RLSSQL())
+}
+
+func TestTable_RLSSQL_EnableOnly(t *testing.T) {
+	tbl := newTable("public", "users")
+	tbl.RowSecurity = true
+	assert.Equal(t, "ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;", tbl.RLSSQL())
+}
+
+func TestTable_RLSSQL_EnableAndForce(t *testing.T) {
+	tbl := newTable("public", "users")
+	tbl.RowSecurity = true
+	tbl.ForceRowSecurity = true
+	assert.Equal(t,
+		"ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;\n"+
+			"ALTER TABLE public.users FORCE ROW LEVEL SECURITY;",
+		tbl.RLSSQL())
+}
+
+func TestTable_RLSSQL_WithPolicies(t *testing.T) {
+	tbl := newTable("public", "users")
+	tbl.RowSecurity = true
+	using := "owner = current_user"
+	tbl.Policies.Set("p", &Policy{
+		Name: "p", Schema: "public", Table: "users",
+		Permissive: true, Command: 'r', Using: &using,
+	})
+	got := tbl.RLSSQL()
+	assert.Contains(t, got, "ENABLE ROW LEVEL SECURITY;")
+	assert.Contains(t, got, "CREATE POLICY p ON public.users FOR SELECT USING (owner = current_user);")
+}
+
+// nil-Policies guard: an older Table built without orderedmap-init must not
+// panic on RLSSQL even though the parser/catalog now always initialize it.
+func TestTable_RLSSQL_NilPolicies(t *testing.T) {
+	tbl := &Table{Schema: "public", Name: "users"}
+	assert.Empty(t, tbl.RLSSQL())
+}
+
+func TestTableToSQL_IncludesRLS(t *testing.T) {
+	tbl := newTable("public", "users")
+	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.RowSecurity = true
+	out := TableToSQL(tbl)
+	assert.Contains(t, out, "CREATE TABLE public.users")
+	assert.Contains(t, out, "ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;")
 }
 
 func TestTable_FQTN(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -240,9 +240,11 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				continue
 			}
 
-			if applyAlterTableRLS(as, t) {
-				continue
-			}
+			// RLS toggles and constraint subcommands can coexist in one
+			// ALTER TABLE statement. applyAlterTableRLS picks up only the RLS
+			// subtypes; parseAlterTableConstraint picks up AT_AddConstraint.
+			// They walk the same cmd list independently, so run both.
+			applyAlterTableRLS(as, t)
 
 			con, fk, err := parseAlterTableConstraint(as, defaultSchema)
 			if err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -240,6 +240,10 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				continue
 			}
 
+			if applyAlterTableRLS(as, t) {
+				continue
+			}
+
 			con, fk, err := parseAlterTableConstraint(as, defaultSchema)
 			if err != nil {
 				return nil, err
@@ -260,6 +264,16 @@ func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				if err := setUnique(t.Constraints, con.Name, "constraint", con); err != nil {
 					return nil, err
 				}
+			}
+
+		case node.GetCreatePolicyStmt() != nil:
+			policy, err := parseCreatePolicyStmt(node.GetCreatePolicyStmt(), defaultSchema, tables)
+			if err != nil {
+				return nil, err
+			}
+			if renameFrom != "" {
+				unquoted := normalizeUnqualifiedDirective(renameFrom)
+				policy.RenameFrom = &unquoted
 			}
 
 		case node.GetCommentStmt() != nil:
@@ -290,6 +304,7 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 		Constraints: orderedmap.New[string, *model.Constraint](),
 		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
 		Indexes:     orderedmap.New[string, *model.Index](),
+		Policies:    orderedmap.New[string, *model.Policy](),
 	}
 
 	if cs.Tablespacename != "" {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1290,6 +1290,25 @@ CREATE TABLE public.items (
 	assert.Contains(t, err.Error(), "duplicate foreign key")
 }
 
+func TestParseSQL_PolicyOnUnknownTable(t *testing.T) {
+	sql := `CREATE POLICY p ON public.missing FOR SELECT USING (true);`
+
+	_, err := parser.ParseSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parent table")
+}
+
+func TestParseSQL_DuplicatePolicy(t *testing.T) {
+	sql := `CREATE TABLE public.documents (id bigint NOT NULL, owner text, CONSTRAINT documents_pkey PRIMARY KEY (id));
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.documents FOR SELECT USING (owner = current_user);
+CREATE POLICY p ON public.documents FOR ALL USING (owner = current_user);`
+
+	_, err := parser.ParseSQL(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate policy")
+}
+
 func TestParseSQLWithSchema_ViewComment(t *testing.T) {
 	sql := `CREATE VIEW active_users AS SELECT 1;
 COMMENT ON VIEW active_users IS 'Active users';`
@@ -1474,6 +1493,27 @@ CREATE INDEX idx_new ON public.users (name);`
 	require.True(t, ok)
 	require.NotNil(t, idx.RenameFrom)
 	assert.Equal(t, "idx_old", *idx.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_Policy(t *testing.T) {
+	sql := `CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+-- pist:renamed-from old_policy
+CREATE POLICY new_policy ON public.documents FOR SELECT USING (owner = current_user);`
+
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.documents")
+	require.True(t, ok)
+	pol, ok := tbl.Policies.GetOk("new_policy")
+	require.True(t, ok)
+	require.NotNil(t, pol.RenameFrom)
+	assert.Equal(t, "old_policy", *pol.RenameFrom)
 }
 
 func TestParseSQL_RenameDirective_Constraint(t *testing.T) {

--- a/parser/policy.go
+++ b/parser/policy.go
@@ -8,14 +8,13 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-// applyAlterTableRLS handles ALTER TABLE subtypes that toggle row-level
-// security flags on the table. Returns true when the statement was an RLS
-// toggle (so the caller can skip constraint parsing for the same statement).
-// Note: PostgreSQL allows mixing constraint changes with RLS toggles in one
-// ALTER TABLE statement. The desired-SQL convention here keeps each ALTER
-// TABLE single-purpose, mirroring how the rest of the parser treats them.
-func applyAlterTableRLS(as *pg_query.AlterTableStmt, t *model.Table) bool {
-	handled := false
+// applyAlterTableRLS scans an ALTER TABLE statement for row-level security
+// toggle subcommands (ENABLE / DISABLE / FORCE / NO FORCE) and applies them
+// to the table's flags. Non-RLS subcommands are ignored, so the caller can
+// invoke parseAlterTableConstraint on the same statement to pick up any
+// AT_AddConstraint subcommands — PostgreSQL allows mixing the two in one
+// ALTER TABLE.
+func applyAlterTableRLS(as *pg_query.AlterTableStmt, t *model.Table) {
 	for _, cmdNode := range as.Cmds {
 		cmd := cmdNode.GetAlterTableCmd()
 		if cmd == nil {
@@ -24,19 +23,14 @@ func applyAlterTableRLS(as *pg_query.AlterTableStmt, t *model.Table) bool {
 		switch cmd.Subtype {
 		case pg_query.AlterTableType_AT_EnableRowSecurity:
 			t.RowSecurity = true
-			handled = true
 		case pg_query.AlterTableType_AT_DisableRowSecurity:
 			t.RowSecurity = false
-			handled = true
 		case pg_query.AlterTableType_AT_ForceRowSecurity:
 			t.ForceRowSecurity = true
-			handled = true
 		case pg_query.AlterTableType_AT_NoForceRowSecurity:
 			t.ForceRowSecurity = false
-			handled = true
 		}
 	}
-	return handled
 }
 
 // parseCreatePolicyStmt converts a CreatePolicyStmt into a model.Policy and

--- a/parser/policy.go
+++ b/parser/policy.go
@@ -1,0 +1,150 @@
+package parser
+
+import (
+	"fmt"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// applyAlterTableRLS handles ALTER TABLE subtypes that toggle row-level
+// security flags on the table. Returns true when the statement was an RLS
+// toggle (so the caller can skip constraint parsing for the same statement).
+// Note: PostgreSQL allows mixing constraint changes with RLS toggles in one
+// ALTER TABLE statement. The desired-SQL convention here keeps each ALTER
+// TABLE single-purpose, mirroring how the rest of the parser treats them.
+func applyAlterTableRLS(as *pg_query.AlterTableStmt, t *model.Table) bool {
+	handled := false
+	for _, cmdNode := range as.Cmds {
+		cmd := cmdNode.GetAlterTableCmd()
+		if cmd == nil {
+			continue
+		}
+		switch cmd.Subtype {
+		case pg_query.AlterTableType_AT_EnableRowSecurity:
+			t.RowSecurity = true
+			handled = true
+		case pg_query.AlterTableType_AT_DisableRowSecurity:
+			t.RowSecurity = false
+			handled = true
+		case pg_query.AlterTableType_AT_ForceRowSecurity:
+			t.ForceRowSecurity = true
+			handled = true
+		case pg_query.AlterTableType_AT_NoForceRowSecurity:
+			t.ForceRowSecurity = false
+			handled = true
+		}
+	}
+	return handled
+}
+
+// parseCreatePolicyStmt converts a CreatePolicyStmt into a model.Policy and
+// attaches it to the owning table. Returns the created policy so the caller
+// can apply post-parse decorations (e.g. RenameFrom). The table must already
+// exist in `tables`, otherwise an error is returned.
+func parseCreatePolicyStmt(
+	cps *pg_query.CreatePolicyStmt,
+	defaultSchema string,
+	tables *orderedmap.Map[string, *model.Table],
+) (*model.Policy, error) {
+	if cps.Table == nil {
+		return nil, fmt.Errorf("CREATE POLICY: missing table reference")
+	}
+	schema := cps.Table.Schemaname
+	if schema == "" {
+		schema = defaultSchema
+	}
+	fqtn := model.Ident(schema, cps.Table.Relname)
+	tbl, ok := tables.GetOk(fqtn)
+	if !ok {
+		return nil, fmt.Errorf("CREATE POLICY %s: parent table %s not defined", cps.PolicyName, fqtn)
+	}
+
+	cmd, err := parsePolicyCommand(cps.CmdName)
+	if err != nil {
+		return nil, fmt.Errorf("CREATE POLICY %s: %w", cps.PolicyName, err)
+	}
+
+	roles, err := parsePolicyRoles(cps.Roles)
+	if err != nil {
+		return nil, fmt.Errorf("CREATE POLICY %s: %w", cps.PolicyName, err)
+	}
+
+	policy := &model.Policy{
+		Name:       cps.PolicyName,
+		Schema:     schema,
+		Table:      cps.Table.Relname,
+		Permissive: cps.Permissive,
+		Command:    cmd,
+		Roles:      roles,
+	}
+
+	if cps.Qual != nil {
+		using, err := deparseExpr(cps.Qual)
+		if err != nil {
+			return nil, fmt.Errorf("CREATE POLICY %s: failed to deparse USING: %w", cps.PolicyName, err)
+		}
+		policy.Using = &using
+	}
+	if cps.WithCheck != nil {
+		wc, err := deparseExpr(cps.WithCheck)
+		if err != nil {
+			return nil, fmt.Errorf("CREATE POLICY %s: failed to deparse WITH CHECK: %w", cps.PolicyName, err)
+		}
+		policy.WithCheck = &wc
+	}
+
+	if err := setUnique(tbl.Policies, policy.Name, "policy", policy); err != nil {
+		return nil, err
+	}
+	return policy, nil
+}
+
+// parsePolicyCommand maps the parser-emitted command name to the catalog
+// representation in pg_policy.polcmd.
+func parsePolicyCommand(name string) (model.PolicyCommand, error) {
+	switch name {
+	case "", "all":
+		return '*', nil
+	case "select":
+		return 'r', nil
+	case "insert":
+		return 'a', nil
+	case "update":
+		return 'w', nil
+	case "delete":
+		return 'd', nil
+	default:
+		return 0, fmt.Errorf("unsupported policy command: %s", name)
+	}
+}
+
+// parsePolicyRoles converts a list of RoleSpec nodes into role name strings.
+// Reserved role specifiers (CURRENT_USER, CURRENT_ROLE, SESSION_USER, PUBLIC)
+// are kept lower-cased so the diff layer can reliably compare them.
+func parsePolicyRoles(nodes []*pg_query.Node) ([]string, error) {
+	if len(nodes) == 0 {
+		return nil, nil
+	}
+	roles := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		rs := n.GetRoleSpec()
+		if rs == nil {
+			return nil, fmt.Errorf("expected RoleSpec in role list")
+		}
+		switch rs.Roletype {
+		case pg_query.RoleSpecType_ROLESPEC_PUBLIC:
+			roles = append(roles, "public")
+		case pg_query.RoleSpecType_ROLESPEC_CURRENT_USER:
+			roles = append(roles, "current_user")
+		case pg_query.RoleSpecType_ROLESPEC_CURRENT_ROLE:
+			roles = append(roles, "current_role")
+		case pg_query.RoleSpecType_ROLESPEC_SESSION_USER:
+			roles = append(roles, "session_user")
+		default:
+			roles = append(roles, rs.Rolename)
+		}
+	}
+	return roles, nil
+}

--- a/parser/policy_test.go
+++ b/parser/policy_test.go
@@ -140,3 +140,20 @@ CREATE POLICY q ON public.t AS PERMISSIVE FOR ALL USING (true);`
 	assert.False(t, p.Permissive)
 	assert.True(t, q.Permissive)
 }
+
+// PostgreSQL allows ENABLE ROW LEVEL SECURITY and ADD CONSTRAINT in the
+// same ALTER TABLE statement. Both must take effect — earlier versions of
+// the parser short-circuited after applying the RLS toggle and silently
+// dropped the constraint.
+func TestParseSQL_Policy_MixedRLSAndConstraint(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int, code text);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY, ADD CONSTRAINT t_code_key UNIQUE (code);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	tbl, _ := result.Tables.GetOk("public.t")
+	require.NotNil(t, tbl)
+	assert.True(t, tbl.RowSecurity, "RLS flag must be applied")
+	con, ok := tbl.Constraints.GetOk("t_code_key")
+	require.True(t, ok, "constraint from same ALTER TABLE must not be dropped")
+	assert.True(t, con.Type.IsUniqueConstraint())
+}

--- a/parser/policy_test.go
+++ b/parser/policy_test.go
@@ -1,0 +1,142 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+// Each test exercises a specific branch in parser/policy.go via the public
+// ParseSQL entry point so coverage credits the parser package directly
+// (integration tests in pistachio_test do not contribute here).
+
+func TestParseSQL_Policy_DefaultSchemaFallback(t *testing.T) {
+	// Unqualified table reference in CREATE POLICY → schema falls back to
+	// defaultSchema (public).
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON t USING (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	tbl, _ := result.Tables.GetOk("public.t")
+	pol, ok := tbl.Policies.GetOk("p")
+	require.True(t, ok)
+	assert.Equal(t, "public", pol.Schema)
+}
+
+func TestParseSQL_Policy_RoleSpec_Public(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t TO PUBLIC USING (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	pol, _ := result.Tables.Get("public.t").Policies.GetOk("p")
+	assert.Equal(t, []string{"public"}, pol.Roles)
+}
+
+func TestParseSQL_Policy_RoleSpec_CurrentUser(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t TO current_user USING (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	pol, _ := result.Tables.Get("public.t").Policies.GetOk("p")
+	assert.Equal(t, []string{"current_user"}, pol.Roles)
+}
+
+func TestParseSQL_Policy_RoleSpec_SessionUser(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t TO session_user USING (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	pol, _ := result.Tables.Get("public.t").Policies.GetOk("p")
+	assert.Equal(t, []string{"session_user"}, pol.Roles)
+}
+
+func TestParseSQL_Policy_RoleSpec_CurrentRole(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t TO current_role USING (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	pol, _ := result.Tables.Get("public.t").Policies.GetOk("p")
+	assert.Equal(t, []string{"current_role"}, pol.Roles)
+}
+
+func TestParseSQL_Policy_RoleSpec_NamedRole(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t TO app_user USING (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	pol, _ := result.Tables.Get("public.t").Policies.GetOk("p")
+	assert.Equal(t, []string{"app_user"}, pol.Roles)
+}
+
+func TestParseSQL_Policy_Command_Insert(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t FOR INSERT WITH CHECK (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	pol, _ := result.Tables.Get("public.t").Policies.GetOk("p")
+	assert.Equal(t, "INSERT", pol.Command.String())
+}
+
+func TestParseSQL_Policy_Command_Update(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t FOR UPDATE USING (true) WITH CHECK (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	pol, _ := result.Tables.Get("public.t").Policies.GetOk("p")
+	assert.Equal(t, "UPDATE", pol.Command.String())
+}
+
+func TestParseSQL_Policy_Command_Delete(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t FOR DELETE USING (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	pol, _ := result.Tables.Get("public.t").Policies.GetOk("p")
+	assert.Equal(t, "DELETE", pol.Command.String())
+}
+
+func TestParseSQL_Policy_DisableRowSecurity(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.t DISABLE ROW LEVEL SECURITY;`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	tbl, _ := result.Tables.GetOk("public.t")
+	assert.False(t, tbl.RowSecurity)
+}
+
+func TestParseSQL_Policy_NoForceRowSecurity(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.t FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.t NO FORCE ROW LEVEL SECURITY;`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	tbl, _ := result.Tables.GetOk("public.t")
+	assert.False(t, tbl.ForceRowSecurity)
+}
+
+func TestParseSQL_Policy_RestrictivePermissive(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON public.t AS RESTRICTIVE FOR ALL USING (true);
+CREATE POLICY q ON public.t AS PERMISSIVE FOR ALL USING (true);`
+	result, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	tbl, _ := result.Tables.GetOk("public.t")
+	p, _ := tbl.Policies.GetOk("p")
+	q, _ := tbl.Policies.GetOk("q")
+	assert.False(t, p.Permissive)
+	assert.True(t, q.Permissive)
+}

--- a/remap.go
+++ b/remap.go
@@ -58,10 +58,35 @@ func (client *Client) remapTableSchemas(tables *orderedmap.Map[string, *model.Ta
 			}
 		}
 
+		remapPolicies(t.Policies, client.RemapSchema, replacer)
+
 		remapped.Set(t.FQTN(), t)
 	}
 
 	return remapped
+}
+
+// remapPolicies rewrites the Schema field on each policy and applies the
+// schema replacer to USING / WITH CHECK expressions so cross-schema
+// references in subqueries / function calls follow the table schema.
+// `policies` is always non-nil because both parser and catalog initialize
+// Table.Policies.
+func remapPolicies(
+	policies *orderedmap.Map[string, *model.Policy],
+	mapSchema func(string) string,
+	replacer *strings.Replacer,
+) {
+	for _, p := range policies.CollectValues() {
+		p.Schema = mapSchema(p.Schema)
+		if p.Using != nil {
+			expr := replacer.Replace(*p.Using)
+			p.Using = &expr
+		}
+		if p.WithCheck != nil {
+			expr := replacer.Replace(*p.WithCheck)
+			p.WithCheck = &expr
+		}
+	}
 }
 
 func (client *Client) remapViewSchemas(views *orderedmap.Map[string, *model.View]) *orderedmap.Map[string, *model.View] {
@@ -105,6 +130,8 @@ func (client *Client) reverseRemapTableSchemas(tables *orderedmap.Map[string, *m
 				fk.RefSchema = &mapped
 			}
 		}
+
+		remapPolicies(t.Policies, client.ReverseRemapSchema, replacer)
 
 		remapped.Set(t.FQTN(), t)
 	}

--- a/remap_test.go
+++ b/remap_test.go
@@ -782,3 +782,150 @@ CREATE TABLE myschema.users (
 	require.NoError(t, err)
 	assert.Contains(t, got.String(), "name text")
 }
+
+// Verifies that --schema-map remaps the table schema in CREATE POLICY / ALTER
+// POLICY / DROP POLICY targets, and that USING / WITH CHECK expressions get
+// the same schema substitution applied so cross-schema references stay
+// consistent on the desired side.
+func TestPlan_WithSchemaMap_Policy_NoDiff(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE myschema.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON myschema.documents FOR SELECT USING (owner = current_user);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL)
+}
+
+// Verifies that the schema replacer rewrites schema-qualified references
+// inside USING expressions. Uses a schema-qualified function call so the
+// schema prefix survives both pg_get_expr rendering on the catalog side and
+// pg_query deparsing on the desired side, isolating the replacer's behaviour
+// from unrelated normalization concerns (e.g. subquery column qualification).
+func TestPlan_WithSchemaMap_Policy_USING_SchemaRef(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE FUNCTION myschema.is_admin() RETURNS boolean AS $$ SELECT true $$ LANGUAGE SQL IMMUTABLE;
+CREATE TABLE myschema.documents (
+    id bigint NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE myschema.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY visible ON myschema.documents FOR SELECT USING (myschema.is_admin());
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY visible ON public.documents FOR SELECT USING (public.is_admin());`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL, "schema replacement on policy USING should yield no diff")
+}
+
+// Verifies that schema replacement also walks WITH CHECK expressions.
+// Together with TestPlan_WithSchemaMap_Policy_USING_SchemaRef this ensures
+// both clause replacers have coverage.
+func TestPlan_WithSchemaMap_Policy_WithCheck_SchemaRef(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE FUNCTION myschema.is_admin() RETURNS boolean AS $$ SELECT true $$ LANGUAGE SQL IMMUTABLE;
+CREATE TABLE myschema.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE myschema.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY mod ON myschema.documents FOR ALL USING (myschema.is_admin()) WITH CHECK (myschema.is_admin());
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY mod ON public.documents FOR ALL USING (public.is_admin()) WITH CHECK (public.is_admin());`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Empty(t, got.SQL, "schema replacement on policy WITH CHECK should yield no diff")
+}
+
+// When the desired schema differs in policy attributes, the diff must target
+// the real database schema name (not the desired-side mapped name).
+func TestPlan_WithSchemaMap_Policy_AlterUsing(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE myschema.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON myschema.documents FOR SELECT USING (owner = current_user);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = session_user);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "ALTER POLICY owner_select ON myschema.documents")
+	assert.NotContains(t, got.SQL, "ALTER POLICY owner_select ON public.documents")
+}

--- a/test/scenario/rls.test.sh
+++ b/test/scenario/rls.test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Scenario test: row-level security (RLS) and policies
-# Walks the desired schema through enable → policies → modify → drop → disable,
-# verifying drift-free state at every step.
+# Walks the desired schema through enable → policies → modify → recreate
+# (command change) → drop → force → disable, verifying drift-free state at
+# every step.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/test/scenario/rls.test.sh
+++ b/test/scenario/rls.test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Scenario test: row-level security (RLS) and policies
+# Walks the desired schema through enable → policies → modify → drop → disable,
+# verifying drift-free state at every step.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/rls"
+
+setup_db "$DATA/init.sql"
+
+run_step "step 1: enable RLS" \
+  "ENABLE ROW LEVEL SECURITY" \
+  "$DATA/step1_enable.sql"
+
+run_step "step 2: add policies" \
+  "CREATE POLICY owner_select" \
+  "$DATA/step2_add_policies.sql"
+
+run_step "step 3: alter USING in place" \
+  "ALTER POLICY owner_select" \
+  "$DATA/step3_alter_using.sql"
+
+run_step "step 4: change command (DROP+CREATE)" \
+  "DROP POLICY owner_select" \
+  "$DATA/step4_change_command.sql"
+
+run_step "step 5: drop one policy" \
+  "DROP POLICY owner_modify" \
+  "$DATA/step5_drop_policy.sql"
+
+run_step "step 6: force RLS" \
+  "FORCE ROW LEVEL SECURITY" \
+  "$DATA/step6_force.sql"
+
+run_step "step 7: disable RLS" \
+  "DISABLE ROW LEVEL SECURITY" \
+  "$DATA/step7_disable.sql"
+
+summary

--- a/test/scenario/testdata/rls/init.sql
+++ b/test/scenario/testdata/rls/init.sql
@@ -1,0 +1,6 @@
+CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    body text,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/rls/step1_enable.sql
+++ b/test/scenario/testdata/rls/step1_enable.sql
@@ -1,0 +1,7 @@
+CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    body text,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;

--- a/test/scenario/testdata/rls/step2_add_policies.sql
+++ b/test/scenario/testdata/rls/step2_add_policies.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    body text,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);

--- a/test/scenario/testdata/rls/step3_alter_using.sql
+++ b/test/scenario/testdata/rls/step3_alter_using.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    body text,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = session_user);
+CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);

--- a/test/scenario/testdata/rls/step4_change_command.sql
+++ b/test/scenario/testdata/rls/step4_change_command.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    body text,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON public.documents FOR ALL USING (owner = session_user);
+CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);

--- a/test/scenario/testdata/rls/step5_drop_policy.sql
+++ b/test/scenario/testdata/rls/step5_drop_policy.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    body text,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON public.documents FOR ALL USING (owner = session_user);

--- a/test/scenario/testdata/rls/step6_force.sql
+++ b/test/scenario/testdata/rls/step6_force.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    body text,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+CREATE POLICY owner_select ON public.documents FOR ALL USING (owner = session_user);

--- a/test/scenario/testdata/rls/step7_disable.sql
+++ b/test/scenario/testdata/rls/step7_disable.sql
@@ -1,0 +1,6 @@
+CREATE TABLE public.documents (
+    id bigint NOT NULL,
+    owner text NOT NULL,
+    body text,
+    CONSTRAINT documents_pkey PRIMARY KEY (id)
+);

--- a/testdata/apply/rls_alter_using.yml
+++ b/testdata/apply/rls_alter_using.yml
@@ -1,0 +1,27 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = session_user);
+applied: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING ((owner = SESSION_USER));
+verify_no_drift: true

--- a/testdata/apply/rls_change_command.yml
+++ b/testdata/apply/rls_change_command.yml
@@ -1,0 +1,27 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR ALL USING (owner = current_user);
+applied: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents USING ((owner = CURRENT_USER));
+verify_no_drift: true

--- a/testdata/apply/rls_drop_policy.yml
+++ b/testdata/apply/rls_drop_policy.yml
@@ -1,0 +1,25 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+applied: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+verify_no_drift: true

--- a/testdata/apply/rls_drop_policy_disallowed.yml
+++ b/testdata/apply/rls_drop_policy_disallowed.yml
@@ -1,0 +1,30 @@
+drop_policy:
+  allow_drop: []
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+applied_sql: ""
+disallowed_drops: |
+  -- skipped: DROP POLICY owner_select ON public.documents;
+applied: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING ((owner = CURRENT_USER));

--- a/testdata/apply/rls_enable_with_policy.yml
+++ b/testdata/apply/rls_enable_with_policy.yml
@@ -1,0 +1,25 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+applied: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING ((owner = CURRENT_USER));
+verify_no_drift: true

--- a/testdata/apply/rls_partition_child.yml
+++ b/testdata/apply/rls_partition_child.yml
@@ -1,0 +1,34 @@
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  ALTER TABLE public.events_2024 ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.events_2024 FOR SELECT USING (owner = current_user);
+applied: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  )
+  PARTITION BY RANGE (created_at);
+
+  -- public.events_2024
+  CREATE TABLE public.events_2024 PARTITION OF events FOR VALUES FROM ('2024-01-01 00:00:00+00') TO ('2025-01-01 00:00:00+00');
+
+  ALTER TABLE public.events_2024 ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.events_2024 FOR SELECT USING ((owner = CURRENT_USER));
+verify_no_drift: true

--- a/testdata/apply/rls_rename_policy.yml
+++ b/testdata/apply/rls_rename_policy.yml
@@ -1,0 +1,28 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY old_name ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- pist:renamed-from old_name
+  CREATE POLICY new_name ON public.documents FOR SELECT USING (owner = current_user);
+applied: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY new_name ON public.documents FOR SELECT USING ((owner = CURRENT_USER));
+verify_no_drift: true

--- a/testdata/apply/rls_with_role.yml
+++ b/testdata/apply/rls_with_role.yml
@@ -1,0 +1,25 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres USING (owner = current_user);
+applied: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres USING ((owner = CURRENT_USER));
+verify_no_drift: true

--- a/testdata/dump/omit_schema_rls.yml
+++ b/testdata/dump/omit_schema_rls.yml
@@ -1,0 +1,21 @@
+omit_schema: true
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+dump: |
+  -- documents
+  CREATE TABLE documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE documents FORCE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON documents FOR SELECT USING ((owner = CURRENT_USER));

--- a/testdata/dump/rls_commands.yml
+++ b/testdata/dump/rls_commands.yml
@@ -1,0 +1,22 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY ins_pol ON public.documents FOR INSERT WITH CHECK ((owner = CURRENT_USER));
+  CREATE POLICY upd_pol ON public.documents FOR UPDATE USING ((owner = CURRENT_USER)) WITH CHECK ((owner = CURRENT_USER));
+  CREATE POLICY del_pol ON public.documents FOR DELETE USING ((owner = CURRENT_USER));
+dump: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY del_pol ON public.documents FOR DELETE USING ((owner = CURRENT_USER));
+  CREATE POLICY ins_pol ON public.documents FOR INSERT WITH CHECK ((owner = CURRENT_USER));
+  CREATE POLICY upd_pol ON public.documents FOR UPDATE USING ((owner = CURRENT_USER)) WITH CHECK ((owner = CURRENT_USER));

--- a/testdata/dump/rls_force.yml
+++ b/testdata/dump/rls_force.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+dump: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;

--- a/testdata/dump/rls_restrictive.yml
+++ b/testdata/dump/rls_restrictive.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY restrict_others ON public.documents AS RESTRICTIVE FOR ALL USING ((owner = CURRENT_USER));
+dump: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY restrict_others ON public.documents AS RESTRICTIVE USING ((owner = CURRENT_USER));

--- a/testdata/dump/rls_simple.yml
+++ b/testdata/dump/rls_simple.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      body text,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+dump: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      body text,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING ((owner = CURRENT_USER));

--- a/testdata/dump/rls_with_check.yml
+++ b/testdata/dump/rls_with_check.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING ((owner = CURRENT_USER)) WITH CHECK ((owner = CURRENT_USER));
+dump: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents USING ((owner = CURRENT_USER)) WITH CHECK ((owner = CURRENT_USER));

--- a/testdata/dump/rls_with_role.yml
+++ b/testdata/dump/rls_with_role.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres USING ((owner = CURRENT_USER));
+dump: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres USING ((owner = CURRENT_USER));

--- a/testdata/parser/rls_disable_no_force.yml
+++ b/testdata/parser/rls_disable_no_force.yml
@@ -1,0 +1,20 @@
+input: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  -- Explicit DISABLE / NO FORCE in desired SQL is unusual (the declarative
+  -- form is to omit ENABLE / FORCE), but pistachio's parser must accept the
+  -- statements and resolve them to the corresponding flag-cleared state.
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents NO FORCE ROW LEVEL SECURITY;
+expected: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );

--- a/testdata/parser/rls_policy.yml
+++ b/testdata/parser/rls_policy.yml
@@ -1,0 +1,22 @@
+input: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+  CREATE POLICY owner_modify ON public.documents AS RESTRICTIVE FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);
+expected: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+  CREATE POLICY owner_modify ON public.documents AS RESTRICTIVE USING (owner = current_user) WITH CHECK (owner = current_user);

--- a/testdata/parser/rls_policy_commands.yml
+++ b/testdata/parser/rls_policy_commands.yml
@@ -1,0 +1,24 @@
+input: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY p_ins ON public.documents FOR INSERT WITH CHECK (owner = current_user);
+  CREATE POLICY p_upd ON public.documents FOR UPDATE USING (owner = current_user) WITH CHECK (owner = current_user);
+  CREATE POLICY p_del ON public.documents FOR DELETE USING (owner = current_user);
+  CREATE POLICY p_role ON public.documents FOR SELECT TO postgres USING (owner = current_user);
+expected: |
+  -- public.documents
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY p_ins ON public.documents FOR INSERT WITH CHECK (owner = current_user);
+  CREATE POLICY p_upd ON public.documents FOR UPDATE USING (owner = current_user) WITH CHECK (owner = current_user);
+  CREATE POLICY p_del ON public.documents FOR DELETE USING (owner = current_user);
+  CREATE POLICY p_role ON public.documents FOR SELECT TO postgres USING (owner = current_user);

--- a/testdata/plan/rls_add_policy.yml
+++ b/testdata/plan/rls_add_policy.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+plan: |
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);

--- a/testdata/plan/rls_add_policy_with_role.yml
+++ b/testdata/plan/rls_add_policy_with_role.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres USING (owner = current_user);
+plan: |
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres USING (owner = current_user);

--- a/testdata/plan/rls_add_using.yml
+++ b/testdata/plan/rls_add_using.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL WITH CHECK (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);
+plan: |
+  ALTER POLICY owner_modify ON public.documents USING (owner = current_user);

--- a/testdata/plan/rls_add_with_check.yml
+++ b/testdata/plan/rls_add_with_check.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);
+plan: |
+  ALTER POLICY owner_modify ON public.documents WITH CHECK (owner = current_user);

--- a/testdata/plan/rls_alter_multi.yml
+++ b/testdata/plan/rls_alter_multi.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL TO postgres USING (owner = current_user) WITH CHECK (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = session_user) WITH CHECK (owner = session_user);
+plan: |
+  ALTER POLICY owner_modify ON public.documents TO public USING (owner = session_user) WITH CHECK (owner = session_user);

--- a/testdata/plan/rls_alter_roles.yml
+++ b/testdata/plan/rls_alter_roles.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+plan: |
+  ALTER POLICY owner_select ON public.documents TO public;

--- a/testdata/plan/rls_alter_using.yml
+++ b/testdata/plan/rls_alter_using.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = session_user);
+plan: |
+  ALTER POLICY owner_select ON public.documents USING (owner = session_user);

--- a/testdata/plan/rls_alter_with_check.yml
+++ b/testdata/plan/rls_alter_with_check.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = session_user);
+plan: |
+  ALTER POLICY owner_modify ON public.documents WITH CHECK (owner = session_user);

--- a/testdata/plan/rls_change_command.yml
+++ b/testdata/plan/rls_change_command.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR ALL USING (owner = current_user);
+plan: |
+  DROP POLICY owner_select ON public.documents;
+  CREATE POLICY owner_select ON public.documents USING (owner = current_user);

--- a/testdata/plan/rls_change_permissive.yml
+++ b/testdata/plan/rls_change_permissive.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR ALL USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents AS RESTRICTIVE FOR ALL USING (owner = current_user);
+plan: |
+  DROP POLICY owner_select ON public.documents;
+  CREATE POLICY owner_select ON public.documents AS RESTRICTIVE USING (owner = current_user);

--- a/testdata/plan/rls_disable.yml
+++ b/testdata/plan/rls_disable.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.documents DISABLE ROW LEVEL SECURITY;

--- a/testdata/plan/rls_disable_keeps_policies.yml
+++ b/testdata/plan/rls_disable_keeps_policies.yml
@@ -1,0 +1,21 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  -- ENABLE removed; policy retained. Should emit DISABLE only and never DROP POLICY.
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+drop_policy:
+  allow_drop: []
+plan: |
+  ALTER TABLE public.documents DISABLE ROW LEVEL SECURITY;
+disallowed_drops: ""

--- a/testdata/plan/rls_drop_policy.yml
+++ b/testdata/plan/rls_drop_policy.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+plan: |
+  DROP POLICY owner_select ON public.documents;

--- a/testdata/plan/rls_drop_policy_disallowed.yml
+++ b/testdata/plan/rls_drop_policy_disallowed.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+drop_policy:
+  allow_drop: []
+plan: ""
+disallowed_drops: |
+  -- skipped: DROP POLICY owner_select ON public.documents;

--- a/testdata/plan/rls_drop_using.yml
+++ b/testdata/plan/rls_drop_using.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL WITH CHECK (owner = current_user);
+plan: |
+  DROP POLICY owner_modify ON public.documents;
+  CREATE POLICY owner_modify ON public.documents WITH CHECK (owner = current_user);

--- a/testdata/plan/rls_drop_with_check.yml
+++ b/testdata/plan/rls_drop_with_check.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user) WITH CHECK (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_modify ON public.documents FOR ALL USING (owner = current_user);
+plan: |
+  DROP POLICY owner_modify ON public.documents;
+  CREATE POLICY owner_modify ON public.documents USING (owner = current_user);

--- a/testdata/plan/rls_enable.yml
+++ b/testdata/plan/rls_enable.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+plan: |
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;

--- a/testdata/plan/rls_force.yml
+++ b/testdata/plan/rls_force.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+plan: |
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;

--- a/testdata/plan/rls_multi_role.yml
+++ b/testdata/plan/rls_multi_role.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres, pg_read_all_data USING (owner = current_user);
+plan: |
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres, pg_read_all_data USING (owner = current_user);

--- a/testdata/plan/rls_multi_role_no_diff.yml
+++ b/testdata/plan/rls_multi_role_no_diff.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO postgres, pg_read_all_data USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- Order differs from init; equalRoles should normalize via sort.
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO pg_read_all_data, postgres USING (owner = current_user);
+plan: ""

--- a/testdata/plan/rls_multiple_policies.yml
+++ b/testdata/plan/rls_multiple_policies.yml
@@ -1,0 +1,21 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY pol_a ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY pol_a ON public.documents FOR SELECT USING (owner = current_user);
+  CREATE POLICY pol_b ON public.documents FOR INSERT WITH CHECK (owner = current_user);
+  CREATE POLICY pol_c ON public.documents AS RESTRICTIVE FOR DELETE USING (owner = current_user);
+plan: |
+  CREATE POLICY pol_b ON public.documents FOR INSERT WITH CHECK (owner = current_user);
+  CREATE POLICY pol_c ON public.documents AS RESTRICTIVE FOR DELETE USING (owner = current_user);

--- a/testdata/plan/rls_new_table.yml
+++ b/testdata/plan/rls_new_table.yml
@@ -1,0 +1,17 @@
+init: ""
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+plan: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);

--- a/testdata/plan/rls_no_force.yml
+++ b/testdata/plan/rls_no_force.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.documents FORCE ROW LEVEL SECURITY;
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+plan: |
+  ALTER TABLE public.documents NO FORCE ROW LEVEL SECURITY;

--- a/testdata/plan/rls_partition_child.yml
+++ b/testdata/plan/rls_partition_child.yml
@@ -1,0 +1,21 @@
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  ALTER TABLE public.events_2024 ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.events_2024 FOR SELECT USING (owner = current_user);
+plan: |
+  ALTER TABLE public.events_2024 ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.events_2024 FOR SELECT USING (owner = current_user);

--- a/testdata/plan/rls_public_explicit_no_diff.yml
+++ b/testdata/plan/rls_public_explicit_no_diff.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY owner_select ON public.documents FOR SELECT TO PUBLIC USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- TO PUBLIC and omitted TO are equivalent in PostgreSQL — no diff expected.
+  CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current_user);
+plan: ""

--- a/testdata/plan/rls_rename_destination_conflict.yml
+++ b/testdata/plan/rls_rename_destination_conflict.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY old_name ON public.documents FOR SELECT USING (owner = current_user);
+  CREATE POLICY new_name ON public.documents FOR ALL USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- pist:renamed-from old_name
+  CREATE POLICY new_name ON public.documents FOR ALL USING (owner = current_user);
+error: destination already exists

--- a/testdata/plan/rls_rename_policy.yml
+++ b/testdata/plan/rls_rename_policy.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY old_name ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- pist:renamed-from old_name
+  CREATE POLICY new_name ON public.documents FOR SELECT USING (owner = current_user);
+plan: |
+  ALTER POLICY old_name ON public.documents RENAME TO new_name;

--- a/testdata/plan/rls_rename_source_missing.yml
+++ b/testdata/plan/rls_rename_source_missing.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- pist:renamed-from nonexistent
+  CREATE POLICY new_name ON public.documents FOR SELECT USING (owner = current_user);
+error: rename source policy nonexistent not found

--- a/testdata/plan/rls_rename_with_alter.yml
+++ b/testdata/plan/rls_rename_with_alter.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY old_name ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- pist:renamed-from old_name
+  CREATE POLICY new_name ON public.documents FOR SELECT USING (owner = session_user);
+plan: |
+  ALTER POLICY old_name ON public.documents RENAME TO new_name;
+  ALTER POLICY new_name ON public.documents USING (owner = session_user);

--- a/testdata/plan/rls_rename_with_recreate.yml
+++ b/testdata/plan/rls_rename_with_recreate.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY old_name ON public.documents FOR SELECT USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- pist:renamed-from old_name
+  CREATE POLICY new_name ON public.documents FOR ALL USING (owner = current_user);
+plan: |
+  DROP POLICY old_name ON public.documents;
+  CREATE POLICY new_name ON public.documents USING (owner = current_user);

--- a/testdata/plan/rls_reserved_role.yml
+++ b/testdata/plan/rls_reserved_role.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- Reserved role specs in TO are emitted verbatim by the parser; PostgreSQL
+  -- resolves them at apply time to the actual current/session role, so the
+  -- desired SQL cannot round-trip through the catalog. This fixture only
+  -- verifies the parse → emit path, not no-drift.
+  CREATE POLICY current_user_select ON public.documents FOR SELECT TO current_user USING (owner = current_user);
+  CREATE POLICY session_user_select ON public.documents FOR SELECT TO session_user USING (owner = session_user);
+plan: |
+  CREATE POLICY current_user_select ON public.documents FOR SELECT TO current_user USING (owner = current_user);
+  CREATE POLICY session_user_select ON public.documents FOR SELECT TO session_user USING (owner = session_user);


### PR DESCRIPTION
## Summary

- Adds support for `ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY` and `CREATE/ALTER/DROP POLICY` end-to-end (parser, catalog, diff, dump).
- Policies are modeled as **table-subordinate** (alongside Indexes / Constraints / FKs) so RLS flags and policies share the table's lifecycle, dump ordering, and `--allow-drop` semantics. New `policy` value added to `--allow-drop` enum.
- Diff emits `ALTER POLICY` for in-place TO / USING / WITH CHECK changes; `DROP+CREATE` for Command / Permissive changes or USING / WITH CHECK clause removals (PostgreSQL has no syntax to drop those clauses in place); `ALTER POLICY ... RENAME TO` via the existing `-- pist:renamed-from` directive.
- Schema map and `--omit-schema` are walked through policy `Schema` and `USING` / `WITH CHECK` expression strings.
- Two PostgreSQL behaviors are documented as TODOs: subquery column-qualifier normalization in policy expressions, and the `TO CURRENT_USER / SESSION_USER / CURRENT_ROLE` round-trip limitation (PostgreSQL resolves these to the actual role at policy creation time).

## Test plan

- [x] `make lint` clean
- [x] `make test` — 24 plan, 8 apply, 7 dump, 3 parser RLS fixtures + diff/policies_test.go + model/policy_test.go all pass
- [x] `make test-scenario` — new `rls.test.sh` (7-step enable → policies → modify → rename → drop → force → disable) drift-free; existing scenarios unchanged
- [x] Coverage 93.47% (mode=set), in line with main baseline (93.85%) and well above the 88% codecov target

🤖 Generated with [Claude Code](https://claude.com/claude-code)