### PR TITLE
Move allowAllDrops into diff/export_test.go

### DIFF
--- a/diff/drop_policy.go
+++ b/diff/drop_policy.go
@@ -5,11 +5,6 @@ type DropChecker interface {
 	IsDropAllowed(objectType string) bool
 }
 
-// allowAllDrops is a DropChecker that allows all drops.
-type allowAllDrops struct{}
-
-func (allowAllDrops) IsDropAllowed(string) bool { return true }
-
 // denyAllDrops is a DropChecker that denies all drops.
 type denyAllDrops struct{}
 

--- a/diff/export_test.go
+++ b/diff/export_test.go
@@ -1,7 +1,14 @@
 package diff
 
-// AllowAllDrops and DenyAllDrops are exposed only to tests; production callers
-// pass a *cmd.DropPolicy as the DropChecker.
+// allowAllDrops is a DropChecker that permits every drop. It is a fixture used
+// only by tests; production callers either pass a *cmd.DropPolicy or rely on
+// normalizeDropChecker's default of denyAllDrops.
+type allowAllDrops struct{}
+
+func (allowAllDrops) IsDropAllowed(string) bool { return true }
+
+// AllowAllDrops and DenyAllDrops are exposed to external test packages
+// (package diff_test) via type aliases.
 type (
 	AllowAllDrops = allowAllDrops
 	DenyAllDrops  = denyAllDrops


### PR DESCRIPTION
## Summary
`allowAllDrops` is a `DropChecker` fixture used only by tests — production code relies on `normalizeDropChecker`'s default (`denyAllDrops`) or a caller-provided `*cmd.DropPolicy`. Keeping its definition in the production-compiled `drop_policy.go` meant `deadcode -test=false ./cmd/pist` correctly flagged `allowAllDrops.IsDropAllowed` as unreachable.

Move the type and its method into `diff/export_test.go` (compiled only under the test build tag) alongside the existing `AllowAllDrops` type alias for external `package diff_test` consumers. `denyAllDrops` stays in `drop_policy.go` because `normalizeDropChecker` constructs it on the production path.

After this change, `deadcode -test=false ./cmd/pist` only reports the intentionally-retained `Catalog.Sequences` / `Sequence.String` (documented for future use in #165).

## Test plan
- [x] make build
- [x] make vet
- [x] make lint (0 issues)
- [x] go test ./diff/...
- [x] `deadcode -test=false ./cmd/pist` — `allowAllDrops.IsDropAllowed` no longer reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)