### PR TITLE
Remove unused Parse* helper functions

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -47,23 +47,6 @@ func ReadSQLFile(path string) (string, error) {
 	return string(data), nil
 }
 
-func ParseSQLFile(path string) (*ParseResult, error) {
-	return ParseSQLFileWithSchema(path, "public")
-}
-
-func ParseSQLFileWithSchema(path string, defaultSchema string) (*ParseResult, error) {
-	sql, err := ReadSQLFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	return ParseSQLWithSchema(sql, defaultSchema)
-}
-
-func ParseSQLFiles(paths []string) (*ParseResult, error) {
-	return ParseSQLFilesWithSchema(paths, "public")
-}
-
 func ParseSQLFilesWithSchema(paths []string, defaultSchema string) (*ParseResult, error) {
 	var sqls []string
 	for _, path := range paths {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -39,56 +39,6 @@ func TestParseSQL(t *testing.T) {
 	}
 }
 
-func TestParseSQLFile(t *testing.T) {
-	tmpFile := filepath.Join(t.TempDir(), "test.sql")
-	sql := `CREATE TABLE public.users (
-    id integer NOT NULL,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`
-	require.NoError(t, os.WriteFile(tmpFile, []byte(sql), 0o644))
-
-	result, err := parser.ParseSQLFile(tmpFile)
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.Tables.Len())
-
-	tbl, ok := result.Tables.GetOk("public.users")
-	require.True(t, ok)
-	assert.Equal(t, "users", tbl.Name)
-	assert.Equal(t, "public", tbl.Schema)
-}
-
-func TestParseSQLFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-	file1 := filepath.Join(tmpDir, "tables.sql")
-	file2 := filepath.Join(tmpDir, "views.sql")
-
-	require.NoError(t, os.WriteFile(file1, []byte(`CREATE TABLE public.users (
-    id integer NOT NULL,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);`), 0o644))
-	require.NoError(t, os.WriteFile(file2, []byte(`CREATE TABLE public.posts (
-    id integer NOT NULL,
-    CONSTRAINT posts_pkey PRIMARY KEY (id)
-);`), 0o644))
-
-	result, err := parser.ParseSQLFiles([]string{file1, file2})
-	require.NoError(t, err)
-	assert.Equal(t, 2, result.Tables.Len())
-
-	_, ok := result.Tables.GetOk("public.users")
-	assert.True(t, ok)
-	_, ok = result.Tables.GetOk("public.posts")
-	assert.True(t, ok)
-}
-
-func TestParseSQLFiles_FileNotFound(t *testing.T) {
-	tmpFile := filepath.Join(t.TempDir(), "exists.sql")
-	require.NoError(t, os.WriteFile(tmpFile, []byte("CREATE TABLE t (id int);"), 0o644))
-
-	_, err := parser.ParseSQLFiles([]string{tmpFile, "/nonexistent/file.sql"})
-	require.Error(t, err)
-}
-
 func TestReadSQLFile(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "test.sql")
 	sql := "SELECT 1;"
@@ -138,11 +88,6 @@ func TestReadSQLFile_Stdin_ReadAll(t *testing.T) {
 	got, err := parser.ReadSQLFile("-")
 	require.NoError(t, err)
 	assert.Equal(t, "", got)
-}
-
-func TestParseSQLFile_NotFound(t *testing.T) {
-	_, err := parser.ParseSQLFile("/nonexistent/file.sql")
-	require.Error(t, err)
 }
 
 func TestParseSQL_InvalidSQL(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove `ParseSQLFile`, `ParseSQLFileWithSchema`, and `ParseSQLFiles` from `parser/parser.go` — none of them are reachable from production code.
- Only `ParseSQLFilesWithSchema` is used (from `diff_all.go`), so the schemaless wrappers and the single-file variants are dead weight.
- Drop the corresponding standalone tests (`TestParseSQLFile`, `TestParseSQLFiles`, `TestParseSQLFiles_FileNotFound`, `TestParseSQLFile_NotFound`); coverage of the file/stdin reading path is preserved by `TestReadSQLFile*` and the `ParseSQLFilesWithSchema` integration paths.

## Test plan
- [x] make build
- [x] make vet
- [x] make lint (0 issues)
- [x] go test ./parser/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)