### PR TITLE
Use unqualified keys in OmitSchema dump helpers

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -63,7 +63,7 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 			}
 			copied.Policies = policies
 		}
-		tables.Set(fqtn, &copied)
+		tables.Set(tableName, &copied)
 	}
 	return tables
 }
@@ -88,7 +88,7 @@ func (r *DumpResult) views() *orderedmap.Map[string, *model.View] {
 			}
 			copied.Indexes = idxs
 		}
-		views.Set(fqvn, &copied)
+		views.Set(viewName, &copied)
 	}
 	return views
 }
@@ -104,7 +104,7 @@ func (r *DumpResult) enums() *orderedmap.Map[string, *model.Enum] {
 	for _, e := range r.Enums.CollectValues() {
 		copied := *e
 		copied.Schema = ""
-		enums.Set(e.FQEN(), &copied)
+		enums.Set(model.Ident(e.Name), &copied)
 	}
 	return enums
 }
@@ -120,7 +120,7 @@ func (r *DumpResult) domains() *orderedmap.Map[string, *model.Domain] {
 	for _, d := range r.Domains.CollectValues() {
 		copied := *d
 		copied.Schema = ""
-		domains.Set(d.FQDN(), &copied)
+		domains.Set(model.Ident(d.Name), &copied)
 	}
 	return domains
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -320,6 +320,53 @@ CREATE TABLE public.users (
 	assert.Contains(t, files["users.sql"], "CREATE TABLE users")
 }
 
+// TestDumpResult_OmitSchema_HelperKeyConsistency verifies that the internal
+// helpers used by String()/Files() build their map with unqualified keys when
+// OmitSchema is true, matching the schema-stripped values they store.
+// Previously the helpers stripped Schema from the value but kept the
+// schema-qualified name as the map key — invisible through String()/Files()
+// (both iterate values) but a self-inconsistent intermediate that would
+// leak to any future caller iterating by key.
+func TestDumpResult_OmitSchema_HelperKeyConsistency(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+
+	for k, v := range pistachio.DumpResultTables(got).All() {
+		assert.Equal(t, model.Ident(v.Name), k, "table key should match unqualified Ident(Name)")
+		assert.Empty(t, v.Schema, "table value Schema should be empty")
+	}
+	for k, v := range pistachio.DumpResultViews(got).All() {
+		assert.Equal(t, model.Ident(v.Name), k, "view key should match unqualified Ident(Name)")
+		assert.Empty(t, v.Schema, "view value Schema should be empty")
+	}
+	for k, v := range pistachio.DumpResultEnums(got).All() {
+		assert.Equal(t, model.Ident(v.Name), k, "enum key should match unqualified Ident(Name)")
+		assert.Empty(t, v.Schema, "enum value Schema should be empty")
+	}
+	for k, v := range pistachio.DumpResultDomains(got).All() {
+		assert.Equal(t, model.Ident(v.Name), k, "domain key should match unqualified Ident(Name)")
+		assert.Empty(t, v.Schema, "domain value Schema should be empty")
+	}
+}
+
 func TestDump_Domain_OmitSchema_PlanNoDiff(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,10 @@
 package pistachio
 
+import (
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
 var (
 	ResolvePreSQL             = resolvePreSQL
 	ResolveConcurrentlyPreSQL = resolveConcurrentlyPreSQL
@@ -7,3 +12,19 @@ var (
 	OrderStatements           = orderStatements
 	CompareTaggedPos          = compareTaggedPos
 )
+
+func DumpResultTables(r *DumpResult) *orderedmap.Map[string, *model.Table] {
+	return r.tables()
+}
+
+func DumpResultViews(r *DumpResult) *orderedmap.Map[string, *model.View] {
+	return r.views()
+}
+
+func DumpResultEnums(r *DumpResult) *orderedmap.Map[string, *model.Enum] {
+	return r.enums()
+}
+
+func DumpResultDomains(r *DumpResult) *orderedmap.Map[string, *model.Domain] {
+	return r.domains()
+}


### PR DESCRIPTION
## Summary

- The internal helpers `tables()`, `views()`, `enums()`, and `domains()` on `DumpResult` build a new `orderedmap` when `OmitSchema` is true. Each entry's value had its `Schema` field zeroed but was stored under the schema-qualified `FQTN` / `FQVN` / `FQEN` / `FQDN` as the map key, leaving the local map self-inconsistent (key includes `"public."`, value's `Schema` is `""`).
- Today this is invisible to users because `String()` and `Files()` iterate values rather than keys, but it leaks the moment any caller iterates those maps by key. Use the unqualified `model.Ident(name)` form so keys and values agree.

## Test plan

- [x] New `TestDumpResult_OmitSchema_HelperKeyConsistency` exposes the helpers via `export_test.go` and asserts every `(key, value)` pair has `key == model.Ident(value.Name)` and `value.Schema == ""`.
- [x] Existing dump fixtures (which exercise `String()`) continue to pass — the user-facing SQL output is unchanged.
- [x] `make vet`, `make lint`, `make test` pass.