### PR TITLE
Match FK dependency lookups against quoted map keys in toposort

### DIFF
--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -47,7 +47,9 @@ func OrderFromSchema(
 			}
 		}
 
-		// FK dependencies
+		// FK dependencies. Use model.Ident so the lookup matches the map keys
+		// (which are also model.Ident-formed) for non-safe identifiers like
+		// quoted or reserved-word names.
 		if t.ForeignKeys != nil {
 			for _, fk := range t.ForeignKeys.CollectValues() {
 				refSchema := t.Schema
@@ -55,7 +57,7 @@ func OrderFromSchema(
 					refSchema = *fk.RefSchema
 				}
 				if fk.RefTable != nil {
-					ref := refSchema + "." + *fk.RefTable
+					ref := model.Ident(refSchema, *fk.RefTable)
 					if defined[ref] {
 						g.AddEdge(k, ref)
 					}

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -278,6 +278,135 @@ func TestOrderFromSchema_PartitionChild(t *testing.T) {
 	assert.Less(t, idx["public.events"], idx["public.events_2024"], "partition parent before child")
 }
 
+func TestOrderFromSchema_FKWithQuotedRefTable(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	// Both names require quoting (mixed case). Source ("Comments") sorts
+	// before target ("Users") alphabetically, so without the FK edge being
+	// registered, the toposort fallback would emit source first — which is
+	// wrong. The edge can only be registered when the FK lookup uses the
+	// same quoted form as the map keys.
+	refTable := "Users"
+	refSchema := "public"
+
+	tables := orderedmap.New[string, *model.Table]()
+
+	users := &model.Table{Schema: "public", Name: "Users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set(model.Ident("public", "Users"), users)
+
+	comments := &model.Table{Schema: "public", Name: "Comments"}
+	comments.Columns = orderedmap.New[string, *model.Column]()
+	comments.Indexes = orderedmap.New[string, *model.Index]()
+	comments.Constraints = orderedmap.New[string, *model.Constraint]()
+	comments.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	comments.ForeignKeys.Set("comments_user_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "comments_user_fk"},
+		RefSchema:  &refSchema,
+		RefTable:   &refTable,
+	})
+	tables.Set(model.Ident("public", "Comments"), comments)
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx[model.Ident("public", "Users")], idx[model.Ident("public", "Comments")], "FK target before source for quoted ref table")
+}
+
+func TestOrderFromSchema_FKWithReservedWordRefTable(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	// "order" is a reserved word; both names quoted so alphabetical fallback
+	// puts source ("Items") before target ("order").
+	refTable := "order"
+	refSchema := "public"
+
+	tables := orderedmap.New[string, *model.Table]()
+
+	orderTbl := &model.Table{Schema: "public", Name: "order"}
+	orderTbl.Columns = orderedmap.New[string, *model.Column]()
+	orderTbl.Indexes = orderedmap.New[string, *model.Index]()
+	orderTbl.Constraints = orderedmap.New[string, *model.Constraint]()
+	orderTbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set(model.Ident("public", "order"), orderTbl)
+
+	items := &model.Table{Schema: "public", Name: "Items"}
+	items.Columns = orderedmap.New[string, *model.Column]()
+	items.Indexes = orderedmap.New[string, *model.Index]()
+	items.Constraints = orderedmap.New[string, *model.Constraint]()
+	items.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	items.ForeignKeys.Set("items_order_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "items_order_fk"},
+		RefSchema:  &refSchema,
+		RefTable:   &refTable,
+	})
+	tables.Set(model.Ident("public", "Items"), items)
+
+	sorted, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range sorted {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx[model.Ident("public", "order")], idx[model.Ident("public", "Items")], "FK target before source for reserved-word ref table")
+}
+
+func TestOrderFromSchema_FKWithQuotedRefSchema(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	// Quoted schema name. Source schema "AppPublic" sorts before target
+	// schema "Refs" alphabetically, so without the edge, source would come first.
+	refTable := "users"
+	refSchema := "Refs"
+
+	tables := orderedmap.New[string, *model.Table]()
+
+	users := &model.Table{Schema: "Refs", Name: "users"}
+	users.Columns = orderedmap.New[string, *model.Column]()
+	users.Indexes = orderedmap.New[string, *model.Index]()
+	users.Constraints = orderedmap.New[string, *model.Constraint]()
+	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set(model.Ident("Refs", "users"), users)
+
+	posts := &model.Table{Schema: "AppPublic", Name: "posts"}
+	posts.Columns = orderedmap.New[string, *model.Column]()
+	posts.Indexes = orderedmap.New[string, *model.Index]()
+	posts.Constraints = orderedmap.New[string, *model.Constraint]()
+	posts.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	posts.ForeignKeys.Set("posts_user_fk", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "posts_user_fk"},
+		RefSchema:  &refSchema,
+		RefTable:   &refTable,
+	})
+	tables.Set(model.Ident("AppPublic", "posts"), posts)
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx[model.Ident("Refs", "users")], idx[model.Ident("AppPublic", "posts")], "FK target before source across quoted schemas")
+}
+
 func TestOrderFromSchema_FKWithDefaultSchema(t *testing.T) {
 	enums := orderedmap.New[string, *model.Enum]()
 	domains := orderedmap.New[string, *model.Domain]()


### PR DESCRIPTION
## Summary

- `OrderFromSchema` stored tables under `model.Ident`-formed keys (e.g. `"public"."Users"` for non-safe identifiers) but built the FK lookup key by raw string concatenation (`refSchema + "." + RefTable`). For tables whose name or schema requires quoting, the lookup never matched and the FK dependency edge was silently dropped — producing wrong DDL ordering that the alphabetical fallback only sometimes happened to mask.
- Use `model.Ident` for the lookup so it matches the map keys.

## Out of scope

`PartitionOf` lookup and `resolveTypeDep` have analogous representation mismatches but require different fixes:

- `catalog/tables.go` stores `PartitionOf` as a bare relname (no schema, no quoting), so the lookup against schema-qualified `defined` keys fails for catalog-built tables. Parser-built tables already store `PartitionOf` via `model.Ident`, so the lookup works there.
- `resolveTypeDep` receives `typeName` already in display form (e.g. parser pg_query output may include quoting), so we can't simply wrap it in `model.Ident`.

Both are pre-existing and out of scope for this PR.

## Test plan

- [x] Three new unit tests cover the previously-broken cases: quoted ref table, reserved-word ref table, quoted ref schema. Each is constructed so the alphabetical sort fallback would put the FK source before its target — only a correctly-registered dependency edge produces the correct order.
- [x] `make vet`, `make lint`, `make test` pass.