### PR TITLE
Unexport parser internals (ParseSQLWithSchema, ReadSQLFile, directive helpers)

### DIFF
--- a/parser/directive.go
+++ b/parser/directive.go
@@ -26,9 +26,9 @@ var knownDirectives = map[string]bool{
 	"concurrently": true,
 }
 
-// ValidateDirectives checks for unknown -- pist: directives in the raw SQL
+// validateDirectives checks for unknown -- pist: directives in the raw SQL
 // and returns an error if any are found.
-func ValidateDirectives(rawSQL string) error {
+func validateDirectives(rawSQL string) error {
 	matches := anyDirectivePattern.FindAllStringSubmatch(rawSQL, -1)
 	for _, m := range matches {
 		name := strings.TrimSpace(m[1])
@@ -53,11 +53,11 @@ type ExecuteStmt struct {
 	CheckSQL string // Optional condition check SQL (empty = always execute)
 }
 
-// ExtractExecuteDirectives scans raw SQL for `-- pist:execute [<check SQL>]`
+// extractExecuteDirectives scans raw SQL for `-- pist:execute [<check SQL>]`
 // comments and pairs them with the following SQL statement.
 // Returns the execute statements and a set of statement locations to skip
 // during normal parsing.
-func ExtractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*ExecuteStmt, map[int32]bool, error) {
+func extractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*ExecuteStmt, map[int32]bool, error) {
 	var executeStmts []*ExecuteStmt
 	skipLocations := make(map[int32]bool)
 
@@ -118,10 +118,10 @@ func FormatExecuteStmt(es *ExecuteStmt) string {
 	return fmt.Sprintf("%s\n%s", directive, sql)
 }
 
-// QualifyRenameFrom qualifies a renamed-from value with the default schema
+// qualifyRenameFrom qualifies a renamed-from value with the default schema
 // if it does not already contain a schema. Quoted identifiers containing
 // dots (e.g. `"a.b"`) are treated as a single identifier.
-func QualifyRenameFrom(value, defaultSchema string) string {
+func qualifyRenameFrom(value, defaultSchema string) string {
 	parts := splitQualifiedName(value)
 	for i, p := range parts {
 		parts[i] = unquoteIdent(p)
@@ -199,12 +199,12 @@ func splitQualifiedName(s string) []string {
 	return parts
 }
 
-// ExtractStmtDirectives scans raw SQL for `-- pist:renamed-from <name>` comments
+// extractStmtDirectives scans raw SQL for `-- pist:renamed-from <name>` comments
 // that appear in each statement's raw text region (including leading comments).
 // pg_query includes leading comments in StmtLocation/StmtLen, so we scan the
 // raw text of each statement for the directive.
 // Returns a map from StmtLocation to the old name string.
-func ExtractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]string {
+func extractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]string {
 	directives := make(map[int32]string)
 
 	for _, stmt := range stmts {
@@ -234,10 +234,10 @@ func ExtractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]s
 	return directives
 }
 
-// ExtractConcurrentlyDirectives scans raw SQL for `-- pist:concurrently` comments
+// extractConcurrentlyDirectives scans raw SQL for `-- pist:concurrently` comments
 // that appear in each statement's leading comment region.
 // Returns a set of StmtLocations that have the directive.
-func ExtractConcurrentlyDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]bool {
+func extractConcurrentlyDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]bool {
 	directives := make(map[int32]bool)
 
 	for _, stmt := range stmts {
@@ -278,17 +278,17 @@ func findLeadingCommentEnd(s string) int {
 	return offset
 }
 
-// InlineDirectives holds rename directives for columns and constraints within a CREATE TABLE.
-type InlineDirectives struct {
+// inlineDirectives holds rename directives for columns and constraints within a CREATE TABLE.
+type inlineDirectives struct {
 	Columns     map[string]string // new column name → old column name
 	Constraints map[string]string // new constraint name → old constraint name
 }
 
-// ExtractInlineDirectives scans the raw text of a CREATE TABLE statement for
+// extractInlineDirectives scans the raw text of a CREATE TABLE statement for
 // `-- pist:renamed-from <old_name>` directives that appear on lines immediately
 // before column or constraint definitions.
-func ExtractInlineDirectives(rawCreateTableSQL string) *InlineDirectives {
-	result := &InlineDirectives{
+func extractInlineDirectives(rawCreateTableSQL string) *inlineDirectives {
+	result := &inlineDirectives{
 		Columns:     make(map[string]string),
 		Constraints: make(map[string]string),
 	}

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -14,7 +14,7 @@ func TestExtractStmtDirectives(t *testing.T) {
 CREATE TYPE public.new_status AS ENUM ('active', 'inactive');`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
-		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		dirs := extractStmtDirectives(sql, result.Stmts)
 		assert.Len(t, dirs, 1)
 		assert.Equal(t, "public.old_status", dirs[result.Stmts[0].StmtLocation])
 	})
@@ -26,7 +26,7 @@ CREATE TYPE public.new_status AS ENUM ('active');
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
-		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		dirs := extractStmtDirectives(sql, result.Stmts)
 		assert.Len(t, dirs, 2)
 		assert.Equal(t, "public.old_status", dirs[result.Stmts[0].StmtLocation])
 		assert.Equal(t, "public.old_users", dirs[result.Stmts[1].StmtLocation])
@@ -36,7 +36,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 		sql := `CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
-		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		dirs := extractStmtDirectives(sql, result.Stmts)
 		assert.Empty(t, dirs)
 	})
 
@@ -46,7 +46,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 CREATE TABLE public.posts (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
-		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		dirs := extractStmtDirectives(sql, result.Stmts)
 		assert.Len(t, dirs, 1)
 		assert.Equal(t, "public.old_posts", dirs[result.Stmts[1].StmtLocation])
 	})
@@ -56,7 +56,7 @@ CREATE TABLE public.posts (id integer NOT NULL);`
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
-		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		dirs := extractStmtDirectives(sql, result.Stmts)
 		assert.Equal(t, "public.old_name", dirs[result.Stmts[0].StmtLocation])
 	})
 
@@ -65,7 +65,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
-		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		dirs := extractStmtDirectives(sql, result.Stmts)
 		assert.Equal(t, "old_name", dirs[result.Stmts[0].StmtLocation])
 	})
 
@@ -74,7 +74,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
-		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		dirs := extractStmtDirectives(sql, result.Stmts)
 		assert.Empty(t, dirs)
 	})
 
@@ -83,7 +83,7 @@ CREATE TABLE public.users (id integer NOT NULL);`
 CREATE TABLE public.users (id integer NOT NULL);`
 		result, err := pg_query.Parse(sql)
 		require.NoError(t, err)
-		dirs := ExtractStmtDirectives(sql, result.Stmts)
+		dirs := extractStmtDirectives(sql, result.Stmts)
 		assert.Empty(t, dirs)
 	})
 }
@@ -96,7 +96,7 @@ func TestExtractInlineDirectives_Columns(t *testing.T) {
     display_name text NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );`
-		dirs := ExtractInlineDirectives(sql).Columns
+		dirs := extractInlineDirectives(sql).Columns
 		assert.Len(t, dirs, 1)
 		assert.Equal(t, "name", dirs["display_name"])
 	})
@@ -108,7 +108,7 @@ func TestExtractInlineDirectives_Columns(t *testing.T) {
     -- pist:renamed-from name
     display_name text NOT NULL
 );`
-		dirs := ExtractInlineDirectives(sql).Columns
+		dirs := extractInlineDirectives(sql).Columns
 		assert.Len(t, dirs, 2)
 		assert.Equal(t, "uid", dirs["id"])
 		assert.Equal(t, "name", dirs["display_name"])
@@ -119,7 +119,7 @@ func TestExtractInlineDirectives_Columns(t *testing.T) {
     id integer NOT NULL,
     name text NOT NULL
 );`
-		dirs := ExtractInlineDirectives(sql).Columns
+		dirs := extractInlineDirectives(sql).Columns
 		assert.Empty(t, dirs)
 	})
 
@@ -128,7 +128,7 @@ func TestExtractInlineDirectives_Columns(t *testing.T) {
     -- pist:renamed-from "Old Name"
     "New Name" text NOT NULL
 );`
-		dirs := ExtractInlineDirectives(sql).Columns
+		dirs := extractInlineDirectives(sql).Columns
 		assert.Equal(t, "Old Name", dirs["New Name"])
 	})
 
@@ -139,7 +139,7 @@ func TestExtractInlineDirectives_Columns(t *testing.T) {
     new_col text,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );`
-		dirs := ExtractInlineDirectives(sql).Columns
+		dirs := extractInlineDirectives(sql).Columns
 		assert.Len(t, dirs, 1)
 		assert.Equal(t, "old_col", dirs["new_col"])
 	})
@@ -153,7 +153,7 @@ func TestExtractInlineDirectives_Constraint(t *testing.T) {
     -- pist:renamed-from users_code_key
     CONSTRAINT users_code_unique UNIQUE (code)
 );`
-	dirs := ExtractInlineDirectives(sql)
+	dirs := extractInlineDirectives(sql)
 	assert.Empty(t, dirs.Columns)
 	assert.Len(t, dirs.Constraints, 1)
 	assert.Equal(t, "users_code_key", dirs.Constraints["users_code_unique"])
@@ -168,7 +168,7 @@ func TestExtractInlineDirectives_Mixed(t *testing.T) {
     -- pist:renamed-from old_unique
     CONSTRAINT new_unique UNIQUE (display_name)
 );`
-	dirs := ExtractInlineDirectives(sql)
+	dirs := extractInlineDirectives(sql)
 	assert.Len(t, dirs.Columns, 1)
 	assert.Equal(t, "name", dirs.Columns["display_name"])
 	assert.Len(t, dirs.Constraints, 1)
@@ -210,12 +210,12 @@ func TestNormalizeUnqualifiedDirective(t *testing.T) {
 }
 
 func TestQualifyRenameFrom(t *testing.T) {
-	assert.Equal(t, "public.old_name", QualifyRenameFrom("old_name", "public"))
-	assert.Equal(t, "public.old_name", QualifyRenameFrom("public.old_name", "public"))
-	assert.Equal(t, "myschema.old_name", QualifyRenameFrom("myschema.old_name", "public"))
-	assert.Equal(t, `public."Old Name"`, QualifyRenameFrom(`"Old Name"`, "public"))
+	assert.Equal(t, "public.old_name", qualifyRenameFrom("old_name", "public"))
+	assert.Equal(t, "public.old_name", qualifyRenameFrom("public.old_name", "public"))
+	assert.Equal(t, "myschema.old_name", qualifyRenameFrom("myschema.old_name", "public"))
+	assert.Equal(t, `public."Old Name"`, qualifyRenameFrom(`"Old Name"`, "public"))
 	// Quoted identifier containing a dot should be treated as single name
-	assert.Equal(t, `public."a.b"`, QualifyRenameFrom(`"a.b"`, "public"))
+	assert.Equal(t, `public."a.b"`, qualifyRenameFrom(`"a.b"`, "public"))
 }
 
 func TestExtractStmtDirectives_QuotedName(t *testing.T) {
@@ -223,7 +223,7 @@ func TestExtractStmtDirectives_QuotedName(t *testing.T) {
 CREATE TABLE public.users (id integer NOT NULL);`
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
-	dirs := ExtractStmtDirectives(sql, result.Stmts)
+	dirs := extractStmtDirectives(sql, result.Stmts)
 	assert.Equal(t, `"My Schema"."Old Name"`, dirs[result.Stmts[0].StmtLocation])
 }
 
@@ -263,7 +263,7 @@ CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LAN
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := extractExecuteDirectives(sql, result.Stmts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0].SQL, "CREATE OR REPLACE FUNCTION")
@@ -278,7 +278,7 @@ CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LAN
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, _, err := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, _, err := extractExecuteDirectives(sql, result.Stmts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	// Trailing semicolon should be stripped from check SQL
@@ -292,7 +292,7 @@ GRANT SELECT ON public.users TO readonly_role;`
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := extractExecuteDirectives(sql, result.Stmts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0].SQL, "GRANT select")
@@ -308,7 +308,7 @@ CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LAN
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := extractExecuteDirectives(sql, result.Stmts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0].SQL, "CREATE OR REPLACE FUNCTION")
@@ -326,7 +326,7 @@ CREATE OR REPLACE FUNCTION public.func2() RETURNS void AS $$ BEGIN END; $$ LANGU
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := extractExecuteDirectives(sql, result.Stmts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 2)
 	assert.Equal(t, "", stmts[0].CheckSQL)
@@ -340,7 +340,7 @@ func TestExtractExecuteDirectives_None(t *testing.T) {
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	stmts, skip, err := ExtractExecuteDirectives(sql, result.Stmts)
+	stmts, skip, err := extractExecuteDirectives(sql, result.Stmts)
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 	assert.Empty(t, skip)
@@ -354,7 +354,7 @@ CREATE INDEX idx_email ON public.users USING btree (email);`
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	directives := ExtractConcurrentlyDirectives(sql, result.Stmts)
+	directives := extractConcurrentlyDirectives(sql, result.Stmts)
 	assert.True(t, directives[result.Stmts[0].StmtLocation])
 	assert.False(t, directives[result.Stmts[1].StmtLocation])
 }
@@ -367,7 +367,7 @@ CREATE INDEX idx_name ON public.users USING btree (name);`
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	directives := ExtractConcurrentlyDirectives(sql, result.Stmts)
+	directives := extractConcurrentlyDirectives(sql, result.Stmts)
 	assert.True(t, directives[result.Stmts[0].StmtLocation])
 }
 
@@ -377,50 +377,50 @@ func TestExtractConcurrentlyDirectives_noDirective(t *testing.T) {
 	result, err := pg_query.Parse(sql)
 	require.NoError(t, err)
 
-	directives := ExtractConcurrentlyDirectives(sql, result.Stmts)
+	directives := extractConcurrentlyDirectives(sql, result.Stmts)
 	assert.Empty(t, directives)
 }
 
 func TestValidateDirectives_Valid(t *testing.T) {
-	assert.NoError(t, ValidateDirectives("-- pist:renamed-from old"))
-	assert.NoError(t, ValidateDirectives("-- pist:execute SELECT true"))
-	assert.NoError(t, ValidateDirectives("-- pist:execute"))
-	assert.NoError(t, ValidateDirectives("-- pist:concurrently"))
-	assert.NoError(t, ValidateDirectives("SELECT 1; -- no directives"))
+	assert.NoError(t, validateDirectives("-- pist:renamed-from old"))
+	assert.NoError(t, validateDirectives("-- pist:execute SELECT true"))
+	assert.NoError(t, validateDirectives("-- pist:execute"))
+	assert.NoError(t, validateDirectives("-- pist:concurrently"))
+	assert.NoError(t, validateDirectives("SELECT 1; -- no directives"))
 }
 
 func TestValidateDirectives_ConcurrentlyWithArgs(t *testing.T) {
-	err := ValidateDirectives("-- pist:concurrently extra")
+	err := validateDirectives("-- pist:concurrently extra")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "-- pist:concurrently does not accept arguments")
 }
 
 func TestValidateDirectives_UnknownDirective(t *testing.T) {
-	err := ValidateDirectives("-- pist:exec")
+	err := validateDirectives("-- pist:exec")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown directive: -- pist:exec")
 }
 
 func TestValidateDirectives_Typo(t *testing.T) {
-	err := ValidateDirectives("-- pist:rename-from old")
+	err := validateDirectives("-- pist:rename-from old")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown directive: -- pist:rename-from")
 }
 
 func TestValidateDirectives_UnknownFoobar(t *testing.T) {
-	err := ValidateDirectives("-- pist:foobar something")
+	err := validateDirectives("-- pist:foobar something")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown directive: -- pist:foobar")
 }
 
 func TestValidateDirectives_SpaceAfterColon(t *testing.T) {
-	err := ValidateDirectives("-- pist: exec")
+	err := validateDirectives("-- pist: exec")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown directive: -- pist:exec")
 }
 
 func TestValidateDirectives_MissingName(t *testing.T) {
-	err := ValidateDirectives("-- pist:")
+	err := validateDirectives("-- pist:")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing directive name")
 }

--- a/parser/export_test.go
+++ b/parser/export_test.go
@@ -1,6 +1,9 @@
 package parser
 
-// ParseSQLWithSchema is exposed only to tests; the production entry point
-// is ParseSQLFilesWithSchema, which calls the unexported parseSQLWithSchema
-// internally.
-var ParseSQLWithSchema = parseSQLWithSchema
+// ParseSQLWithSchema and ReadSQLFile are exposed only to tests; the production
+// entry point is ParseSQLFilesWithSchema, which calls the unexported
+// parseSQLWithSchema and readSQLFile internally.
+var (
+	ParseSQLWithSchema = parseSQLWithSchema
+	ReadSQLFile        = readSQLFile
+)

--- a/parser/export_test.go
+++ b/parser/export_test.go
@@ -1,0 +1,6 @@
+package parser
+
+// ParseSQLWithSchema is exposed only to tests; the production entry point
+// is ParseSQLFilesWithSchema, which calls the unexported parseSQLWithSchema
+// internally.
+var ParseSQLWithSchema = parseSQLWithSchema

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -57,10 +57,10 @@ func ParseSQLFilesWithSchema(paths []string, defaultSchema string) (*ParseResult
 		sqls = append(sqls, sql)
 	}
 
-	return ParseSQLWithSchema(strings.Join(sqls, "\n"), defaultSchema)
+	return parseSQLWithSchema(strings.Join(sqls, "\n"), defaultSchema)
 }
 
-func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) {
+func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) {
 	if err := ValidateDirectives(sql); err != nil {
 		return nil, err
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -27,7 +27,7 @@ func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error
 	return nil
 }
 
-func ReadSQLFile(path string) (string, error) {
+func readSQLFile(path string) (string, error) {
 	var data []byte
 	var err error
 
@@ -50,7 +50,7 @@ func ReadSQLFile(path string) (string, error) {
 func ParseSQLFilesWithSchema(paths []string, defaultSchema string) (*ParseResult, error) {
 	var sqls []string
 	for _, path := range paths {
-		sql, err := ReadSQLFile(path)
+		sql, err := readSQLFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -61,7 +61,7 @@ func ParseSQLFilesWithSchema(paths []string, defaultSchema string) (*ParseResult
 }
 
 func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) {
-	if err := ValidateDirectives(sql); err != nil {
+	if err := validateDirectives(sql); err != nil {
 		return nil, err
 	}
 
@@ -75,9 +75,9 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	enums := orderedmap.New[string, *model.Enum]()
 	domains := orderedmap.New[string, *model.Domain]()
 
-	stmtDirectives := ExtractStmtDirectives(sql, result.Stmts)
-	concurrentlyDirectives := ExtractConcurrentlyDirectives(sql, result.Stmts)
-	executeStmts, executeSkipLocations, err := ExtractExecuteDirectives(sql, result.Stmts)
+	stmtDirectives := extractStmtDirectives(sql, result.Stmts)
+	concurrentlyDirectives := extractConcurrentlyDirectives(sql, result.Stmts)
+	executeStmts, executeSkipLocations, err := extractExecuteDirectives(sql, result.Stmts)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if renameFrom != "" {
-				qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 				enum.RenameFrom = &qualified
 			}
 			if err := setUnique(enums, enum.FQEN(), "enum", enum); err != nil {
@@ -111,7 +111,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if renameFrom != "" {
-				qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 				domain.RenameFrom = &qualified
 			}
 			if err := setUnique(domains, domain.FQDN(), "domain", domain); err != nil {
@@ -124,7 +124,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if renameFrom != "" {
-				qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 				table.RenameFrom = &qualified
 			}
 
@@ -134,7 +134,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				stmtEnd = int32(len(sql))
 			}
 			rawStmtSQL := sql[rawStmt.StmtLocation:stmtEnd]
-			inlineDirectives := ExtractInlineDirectives(rawStmtSQL)
+			inlineDirectives := extractInlineDirectives(rawStmtSQL)
 			for colName, oldName := range inlineDirectives.Columns {
 				if col, ok := table.Columns.GetOk(colName); ok {
 					old := oldName
@@ -161,7 +161,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				return nil, err
 			}
 			if renameFrom != "" {
-				qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 				view.RenameFrom = &qualified
 			}
 			if err := setUnique(views, view.FQVN(), "view", view); err != nil {
@@ -176,7 +176,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 					return nil, err
 				}
 				if renameFrom != "" {
-					qualified := QualifyRenameFrom(renameFrom, defaultSchema)
+					qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 					view.RenameFrom = &qualified
 				}
 				if err := setUnique(views, view.FQVN(), "materialized view", view); err != nil {
@@ -263,7 +263,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		}
 	}
 
-	if err := ValidateColumnRefs(tables); err != nil {
+	if err := validateColumnRefs(tables); err != nil {
 		return nil, err
 	}
 

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-// ValidateColumnRefs returns an error if any index, constraint, or foreign-key
+// validateColumnRefs returns an error if any index, constraint, or foreign-key
 // definition on a desired table references a column that does not exist in
 // that table's desired column set. All violations across all tables are
 // aggregated via errors.Join so a single plan run reports every problem.
@@ -22,7 +22,7 @@ import (
 // columns (PkAttrs, on the parent table) are out of scope. Tables that
 // inherit columns from a parent (declarative partition children and
 // INHERITS-style children) are skipped.
-func ValidateColumnRefs(tables *orderedmap.Map[string, *model.Table]) error {
+func validateColumnRefs(tables *orderedmap.Map[string, *model.Table]) error {
 	var errs []error
 	for fqtn, t := range tables.All() {
 		// Skip both partition children (PartitionOf + PartitionBound set) and

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -44,7 +44,7 @@ func TestValidateColumnRefs_Valid(t *testing.T) {
 		Type:       model.ConstraintType('u'),
 		Definition: "UNIQUE (name)",
 	})
-	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
 func TestValidateColumnRefs_IndexMissingColumn(t *testing.T) {
@@ -53,7 +53,7 @@ func TestValidateColumnRefs_IndexMissingColumn(t *testing.T) {
 		Name:       "idx_users_name",
 		Definition: "CREATE INDEX idx_users_name ON public.users (name)",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column name referenced in index idx_users_name does not exist on table public.users")
 }
@@ -65,7 +65,7 @@ func TestValidateColumnRefs_CheckMissingColumn(t *testing.T) {
 		Type:       model.ConstraintType('c'),
 		Definition: "CHECK ((qty > 0))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column qty referenced in CHECK constraint products_qty_check does not exist on table public.products")
 }
@@ -79,7 +79,7 @@ func TestValidateColumnRefs_FKMissingLocalColumn(t *testing.T) {
 			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
 		},
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column user_id referenced in foreign key fk does not exist on table public.orders")
 }
@@ -95,14 +95,14 @@ func TestValidateColumnRefs_FKReferencedColumnNotChecked(t *testing.T) {
 			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(nonexistent_pk)",
 		},
 	})
-	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
 func TestValidateColumnRefs_AggregatesMultiple(t *testing.T) {
 	tbl := newValidatableTable("t", "id")
 	tbl.Indexes.Set("idx_a", &model.Index{Name: "idx_a", Definition: "CREATE INDEX idx_a ON public.t (a)"})
 	tbl.Constraints.Set("c_b", &model.Constraint{Name: "c_b", Type: model.ConstraintType('c'), Definition: "CHECK ((b > 0))"})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	msg := err.Error()
 	assert.Contains(t, msg, "column a referenced in index idx_a")
@@ -129,7 +129,7 @@ func TestValidateColumnRefs_InheritsChildSkipped(t *testing.T) {
 		Type:       model.ConstraintType('p'),
 		Definition: "PRIMARY KEY (id)",
 	})
-	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
 func TestValidateColumnRefs_DeduplicatesPerObject(t *testing.T) {
@@ -141,7 +141,7 @@ func TestValidateColumnRefs_DeduplicatesPerObject(t *testing.T) {
 		Type:       model.ConstraintType('c'),
 		Definition: "CHECK ((qty > 0 AND qty < 100))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	count := strings.Count(err.Error(), "column qty referenced")
 	assert.Equal(t, 1, count)
@@ -162,7 +162,7 @@ func TestValidateColumnRefs_PartitionChildSkipped(t *testing.T) {
 	}
 	// Index references a column not in the (empty) inherited child column set.
 	tbl.Indexes.Set("idx", &model.Index{Name: "idx", Definition: "CREATE INDEX idx ON public.events_2024 (id)"})
-	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
 func TestValidateColumnRefs_ExpressionIndexMissingColumn(t *testing.T) {
@@ -172,7 +172,7 @@ func TestValidateColumnRefs_ExpressionIndexMissingColumn(t *testing.T) {
 		Name:       "idx_users_email_lower",
 		Definition: "CREATE INDEX idx_users_email_lower ON public.users (lower(email))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column email referenced in index idx_users_email_lower")
 }
@@ -187,7 +187,7 @@ func TestValidateColumnRefs_FKCompositeLocalPartialMiss(t *testing.T) {
 			Definition: "FOREIGN KEY (tenant_id, user_id) REFERENCES public.users(tenant_id, id)",
 		},
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	msg := err.Error()
 	assert.Contains(t, msg, "column user_id referenced in foreign key fk_buyer")
@@ -205,7 +205,7 @@ func TestValidateColumnRefs_SelfReferencingFK(t *testing.T) {
 			Definition: "FOREIGN KEY (parent_id) REFERENCES public.nodes(id)",
 		},
 	})
-	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
 func TestValidateColumnRefs_ExpressionIndexValid(t *testing.T) {
@@ -214,7 +214,7 @@ func TestValidateColumnRefs_ExpressionIndexValid(t *testing.T) {
 		Name:       "idx",
 		Definition: "CREATE INDEX idx ON public.users (lower(email))",
 	})
-	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
 func TestValidateColumnRefs_PartialIndexWhereChecked(t *testing.T) {
@@ -223,7 +223,7 @@ func TestValidateColumnRefs_PartialIndexWhereChecked(t *testing.T) {
 		Name:       "idx",
 		Definition: "CREATE INDEX idx ON public.users (id) WHERE deleted_at IS NULL",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column deleted_at referenced in index idx")
 }
@@ -235,7 +235,7 @@ func TestValidateColumnRefs_ExclusionChecked(t *testing.T) {
 		Type:       model.ConstraintType('x'),
 		Definition: "EXCLUDE USING gist (room WITH =, during WITH &&)",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column during referenced in EXCLUDE constraint no_overlap")
 }
@@ -246,7 +246,7 @@ func TestValidateColumnRefs_QuotedIdentifier(t *testing.T) {
 		Name:       "idx",
 		Definition: `CREATE INDEX idx ON public.t ("MyName")`,
 	})
-	require.NoError(t, ValidateColumnRefs(tablesMap(tbl)))
+	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
 func TestValidateColumnRefs_CheckBoolExprChecked(t *testing.T) {
@@ -256,7 +256,7 @@ func TestValidateColumnRefs_CheckBoolExprChecked(t *testing.T) {
 		Type:       model.ConstraintType('c'),
 		Definition: "CHECK ((a > 0 AND b < 100))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	msg := err.Error()
 	assert.Contains(t, msg, "column a referenced")
@@ -270,7 +270,7 @@ func TestValidateColumnRefs_CheckTypeCastChecked(t *testing.T) {
 		Type:       model.ConstraintType('c'),
 		Definition: "CHECK ((status::text = 'a'))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column status referenced")
 }
@@ -282,7 +282,7 @@ func TestValidateColumnRefs_CheckCoalesceChecked(t *testing.T) {
 		Type:       model.ConstraintType('c'),
 		Definition: "CHECK ((COALESCE(qty, 0) > 0))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column qty referenced")
 }
@@ -294,7 +294,7 @@ func TestValidateColumnRefs_CheckCaseChecked(t *testing.T) {
 		Type:       model.ConstraintType('c'),
 		Definition: "CHECK (((CASE WHEN flag THEN 1 ELSE 0 END) = 1))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column flag referenced")
 }
@@ -306,7 +306,7 @@ func TestValidateColumnRefs_CheckInListChecked(t *testing.T) {
 		Type:       model.ConstraintType('c'),
 		Definition: "CHECK ((status IN ('a', 'b')))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column status referenced")
 }
@@ -318,7 +318,7 @@ func TestValidateColumnRefs_CheckAnyArrayChecked(t *testing.T) {
 		Type:       model.ConstraintType('c'),
 		Definition: "CHECK ((status = ANY (ARRAY['a'::text, 'b'::text])))",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column status referenced")
 }
@@ -338,7 +338,7 @@ func TestValidateColumnRefs_MultiTableScoping(t *testing.T) {
 		Definition: "CREATE INDEX idx_bad ON public.bad (name)",
 	})
 
-	err := ValidateColumnRefs(tablesMap(good, bad))
+	err := validateColumnRefs(tablesMap(good, bad))
 	require.Error(t, err)
 	msg := err.Error()
 	assert.Contains(t, msg, "table public.bad")
@@ -353,7 +353,7 @@ func TestValidateColumnRefs_CompositeKeyPartialMiss(t *testing.T) {
 		Name:       "idx",
 		Definition: "CREATE INDEX idx ON public.t (a, b)",
 	})
-	err := ValidateColumnRefs(tablesMap(tbl))
+	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	msg := err.Error()
 	assert.Contains(t, msg, "column a referenced in index idx")

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -381,7 +381,7 @@ func TestParseSQLWithSchema_RejectsUnresolvedColumnRef(t *testing.T) {
 );
 CREATE INDEX idx_users_name ON users (name);`
 
-	_, err := ParseSQLWithSchema(sql, "public")
+	_, err := parseSQLWithSchema(sql, "public")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column name referenced in index idx_users_name does not exist on table public.users")
 }
@@ -394,7 +394,7 @@ func TestParseSQLWithSchema_AcceptsResolvedColumnRefs(t *testing.T) {
 );
 CREATE INDEX idx_users_name ON users (name);`
 
-	_, err := ParseSQLWithSchema(sql, "public")
+	_, err := parseSQLWithSchema(sql, "public")
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary
Shrink the `parser` package's public surface to just the production entry points (`ParseSQLFilesWithSchema` and the result types). Identifiers that were exported but never used outside the package are now lowercase.

Renamed:
- `ParseSQLWithSchema` → `parseSQLWithSchema` (alias kept in `export_test.go` for external test access)
- `ReadSQLFile` → `readSQLFile` (alias kept in `export_test.go`)
- `ValidateDirectives` → `validateDirectives`
- `ExtractStmtDirectives` → `extractStmtDirectives`
- `ExtractConcurrentlyDirectives` → `extractConcurrentlyDirectives`
- `ExtractExecuteDirectives` → `extractExecuteDirectives`
- `ExtractInlineDirectives` → `extractInlineDirectives`
- `InlineDirectives` (type) → `inlineDirectives`
- `QualifyRenameFrom` → `qualifyRenameFrom`
- `ValidateColumnRefs` → `validateColumnRefs`

The directive/validation helpers are exercised only by same-package tests (`directive_test.go`, `validate_test.go`), so no `export_test.go` plumbing is needed for those.

## Test plan
- [x] make build
- [x] make vet
- [x] make lint (0 issues)
- [x] go test ./parser/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)