### PR TITLE
Round-trip named NOT NULL constraints on PG18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Round-trip named NOT NULL constraints on PG18. Inline `CONSTRAINT <name> NOT NULL` is now captured by the parser, read from `pg_constraint` (`contype='n'`) by `catalog.ListColumnsByTable`, rendered in `CREATE TABLE` / `ADD COLUMN`, and renamed via `ALTER TABLE ... RENAME CONSTRAINT` when both sides are NOT NULL with explicit but different names. PG18's auto-generated `<table>_<col>_not_null` names are stripped on read so unnamed declarations round-trip cleanly across column and table renames. Adding or removing a name on an already-NOT-NULL column requires PG18's standalone `ALTER ... ADD CONSTRAINT NOT NULL` syntax (not yet supported by `pg_query_go`) and is a documented no-op in v1; PG<18 silently drops user-supplied names at apply time. ([#157](https://github.com/winebarrel/pistachio/pull/157))
+
 ## [1.5.2] - 2026-05-09
 
 * Fix `Constraint.Columns` returned by `catalog.ListConstraintsByTable` to contain only the columns owned by each constraint. The `column_t` CTE previously grouped by `attrelid`, so every constraint on a table received the union of all sibling constraints' `conkey` columns; on PG18 the additional `contype='n'` rows compounded this with duplicates. Latent since the first commit because no diff/dump path consumed the field, but the catalog now reports the correct per-constraint column list. ([#158](https://github.com/winebarrel/pistachio/pull/158))

--- a/TODO.md
+++ b/TODO.md
@@ -163,6 +163,40 @@ documented prominently.
 Origin: post-RLS-support audit. No fix planned — this is a PostgreSQL
 behavior that affects the catalog round-trip, not a pistachio bug.
 
+## Named NOT NULL constraints: name add/remove on existing columns
+
+`Column.NotNullName` round-trips on PG18, and a name change between two
+named NOT NULL constraints is emitted as `RENAME CONSTRAINT`. The
+following transitions are no-ops in v1:
+
+- nullable → NOT NULL with an explicit desired name: emits `SET NOT NULL`
+  (PG auto-generates a name) but does not apply the desired name.
+- NOT NULL with explicit current name → still NOT NULL but unnamed: keeps
+  the current name in place.
+
+Both require PG18's standalone `ALTER TABLE ... ADD CONSTRAINT name NOT NULL col`
+syntax, which `pg_query_go` does not yet parse (libpg_query PR #317 is
+still in draft as of 2026-05). Once that lands, the parser can accept
+the standalone form and the diff can drop the no-op branches.
+
+A second limitation: `catalog.ListColumnsByTable` strips any constraint
+name with the `_not_null` suffix to mask PG18's auto-naming (which does
+not follow column or table renames). An explicit user name that happens
+to end in `_not_null` is therefore lost on round-trip. A more precise
+heuristic would need to compare against the auto-name pattern at the
+time of the most recent rename, which is not available from the
+catalog alone.
+
+A third limitation: on PG<18 the parser still captures the inline name,
+but PostgreSQL silently drops it at apply time. The diff layer treats
+the resulting "current has no name, desired has a name" mismatch as a
+no-op (the same v1 behavior used for adding a name to an existing
+NOT NULL on PG18), so no drift loop occurs — the explicit name is
+simply not honored on PG<18. This is a PG18-only feature and should
+be documented as such if it ever surfaces in user-facing docs.
+
+Origin: [#157](https://github.com/winebarrel/pistachio/pull/157).
+
 ## Plan-time error promotion: forgotten dependent reference
 
 When desired SQL references the new column name in a dependent

--- a/catalog/columns.go
+++ b/catalog/columns.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/winebarrel/pistachio/model"
@@ -24,6 +25,10 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 				ELSE pg_catalog.format_type(a.atttypid, a.atttypmod)
 			END AS type_name,
 			a.attnotnull,
+			-- PG18 stores per-column NOT NULL as pg_constraint rows with
+			-- contype='n' and a single conkey entry. Pre-PG18 has no such row,
+			-- so the LEFT JOIN yields NULL there.
+			nn.conname AS not_null_name,
 			CASE
 				WHEN a.attidentity = '' AND pg_catalog.pg_get_serial_sequence(a.attrelid::regclass::text, a.attname) IS NOT NULL
 				THEN NULL
@@ -43,6 +48,9 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 			-- https://www.postgresql.org/docs/current/catalog-pg-description.html
 			LEFT JOIN pg_catalog.pg_description d ON d.objoid = a.attrelid
 			AND d.objsubid = a.attnum
+			LEFT JOIN pg_catalog.pg_constraint nn ON nn.conrelid = a.attrelid
+			AND nn.contype = 'n'
+			AND nn.conkey = ARRAY[a.attnum]
 		WHERE
 			a.attrelid = @table_oid
 			AND a.attnum >= 1
@@ -68,6 +76,7 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 			&col.Name,
 			&col.TypeName,
 			&col.NotNull,
+			&col.NotNullName,
 			&col.Default,
 			&col.Identity,
 			&col.Generated,
@@ -76,6 +85,16 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 		)
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan column info: %w", err)
+		}
+		// PG18 auto-names unnamed NOT NULL constraints as <table>_<col>_not_null
+		// (see ChooseConstraintName in src/backend/catalog/pg_constraint.c). The
+		// auto-name does not follow column or table renames, so checking the
+		// current <table>_<col>_ prefix is too strict. Strip any name with the
+		// _not_null suffix as a heuristic so unnamed declarations round-trip as
+		// unnamed across renames; the trade-off is that a user-supplied explicit
+		// name ending in "_not_null" would be lost on round-trip.
+		if col.NotNullName != nil && strings.HasSuffix(*col.NotNullName, "_not_null") {
+			col.NotNullName = nil
 		}
 		cols = append(cols, &col)
 	}

--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -54,9 +54,9 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 			LEFT JOIN column_t col ON col.con_oid = con.oid
 		WHERE
 			con.conrelid = @table_oid
-			-- PG18 exposes per-column NOT NULL constraints (contype='n') as
-			-- pg_constraint rows. They are already represented by the column's
-			-- attnotnull and have no analogue in PG<18, so skip them here.
+			-- PG18's per-column NOT NULL rows (contype='n') are read into
+			-- Column.NotNull / Column.NotNullName by ListColumnsByTable; this
+			-- query only returns table-level constraints.
 			AND con.contype <> 'n'
 		ORDER BY
 			array_position('{p,u,c,x,f}'::"char"[], con.contype),

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -287,6 +287,9 @@ func addColumnSQL(fqtn string, col *model.Column) string {
 	}
 
 	if col.NotNull && !col.Identity.IsIdentityColumn() {
+		if col.NotNullName != nil {
+			sql += " CONSTRAINT " + model.Ident(*col.NotNullName)
+		}
 		sql += " NOT NULL"
 	}
 
@@ -362,6 +365,17 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 		} else {
 			stmts = append(stmts, "ALTER TABLE "+fqtn+" ALTER COLUMN "+colIdent+" DROP NOT NULL;")
 		}
+	} else if current.NotNull && desired.NotNull && !desIsIdent &&
+		current.NotNullName != nil && desired.NotNullName != nil &&
+		*current.NotNullName != *desired.NotNullName {
+		// Both sides NOT NULL with explicit but different names — rename in place.
+		// Adding/removing a name on an existing NOT NULL needs PG18's standalone
+		// ALTER ... ADD CONSTRAINT NOT NULL syntax (not yet supported by
+		// pg_query_go); left out of v1. Identity columns are skipped to match
+		// Table.SQL / addColumnSQL, which intentionally do not render
+		// "CONSTRAINT <name> NOT NULL" on identity columns — emitting a rename
+		// here would surface a name the dumper hides.
+		stmts = append(stmts, "ALTER TABLE "+fqtn+" RENAME CONSTRAINT "+model.Ident(*current.NotNullName)+" TO "+model.Ident(*desired.NotNullName)+";")
 	}
 
 	return stmts

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -373,6 +373,131 @@ func TestDiffColumns_alterNotNull_drop(t *testing.T) {
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;", stmts[0])
 }
 
+func TestDiffColumns_renameNotNullConstraint(t *testing.T) {
+	oldName := "users_name_nn_old"
+	newName := "users_name_nn_new"
+
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &oldName})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &newName})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.users RENAME CONSTRAINT users_name_nn_old TO users_name_nn_new;"}, stmts)
+}
+
+func TestDiffColumns_notNullName_sameName_isNoOp(t *testing.T) {
+	name := "users_name_nn"
+
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffColumns_notNullName_addOrDrop_isNoOp(t *testing.T) {
+	name := "users_name_nn"
+
+	// Adding a name to an existing unnamed NOT NULL: no-op in v1.
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+
+	// Dropping a name from a named NOT NULL: also no-op in v1.
+	current = orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
+
+	desired = orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
+
+	stmts, _, err = diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffColumns_renameNotNullConstraint_skipsIdentityColumn(t *testing.T) {
+	// Identity columns are implicitly NOT NULL, and Table.SQL / addColumnSQL
+	// intentionally do not render "CONSTRAINT <name> NOT NULL" on identity
+	// columns. The rename branch must therefore also skip them — emitting a
+	// RENAME CONSTRAINT here would surface a name the dumper hides.
+	oldName := "users_id_nn_old"
+	newName := "users_id_nn_new"
+
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("id", &model.Column{
+		Name: "id", TypeName: "integer", NotNull: true,
+		NotNullName: &oldName, Identity: model.ColumnIdentity('a'),
+	})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("id", &model.Column{
+		Name: "id", TypeName: "integer", NotNull: true,
+		NotNullName: &newName, Identity: model.ColumnIdentity('a'),
+	})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffColumns_setNotNull_withDesiredName_ignoresName(t *testing.T) {
+	// Nullable → NOT NULL with explicit desired name. v1 emits SET NOT NULL only;
+	// the name is not applied (it would require PG18's standalone ADD CONSTRAINT
+	// NOT NULL syntax).
+	name := "users_name_nn"
+
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text"})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;"}, stmts)
+}
+
+func TestDiffColumns_dropNotNull_loseCurrentName(t *testing.T) {
+	// NOT NULL with explicit current name → nullable. DROP NOT NULL implicitly
+	// drops the constraint (and the name with it).
+	name := "users_name_nn"
+
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;"}, stmts)
+}
+
+func TestDiffColumns_addColumn_withNotNullName(t *testing.T) {
+	name := "users_email_nn"
+
+	current := orderedmap.New[string, *model.Column]()
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("email", &model.Column{Name: "email", TypeName: "text", NotNull: true, NotNullName: &name})
+
+	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TABLE public.users ADD COLUMN email text CONSTRAINT users_email_nn NOT NULL;"}, stmts)
+}
+
 func TestDiffColumns_identitySkipsNotNull(t *testing.T) {
 	current := orderedmap.New[string, *model.Column]()
 	current.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})

--- a/model/column.go
+++ b/model/column.go
@@ -37,6 +37,7 @@ type Column struct {
 	RenameFrom  *string
 	TypeName    string
 	NotNull     bool
+	NotNullName *string
 	Default     *string
 	Identity    ColumnIdentity
 	Generated   ColumnGenerated

--- a/model/table.go
+++ b/model/table.go
@@ -80,6 +80,9 @@ func (t Table) SQL() string {
 						q += " DEFAULT " + *col.Default
 					}
 					if col.NotNull && !col.Identity.IsIdentityColumn() {
+						if col.NotNullName != nil {
+							q += " CONSTRAINT " + Ident(*col.NotNullName)
+						}
 						q += " NOT NULL"
 					}
 					return q

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -86,6 +86,27 @@ func TestTable_SQL_simple(t *testing.T) {
 	assert.Equal(t, expected, tbl.SQL())
 }
 
+func TestTable_SQL_namedNotNull(t *testing.T) {
+	name := "users_email_nn"
+	tbl := newTable("public", "users")
+	tbl.Columns.Set("email", &Column{Name: "email", TypeName: "text", NotNull: true, NotNullName: &name})
+
+	assert.Contains(t, tbl.SQL(), "email text CONSTRAINT users_email_nn NOT NULL")
+}
+
+func TestTable_SQL_namedNotNull_identityColumnSuppresses(t *testing.T) {
+	// Identity columns are implicitly NOT NULL; the SQL renderer must not emit
+	// either the "NOT NULL" tail or the CONSTRAINT name on identity columns.
+	name := "users_id_nn"
+	tbl := newTable("public", "users")
+	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true, NotNullName: &name, Identity: ColumnIdentity('a')})
+
+	out := tbl.SQL()
+	assert.Contains(t, out, "GENERATED ALWAYS AS IDENTITY")
+	assert.NotContains(t, out, "CONSTRAINT users_id_nn")
+	assert.NotContains(t, out, "NOT NULL")
+}
+
 func TestTable_SQL_unlogged(t *testing.T) {
 	tbl := newTable("public", "temp_data")
 	tbl.Unlogged = true

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -430,6 +430,10 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 		switch con.Contype {
 		case pg_query.ConstrType_CONSTR_NOTNULL:
 			col.NotNull = true
+			if con.Conname != "" {
+				name := con.Conname
+				col.NotNullName = &name
+			}
 		case pg_query.ConstrType_CONSTR_DEFAULT:
 			if con.RawExpr != nil {
 				def, err := deparseExpr(con.RawExpr)

--- a/testdata/apply/add_column_named_not_null.yml
+++ b/testdata/apply/add_column_named_not_null.yml
@@ -1,0 +1,31 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text CONSTRAINT users_email_nn NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+# PG<18 silently discards the explicit NOT NULL constraint name at apply time,
+# so the dump round-trips back as unnamed.
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+# PG18 stores the explicit name in pg_constraint, so it round-trips.
+applied_pg18: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text CONSTRAINT users_email_nn NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+# Confirm a re-plan produces no further DDL on PG18 (the named NOT NULL on the
+# new column matches between desired and current).
+verify_no_drift: true

--- a/testdata/dump/named_not_null.yml
+++ b/testdata/dump/named_not_null.yml
@@ -1,0 +1,24 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text CONSTRAINT users_email_nn NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+# PG<18 silently discards the explicit NOT NULL constraint name at apply time
+# (per-column NOT NULL is not stored in pg_constraint), so the dump comes back
+# unnamed.
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+# PG18 stores the explicit name as a pg_constraint row, so the name round-trips.
+dump_pg18: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text CONSTRAINT users_email_nn NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/parser/named_not_null.yml
+++ b/testdata/parser/named_not_null.yml
@@ -1,0 +1,13 @@
+input: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text CONSTRAINT users_email_nn NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text CONSTRAINT users_email_nn NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/parser/named_not_null_with_pk.yml
+++ b/testdata/parser/named_not_null_with_pk.yml
@@ -1,0 +1,12 @@
+input: |
+  CREATE TABLE public.users (
+      id integer CONSTRAINT users_id_pk PRIMARY KEY,
+      email text CONSTRAINT users_email_nn NOT NULL
+  );
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text CONSTRAINT users_email_nn NOT NULL,
+      CONSTRAINT users_id_pk PRIMARY KEY (id)
+  );


### PR DESCRIPTION
## Summary
- Preserve user-supplied NOT NULL constraint names through parse → catalog → diff → dump on PG18, integrating PG18's `pg_constraint` rows with `contype='n'` into the existing column-attribute model
- Strip PG18 auto-generated `_not_null` names so unnamed declarations round-trip cleanly across column/table renames

## Background
PG18 stores per-column NOT NULL as `pg_constraint` rows. The parser previously discarded any inline `CONSTRAINT name NOT NULL`, so a name written by the user could not survive a dump/apply cycle even on PG18. This change makes that round-trip work — names are now read into `Column.NotNullName` by `ListColumnsByTable`.

`pg_query_go` is still on PG17 source, so PG18's standalone `ALTER ... ADD CONSTRAINT name NOT NULL col` is not parseable. v1 therefore supports:
- inline `CONSTRAINT name NOT NULL` in `CREATE TABLE` / `ADD COLUMN`
- `RENAME CONSTRAINT` when both sides are NOT NULL with explicit but different names

Adding or removing a name on an already-NOT-NULL column is a no-op in v1; transitioning nullable→named NOT NULL emits `SET NOT NULL` (the name is not applied).

## Trade-offs
- An explicit user name ending in `_not_null` would not round-trip — the auto-name strip is a suffix heuristic. Documented as a known edge case
- On PG<18 the parser captures the name, but PostgreSQL drops it silently at apply time. The diff layer treats the resulting `current.NotNullName=nil` vs `desired.NotNullName="..."` mismatch as a no-op (same v1 behavior as adding a name to an unnamed NOT NULL on PG18), so **no drift loop occurs** — the explicit name is simply not honored on PG<18. PG18-only feature

## Coverage
Per-package coverage on PG18 vs `main`:

| Package | main | this PR |
|---|---|---|
| pistachio | 97.9% | 97.9% |
| catalog | 83.4% | 83.5% |
| diff | 96.6% | 96.6% |
| model | 99.5% | 99.5% |
| parser | 91.2% | 91.2% |

## Test plan
- [x] `make test` on PG15 and PG18
- [x] `make test-scenario` on PG15 and PG18
- [x] `make lint`
- [x] New unit tests cover: parser inline name, model SQL with/without name, identity column suppresses both, diff add/alter/rename/no-op cases
- [x] New fixtures cover: parser round-trip (named, named+PK), dump round-trip with `dump_pg18` override, apply round-trip with `applied_pg18` + `verify_no_drift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)