### PR TITLE
Remove ExtractColumnDirectives convenience wrapper

### DIFF
--- a/parser/directive.go
+++ b/parser/directive.go
@@ -334,11 +334,6 @@ func ExtractInlineDirectives(rawCreateTableSQL string) *InlineDirectives {
 	return result
 }
 
-// ExtractColumnDirectives is a convenience wrapper for backward compatibility.
-func ExtractColumnDirectives(rawCreateTableSQL string) map[string]string {
-	return ExtractInlineDirectives(rawCreateTableSQL).Columns
-}
-
 // scanQuotedIdent scans a quoted identifier from the start of s, handling ""
 // escape sequences. Returns the unquoted name and true if successful.
 func scanQuotedIdent(s string) (string, bool) {

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -88,7 +88,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 	})
 }
 
-func TestExtractColumnDirectives(t *testing.T) {
+func TestExtractInlineDirectives_Columns(t *testing.T) {
 	t.Run("single column directive", func(t *testing.T) {
 		sql := `CREATE TABLE public.users (
     id integer NOT NULL,
@@ -96,7 +96,7 @@ func TestExtractColumnDirectives(t *testing.T) {
     display_name text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );`
-		dirs := ExtractColumnDirectives(sql)
+		dirs := ExtractInlineDirectives(sql).Columns
 		assert.Len(t, dirs, 1)
 		assert.Equal(t, "name", dirs["display_name"])
 	})
@@ -108,7 +108,7 @@ func TestExtractColumnDirectives(t *testing.T) {
     -- pist:renamed-from name
     display_name text NOT NULL
 );`
-		dirs := ExtractColumnDirectives(sql)
+		dirs := ExtractInlineDirectives(sql).Columns
 		assert.Len(t, dirs, 2)
 		assert.Equal(t, "uid", dirs["id"])
 		assert.Equal(t, "name", dirs["display_name"])
@@ -119,7 +119,7 @@ func TestExtractColumnDirectives(t *testing.T) {
     id integer NOT NULL,
     name text NOT NULL
 );`
-		dirs := ExtractColumnDirectives(sql)
+		dirs := ExtractInlineDirectives(sql).Columns
 		assert.Empty(t, dirs)
 	})
 
@@ -128,7 +128,7 @@ func TestExtractColumnDirectives(t *testing.T) {
     -- pist:renamed-from "Old Name"
     "New Name" text NOT NULL
 );`
-		dirs := ExtractColumnDirectives(sql)
+		dirs := ExtractInlineDirectives(sql).Columns
 		assert.Equal(t, "Old Name", dirs["New Name"])
 	})
 
@@ -139,7 +139,7 @@ func TestExtractColumnDirectives(t *testing.T) {
     new_col text,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );`
-		dirs := ExtractColumnDirectives(sql)
+		dirs := ExtractInlineDirectives(sql).Columns
 		assert.Len(t, dirs, 1)
 		assert.Equal(t, "old_col", dirs["new_col"])
 	})


### PR DESCRIPTION
## Summary
- `parser.ExtractColumnDirectives` was a one-line wrapper returning `ExtractInlineDirectives(...).Columns` and had no production callers.
- Its own comment claimed "backward compatibility", but the parser package is internal — there is no external API to keep compatible.
- Drop the wrapper and rename the dedicated test to `TestExtractInlineDirectives_Columns`, calling `ExtractInlineDirectives(sql).Columns` directly so column-directive coverage is preserved.

## Test plan
- [x] make build
- [x] make vet
- [x] make lint (0 issues)
- [x] go test ./parser/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)