### PR TITLE
Print summary header and footer in dump --split mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ The following references are **not** auto-rewritten and may produce a redundant 
 
 ### Split dump
 
-Use `--split` to output each table/view/enum as a separate file in the specified directory.
+Use `--split` to output each table/view/enum/domain as a separate file in the specified directory.
 
 ```bash
 pist dump --split ./schema/
@@ -387,7 +387,7 @@ pist apply schema.sql                 # apply it
 Or split schema into multiple files and use them together:
 
 ```bash
-pist dump --split ./schema/       # dump per table/view/enum
+pist dump --split ./schema/       # dump per table/view/enum/domain
 pist plan ./schema/*.sql          # review the diff
 pist apply ./schema/*.sql         # apply it
 ```

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ pist dump --omit-schema
 # => CREATE TABLE users (...) instead of CREATE TABLE public.users (...)
 
 pist dump --omit-schema --split ./schema/
+# -- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains)
+# -- Wrote 2 file(s) to ./schema/
 # (writes ./schema/users.sql, ./schema/orders.sql, ...)
 ```
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,9 @@ Use `--split` to output each table/view/enum as a separate file in the specified
 
 ```bash
 pist dump --split ./schema/
-# => ./schema/public.status.sql, ./schema/public.users.sql, ./schema/public.orders.sql, ...
+# -- Dump of schema public (3 tables, 0 views, 1 enum, 0 domains)
+# -- Wrote 4 file(s) to ./schema/
+# (writes ./schema/public.status.sql, ./schema/public.users.sql, ./schema/public.orders.sql, ...)
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ pist dump --omit-schema
 # => CREATE TABLE users (...) instead of CREATE TABLE public.users (...)
 
 pist dump --omit-schema --split ./schema/
-# => ./schema/users.sql, ./schema/orders.sql, ...
+# (writes ./schema/users.sql, ./schema/orders.sql, ...)
 ```
 
 When schema is omitted in SQL files, `plan` and `apply` use the schema specified by `-n`:

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -234,6 +234,14 @@ CREATE TABLE public.users (
 }
 
 func TestDump_Run_Split_WriteError(t *testing.T) {
+	// This test forces os.WriteFile to fail by making the split dir read-only.
+	// Root bypasses the permission check, so the WriteFile call would succeed
+	// and our error-path assertions would spuriously fail. CI containers
+	// commonly run as root, so skip there rather than fake-fail.
+	if os.Geteuid() == 0 {
+		t.Skip("read-only-dir trick does not block root")
+	}
+
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -3,6 +3,7 @@ package command_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,9 +98,11 @@ CREATE TABLE public.posts (
 	require.NoError(t, err)
 	assert.Contains(t, string(postsData), "CREATE TABLE public.posts")
 
-	assert.Contains(t, buf.String(), "public.users.sql")
-	assert.Contains(t, buf.String(), "public.posts.sql")
-	assert.NotContains(t, buf.String(), "-- Dump of")
+	out := buf.String()
+	assert.Contains(t, out, "-- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains)")
+	assert.Contains(t, out, fmt.Sprintf("-- Wrote 2 file(s) to %s", splitDir))
+	assert.NotContains(t, out, "public.users.sql")
+	assert.NotContains(t, out, "public.posts.sql")
 }
 
 func TestDump_Run_Empty(t *testing.T) {
@@ -174,7 +177,9 @@ func TestDump_Run_Split_Empty(t *testing.T) {
 	entries, err := os.ReadDir(splitDir)
 	require.NoError(t, err)
 	assert.Empty(t, entries)
-	assert.Empty(t, buf.String())
+	out := buf.String()
+	assert.Contains(t, out, "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains)")
+	assert.Contains(t, out, fmt.Sprintf("-- Wrote 0 file(s) to %s", splitDir))
 }
 
 func TestDump_Run_Split_SpecialCharacters(t *testing.T) {

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -229,6 +229,8 @@ CREATE TABLE public.users (
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create directory")
+	// MkdirAll runs before the header, so nothing should land on stdout.
+	assert.Empty(t, buf.String())
 }
 
 func TestDump_Run_Split_WriteError(t *testing.T) {
@@ -255,6 +257,12 @@ CREATE TABLE public.users (
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to write")
+	// On the write-failure path the header has already been emitted
+	// (it precedes the file loop) but the footer must not appear,
+	// so partial output is unambiguous from a successful run.
+	out := buf.String()
+	assert.Contains(t, out, "-- Dump of schema public")
+	assert.NotContains(t, out, "-- Wrote")
 }
 
 func TestPlan_Run_Error(t *testing.T) {

--- a/cmd/command/dump.go
+++ b/cmd/command/dump.go
@@ -30,13 +30,17 @@ func (cmd *Dump) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
+	fmt.Fprintf(w, "-- Dump of %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
+
+	count := 0
 	for name, content := range result.Files() {
 		path := filepath.Join(cmd.Split, name)
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			return fmt.Errorf("failed to write %s: %w", path, err)
 		}
-		fmt.Fprintln(w, path) //nolint:errcheck
+		count++
 	}
 
+	fmt.Fprintf(w, "-- Wrote %d file(s) to %s\n", count, cmd.Split) //nolint:errcheck
 	return nil
 }

--- a/dump.go
+++ b/dump.go
@@ -12,7 +12,7 @@ import (
 
 type DumpOptions struct {
 	FilterOptions
-	Split      string `help:"Output each table/view/enum as a separate file in the specified directory."`
+	Split      string `help:"Output each table/view/enum/domain as a separate file in the specified directory."`
 	OmitSchema bool   `help:"Omit schema name from the dump output."`
 }
 


### PR DESCRIPTION
## Summary

- `dump --split` no longer prints per-file paths. Instead, it prints the same `-- Dump of <schema> (<summary>)` header used in non-split mode, then a `-- Wrote N file(s) to <dir>` footer.
- Empty schemas now print the header + `Wrote 0 file(s)` footer instead of being silent, so a successful no-op is visible.
- README example updated to reflect the new output shape.

**Note:** This is a behavior change — anything piping the previous per-path listing into `xargs` or similar will need to enumerate the directory itself.

Output:

```
-- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains)
-- Wrote 2 file(s) to /tmp/out
```

## Test plan

- [x] `make test` — all packages pass; `TestDump_Run_Split` and `TestDump_Run_Split_Empty` updated to assert the new header/footer and absence of the old per-path lines
- [x] `make lint` — 0 issues
- [x] Manual smoke test against a real PostgreSQL: header + footer print, `--split` directory contains the expected `.sql` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)