### PR TITLE
Add pre-commit hook to run make lint before git commit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "make lint || exit 2",
+            "if": "Bash(git commit:*)",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a Claude Code PreToolUse hook in `.claude/settings.json` that runs `make lint` before any `git commit` invoked through the Bash tool.
- Scoped via `if: Bash(git commit:*)` so the hook only fires on commit, not on every Bash call.
- A non-zero lint exit blocks the commit (exit code 2).

## Test plan
- [x] Positive case: clean tree → `git commit --allow-empty` succeeds (lint passes, hook returns 0)
- [x] Negative case: introduce an unused-variable lint error → `git commit` is blocked with `PreToolUse:Bash hook error` and no commit is created
- [x] Filter: non-git Bash calls (e.g. `ls`) do not trigger lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)