### PR TITLE
Document Sequences as reserved for future use

### DIFF
--- a/catalog/sequences.go
+++ b/catalog/sequences.go
@@ -9,6 +9,11 @@ import (
 )
 
 // Sequences returns all sequences in the filtered schemas.
+//
+// Currently this method has no production callers — sequences are not yet
+// consumed by the diff/apply pipeline. It is intentionally kept as the
+// foundation for future sequence-aware schema management; do not delete
+// it as dead code.
 func (c *Catalog) Sequences(ctx context.Context) ([]model.Sequence, error) {
 	q := `
 		WITH

--- a/model/sequence.go
+++ b/model/sequence.go
@@ -2,6 +2,10 @@ package model
 
 import "fmt"
 
+// Sequence holds metadata for a PostgreSQL sequence. It is currently
+// populated only by catalog.Catalog.Sequences and not yet consumed by the
+// diff/apply pipeline; it is intentionally kept for future sequence-aware
+// schema management and should not be deleted as dead code.
 type Sequence struct {
 	OID         uint32
 	Schema      string


### PR DESCRIPTION
## Summary
`catalog.Catalog.Sequences` and `model.Sequence` are fully implemented on the catalog-read side but are not yet wired into the diff/apply pipeline. A naive call-graph audit would flag both as dead code.

Add short godoc comments on each so future readers (and reviewers running unexport / dead-code sweeps) know the absence of production callers is intentional and that these are kept as the foundation for future sequence-aware schema management.

No behavioral changes.

## Test plan
- [x] make build
- [x] make vet
- [x] make lint (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)