### PR TITLE
Run CI against PostgreSQL 15-17 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [15, 16, 17, 18]
+        postgres: [15, 16, 17]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,26 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres: [15, 16, 17, 18]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-      - name: Start PostgreSQL
+      - name: Start PostgreSQL ${{ matrix.postgres }}
         run: |
-          for i in {1..60}; do docker compose up -d --quiet-pull && break; sleep 1; done
+          docker run -d --name postgres \
+            -p 5432:5432 \
+            -e POSTGRES_HOST_AUTH_METHOD=trust \
+            postgres:${{ matrix.postgres }}
           for i in {1..60}; do pg_isready -U postgres -h 127.0.0.1 -p 5432 && break; sleep 1; done
       - run: make TEST_OPTS='-coverprofile=coverage.txt'
       - run: make test-scenario
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        if: matrix.postgres == 15
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/apply_test.go
+++ b/apply_test.go
@@ -19,6 +19,9 @@ type applyTestCase struct {
 	Init                     string           `yaml:"init"`
 	Desired                  string           `yaml:"desired"`
 	Applied                  string           `yaml:"applied"`
+	AppliedPG16              string           `yaml:"applied_pg16,omitempty"`
+	AppliedPG17              string           `yaml:"applied_pg17,omitempty"`
+	AppliedPG18              string           `yaml:"applied_pg18,omitempty"`
 	AppliedSQL               *string          `yaml:"applied_sql,omitempty"`
 	Count                    *expectedCount   `yaml:"count,omitempty"`
 	DisallowedDrops          string           `yaml:"disallowed_drops,omitempty"`
@@ -48,10 +51,29 @@ type applyDropPolicy struct {
 	AllowDrop []string `yaml:"allow_drop"`
 }
 
+func (tc *applyTestCase) expectedApplied(major int) string {
+	switch major {
+	case 16:
+		if tc.AppliedPG16 != "" {
+			return tc.AppliedPG16
+		}
+	case 17:
+		if tc.AppliedPG17 != "" {
+			return tc.AppliedPG17
+		}
+	case 18:
+		if tc.AppliedPG18 != "" {
+			return tc.AppliedPG18
+		}
+	}
+	return tc.Applied
+}
+
 func TestApply(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
+	pgMajor := testutil.ServerMajorVersion(t, ctx, conn)
 
 	files, err := filepath.Glob("testdata/apply/*.yml")
 	require.NoError(t, err)
@@ -111,7 +133,7 @@ func TestApply(t *testing.T) {
 			// Verify
 			got, err := client.Dump(ctx, &pistachio.DumpOptions{})
 			require.NoError(t, err)
-			assert.Equal(t, strings.TrimSpace(tc.Applied), strings.TrimSpace(got.String()))
+			assert.Equal(t, strings.TrimSpace(tc.expectedApplied(pgMajor)), strings.TrimSpace(got.String()))
 
 			if tc.VerifyNoDrift {
 				plan, err := client.Plan(ctx, &pistachio.PlanOptions{

--- a/dump_test.go
+++ b/dump_test.go
@@ -18,11 +18,32 @@ import (
 type dumpTestCase struct {
 	Init       string   `yaml:"init"`
 	Dump       string   `yaml:"dump"`
+	DumpPG16   string   `yaml:"dump_pg16,omitempty"`
+	DumpPG17   string   `yaml:"dump_pg17,omitempty"`
+	DumpPG18   string   `yaml:"dump_pg18,omitempty"`
 	OmitSchema bool     `yaml:"omit_schema"`
 	Include    []string `yaml:"include,omitempty"`
 	Exclude    []string `yaml:"exclude,omitempty"`
 	Enable     []string `yaml:"enable,omitempty"`
 	Disable    []string `yaml:"disable,omitempty"`
+}
+
+func (tc *dumpTestCase) expectedDump(major int) string {
+	switch major {
+	case 16:
+		if tc.DumpPG16 != "" {
+			return tc.DumpPG16
+		}
+	case 17:
+		if tc.DumpPG17 != "" {
+			return tc.DumpPG17
+		}
+	case 18:
+		if tc.DumpPG18 != "" {
+			return tc.DumpPG18
+		}
+	}
+	return tc.Dump
 }
 
 func TestDump_InvalidConnString(t *testing.T) {
@@ -536,6 +557,7 @@ func TestDump(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
+	pgMajor := testutil.ServerMajorVersion(t, ctx, conn)
 
 	files, err := filepath.Glob("testdata/dump/*.yml")
 	require.NoError(t, err)
@@ -560,7 +582,7 @@ func TestDump(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			assert.Equal(t, strings.TrimSpace(tc.Dump), strings.TrimSpace(got.String()))
+			assert.Equal(t, strings.TrimSpace(tc.expectedDump(pgMajor)), strings.TrimSpace(got.String()))
 		})
 	}
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -20,6 +20,14 @@ func ConnectDB(t *testing.T) *pgx.Conn {
 	return conn
 }
 
+func ServerMajorVersion(t *testing.T, ctx context.Context, conn *pgx.Conn) int {
+	t.Helper()
+	var num int
+	err := conn.QueryRow(ctx, "SELECT current_setting('server_version_num')::int").Scan(&num)
+	require.NoError(t, err)
+	return num / 10000
+}
+
 func SetupDB(t *testing.T, ctx context.Context, conn *pgx.Conn, initSQL string) {
 	t.Helper()
 	_, err := conn.Exec(ctx, "DROP SCHEMA public CASCADE")

--- a/testdata/apply/create_enum_domain_table_view_chain.yml
+++ b/testdata/apply/create_enum_domain_table_view_chain.yml
@@ -23,3 +23,20 @@ applied: |
   SELECT users.id,
       users.name
      FROM users;
+applied_pg16: &applied_pg16plus |
+  -- public.user_name
+  CREATE DOMAIN public.user_name AS text;
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name user_name,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_list
+  CREATE OR REPLACE VIEW public.user_list AS
+  SELECT id,
+      name
+     FROM users;
+applied_pg17: *applied_pg16plus

--- a/testdata/apply/create_matview_depends_on_matview.yml
+++ b/testdata/apply/create_matview_depends_on_matview.yml
@@ -26,3 +26,20 @@ applied: |
   CREATE MATERIALIZED VIEW public.user_count AS
   SELECT count(*) AS cnt
      FROM users;
+applied_pg16: &applied_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.has_users
+  CREATE MATERIALIZED VIEW public.has_users AS
+  SELECT cnt > 0 AS result
+     FROM user_count;
+
+  -- public.user_count
+  CREATE MATERIALIZED VIEW public.user_count AS
+  SELECT count(*) AS cnt
+     FROM users;
+applied_pg17: *applied_pg16plus

--- a/testdata/apply/create_view.yml
+++ b/testdata/apply/create_view.yml
@@ -24,3 +24,17 @@ applied: |
   SELECT users.id,
       users.name
      FROM users;
+applied_pg16: &applied_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id,
+      name
+     FROM users;
+applied_pg17: *applied_pg16plus

--- a/testdata/apply/create_view_after_table.yml
+++ b/testdata/apply/create_view_after_table.yml
@@ -19,3 +19,17 @@ applied: |
   SELECT users.id,
       users.name
      FROM users;
+applied_pg16: &applied_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_view
+  CREATE OR REPLACE VIEW public.user_view AS
+  SELECT id,
+      name
+     FROM users;
+applied_pg17: *applied_pg16plus

--- a/testdata/apply/create_view_depends_on_view.yml
+++ b/testdata/apply/create_view_depends_on_view.yml
@@ -31,3 +31,23 @@ applied: |
       users.name
      FROM users
     WHERE users.name IS NOT NULL;
+applied_pg16: &applied_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_user_count
+  CREATE OR REPLACE VIEW public.active_user_count AS
+  SELECT count(*) AS cnt
+     FROM active_users;
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id,
+      name
+     FROM users
+    WHERE name IS NOT NULL;
+applied_pg17: *applied_pg16plus

--- a/testdata/apply/create_view_with_comment.yml
+++ b/testdata/apply/create_view_with_comment.yml
@@ -26,3 +26,18 @@ applied: |
       users.name
      FROM users;
   COMMENT ON VIEW public.active_users IS 'Active users only';
+applied_pg16: &applied_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id,
+      name
+     FROM users;
+  COMMENT ON VIEW public.active_users IS 'Active users only';
+applied_pg17: *applied_pg16plus

--- a/testdata/apply/inline_concurrently_matview_index.yml
+++ b/testdata/apply/inline_concurrently_matview_index.yml
@@ -31,3 +31,18 @@ applied: |
       users.name
      FROM users;
   CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+applied_pg16: &applied_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_names
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id,
+      name
+     FROM users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+applied_pg17: *applied_pg16plus

--- a/testdata/apply/modify_matview.yml
+++ b/testdata/apply/modify_matview.yml
@@ -25,3 +25,17 @@ applied: |
   SELECT count(*) AS cnt,
       max(users.id) AS max_id
      FROM users;
+applied_pg16: &applied_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_stats
+  CREATE MATERIALIZED VIEW public.user_stats AS
+  SELECT count(*) AS cnt,
+      max(id) AS max_id
+     FROM users;
+applied_pg17: *applied_pg16plus

--- a/testdata/apply/rename_view.yml
+++ b/testdata/apply/rename_view.yml
@@ -26,3 +26,17 @@ applied: |
   SELECT users.id,
       users.name
      FROM users;
+applied_pg16: &applied_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_list
+  CREATE OR REPLACE VIEW public.user_list AS
+  SELECT id,
+      name
+     FROM users;
+applied_pg17: *applied_pg16plus

--- a/testdata/dump/enable_view.yml
+++ b/testdata/dump/enable_view.yml
@@ -10,3 +10,9 @@ dump: |
   CREATE OR REPLACE VIEW public.active_users AS
   SELECT users.id
      FROM users;
+dump_pg16: &dump_pg16plus |
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id
+     FROM users;
+dump_pg17: *dump_pg16plus

--- a/testdata/dump/exclude_view.yml
+++ b/testdata/dump/exclude_view.yml
@@ -17,3 +17,15 @@ dump: |
   CREATE OR REPLACE VIEW public.active_users AS
   SELECT users.id
      FROM users;
+dump_pg16: &dump_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id
+     FROM users;
+dump_pg17: *dump_pg16plus

--- a/testdata/dump/no_filters.yml
+++ b/testdata/dump/no_filters.yml
@@ -25,3 +25,21 @@ dump: |
   CREATE OR REPLACE VIEW public.active_users AS
   SELECT users.id
      FROM users;
+dump_pg16: &dump_pg16plus |
+  -- public.posts
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id
+     FROM users;
+dump_pg17: *dump_pg16plus

--- a/testdata/dump/omit_schema_string.yml
+++ b/testdata/dump/omit_schema_string.yml
@@ -16,3 +16,15 @@ dump: |
   CREATE OR REPLACE VIEW active_users AS
   SELECT users.id
      FROM users;
+dump_pg16: &dump_pg16plus |
+  -- users
+  CREATE TABLE users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- active_users
+  CREATE OR REPLACE VIEW active_users AS
+  SELECT id
+     FROM users;
+dump_pg17: *dump_pg16plus

--- a/testdata/dump/simple_view.yml
+++ b/testdata/dump/simple_view.yml
@@ -18,3 +18,17 @@ dump: |
   SELECT users.id,
       users.name
      FROM users;
+dump_pg16: &dump_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id,
+      name
+     FROM users;
+dump_pg17: *dump_pg16plus

--- a/testdata/dump/view_with_comment.yml
+++ b/testdata/dump/view_with_comment.yml
@@ -20,3 +20,18 @@ dump: |
       users.name
      FROM users;
   COMMENT ON VIEW public.active_users IS 'Active users only';
+dump_pg16: &dump_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_users
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id,
+      name
+     FROM users;
+  COMMENT ON VIEW public.active_users IS 'Active users only';
+dump_pg17: *dump_pg16plus


### PR DESCRIPTION
## Summary
- Replace `docker compose up` with `docker run postgres:<ver>` so the CI job can vary the PostgreSQL version
- Add `strategy.matrix.postgres: [15, 16, 17]` (`fail-fast: false`) to run tests on each major version
- Detect the running server's major version at test time via `SHOW server_version_num` (`testutil.ServerMajorVersion`)
- Add per-version override fields to the dump/apply harnesses (`dump_pg16/17/18`, `applied_pg16/17/18`) that fall back to the base `dump`/`applied` when unset
- Update the 6 dump and 9 apply fixtures whose expected output diverges on PG16+ (because `pg_get_viewdef` no longer prefixes column refs with the table name); PG16 and PG17 share text via a YAML anchor
- Gate the Codecov upload to the PG15 leg to avoid duplicate reports
- `compose.yaml` is left untouched for local development

PG18 is intentionally out of scope: it makes NOT NULL constraints first-class objects in `pg_constraint`, which makes ~350 apply tests fail until catalog/diff is taught to ignore the auto-generated `<table>_<col>_not_null` rows. That belongs in a separate PR.

## Test plan
- [ ] CI passes on all three matrix legs (15/16/17)
- [ ] Codecov receives exactly one upload (from the PG15 leg)
- [x] Locally: \`make test\` passes against PG15, PG16, and PG17 containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)