### PR TITLE
Drop raw-form fallback in schema-replacer pair list

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -11,6 +11,7 @@ var (
 	ExtractObjectName         = extractObjectName
 	OrderStatements           = orderStatements
 	CompareTaggedPos          = compareTaggedPos
+	BuildDefReplacer          = buildDefReplacer
 )
 
 func DumpResultTables(r *DumpResult) *orderedmap.Map[string, *model.Table] {

--- a/remap.go
+++ b/remap.go
@@ -9,18 +9,18 @@ import (
 
 // buildDefReplacer builds a strings.Replacer that replaces schema-qualified
 // prefixes in raw SQL definitions (e.g. "staging." → "public.").
-// It handles both unquoted and quoted schema identifiers.
+//
+// All inputs to this replacer come from canonical SQL — pg_get_*def output
+// from the catalog or pg_query deparse output from the parser — so any
+// identifier that requires quoting is already wrapped in double quotes.
+// Only the model.Ident form is added to the pair list. Adding an unquoted
+// fallback (e.g. raw `a.b.` for a schema literally named `a.b`) would
+// dangerously collide with three-part references like `a.b.col` (schema
+// `a`, table `b`, column `col`).
 func buildDefReplacer(schemaMap map[string]string) *strings.Replacer {
 	var pairs []string
 	for from, to := range schemaMap {
-		fromIdent := model.Ident(from)
-		toIdent := model.Ident(to)
-		// Always add the Ident form (handles quoting)
-		pairs = append(pairs, fromIdent+".", toIdent+".")
-		// If Ident differs from raw name, also add the raw form
-		if fromIdent != from {
-			pairs = append(pairs, from+".", to+".")
-		}
+		pairs = append(pairs, model.Ident(from)+".", model.Ident(to)+".")
 	}
 	return strings.NewReplacer(pairs...)
 }

--- a/remap_test.go
+++ b/remap_test.go
@@ -35,6 +35,38 @@ func setupSchemaDB(t *testing.T, ctx context.Context, schema string, initSQL str
 	return conn.Config().ConnString()
 }
 
+func TestBuildDefReplacer_QuotedSchema(t *testing.T) {
+	// Schema names that need quoting in canonical SQL (e.g. names with
+	// uppercase letters or spaces) appear in catalog/parser output as the
+	// quoted form. The replacer matches only that form.
+	replacer := pistachio.BuildDefReplacer(map[string]string{
+		"My Schema": "public",
+		"Users":     "people",
+	})
+
+	assert.Equal(t, "public.t", replacer.Replace(`"My Schema".t`))
+	assert.Equal(t, "people.t", replacer.Replace(`"Users".t`))
+}
+
+// TestBuildDefReplacer_PreservesThreePartReference guards against the trap
+// where adding an unquoted-form pair (e.g. `a.b.` for a schema literally
+// named `a.b`) would silently rewrite a legitimate three-part column
+// reference `a.b.col` (schema `a`, table `b`, column `col`). Only the
+// quoted form gets added to the pair list, so the three-part reference
+// must pass through unchanged.
+func TestBuildDefReplacer_PreservesThreePartReference(t *testing.T) {
+	replacer := pistachio.BuildDefReplacer(map[string]string{
+		"a.b": "x", // a schema literally named "a.b"
+		"a":   "y",
+	})
+
+	// Three-part column reference for schema `a`, table `b`, column `col`.
+	// Schema `a` must be rewritten, but `b` (the table) must not be touched.
+	assert.Equal(t, "y.b.col", replacer.Replace("a.b.col"))
+	// Real reference to the dotted-name schema uses the quoted form.
+	assert.Equal(t, "x.col", replacer.Replace(`"a.b".col`))
+}
+
 func TestAfterApply(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		o := &pistachio.Options{SchemaMap: map[string]string{"staging": "public"}}

--- a/remap_test.go
+++ b/remap_test.go
@@ -51,9 +51,10 @@ func TestBuildDefReplacer_QuotedSchema(t *testing.T) {
 // TestBuildDefReplacer_PreservesThreePartReference guards against the trap
 // where adding an unquoted-form pair (e.g. `a.b.` for a schema literally
 // named `a.b`) would silently rewrite a legitimate three-part column
-// reference `a.b.col` (schema `a`, table `b`, column `col`). Only the
-// quoted form gets added to the pair list, so the three-part reference
-// must pass through unchanged.
+// reference `a.b.col` (schema `a`, table `b`, column `col`) by collapsing
+// the schema+table prefix into the dotted-name schema's mapped value. The
+// schema portion may legitimately be rewritten (`a.` → `y.`), but the
+// table/column segments (`b.col`) must remain intact.
 func TestBuildDefReplacer_PreservesThreePartReference(t *testing.T) {
 	replacer := pistachio.BuildDefReplacer(map[string]string{
 		"a.b": "x", // a schema literally named "a.b"


### PR DESCRIPTION
## Summary

\`buildDefReplacer\` added two pairs to the replacer whenever \`model.Ident(from) != from\`: the canonical quoted form (e.g. \`\"a.b\".\`) and the raw concatenated form (e.g. \`a.b.\`).

All inputs to this replacer come from canonical SQL — catalog \`pg_get_*def\` output and parser pg_query deparse — and never contain the raw form for identifiers that require quoting, so the raw-form pair could not legitimately match anything. It could, however, collide with a three-part column reference: with \`SchemaMap{\"a.b\": \"x\"}\`, the raw pair \`a.b.\` rewrote \`a.b.col\` (a three-part name meaning schema \`a\`, table \`b\`, column \`col\`) to \`x.col\`, silently corrupting an unrelated reference.

Drop the raw-form fallback. Only the \`model.Ident\` form is added, so the replacer matches exactly the canonical quoted reference for schemas whose name needs quoting and never overlaps with three-part references.

## Note on the original ‘determinism’ framing

This PR previously framed the bug as a non-determinism issue arising from \`a.\` and \`a.b.\` overlapping in the replacer trie. Copilot reviewers correctly pointed out that valid SQL for a schema named \`a.b\` uses the quoted form \`\"a.b\".foo\`, never the raw \`a.b.foo\`, and that the only way \`a.b.\` ends up in the replacer at all is via the unsafe raw fallback — which is itself the actual bug. With the fallback removed, only quoted-form pairs remain, and \`.\` always sits at the trie boundary, so two distinct schemas can never produce trie-prefix-overlapping pairs and ordering is irrelevant.

## Test plan

- [x] New \`TestBuildDefReplacer_PreservesThreePartReference\` exercises \`SchemaMap{\"a.b\": \"x\", \"a\": \"y\"}\` against both the unsafe form (\`a.b.col\` → must rewrite as schema \`a\` only, yielding \`y.b.col\`) and the canonical form (\`\"a.b\".col\` → must rewrite the dotted-name schema, yielding \`x.col\`). Verified the test fails on the previous raw-fallback code and passes after the fix.
- [x] New \`TestBuildDefReplacer_QuotedSchema\` covers ordinary quoted-name rewrites.
- [x] Existing \`TestDump_WithSchemaMap_QuotedSchema\` (schema \`\"My Schema\"\`) continues to pass — catalog output uses the quoted form, which the remaining pair handles.
- [x] \`make vet\`, \`make lint\`, \`make test\` pass.