### PR TITLE
Unexport toposort, diff, and pgast internals

### DIFF
--- a/diff/domains.go
+++ b/diff/domains.go
@@ -15,7 +15,7 @@ type DomainDiffResult struct {
 }
 
 func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain], dc DropChecker) (*DomainDiffResult, error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 	result := &DomainDiffResult{}
 
 	// Detect renames

--- a/diff/drop_policy.go
+++ b/diff/drop_policy.go
@@ -5,20 +5,20 @@ type DropChecker interface {
 	IsDropAllowed(objectType string) bool
 }
 
-// AllowAllDrops is a DropChecker that allows all drops.
-type AllowAllDrops struct{}
+// allowAllDrops is a DropChecker that allows all drops.
+type allowAllDrops struct{}
 
-func (AllowAllDrops) IsDropAllowed(string) bool { return true }
+func (allowAllDrops) IsDropAllowed(string) bool { return true }
 
-// DenyAllDrops is a DropChecker that denies all drops.
-type DenyAllDrops struct{}
+// denyAllDrops is a DropChecker that denies all drops.
+type denyAllDrops struct{}
 
-func (DenyAllDrops) IsDropAllowed(string) bool { return false }
+func (denyAllDrops) IsDropAllowed(string) bool { return false }
 
-// NormalizeDropChecker returns dc if non-nil, otherwise returns DenyAllDrops.
-func NormalizeDropChecker(dc DropChecker) DropChecker {
+// normalizeDropChecker returns dc if non-nil, otherwise returns denyAllDrops.
+func normalizeDropChecker(dc DropChecker) DropChecker {
 	if dc == nil {
-		return DenyAllDrops{}
+		return denyAllDrops{}
 	}
 	return dc
 }

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -15,7 +15,7 @@ type EnumDiffResult struct {
 }
 
 func DiffEnums(current, desired *orderedmap.Map[string, *model.Enum], dc DropChecker) (*EnumDiffResult, error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 	result := &EnumDiffResult{}
 
 	// Detect renames

--- a/diff/export_test.go
+++ b/diff/export_test.go
@@ -1,0 +1,8 @@
+package diff
+
+// AllowAllDrops and DenyAllDrops are exposed only to tests; production callers
+// pass a *cmd.DropPolicy as the DropChecker.
+type (
+	AllowAllDrops = allowAllDrops
+	DenyAllDrops  = denyAllDrops
+)

--- a/diff/policies.go
+++ b/diff/policies.go
@@ -43,7 +43,7 @@ func diffPolicies(
 	current, desired *orderedmap.Map[string, *model.Policy],
 	dc DropChecker,
 ) (stmts []string, disallowed []string, err error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 
 	// Callers (diffTable) always pass initialized maps from parser/catalog,
 	// so no nil-guard is needed here.

--- a/diff/policies_test.go
+++ b/diff/policies_test.go
@@ -66,7 +66,7 @@ func TestDiffPolicies_NoChange(t *testing.T) {
 	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
 	des.Set("p", newPolicy("p", 'r', withUsing("true")))
 
-	stmts, disallowed, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, disallowed, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 	assert.Empty(t, disallowed)
@@ -77,7 +77,7 @@ func TestDiffPolicies_AddPolicy(t *testing.T) {
 	des := orderedmap.New[string, *model.Policy]()
 	des.Set("p", newPolicy("p", 'r', withUsing("true")))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE POLICY p ON public.documents FOR SELECT USING (true);"}, stmts)
 }
@@ -87,7 +87,7 @@ func TestDiffPolicies_DropPolicy_Allowed(t *testing.T) {
 	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
 	des := orderedmap.New[string, *model.Policy]()
 
-	stmts, disallowed, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, disallowed, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP POLICY p ON public.documents;"}, stmts)
 	assert.Empty(t, disallowed)
@@ -98,7 +98,7 @@ func TestDiffPolicies_DropPolicy_Disallowed(t *testing.T) {
 	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
 	des := orderedmap.New[string, *model.Policy]()
 
-	stmts, disallowed, err := diffPolicies("public.documents", cur, des, DenyAllDrops{})
+	stmts, disallowed, err := diffPolicies("public.documents", cur, des, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 	assert.Equal(t, []string{"-- skipped: DROP POLICY p ON public.documents;"}, disallowed)
@@ -110,7 +110,7 @@ func TestDiffPolicies_AlterUsing(t *testing.T) {
 	cur.Set("p", newPolicy("p", 'r', withUsing("a")))
 	des.Set("p", newPolicy("p", 'r', withUsing("b")))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER POLICY p ON public.documents USING (b);"}, stmts)
 }
@@ -121,7 +121,7 @@ func TestDiffPolicies_RecreateOnCommandChange(t *testing.T) {
 	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
 	des.Set("p", newPolicy("p", '*', withUsing("true")))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"DROP POLICY p ON public.documents;",
@@ -135,7 +135,7 @@ func TestDiffPolicies_RecreateOnPermissiveChange(t *testing.T) {
 	cur.Set("p", newPolicy("p", '*', withUsing("true")))
 	des.Set("p", newPolicy("p", '*', withUsing("true"), restrictive()))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"DROP POLICY p ON public.documents;",
@@ -149,7 +149,7 @@ func TestDiffPolicies_RecreateOnUsingRemoval(t *testing.T) {
 	cur.Set("p", newPolicy("p", '*', withUsing("a"), withWithCheck("b")))
 	des.Set("p", newPolicy("p", '*', withWithCheck("b")))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"DROP POLICY p ON public.documents;",
@@ -163,7 +163,7 @@ func TestDiffPolicies_Rename(t *testing.T) {
 	cur.Set("old", newPolicy("old", 'r', withUsing("true")))
 	des.Set("new", newPolicy("new", 'r', withUsing("true"), renameFrom("old")))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER POLICY old ON public.documents RENAME TO new;"}, stmts)
 }
@@ -173,7 +173,7 @@ func TestDiffPolicies_RenameSourceMissing(t *testing.T) {
 	des := orderedmap.New[string, *model.Policy]()
 	des.Set("new", newPolicy("new", 'r', withUsing("true"), renameFrom("nonexistent")))
 
-	_, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	_, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source policy nonexistent not found")
 }
@@ -231,7 +231,7 @@ func TestDiffPolicies_AlterRoles(t *testing.T) {
 	cur.Set("p", newPolicy("p", 'r', withUsing("true"), func(p *model.Policy) { p.Roles = []string{"public"} }))
 	des.Set("p", newPolicy("p", 'r', withUsing("true"), func(p *model.Policy) { p.Roles = []string{"app_user"} }))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER POLICY p ON public.documents TO app_user;"}, stmts)
 }
@@ -243,7 +243,7 @@ func TestDiffPolicies_AlterRoles_EmptyToPublic(t *testing.T) {
 	cur.Set("p", newPolicy("p", 'r', withUsing("true"), func(p *model.Policy) { p.Roles = []string{"app_user"} }))
 	des.Set("p", newPolicy("p", 'r', withUsing("true")))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER POLICY p ON public.documents TO public;"}, stmts)
 }
@@ -255,7 +255,7 @@ func TestDiffPolicies_AddWithCheckInPlace(t *testing.T) {
 	cur.Set("p", newPolicy("p", '*', withUsing("a")))
 	des.Set("p", newPolicy("p", '*', withUsing("a"), withWithCheck("b")))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER POLICY p ON public.documents WITH CHECK (b);"}, stmts)
 }
@@ -270,7 +270,7 @@ func TestDiffPolicies_RenameAndRecreate(t *testing.T) {
 	// Rename old → new AND change command from SELECT to ALL.
 	des.Set("new", newPolicy("new", '*', withUsing("true"), renameFrom("old")))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"DROP POLICY old ON public.documents;",
@@ -288,7 +288,7 @@ func TestDiffPolicies_Rename_QuotedIdentifierWithArrow(t *testing.T) {
 	cur.Set(`a->b`, newPolicy(`a->b`, 'r', withUsing("true")))
 	des.Set(`c`, newPolicy(`c`, 'r', withUsing("true"), renameFrom(`a->b`)))
 
-	stmts, _, err := diffPolicies("public.documents", cur, des, AllowAllDrops{})
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{`ALTER POLICY "a->b" ON public.documents RENAME TO c;`}, stmts)
 }

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -22,7 +22,7 @@ type TableDiffResult struct {
 }
 
 func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropChecker) (*TableDiffResult, error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 	result := &TableDiffResult{}
 
 	// Detect renames
@@ -121,7 +121,7 @@ type tableDiffResult struct {
 }
 
 func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult, error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 	result := &tableDiffResult{}
 	fqtn := desired.FQTN()
 
@@ -222,7 +222,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 }
 
 func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column], dc DropChecker) (stmts []string, disallowed []string, err error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 
 	// Detect renames
 	renameStmts, current, err := detectColumnRenames(fqtn, current, desired)
@@ -520,7 +520,7 @@ func equalConstraintDef(a, b string) bool {
 }
 
 func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *model.Constraint], dc DropChecker) (stmts []string, disallowed []string, err error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 
 	// Detect renames
 	renameStmts, current, renamedFrom, err := detectConstraintRenames(fqtn, current, desired)
@@ -611,7 +611,7 @@ type diffIndexesResult struct {
 }
 
 func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], dc DropChecker) (*diffIndexesResult, error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 	result := &diffIndexesResult{}
 
 	// Detect renames
@@ -730,7 +730,7 @@ func createIndexSQL(def string, concurrently bool) (string, error) {
 // --allow-drop=foreign_key; FK drops emitted because the owning table is being
 // dropped follow the table policy (handled in DiffTables).
 func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[string, *model.ForeignKey], dc DropChecker) (dropStmts, addStmts, disallowed []string, err error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 
 	// Detect renames (renames go into addStmts since they may depend on table renames)
 	renameStmts, current, renamedFrom, err := detectForeignKeyRenames(fqtn, current, desired)

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -34,7 +34,7 @@ func TestDiffTables_newTable(t *testing.T) {
 	tbl.Constraints.Set("users_pkey", &model.Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
 	desired.Set("public.users", tbl)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "CREATE TABLE public.users")
@@ -50,7 +50,7 @@ func TestDiffTables_newTable_withExtras(t *testing.T) {
 	tbl.Comment = ptr("Users table")
 	desired.Set("public.users", tbl)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 3)
 	assert.Contains(t, result.Stmts[0], "CREATE TABLE")
@@ -67,7 +67,7 @@ func TestDiffTables_newTable_withExtras_perDirective(t *testing.T) {
 	tbl.Indexes.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Table: "users", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 	desired.Set("public.users", tbl)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 2)
 	assert.Contains(t, result.Stmts[0], "CREATE TABLE")
@@ -88,7 +88,7 @@ func TestDiffTables_modifyTable_addIndex_perDirective(t *testing.T) {
 	dt.Indexes.Set("idx_id", &model.Index{Schema: "public", Name: "idx_id", Table: "users", Definition: "CREATE INDEX idx_id ON public.users USING btree (id)", Concurrently: true})
 	desired.Set("public.users", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "CREATE INDEX CONCURRENTLY")
@@ -101,7 +101,7 @@ func TestDiffTables_dropTable(t *testing.T) {
 
 	current.Set("public.users", newTable("public", "users"))
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP TABLE public.users;"}, result.DropStmts)
 }
@@ -121,7 +121,7 @@ func TestDiffTables_dropTable_withFK(t *testing.T) {
 	})
 	current.Set("public.posts", posts)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.posts DROP CONSTRAINT posts_user_id_fkey;"}, result.FKDropStmts)
 	assert.Equal(t, []string{"DROP TABLE public.users;", "DROP TABLE public.posts;"}, result.DropStmts)
@@ -142,7 +142,7 @@ func TestDiffTables_dropTable_withFK_denied(t *testing.T) {
 	})
 	current.Set("public.posts", posts)
 
-	result, err := DiffTables(current, desired, DenyAllDrops{})
+	result, err := DiffTables(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.FKDropStmts)
 	assert.Empty(t, result.DropStmts)
@@ -154,12 +154,12 @@ func TestDiffTables_dropTable_withFK_denied(t *testing.T) {
 }
 
 func TestNormalizeDropChecker_nil(t *testing.T) {
-	dc := NormalizeDropChecker(nil)
+	dc := normalizeDropChecker(nil)
 	assert.False(t, dc.IsDropAllowed("table"))
 }
 
 func TestNormalizeDropChecker_nonNil(t *testing.T) {
-	dc := NormalizeDropChecker(AllowAllDrops{})
+	dc := normalizeDropChecker(allowAllDrops{})
 	assert.True(t, dc.IsDropAllowed("table"))
 }
 
@@ -181,7 +181,7 @@ func TestDiffTables_dropTable_denied(t *testing.T) {
 
 	current.Set("public.users", newTable("public", "users"))
 
-	result, err := DiffTables(current, desired, DenyAllDrops{})
+	result, err := DiffTables(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 	assert.Empty(t, result.DropStmts)
@@ -196,7 +196,7 @@ func TestDiffColumns_dropColumn_denied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, disallowed, err := diffColumns("public.users", current, desired, DenyAllDrops{})
+	stmts, disallowed, err := diffColumns("public.users", current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 	assert.Equal(t, []string{"-- skipped: ALTER TABLE public.users DROP COLUMN name;"}, disallowed)
@@ -214,7 +214,7 @@ func TestDiffTables_noChange(t *testing.T) {
 	tbl2.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 	desired.Set("public.users", tbl2)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -227,7 +227,7 @@ func TestDiffColumns_addColumn(t *testing.T) {
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ADD COLUMN name text NOT NULL;", stmts[0])
@@ -241,7 +241,7 @@ func TestDiffColumns_dropColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users DROP COLUMN name;", stmts[0])
@@ -254,7 +254,7 @@ func TestDiffColumns_alterType(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;", stmts[0])
@@ -267,7 +267,7 @@ func TestDiffColumns_alterType_withCollation(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], `COLLATE "en_US"`)
@@ -280,7 +280,7 @@ func TestDiffColumns_alterCollation_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("fr_FR")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{`ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text COLLATE "fr_FR";`}, stmts)
 }
@@ -292,7 +292,7 @@ func TestDiffColumns_alterCollation_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{`ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text COLLATE "en_US";`}, stmts)
 }
@@ -304,7 +304,7 @@ func TestDiffColumns_alterCollation_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;"}, stmts)
 }
@@ -316,7 +316,7 @@ func TestDiffColumns_alterCollation_unchanged(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: ptr("en_US")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -328,7 +328,7 @@ func TestDiffColumns_alterDefault_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer", Default: ptr("0")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age SET DEFAULT 0;", stmts[0])
@@ -341,7 +341,7 @@ func TestDiffColumns_alterDefault_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age DROP DEFAULT;", stmts[0])
@@ -354,7 +354,7 @@ func TestDiffColumns_alterNotNull_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;", stmts[0])
@@ -367,7 +367,7 @@ func TestDiffColumns_alterNotNull_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;", stmts[0])
@@ -383,7 +383,7 @@ func TestDiffColumns_renameNotNullConstraint(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &newName})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME CONSTRAINT users_name_nn_old TO users_name_nn_new;"}, stmts)
 }
@@ -397,7 +397,7 @@ func TestDiffColumns_notNullName_sameName_isNoOp(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -412,7 +412,7 @@ func TestDiffColumns_notNullName_addOrDrop_isNoOp(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 
@@ -423,7 +423,7 @@ func TestDiffColumns_notNullName_addOrDrop_isNoOp(t *testing.T) {
 	desired = orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, _, err = diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err = diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -448,7 +448,7 @@ func TestDiffColumns_renameNotNullConstraint_skipsIdentityColumn(t *testing.T) {
 		NotNullName: &newName, Identity: model.ColumnIdentity('a'),
 	})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -465,7 +465,7 @@ func TestDiffColumns_setNotNull_withDesiredName_ignoresName(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;"}, stmts)
 }
@@ -481,7 +481,7 @@ func TestDiffColumns_dropNotNull_loseCurrentName(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;"}, stmts)
 }
@@ -493,7 +493,7 @@ func TestDiffColumns_addColumn_withNotNullName(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("email", &model.Column{Name: "email", TypeName: "text", NotNull: true, NotNullName: &name})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ADD COLUMN email text CONSTRAINT users_email_nn NOT NULL;"}, stmts)
 }
@@ -505,7 +505,7 @@ func TestDiffColumns_identitySkipsNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -547,7 +547,7 @@ func TestDiffConstraints_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0);"}, stmts)
 }
@@ -557,7 +557,7 @@ func TestDiffConstraints_drop(t *testing.T) {
 	current.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
 	desired := orderedmap.New[string, *model.Constraint]()
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users DROP CONSTRAINT chk_age;"}, stmts)
 }
@@ -567,7 +567,7 @@ func TestDiffConstraints_drop_denied(t *testing.T) {
 	current.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
 	desired := orderedmap.New[string, *model.Constraint]()
 
-	stmts, disallowed, err := diffConstraints("public.users", current, desired, DenyAllDrops{})
+	stmts, disallowed, err := diffConstraints("public.users", current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 	assert.Equal(t, []string{"-- skipped: ALTER TABLE public.users DROP CONSTRAINT chk_age;"}, disallowed)
@@ -581,7 +581,7 @@ func TestDiffConstraints_change_denied_alwaysExecutes(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age >= 18)", Validated: true})
 
-	stmts, disallowed, err := diffConstraints("public.users", current, desired, DenyAllDrops{})
+	stmts, disallowed, err := diffConstraints("public.users", current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, disallowed)
 	assert.Equal(t, []string{
@@ -596,7 +596,7 @@ func TestDiffConstraints_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age >= 18)", Validated: true})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_age;", stmts[0])
@@ -608,7 +608,7 @@ func TestDiffConstraints_addNotValid(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: false})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;", stmts[0])
@@ -620,7 +620,7 @@ func TestDiffConstraints_validatedToNotValid(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: false})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_age;", stmts[0])
@@ -633,7 +633,7 @@ func TestDiffConstraints_notValidToValidated(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: true})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users VALIDATE CONSTRAINT chk_age;", stmts[0])
@@ -645,7 +645,7 @@ func TestDiffConstraints_bothNotValid_noChange(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age > 0)", Validated: false})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -656,7 +656,7 @@ func TestDiffConstraints_changeDefinitionAndValidated(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_age", &model.Constraint{Name: "chk_age", Definition: "CHECK (age >= 18)", Validated: false})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_age;", stmts[0])
@@ -669,7 +669,7 @@ func TestDiffConstraints_renameAndNotValid(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age > 0)", Validated: false, RenameFrom: ptr("chk_old")})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_old;", stmts[0])
@@ -682,7 +682,7 @@ func TestDiffConstraints_renameAndChangeDefinition(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age >= 18)", Validated: true, RenameFrom: ptr("chk_old")})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_old;", stmts[0])
@@ -695,7 +695,7 @@ func TestDiffConstraints_renameAndValidate(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age > 0)", Validated: true, RenameFrom: ptr("chk_old")})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users RENAME CONSTRAINT chk_old TO chk_new;", stmts[0])
@@ -708,7 +708,7 @@ func TestDiffConstraints_renameOnly(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age > 0)", Validated: true, RenameFrom: ptr("chk_old")})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users RENAME CONSTRAINT chk_old TO chk_new;", stmts[0])
@@ -720,7 +720,7 @@ func TestDiffConstraints_renameAlreadyAppliedAndNotValid(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age > 0)", Validated: false, RenameFrom: ptr("chk_old")})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 	assert.Equal(t, "ALTER TABLE public.users DROP CONSTRAINT chk_new;", stmts[0])
@@ -732,7 +732,7 @@ func TestDiffIndexes_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE INDEX idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -742,7 +742,7 @@ func TestDiffIndexes_drop(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
 }
@@ -752,7 +752,7 @@ func TestDiffIndexes_drop_denied(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired, DenyAllDrops{})
+	idxResult, err := diffIndexes(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.Stmts)
 	assert.Equal(t, []string{"-- skipped: DROP INDEX public.idx_name;"}, idxResult.DisallowedDropStmts)
@@ -766,7 +766,7 @@ func TestDiffIndexes_change_denied_alwaysExecutes(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	idxResult, err := diffIndexes(current, desired, DenyAllDrops{})
+	idxResult, err := diffIndexes(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.DisallowedDropStmts)
 	assert.Len(t, idxResult.Stmts, 2)
@@ -779,7 +779,7 @@ func TestDiffIndexes_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "DROP INDEX public.idx_name;", idxResult.Stmts[0])
@@ -791,7 +791,7 @@ func TestDiffIndexes_add_uniqueConcurrently_perDirective(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE UNIQUE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE UNIQUE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -801,7 +801,7 @@ func TestDiffIndexes_add_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -813,7 +813,7 @@ func TestDiffIndexes_drop_pureDrop_neverConcurrently(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
 }
@@ -824,7 +824,7 @@ func TestDiffIndexes_change_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", idxResult.Stmts[0])
@@ -837,7 +837,7 @@ func TestDiffIndexes_mixedConcurrently(t *testing.T) {
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 	desired.Set("idx_email", &model.Index{Schema: "public", Name: "idx_email", Definition: "CREATE INDEX idx_email ON public.users USING btree (email)"})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);", idxResult.Stmts[0])
@@ -852,7 +852,7 @@ func TestDiffIndexes_rename_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	// Rename should NOT use CONCURRENTLY even with per-index directive
 	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
@@ -864,7 +864,7 @@ func TestDiffIndexes_partialIndex_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_active", &model.Index{Schema: "public", Name: "idx_active", Definition: "CREATE INDEX idx_active ON public.users USING btree (name) WHERE (active = true)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 1)
 	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
@@ -877,7 +877,7 @@ func TestDiffIndexes_expressionIndex_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_lower", &model.Index{Schema: "public", Name: "idx_lower", Definition: "CREATE INDEX idx_lower ON public.users USING btree (lower(name))", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 1)
 	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
@@ -890,7 +890,7 @@ func TestDiffIndexes_hasConcurrently_directive(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.True(t, idxResult.HasConcurrently)
 }
@@ -928,7 +928,7 @@ func TestDiffForeignKeys_add(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	_, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, addStmts, 1)
 	assert.Contains(t, addStmts[0], "ADD CONSTRAINT fk_user")
@@ -944,7 +944,7 @@ func TestDiffForeignKeys_addNotValid(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	_, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, addStmts, 1)
 	assert.Contains(t, addStmts[0], "ADD CONSTRAINT fk_user")
@@ -960,7 +960,7 @@ func TestDiffForeignKeys_drop(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, dropStmts)
 	assert.Empty(t, addStmts)
@@ -977,7 +977,7 @@ func TestDiffForeignKeys_drop_denied(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 
-	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, DenyAllDrops{})
+	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Empty(t, addStmts)
@@ -1000,7 +1000,7 @@ func TestDiffForeignKeys_change_denied_alwaysExecutes(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, DenyAllDrops{})
+	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, disallowed)
 	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, dropStmts)
@@ -1025,7 +1025,7 @@ func TestDiffForeignKeys_renamedAndChanged_denied_alwaysExecutes(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, DenyAllDrops{})
+	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, disallowed)
 	assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_old;"}, dropStmts)
@@ -1043,7 +1043,7 @@ func TestDiffConstraints_renamedAndChanged_denied_alwaysExecutes(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("chk_new", &model.Constraint{Name: "chk_new", Definition: "CHECK (age >= 18)", Validated: true, RenameFrom: ptr("chk_old")})
 
-	stmts, disallowed, err := diffConstraints("public.users", current, desired, DenyAllDrops{})
+	stmts, disallowed, err := diffConstraints("public.users", current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, disallowed)
 	require.Len(t, stmts, 2)
@@ -1154,7 +1154,7 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 	})
 	desired.Set("public.orders", tbl)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.Stmts, 1)
 	assert.Contains(t, result.Stmts[0], "CREATE TABLE")
@@ -1212,7 +1212,7 @@ func TestDiffForeignKeys_change(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, append(dropStmts, addStmts...), 2)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", dropStmts[0])
@@ -1233,7 +1233,7 @@ func TestDiffForeignKeys_validatedToNotValid(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", dropStmts[0])
@@ -1255,7 +1255,7 @@ func TestDiffForeignKeys_notValidToValidated(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Len(t, addStmts, 1)
@@ -1276,7 +1276,7 @@ func TestDiffForeignKeys_bothNotValid_noChange(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Empty(t, addStmts)
@@ -1296,7 +1296,7 @@ func TestDiffForeignKeys_changeDefinitionAndValidated(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_user;", dropStmts[0])
@@ -1319,7 +1319,7 @@ func TestDiffForeignKeys_renameAndValidate(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Len(t, addStmts, 2)
@@ -1341,7 +1341,7 @@ func TestDiffForeignKeys_renameOnly(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Len(t, addStmts, 1)
@@ -1362,7 +1362,7 @@ func TestDiffForeignKeys_renameAndNotValid(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_old;", dropStmts[0])
@@ -1387,7 +1387,7 @@ func TestDiffForeignKeys_renameAlreadyAppliedAndNotValid(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_new;", dropStmts[0])
@@ -1410,7 +1410,7 @@ func TestDiffForeignKeys_renameAndChangeDefinition(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, dropStmts, 1)
 	assert.Equal(t, "ALTER TABLE public.orders DROP CONSTRAINT fk_old;", dropStmts[0])
@@ -1432,7 +1432,7 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	desired.PartitionBound = &bound
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
 
-	tableResult, err := diffTable(current, desired, AllowAllDrops{})
+	tableResult, err := diffTable(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, tableResult.Stmts, 1)
 	assert.Contains(t, tableResult.Stmts[0], "CREATE INDEX idx_new")
@@ -1452,7 +1452,7 @@ func TestDiffTable_partitionChild_indexRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", RenameFrom: &oldName, Definition: "CREATE INDEX idx_new ON public.events_2024 (id)"})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -1475,7 +1475,7 @@ func TestDiffTable_partitionChild_fkRenameError(t *testing.T) {
 		Table:      "events_2024",
 	})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -1489,7 +1489,7 @@ func TestDiffTable_constraintRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Constraints.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (id)"})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source constraint")
 }
@@ -1503,7 +1503,7 @@ func TestDiffTable_indexRenameError(t *testing.T) {
 	oldName := "nonexistent"
 	desired.Indexes.Set("idx_new", &model.Index{Schema: "public", Name: "idx_new", RenameFrom: &oldName, Definition: "CREATE INDEX idx_new ON public.users (id)"})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -1521,7 +1521,7 @@ func TestDiffTable_fkRenameError(t *testing.T) {
 		Table:      "users",
 	})
 
-	_, err := diffTable(current, desired, AllowAllDrops{})
+	_, err := diffTable(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -1554,7 +1554,7 @@ func TestDiffTable_columnRenameRewritesDependents(t *testing.T) {
 		Definition: "CREATE INDEX idx_users_name ON public.users USING btree (display_name)",
 	})
 
-	tableResult, err := diffTable(current, desired, AllowAllDrops{})
+	tableResult, err := diffTable(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 
 	// Only the RENAME COLUMN should be emitted; no redundant DROP/CREATE
@@ -1700,7 +1700,7 @@ func TestDiffConstraints_noChangeWithTextCast(t *testing.T) {
 		Definition: "CHECK (name <> '')",
 	})
 
-	stmts, _, err := diffConstraints("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1717,7 +1717,7 @@ func TestDiffConstraints_noChangeWithInVsAny(t *testing.T) {
 		Definition: "CHECK (status IN ('active', 'pending'))",
 	})
 
-	stmts, _, err := diffConstraints("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1734,7 +1734,7 @@ func TestDiffConstraints_noChangeWithFormattingDiff(t *testing.T) {
 		Definition: "CHECK (kind = ANY(ARRAY['x'::text, 'y'::text]))",
 	})
 
-	stmts, _, err := diffConstraints("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1828,7 +1828,7 @@ func TestDiffTables_indexWhereClauseSchemaInsensitive(t *testing.T) {
 	})
 	desired.Set("public.products", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -1912,7 +1912,7 @@ func TestDiffTables_indexSchemaInsensitive(t *testing.T) {
 	dt.Indexes.Set("idx", &model.Index{Schema: "", Name: "idx", Table: "users", Definition: "CREATE INDEX idx ON users USING btree (id)"})
 	desired.Set("public.users", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -1931,7 +1931,7 @@ func TestDiffTables_renameTable(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, result.Stmts)
 }
@@ -1950,7 +1950,7 @@ func TestDiffTables_renameTable_selfRename_skipped(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.users", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -1963,7 +1963,7 @@ func TestDiffColumns_renameColumn_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1976,7 +1976,7 @@ func TestDiffConstraints_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("con", &model.Constraint{Name: "con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -1989,7 +1989,7 @@ func TestDiffIndexes_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx", &model.Index{Schema: "public", Name: "idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.Stmts)
 }
@@ -2010,7 +2010,7 @@ func TestDiffForeignKeys_rename_selfRename_skipped(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Empty(t, addStmts)
@@ -2030,7 +2030,7 @@ func TestDiffTables_renameTable_alreadyApplied(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Stmts)
 }
@@ -2053,7 +2053,7 @@ func TestDiffTables_renameTable_withIndex(t *testing.T) {
 	dt.Indexes.Set("idx_users_name", &model.Index{Schema: "public", Name: "idx_users_name", Table: "accounts", Definition: "CREATE INDEX idx_users_name ON public.accounts USING btree (name)"})
 	desired.Set("public.accounts", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	// Should only rename the table, no DROP/CREATE index
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME TO accounts;"}, result.Stmts)
@@ -2085,7 +2085,7 @@ func TestDiffTables_renameTable_withFK(t *testing.T) {
 	})
 	desired.Set("public.purchases", dt)
 
-	result, err := DiffTables(current, desired, AllowAllDrops{})
+	result, err := DiffTables(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME TO purchases;"}, result.Stmts)
 }
@@ -2108,7 +2108,7 @@ func TestDiffTables_renameTable_destinationExists_error(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	_, err := DiffTables(current, desired, AllowAllDrops{})
+	_, err := DiffTables(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -2122,7 +2122,7 @@ func TestDiffColumns_renameColumn_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	_, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	_, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -2141,7 +2141,7 @@ func TestDiffTables_renameTable_crossSchema_error(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("other.users", dt)
 
-	_, err := DiffTables(current, desired, AllowAllDrops{})
+	_, err := DiffTables(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
@@ -2154,7 +2154,7 @@ func TestDiffColumns_renameColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME COLUMN name TO display_name;"}, stmts)
 }
@@ -2167,7 +2167,7 @@ func TestDiffColumns_renameColumn_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -2180,7 +2180,7 @@ func TestDiffConstraints_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME CONSTRAINT old_con TO new_con;"}, stmts)
 }
@@ -2193,7 +2193,7 @@ func TestDiffIndexes_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
 }
@@ -2206,7 +2206,7 @@ func TestDiffConstraints_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	stmts, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	stmts, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -2218,7 +2218,7 @@ func TestDiffConstraints_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	_, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	_, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source constraint")
 }
@@ -2231,7 +2231,7 @@ func TestDiffIndexes_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired, AllowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.Stmts)
 }
@@ -2243,7 +2243,7 @@ func TestDiffIndexes_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	_, err := diffIndexes(current, desired, AllowAllDrops{})
+	_, err := diffIndexes(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -2264,7 +2264,7 @@ func TestDiffForeignKeys_rename(t *testing.T) {
 		Table:      "orders",
 	})
 
-	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, dropStmts)
 	assert.Equal(t, []string{"ALTER TABLE public.orders RENAME CONSTRAINT old_fk TO new_fk;"}, addStmts)
@@ -2286,7 +2286,7 @@ func TestDiffForeignKeys_rename_alreadyApplied(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 }
 
@@ -2301,7 +2301,7 @@ func TestDiffForeignKeys_rename_sourceNotFound(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source foreign key")
 }
@@ -2315,7 +2315,7 @@ func TestDiffConstraints_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Constraint]()
 	desired.Set("new_con", &model.Constraint{Name: "new_con", RenameFrom: &oldName, Definition: "UNIQUE (code)"})
 
-	_, _, err := diffConstraints("public.users", current, desired, AllowAllDrops{})
+	_, _, err := diffConstraints("public.users", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -2329,7 +2329,7 @@ func TestDiffIndexes_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	_, err := diffIndexes(current, desired, AllowAllDrops{})
+	_, err := diffIndexes(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -2355,7 +2355,7 @@ func TestDiffForeignKeys_rename_destinationExists_error(t *testing.T) {
 		Table:      "orders",
 	})
 
-	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, AllowAllDrops{})
+	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -2370,7 +2370,7 @@ func TestDiffTables_renameTable_sourceNotFound(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("public.accounts", dt)
 
-	_, err := DiffTables(current, desired, AllowAllDrops{})
+	_, err := DiffTables(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }
@@ -2389,7 +2389,7 @@ func TestDiffTables_renameColumn_error_propagates(t *testing.T) {
 	dt.Columns.Set("new_col", &model.Column{Name: "new_col", RenameFrom: &oldName, TypeName: "text"})
 	desired.Set("public.users", dt)
 
-	_, err := DiffTables(current, desired, AllowAllDrops{})
+	_, err := DiffTables(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source column")
 }
@@ -2401,7 +2401,7 @@ func TestDiffColumns_renameColumn_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	_, _, err := diffColumns("public.users", current, desired, AllowAllDrops{})
+	_, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source column")
 }
@@ -2496,7 +2496,7 @@ func TestDiffColumns_addIdentity_fromNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY;",
@@ -2510,7 +2510,7 @@ func TestDiffColumns_addIdentity_fromNullable(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('d')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id SET NOT NULL;",
@@ -2528,7 +2528,7 @@ func TestDiffColumns_addIdentity_fromSerial(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id DROP DEFAULT;",
@@ -2543,7 +2543,7 @@ func TestDiffColumns_addIdentity_fromColumnWithDefault(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id DROP DEFAULT;",
@@ -2558,7 +2558,7 @@ func TestDiffColumns_dropIdentity_keepNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id DROP IDENTITY IF EXISTS;",
@@ -2572,7 +2572,7 @@ func TestDiffColumns_dropIdentity_toNullable(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id DROP IDENTITY IF EXISTS;",
@@ -2587,7 +2587,7 @@ func TestDiffColumns_changeIdentityKind_alwaysToByDefault(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('d')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id SET GENERATED BY DEFAULT;",
@@ -2601,7 +2601,7 @@ func TestDiffColumns_changeIdentityKind_byDefaultToAlways(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id SET GENERATED ALWAYS;",
@@ -2615,7 +2615,7 @@ func TestDiffColumns_identityUnchanged(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, AllowAllDrops{})
+	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }

--- a/diff/views.go
+++ b/diff/views.go
@@ -190,7 +190,7 @@ type ViewDiffResult struct {
 }
 
 func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChecker) (*ViewDiffResult, error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 	result := &ViewDiffResult{}
 
 	// Detect renames
@@ -338,7 +338,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 
 // diffViewIndexes generates DDL for index changes on materialized views.
 func diffViewIndexes(current, desired *model.View, dc DropChecker) (stmts []string, disallowed []string, hasConcurrently bool, err error) {
-	dc = NormalizeDropChecker(dc)
+	dc = normalizeDropChecker(dc)
 	currentIndexes := orderedmap.New[string, *model.Index]()
 	if current.Indexes != nil {
 		currentIndexes = current.Indexes

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -14,7 +14,7 @@ func TestDiffViews_newView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v1")
@@ -25,7 +25,7 @@ func TestDiffViews_dropView(t *testing.T) {
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 	desired := orderedmap.New[string, *model.View]()
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP VIEW public.v1;"}, result.DropStmts)
 }
@@ -35,7 +35,7 @@ func TestDiffViews_dropView_denied(t *testing.T) {
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 	desired := orderedmap.New[string, *model.View]()
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -48,7 +48,7 @@ func TestDiffViews_modifyView(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 2"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v1")
@@ -60,7 +60,7 @@ func TestDiffViews_noChange(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -72,7 +72,7 @@ func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -84,7 +84,7 @@ func TestDiffViews_commentAdd(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", Comment: ptr("my view")})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS 'my view';", result.CreateStmts[0])
@@ -96,7 +96,7 @@ func TestDiffViews_commentDrop(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Equal(t, "COMMENT ON VIEW public.v1 IS NULL;", result.CreateStmts[0])
@@ -110,7 +110,7 @@ func TestDiffViews_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER VIEW public.v1 RENAME TO v2;"}, result.CreateStmts)
 }
@@ -123,7 +123,7 @@ func TestDiffViews_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -137,7 +137,7 @@ func TestDiffViews_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.CreateStmts)
 	assert.Empty(t, result.DropStmts)
@@ -152,7 +152,7 @@ func TestDiffViews_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -165,7 +165,7 @@ func TestDiffViews_rename_crossSchema_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("other.v2", &model.View{Schema: "other", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
 }
@@ -177,7 +177,7 @@ func TestDiffViews_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.View]()
 	desired.Set("public.v2", &model.View{Schema: "public", Name: "v2", RenameFrom: &oldName, Definition: "SELECT 1"})
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }
@@ -281,7 +281,7 @@ func TestDiffViews_newMatview(t *testing.T) {
 		Indexes:    orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW public.mv")
@@ -301,7 +301,7 @@ func TestDiffViews_newMatviewWithIndex(t *testing.T) {
 	})
 	desired.Set("public.mv", mv)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	require.Len(t, result.CreateStmts, 2)
 	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW")
@@ -316,7 +316,7 @@ func TestDiffViews_dropMatview(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.View]()
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.DropStmts, 1)
 	assert.Contains(t, result.DropStmts[0], "DROP MATERIALIZED VIEW public.mv")
@@ -330,7 +330,7 @@ func TestDiffViews_dropMatview_denied(t *testing.T) {
 	})
 	desired := orderedmap.New[string, *model.View]()
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Equal(t, []string{"-- skipped: DROP MATERIALIZED VIEW public.mv;"}, result.DisallowedDropStmts)
@@ -348,7 +348,7 @@ func TestDiffViews_modifyMatview(t *testing.T) {
 		Definition: "SELECT 2 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	// Materialized views must be dropped and recreated
 	assert.Len(t, result.DropStmts, 1)
@@ -372,7 +372,7 @@ func TestDiffViews_modifyMatview_preservesComment(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	// DROP+CREATE loses the comment, so it must be re-applied
 	assert.Len(t, result.DropStmts, 1)
@@ -393,7 +393,7 @@ func TestDiffViews_modifyMatview_dropDenied(t *testing.T) {
 		Definition: "SELECT 2 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	// Drop denied: no executable DROP or CREATE; the suppressed recreation
 	// is surfaced as a skipped comment so users can see what was blocked.
@@ -423,7 +423,7 @@ func TestDiffViews_modifyMatview_dropDenied_withCommentChange(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Empty(t, result.CreateStmts, "no executable DDL when recreation is denied, even if comment differs")
@@ -447,7 +447,7 @@ func TestDiffViews_matviewIndexAdd(t *testing.T) {
 	})
 	desired.Set("public.mv", mv)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Len(t, result.CreateStmts, 1)
@@ -471,7 +471,7 @@ func TestDiffViews_matviewIndexDrop(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Len(t, result.CreateStmts, 1)
@@ -499,7 +499,7 @@ func TestDiffViews_matviewIndexAdd_concurrently_parseError(t *testing.T) {
 	})
 	desired.Set("public.mv", mv)
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create index")
 }
@@ -523,7 +523,7 @@ func TestDiffViews_matviewIndexDrop_denied(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Empty(t, result.CreateStmts)
@@ -543,7 +543,7 @@ func TestDiffViews_matviewCommentAdd(t *testing.T) {
 		Definition: "SELECT 1", Comment: &comment, Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "COMMENT ON MATERIALIZED VIEW")
@@ -562,7 +562,7 @@ func TestDiffViews_matviewCommentDrop(t *testing.T) {
 		Definition: "SELECT 1", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 1)
 	assert.Contains(t, result.CreateStmts[0], "COMMENT ON MATERIALIZED VIEW public.mv IS NULL")
@@ -591,7 +591,7 @@ func TestDiffViews_matviewIndexChange(t *testing.T) {
 	})
 	desired.Set("public.mv", mvDesired)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	require.Len(t, result.CreateStmts, 2)
@@ -611,7 +611,7 @@ func TestDiffViews_matviewNoChange(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	assert.Empty(t, result.CreateStmts)
@@ -631,7 +631,7 @@ func TestDiffViews_renameMatview(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, result.DropStmts)
 	require.Len(t, result.CreateStmts, 1)
@@ -651,7 +651,7 @@ func TestDiffViews_viewToMatview(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	require.Len(t, result.DropStmts, 1)
 	assert.Contains(t, result.DropStmts[0], "DROP VIEW public.v")
@@ -671,7 +671,7 @@ func TestDiffViews_matviewToView(t *testing.T) {
 		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	require.Len(t, result.DropStmts, 1)
 	assert.Contains(t, result.DropStmts[0], "DROP MATERIALIZED VIEW public.v")
@@ -693,7 +693,7 @@ func TestDiffViews_viewToMatview_dropDenied(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	result, err := DiffViews(current, desired, DenyAllDrops{})
+	result, err := DiffViews(current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	// Type change denied: no executable DROP/CREATE/comment change; the
 	// suppressed recreation is surfaced as a skipped comment.
@@ -716,7 +716,7 @@ func TestDiffViews_renameTypeMismatch(t *testing.T) {
 		Indexes: orderedmap.New[string, *model.Index](),
 	})
 
-	_, err := DiffViews(current, desired, AllowAllDrops{})
+	_, err := DiffViews(current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "view type mismatch")
 }
@@ -736,7 +736,7 @@ func TestDiffViews_newMatviewWithIndex_perIndexDirective(t *testing.T) {
 	})
 	desired.Set("public.mv", mv)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	require.Len(t, result.CreateStmts, 2)
 	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW")
@@ -767,7 +767,7 @@ func TestDiffViews_matviewIndexChange_perIndexDirective(t *testing.T) {
 	})
 	desired.Set("public.mv", mvDesired)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	require.Len(t, result.CreateStmts, 2)
 	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_mv_n;", result.CreateStmts[0])
@@ -796,7 +796,7 @@ func TestDiffViews_matviewIndexAdd_perIndexDirective(t *testing.T) {
 	})
 	desired.Set("public.mv", mv)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.CreateStmts, 2)
 	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_mv_n ON public.mv USING btree (n);", result.CreateStmts[0])
@@ -821,7 +821,7 @@ func TestDiffViews_modifyMatviewWithIndex_perIndexDirective(t *testing.T) {
 	})
 	desired.Set("public.mv", mv)
 
-	result, err := DiffViews(current, desired, AllowAllDrops{})
+	result, err := DiffViews(current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, result.DropStmts, 1)
 	require.Len(t, result.CreateStmts, 2)

--- a/internal/pgast/pgast.go
+++ b/internal/pgast/pgast.go
@@ -10,10 +10,10 @@ import (
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 )
 
-// ConstraintWrapPrefix is the wrapper used to parse a constraint definition
+// constraintWrapPrefix is the wrapper used to parse a constraint definition
 // fragment (e.g. "PRIMARY KEY (id)") as part of a full statement so that
 // pg_query produces a Constraint node we can inspect or mutate.
-const ConstraintWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
+const constraintWrapPrefix = "ALTER TABLE _t ADD CONSTRAINT _c "
 
 // ParseConstraintDef parses a constraint definition fragment and returns
 // the underlying *pg_query.Constraint. Returns nil for unparseable or
@@ -30,7 +30,7 @@ func ParseConstraintDef(def string) *pg_query.Constraint {
 // full ParseResult and a typed error, so callers that need to mutate the
 // AST and deparse it back can distinguish failure modes.
 func ParseConstraintDefStrict(def string) (*pg_query.ParseResult, *pg_query.Constraint, error) {
-	result, err := pg_query.Parse(ConstraintWrapPrefix + def)
+	result, err := pg_query.Parse(constraintWrapPrefix + def)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse constraint definition: %w", err)
 	}
@@ -61,10 +61,10 @@ func DeparseConstraintDef(result *pg_query.ParseResult) (string, error) {
 		return "", fmt.Errorf("failed to deparse constraint definition: %w", err)
 	}
 	deparsed = strings.TrimSuffix(deparsed, ";")
-	if !strings.HasPrefix(deparsed, ConstraintWrapPrefix) {
+	if !strings.HasPrefix(deparsed, constraintWrapPrefix) {
 		return "", fmt.Errorf("unexpected deparsed form: %s", deparsed)
 	}
-	return strings.TrimPrefix(deparsed, ConstraintWrapPrefix), nil
+	return strings.TrimPrefix(deparsed, constraintWrapPrefix), nil
 }
 
 // WalkExprColumnRefs walks an expression tree and invokes visit for each

--- a/toposort/deps.go
+++ b/toposort/deps.go
@@ -8,17 +8,17 @@ import (
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 )
 
-// StmtInfo holds a parsed statement and its extracted metadata.
-type StmtInfo struct {
+// stmtInfo holds a parsed statement and its extracted metadata.
+type stmtInfo struct {
 	Name string   // Fully qualified object name (e.g. "public.users")
 	SQL  string   // Deparsed SQL statement
 	Deps []string // Names of objects this statement depends on
 }
 
-// ExtractDeps parses SQL containing multiple CREATE statements and returns
+// extractDeps parses SQL containing multiple CREATE statements and returns
 // dependency information for each object. It uses defaultSchema to qualify
 // unqualified identifiers.
-func ExtractDeps(sql string, defaultSchema ...string) ([]*StmtInfo, error) {
+func extractDeps(sql string, defaultSchema ...string) ([]*stmtInfo, error) {
 	schema := "public"
 	if len(defaultSchema) > 0 && defaultSchema[0] != "" {
 		schema = defaultSchema[0]
@@ -37,7 +37,7 @@ func ExtractDeps(sql string, defaultSchema ...string) ([]*StmtInfo, error) {
 		}
 	}
 
-	var stmts []*StmtInfo
+	var stmts []*stmtInfo
 	for _, rawStmt := range result.Stmts {
 		name := objectName(rawStmt, schema)
 		if name == "" {
@@ -53,7 +53,7 @@ func ExtractDeps(sql string, defaultSchema ...string) ([]*StmtInfo, error) {
 
 		deps := extractStmtDeps(rawStmt, schema, defined)
 
-		stmts = append(stmts, &StmtInfo{
+		stmts = append(stmts, &stmtInfo{
 			Name: name,
 			SQL:  deparsed,
 			Deps: deps,

--- a/toposort/export_test.go
+++ b/toposort/export_test.go
@@ -1,0 +1,9 @@
+package toposort
+
+// NewGraph, ExtractDeps, and SortSQL are exposed only to tests; the production
+// entry point is OrderFromSchema, which uses the unexported newGraph internally.
+var (
+	NewGraph    = newGraph
+	ExtractDeps = extractDeps
+	SortSQL     = sortSQL
+)

--- a/toposort/graph.go
+++ b/toposort/graph.go
@@ -5,28 +5,28 @@ import (
 	"sort"
 )
 
-// Graph is a directed acyclic graph for topological sorting.
-type Graph struct {
+// graph is a directed acyclic graph for topological sorting.
+type graph struct {
 	nodes map[string]bool
 	edges map[string][]string // from → [to ...] meaning "from depends on to"
 }
 
-// NewGraph creates a new empty graph.
-func NewGraph() *Graph {
-	return &Graph{
+// newGraph creates a new empty graph.
+func newGraph() *graph {
+	return &graph{
 		nodes: make(map[string]bool),
 		edges: make(map[string][]string),
 	}
 }
 
 // AddNode adds a node to the graph.
-func (g *Graph) AddNode(name string) {
+func (g *graph) AddNode(name string) {
 	g.nodes[name] = true
 }
 
 // AddEdge adds a dependency edge: "from" depends on "to".
 // Both nodes are implicitly added.
-func (g *Graph) AddEdge(from, to string) {
+func (g *graph) AddEdge(from, to string) {
 	g.nodes[from] = true
 	g.nodes[to] = true
 	g.edges[from] = append(g.edges[from], to)
@@ -36,7 +36,7 @@ func (g *Graph) AddEdge(from, to string) {
 // Returns nodes in dependency order (dependencies first).
 // Returns an error if a cycle is detected.
 // Nodes with no dependency ordering are sorted alphabetically for stability.
-func (g *Graph) Sort() ([]string, error) {
+func (g *graph) Sort() ([]string, error) {
 	// Build in-degree map and reverse adjacency list
 	inDegree := make(map[string]int)
 	dependents := make(map[string][]string) // to → [from ...] (who depends on to)

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -18,7 +18,7 @@ func OrderFromSchema(
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
 ) ([]string, error) {
-	g := NewGraph()
+	g := newGraph()
 	defined := collectDefined(enums, domains, tables, views)
 
 	// Enums: no dependencies (leaf nodes)

--- a/toposort/sort.go
+++ b/toposort/sort.go
@@ -2,12 +2,12 @@ package toposort
 
 import "fmt"
 
-// SortSQL parses SQL containing multiple CREATE statements and returns
+// sortSQL parses SQL containing multiple CREATE statements and returns
 // the individual statements sorted in dependency order (dependencies first).
 // An optional defaultSchema can be provided to qualify unqualified identifiers
 // (defaults to "public").
-func SortSQL(sql string, defaultSchema ...string) ([]string, error) {
-	stmts, err := ExtractDeps(sql, defaultSchema...)
+func sortSQL(sql string, defaultSchema ...string) ([]string, error) {
+	stmts, err := extractDeps(sql, defaultSchema...)
 	if err != nil {
 		return nil, err
 	}
@@ -16,8 +16,8 @@ func SortSQL(sql string, defaultSchema ...string) ([]string, error) {
 		return nil, nil
 	}
 
-	g := NewGraph()
-	stmtByName := make(map[string]*StmtInfo, len(stmts))
+	g := newGraph()
+	stmtByName := make(map[string]*stmtInfo, len(stmts))
 
 	for _, s := range stmts {
 		g.AddNode(s.Name)


### PR DESCRIPTION
## Summary
Continue trimming the public surface of internal-only Go packages. Identifiers that were exported but only ever used inside their declaring package are now lowercase.

### `toposort`
The only production caller is `toposort.OrderFromSchema` (used from `diff_all.go`); the rest were reachable from outside only via tests.
- `Graph` (type) → `graph`
- `NewGraph` → `newGraph`
- `StmtInfo` (type) → `stmtInfo`
- `ExtractDeps` → `extractDeps`
- `SortSQL` → `sortSQL`

Methods on `*graph` (`AddNode`, `AddEdge`, `Sort`) and the `StmtInfo` fields (`Name`, `SQL`, `Deps`) stay capitalized so external tests can keep using inferred-typed values. Function aliases live in `toposort/export_test.go`.

### `diff`
The `DropChecker` interface stays exported because `diff_all.go` passes its own implementation through it. The concrete checkers and the helper were only ever used by tests / inside the package:
- `AllowAllDrops` (type) → `allowAllDrops`
- `DenyAllDrops` (type) → `denyAllDrops`
- `NormalizeDropChecker` → `normalizeDropChecker`

Type aliases for the two `DropChecker` implementations live in `diff/export_test.go` so external `diff_test` tests keep compiling.

### `internal/pgast`
- `ConstraintWrapPrefix` → `constraintWrapPrefix` (only referenced inside `pgast.go` itself).

## Test plan
- [x] make build
- [x] make vet
- [x] make lint (0 issues)
- [x] go test ./toposort/... ./diff/... ./internal/pgast/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)