### PR TITLE
Update CHANGELOG for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2026-05-01
+
+* Add row-level security (RLS) and policy support. Parser, catalog, diff, and dump now handle `ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY` and `CREATE/ALTER/DROP POLICY`. Policies are modeled as table-subordinate so they share the table's lifecycle, dump ordering, and `--allow-drop` semantics. Diff emits `ALTER POLICY` for in-place `TO` / `USING` / `WITH CHECK` changes, `DROP+CREATE` for `Command` / `Permissive` changes or clause removals, and `ALTER POLICY ... RENAME TO` via the existing `-- pist:renamed-from` directive. `--allow-drop` now accepts `policy`. Schema map and `--omit-schema` rewrite policy schema and expression references. ([#136](https://github.com/winebarrel/pistachio/pull/136))
+
 ## [1.2.0] - 2026-04-29
 
 * Rewrite column references in same-table indexes, constraints, and foreign keys when a column is renamed via `-- pist:renamed-from`, so a single `ALTER TABLE ... RENAME COLUMN` is emitted without redundant `DROP/CREATE` on dependents. Covers regular / composite / partial / expression / `INCLUDE` / GiST indexes, `UNIQUE` / `PRIMARY KEY` / `CHECK` / `EXCLUDE` constraints, and same-table FKs. ([#123](https://github.com/winebarrel/pistachio/pull/123))


### PR DESCRIPTION
## Summary

- Adds the 1.3.0 entry documenting RLS / policy support from #136.

## Test plan

- [x] CHANGELOG only — no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)