### PR TITLE
Use GitHub Actions service container for PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,24 @@ jobs:
       fail-fast: false
       matrix:
         postgres: [15, 16, 17, 18]
+    services:
+      postgres:
+        image: postgres:${{ matrix.postgres }}
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-      - name: Start PostgreSQL ${{ matrix.postgres }}
-        run: |
-          docker run -d --name postgres \
-            -p 5432:5432 \
-            -e POSTGRES_HOST_AUTH_METHOD=trust \
-            postgres:${{ matrix.postgres }}
-      - name: Wait for PostgreSQL
-        timeout-minutes: 1
-        run: until pg_isready -U postgres -h 127.0.0.1 -p 5432; do sleep 1; done
       - run: make TEST_OPTS='-coverprofile=coverage.txt'
       - run: make test-scenario
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0


### PR DESCRIPTION
## Summary
- Replace the manual `docker run` + `pg_isready` wait steps with a job-level `services.postgres` container.
- Readiness is enforced by the container's `--health-cmd "pg_isready -U postgres"`, so no in-step wait/timeout is needed.

## Test plan
- [ ] CI passes on all matrix versions (PostgreSQL 15-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)