### PR TITLE
Add [Unreleased] CHANGELOG entries for #139–#144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+* Propagate the caller's `context.Context` through `Client.connect`, so timeout / cancellation on the `ctx` passed to `Plan` / `Apply` / `Dump` is honored at the connection establishment phase instead of being silently discarded. ([#139](https://github.com/winebarrel/pistachio/pull/139))
+* Detect and emit DDL for `GENERATED ... AS IDENTITY` column transitions. `none → identity`, `identity → none`, and `ALWAYS ↔ BY DEFAULT` now produce the appropriate `ALTER TABLE ... ALTER COLUMN ADD/DROP/SET GENERATED` statements with required preconditions (`DROP DEFAULT` for columns with an explicit default or `serial`/`bigserial`/`smallserial` type, `SET NOT NULL` before `ADD IDENTITY`, `DROP NOT NULL` after `DROP IDENTITY` when desired is nullable). Previously these toggles were silently ignored, leaving the schema drifted. ([#140](https://github.com/winebarrel/pistachio/pull/140))
+* Match foreign key dependency lookups against quoted map keys in `toposort`, so tables whose name or schema requires quoting (uppercase, reserved words, special characters) get their FK edges registered and DDL is emitted in the correct order. ([#141](https://github.com/winebarrel/pistachio/pull/141))
+* Drop the raw-form fallback in the schema-replacer pair list. Only the canonical `model.Ident` form is added, so a `--schema-map` entry for a schema literally named `a.b` no longer collides with three-part column references like `a.b.col` (schema `a`, table `b`, column `col`). ([#142](https://github.com/winebarrel/pistachio/pull/142))
+* Use unqualified keys in `OmitSchema` dump helpers, so the in-memory `tables()` / `views()` / `enums()` / `domains()` maps used to render `String()` / `Files()` are self-consistent (key matches the value's schema-stripped state). ([#143](https://github.com/winebarrel/pistachio/pull/143))
+* Validate that `Options.Schemas` is non-empty and contains no empty / whitespace-only entries at the top of `Plan` / `Apply` / `Dump`, returning a clear `pistachio:`-prefixed error to library callers instead of relying on a downstream catalog or `model.Ident` failure. ([#144](https://github.com/winebarrel/pistachio/pull/144))
+
 ## [1.3.0] - 2026-05-01
 
 * Add row-level security (RLS) and policy support. Parser, catalog, diff, and dump now handle `ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY` and `CREATE/ALTER/DROP POLICY`. Policies are modeled as table-subordinate so they share the table's lifecycle, dump ordering, and `--allow-drop` semantics. Diff emits `ALTER POLICY` for in-place `TO` / `USING` / `WITH CHECK` changes, `DROP+CREATE` for `Command` / `Permissive` changes or clause removals, and `ALTER POLICY ... RENAME TO` via the existing `-- pist:renamed-from` directive. `--allow-drop` now accepts `policy`. Schema map and `--omit-schema` rewrite policy schema and expression references. ([#136](https://github.com/winebarrel/pistachio/pull/136))


### PR DESCRIPTION
## Summary

Document the six fixes that landed since 1.3.0 under a new `[Unreleased]` section, one bullet per merged PR matching the existing format.

- [#139](https://github.com/winebarrel/pistachio/pull/139) — propagate ctx through `Client.connect`
- [#140](https://github.com/winebarrel/pistachio/pull/140) — emit DDL for `GENERATED ... AS IDENTITY` transitions
- [#141](https://github.com/winebarrel/pistachio/pull/141) — toposort FK lookups against quoted map keys
- [#142](https://github.com/winebarrel/pistachio/pull/142) — drop raw-form fallback in schema replacer
- [#143](https://github.com/winebarrel/pistachio/pull/143) — unqualified keys in `OmitSchema` dump helpers
- [#144](https://github.com/winebarrel/pistachio/pull/144) — validate `Options.Schemas` at boundary

## Test plan

- [x] CHANGELOG-only change; no code touched.