### PR TITLE
Remove unused parser.normalizeDirectiveValue

### DIFF
--- a/parser/directive.go
+++ b/parser/directive.go
@@ -143,18 +143,6 @@ func unquoteIdent(s string) string {
 	return strings.ToLower(s)
 }
 
-// normalizeDirectiveValue normalizes a renamed-from directive value by
-// unquoting each part and re-quoting via model.Ident to match the
-// canonical identifier format used by the parser and diff layer.
-// Used for schema-qualified names (tables, views, enums).
-func normalizeDirectiveValue(s string) string {
-	parts := splitQualifiedName(s)
-	for i, p := range parts {
-		parts[i] = unquoteIdent(p)
-	}
-	return model.Ident(parts...)
-}
-
 // normalizeUnqualifiedDirective normalizes a renamed-from directive value
 // for unqualified names (columns, constraints, indexes, foreign keys)
 // by unquoting the identifier. If a schema-qualified name is provided

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -189,15 +189,6 @@ func TestSplitQualifiedName_SpacesAroundDot(t *testing.T) {
 	assert.Equal(t, []string{"public", "old_table"}, parts)
 }
 
-func TestNormalizeDirectiveValue(t *testing.T) {
-	assert.Equal(t, "public.old_name", normalizeDirectiveValue("public.old_name"))
-	assert.Equal(t, `"Old Name"`, normalizeDirectiveValue(`"Old Name"`))
-	assert.Equal(t, `"My Schema"."Old Name"`, normalizeDirectiveValue(`"My Schema"."Old Name"`))
-	assert.Equal(t, `public."Old Name"`, normalizeDirectiveValue(`public."Old Name"`))
-	assert.Equal(t, `"has""quote"`, normalizeDirectiveValue(`"has""quote"`))
-	assert.Equal(t, "simple", normalizeDirectiveValue("simple"))
-}
-
 func TestNormalizeUnqualifiedDirective(t *testing.T) {
 	assert.Equal(t, "old_name", normalizeUnqualifiedDirective("old_name"))
 	assert.Equal(t, "Old Name", normalizeUnqualifiedDirective(`"Old Name"`))


### PR DESCRIPTION
## Summary
`normalizeDirectiveValue` had no production callers; the only references were inside `TestNormalizeDirectiveValue`, which exists solely to exercise the function itself. Its sibling `normalizeUnqualifiedDirective` is the one actually used by the parser to normalize rename directives at all real call sites.

Drop both the function and its dedicated test.

## Test plan
- [x] make build
- [x] make vet
- [x] make lint (0 issues)
- [x] go test ./parser/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)