### PR TITLE
Remove misspell linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ version: "2"
 linters:
   enable:
     - errorlint
-    - misspell
     - unconvert
   exclusions:
     rules:


### PR DESCRIPTION
## Summary

- Remove `misspell` from the enabled linters in `.golangci.yml`.

## Test plan

- [ ] `make lint` passes in CI
