### PR TITLE
Add Northwind, Employees, and AdventureWorks to sample schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ schema: clean-schema
 	$(MAKE) sample-db SQL_FILE=titanic.sql
 	$(MAKE) sample-db-tar TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/world/world-1.0/world-1.0.tar.gz TAR_SQL_PATH=dbsamples-0.1/world/world.sql
 	$(MAKE) sample-db-tar TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/usda/usda-r18-1.0/usda-r18-1.0.tar.gz TAR_SQL_PATH=usda-r18-1.0/usda.sql
+	$(MAKE) sample-db-url URL=https://raw.githubusercontent.com/pthom/northwind_psql/master/northwind.sql
+	$(MAKE) sample-db-url URL=https://raw.githubusercontent.com/h8/employees-database/master/employees_schema.sql
+	$(MAKE) sample-db-adventureworks
 
 .PHONY: sample-db
 sample-db:
@@ -48,13 +51,26 @@ sample-db:
 sample-db-tar:
 	curl -sSfL $(TAR_URL) | tar xzO $(TAR_SQL_PATH) | psql
 
+.PHONY: sample-db-url
+sample-db-url:
+	curl -sSfL $(URL) | psql
+
+# AdventureWorks (lorint/AdventureWorks-for-Postgres, MIT). Schema-only load:
+# strip \copy lines (data lives in CSVs we don't fetch) and the inline
+# Production.ProductReview INSERT (FK target rows aren't loaded).
+.PHONY: sample-db-adventureworks
+sample-db-adventureworks:
+	curl -sSf https://raw.githubusercontent.com/lorint/AdventureWorks-for-Postgres/master/install.sql \
+	  | awk '/^\\copy/ { next } /^INSERT INTO Production.ProductReview/ { skip=1 } skip { if (/\);[[:space:]]*$$/) skip=0; next } { print }' \
+	  | psql
+
 .PHONY: test-scenario
 test-scenario:
 	bash test/scenario/run.sh
 
 .PHONY: clean-schema
 clean-schema:
-	psql -c 'DROP SCHEMA public CASCADE ; CREATE SCHEMA public'
+	psql -c 'DROP SCHEMA IF EXISTS person, humanresources, production, purchasing, sales, employees CASCADE ; DROP SCHEMA public CASCADE ; CREATE SCHEMA public'
 
 .PHONY: demo
 demo: clean-schema


### PR DESCRIPTION
## Summary

Adds three more PostgreSQL sample databases to \`make schema\` to broaden the surface area for \`pist dump\` / \`pist plan\` testing against realistic schemas.

| Sample | Source | License | Notable shape |
|---|---|---|---|
| Northwind | [pthom/northwind_psql](https://github.com/pthom/northwind_psql) | Ms-PL | Single-schema, classic OLTP, 14 tables |
| Employees | [h8/employees-database](https://github.com/h8/employees-database) | CC BY-SA 3.0 | Dedicated \`employees\` schema with ENUM type, 6 tables |
| AdventureWorks | [lorint/AdventureWorks-for-Postgres](https://github.com/lorint/AdventureWorks-for-Postgres) | MIT | 5 schemas, 68 tables, 21 views, 6 cross-schema DOMAIN references |

A generic \`sample-db-url\` target reuses the existing \`curl \| psql\` pattern for any single-file SQL source.

AdventureWorks needs a small awk filter to drop \`\copy\` directives (CSV data isn't fetched in this schema-only flow) and the inline \`Production.ProductReview\` INSERT (its FK target rows aren't loaded). \`clean-schema\` now also drops the new schemas so re-runs are idempotent.

Source files are downloaded by users on demand via \`make schema\`; nothing is redistributed in this repo.

## Test plan

- [ ] \`make clean-schema && make sample-db-url URL=...northwind.sql\` loads 14 public tables
- [ ] \`make clean-schema && make sample-db-url URL=...employees_schema.sql\` loads \`employees\` schema (6 tables + 1 enum)
- [ ] \`make clean-schema && make sample-db-adventureworks\` loads 5 AW schemas (68 tables + 21 views + 6 domains)
- [ ] \`make schema\` runs end-to-end with all 12 samples, then re-runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)