### PR TITLE
Propagate caller's context through Client.connect

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -29,7 +29,7 @@ type ApplyResult struct {
 }
 
 func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (*ApplyResult, error) {
-	conn, err := client.connect()
+	conn, err := client.connect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ func NewClient(options *Options) *Client {
 	return client
 }
 
-func (client *Client) connect() (*pgx.Conn, error) {
+func (client *Client) connect(ctx context.Context) (*pgx.Conn, error) {
 	cfg, err := pgx.ParseConfig(client.ConnString)
 	if err != nil {
 		return nil, fmt.Errorf("pistachio: failed to parse connection string: %w", err)
@@ -28,7 +28,7 @@ func (client *Client) connect() (*pgx.Conn, error) {
 		cfg.Password = client.Password
 	}
 
-	conn, err := pgx.ConnectConfig(context.Background(), cfg)
+	conn, err := pgx.ConnectConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("pistachio: failed to connect database: %w", err)
 	}

--- a/connect_test.go
+++ b/connect_test.go
@@ -1,0 +1,25 @@
+package pistachio
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnect_PropagatesCancelledContext(t *testing.T) {
+	connStr := os.Getenv("TEST_PIST_CONN_STR")
+	if connStr == "" {
+		connStr = "postgres://postgres@localhost/postgres"
+	}
+	client := NewClient(&Options{ConnString: connStr})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.connect(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/dump.go
+++ b/dump.go
@@ -212,7 +212,7 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 		return nil, fmt.Errorf("--omit-schema cannot be used with multiple schemas")
 	}
 
-	conn, err := client.connect()
+	conn, err := client.connect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/dump_test.go
+++ b/dump_test.go
@@ -79,7 +79,7 @@ func TestDump_CanceledContext(t *testing.T) {
 
 	_, err := client.Dump(canceledCtx, &pistachio.DumpOptions{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to fetch tables")
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestDump_Count(t *testing.T) {

--- a/plan.go
+++ b/plan.go
@@ -59,7 +59,7 @@ type PlanResult struct {
 }
 
 func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResult, error) {
-	conn, err := client.connect()
+	conn, err := client.connect(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- `Client.connect()` used `context.Background()` for `pgx.ConnectConfig`, so timeout/cancellation on the `ctx` passed to `Plan`/`Apply`/`Dump` was ignored at the connection establishment phase.
- Pass the caller's `ctx` through `connect(ctx)` so cancellation propagates correctly.
- The existing `TestDump_CanceledContext` relied on the bug (connect succeeding with the background ctx, then a downstream query observing the cancellation). Updated it to assert the error wraps `context.Canceled`, which is robust to whichever layer first observes the cancellation.

## Test plan

- [x] New `TestConnect_PropagatesCancelledContext` (same-package unit test) verifies a pre-cancelled ctx is honored by `connect()`.
- [x] Updated `TestDump_CanceledContext` keeps end-to-end coverage and now passes whichever layer first sees the cancellation.
- [x] `make vet`, `make lint`, `make test` pass.