### PR TITLE
Support PostgreSQL 18 in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [15, 16, 17]
+        postgres: [15, 16, 17, 18]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -46,6 +46,10 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 			LEFT JOIN column_t col ON col.attrelid = con.conrelid
 		WHERE
 			con.conrelid = @table_oid
+			-- PG18 exposes per-column NOT NULL constraints (contype='n') as
+			-- pg_constraint rows. They are already represented by the column's
+			-- attnotnull and have no analogue in PG<18, so skip them here.
+			AND con.contype <> 'n'
 		ORDER BY
 			array_position('{p,u,c,x,f}'::"char"[], con.contype),
 			con.conname

--- a/testdata/apply/create_enum_domain_table_view_chain.yml
+++ b/testdata/apply/create_enum_domain_table_view_chain.yml
@@ -40,3 +40,4 @@ applied_pg16: &applied_pg16plus |
       name
      FROM users;
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/create_matview_depends_on_matview.yml
+++ b/testdata/apply/create_matview_depends_on_matview.yml
@@ -43,3 +43,4 @@ applied_pg16: &applied_pg16plus |
   SELECT count(*) AS cnt
      FROM users;
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/create_view.yml
+++ b/testdata/apply/create_view.yml
@@ -38,3 +38,4 @@ applied_pg16: &applied_pg16plus |
       name
      FROM users;
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/create_view_after_table.yml
+++ b/testdata/apply/create_view_after_table.yml
@@ -33,3 +33,4 @@ applied_pg16: &applied_pg16plus |
       name
      FROM users;
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/create_view_depends_on_view.yml
+++ b/testdata/apply/create_view_depends_on_view.yml
@@ -51,3 +51,4 @@ applied_pg16: &applied_pg16plus |
      FROM users
     WHERE name IS NOT NULL;
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/create_view_with_comment.yml
+++ b/testdata/apply/create_view_with_comment.yml
@@ -41,3 +41,4 @@ applied_pg16: &applied_pg16plus |
      FROM users;
   COMMENT ON VIEW public.active_users IS 'Active users only';
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/inline_concurrently_matview_index.yml
+++ b/testdata/apply/inline_concurrently_matview_index.yml
@@ -46,3 +46,4 @@ applied_pg16: &applied_pg16plus |
      FROM users;
   CREATE INDEX idx_user_names ON public.user_names USING btree (name);
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/modify_matview.yml
+++ b/testdata/apply/modify_matview.yml
@@ -39,3 +39,4 @@ applied_pg16: &applied_pg16plus |
       max(id) AS max_id
      FROM users;
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/rename_view.yml
+++ b/testdata/apply/rename_view.yml
@@ -40,3 +40,4 @@ applied_pg16: &applied_pg16plus |
       name
      FROM users;
 applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/dump/enable_view.yml
+++ b/testdata/dump/enable_view.yml
@@ -16,3 +16,4 @@ dump_pg16: &dump_pg16plus |
   SELECT id
      FROM users;
 dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus

--- a/testdata/dump/exclude_view.yml
+++ b/testdata/dump/exclude_view.yml
@@ -29,3 +29,4 @@ dump_pg16: &dump_pg16plus |
   SELECT id
      FROM users;
 dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus

--- a/testdata/dump/no_filters.yml
+++ b/testdata/dump/no_filters.yml
@@ -43,3 +43,4 @@ dump_pg16: &dump_pg16plus |
   SELECT id
      FROM users;
 dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus

--- a/testdata/dump/omit_schema_string.yml
+++ b/testdata/dump/omit_schema_string.yml
@@ -28,3 +28,4 @@ dump_pg16: &dump_pg16plus |
   SELECT id
      FROM users;
 dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus

--- a/testdata/dump/simple_view.yml
+++ b/testdata/dump/simple_view.yml
@@ -32,3 +32,4 @@ dump_pg16: &dump_pg16plus |
       name
      FROM users;
 dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus

--- a/testdata/dump/view_with_comment.yml
+++ b/testdata/dump/view_with_comment.yml
@@ -35,3 +35,4 @@ dump_pg16: &dump_pg16plus |
      FROM users;
   COMMENT ON VIEW public.active_users IS 'Active users only';
 dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus


### PR DESCRIPTION
## Summary
- Filter out `contype='n'` rows in `catalog.ListConstraintsByTable`. PG18 introduced first-class `pg_constraint` rows for per-column NOT NULL (`<table>_<col>_not_null`); pre-PG18 those rows do not exist, and NOT NULL is already surfaced via `pg_attribute.attnotnull` in `columns.go`. Without this filter the diff produces spurious `ALTER TABLE ... DROP CONSTRAINT <col>_not_null` statements that fail with `column "id" is in a primary key (SQLSTATE 42P16)`.
- Other `pg_constraint` queries (`indexes.go`, `domains.go`) already use positive `contype` allowlists, so no change is needed there.
- Add `applied_pg18`/`dump_pg18` keys to the 15 view-related fixtures by extending the existing YAML anchor (`*applied_pg16plus` / `*dump_pg16plus`). PG18's `pg_get_viewdef` produces the same unqualified output as PG16/17.
- Re-add `18` to the CI postgres matrix.

## Test plan
- [ ] CI passes on all four matrix legs (15/16/17/18)
- [x] Locally: `make test` passes against PG15, PG16, PG17, and PG18 containers (`-count=1` to bypass cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)