### PR TITLE
Add 1.5.1 to Change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.5.1] - 2026-05-06
+
+* Add PostgreSQL 18 support. PG18 represents per-column NOT NULL as first-class `pg_constraint` rows (`contype='n'`); pistachio now filters them in `catalog.ListConstraintsByTable` since NOT NULL is already surfaced via `pg_attribute.attnotnull`. Without this filter the diff produced spurious `ALTER TABLE ... DROP CONSTRAINT <col>_not_null` statements that PG18 rejects with `column "X" is in a primary key (SQLSTATE 42P16)`. CI now exercises PG15/16/17/18. ([#151](https://github.com/winebarrel/pistachio/pull/151), [#152](https://github.com/winebarrel/pistachio/pull/152))
+
 ## [1.5.0] - 2026-05-05
 
 * Add `--bulk-alter` (also `$PIST_BULK_ALTER`) to combine consecutive `ALTER TABLE` actions on the same table into a single multi-line statement, reducing metadata-lock churn. Foreign keys, `RENAME`, `VALIDATE CONSTRAINT`, RLS toggles, and skipped DROPs are kept as separate statements so semantically distinct operations preserve their independence (`NOT VALID`'s whole point is to defer the expensive validation step). ([#147](https://github.com/winebarrel/pistachio/pull/147))


### PR DESCRIPTION
## Summary
- Add a 1.5.1 entry covering PG18 support (#151 / #152)

🤖 Generated with [Claude Code](https://claude.com/claude-code)