### PR TITLE
Validate non-empty Schemas at boundary in Plan/Apply/Dump

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -29,6 +29,9 @@ type ApplyResult struct {
 }
 
 func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (*ApplyResult, error) {
+	if err := client.validateSchemas(); err != nil {
+		return nil, err
+	}
 	conn, err := client.connect(ctx)
 	if err != nil {
 		return nil, err

--- a/apply_test.go
+++ b/apply_test.go
@@ -573,6 +573,7 @@ func TestApply_EmptySchemas(t *testing.T) {
 
 	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, io.Discard)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one schema must be specified")
 }
 
 func TestApply_InvalidConnString(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -25,9 +26,18 @@ func NewClient(options *Options) *Client {
 // catalog.NewCatalog already errors on empty Schemas, but Schemas[0] is
 // also indexed in diff_all.go before that catalog call would short-circuit
 // in some refactor paths — so guard explicitly with a clear message.
+//
+// Empty/whitespace entries are also rejected: model.Ident drops empty
+// components silently, which would otherwise produce malformed DDL or
+// route changes through search_path into an unintended schema.
 func (client *Client) validateSchemas() error {
 	if len(client.Schemas) == 0 {
 		return errors.New("pistachio: at least one schema must be specified in Options.Schemas")
+	}
+	for _, s := range client.Schemas {
+		if strings.TrimSpace(s) == "" {
+			return errors.New("pistachio: Options.Schemas must not contain empty or whitespace-only entries")
+		}
 	}
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package pistachio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -16,6 +17,19 @@ func NewClient(options *Options) *Client {
 		options,
 	}
 	return client
+}
+
+// validateSchemas guards every public entry point that needs to address at
+// least one schema. The CLI sets Schemas to ["public"] by default via kong,
+// but library callers can construct Options directly and forget it.
+// catalog.NewCatalog already errors on empty Schemas, but Schemas[0] is
+// also indexed in diff_all.go before that catalog call would short-circuit
+// in some refactor paths — so guard explicitly with a clear message.
+func (client *Client) validateSchemas() error {
+	if len(client.Schemas) == 0 {
+		return errors.New("pistachio: at least one schema must be specified in Options.Schemas")
+	}
+	return nil
 }
 
 func (client *Client) connect(ctx context.Context) (*pgx.Conn, error) {

--- a/dump.go
+++ b/dump.go
@@ -208,6 +208,9 @@ func toFileName(schema, name string) string {
 }
 
 func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResult, error) {
+	if err := client.validateSchemas(); err != nil {
+		return nil, err
+	}
 	if options.OmitSchema && len(client.Schemas) > 1 {
 		return nil, fmt.Errorf("--omit-schema cannot be used with multiple schemas")
 	}

--- a/dump_test.go
+++ b/dump_test.go
@@ -60,6 +60,7 @@ func TestDump_EmptySchemas(t *testing.T) {
 
 	_, err := client.Dump(ctx, &pistachio.DumpOptions{})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one schema must be specified")
 }
 
 func TestDump_CanceledContext(t *testing.T) {

--- a/plan.go
+++ b/plan.go
@@ -59,6 +59,9 @@ type PlanResult struct {
 }
 
 func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResult, error) {
+	if err := client.validateSchemas(); err != nil {
+		return nil, err
+	}
 	conn, err := client.connect(ctx)
 	if err != nil {
 		return nil, err

--- a/plan_test.go
+++ b/plan_test.go
@@ -2,6 +2,7 @@ package pistachio_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,6 +138,28 @@ func TestPlan_EmptySchemas(t *testing.T) {
 	_, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one schema must be specified")
+}
+
+func TestPlan_BlankSchemaName(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	for _, name := range []string{"", "   "} {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			client := pistachio.NewClient(&pistachio.Options{
+				ConnString: conn.Config().ConnString(),
+				Schemas:    []string{name},
+			})
+
+			_, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must not contain empty or whitespace-only entries")
+		})
+	}
 }
 
 func TestPlan_InvalidConcurrentlyPreSQLFile(t *testing.T) {

--- a/plan_test.go
+++ b/plan_test.go
@@ -136,6 +136,7 @@ func TestPlan_EmptySchemas(t *testing.T) {
 
 	_, err := client.Plan(ctx, &pistachio.PlanOptions{Files: []string{desiredFile}})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one schema must be specified")
 }
 
 func TestPlan_InvalidConcurrentlyPreSQLFile(t *testing.T) {


### PR DESCRIPTION
## Summary

- The CLI defaults `Options.Schemas` to `["public"]` via kong, but library callers who construct `Options` directly can leave it empty. Today `catalog.NewCatalog` already errors on empty `Schemas`, but `Schemas[0]` is also indexed in `diff_all.go` before reaching that catalog call would short-circuit under any future refactor that re-orders or skips the catalog construction.
- Add an explicit boundary check at the top of `Plan`, `Apply`, and `Dump` that returns a clear pistachio-prefixed error message instead of relying on a downstream component to surface the misuse.

## Test plan

- [x] Existing `TestPlan_EmptySchemas` / `TestApply_EmptySchemas` / `TestDump_EmptySchemas` are tightened to assert the error message contains `"at least one schema must be specified"`.
- [x] `make vet`, `make lint`, `make test` pass.