### PR TITLE
Make pipelined recipes fail-fast and align curl flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 export PGHOST := localhost
 export PGUSER := postgres
 
+# Ensure failures in any stage of a piped recipe (e.g. curl | awk | psql)
+# fail the target. Default /bin/sh on most systems lacks pipefail, so a
+# failing curl can be masked by a successful psql. -o pipefail must be
+# on SHELL itself (not .SHELLFLAGS) so make passes it as a separate arg.
+SHELL := /bin/bash -o pipefail
+.SHELLFLAGS := -c
+
 .PHONY: all
 all: vet test build
 
@@ -60,7 +67,7 @@ sample-db-url:
 # Production.ProductReview INSERT (FK target rows aren't loaded).
 .PHONY: sample-db-adventureworks
 sample-db-adventureworks:
-	curl -sSf https://raw.githubusercontent.com/lorint/AdventureWorks-for-Postgres/master/install.sql \
+	curl -sSfL https://raw.githubusercontent.com/lorint/AdventureWorks-for-Postgres/master/install.sql \
 	  | awk '/^\\copy/ { next } /^INSERT INTO Production.ProductReview/ { skip=1 } skip { if (/\);[[:space:]]*$$/) skip=0; next } { print }' \
 	  | psql
 


### PR DESCRIPTION
## Summary

Follow-ups from the Copilot review on #171:

- **pipefail**: Without \`-o pipefail\`, recipes like \`curl | awk | psql\` only observe \`psql\`'s exit code, so a failing \`curl\` (e.g. 404) is silently masked. Set \`SHELL\` to \`bash -o pipefail\` so multi-stage pipelines fail the target. \`-o pipefail\` has to live on \`SHELL\` itself rather than in \`.SHELLFLAGS\` because make passes \`.SHELLFLAGS\` as a single argv element, which bash rejects when it contains a space-separated option.
- **curl -L**: Add \`-L\` to the AdventureWorks invocation for consistency with the other download targets (\`sample-db-tar\` / \`sample-db-url\`).

Three other Copilot suggestions (URL quoting, \`ON_ERROR_STOP=1\`, pinning to commit SHAs) were intentionally skipped — applying them only to the new targets would be inconsistent with the existing \`sample-db\` / \`sample-db-tar\` recipes, and applying them everywhere is a wider refactor outside this scope.

## Test plan

- [x] \`make sample-db-url URL=https://raw.githubusercontent.com/winebarrel/this-does-not-exist/main/x.sql\` now exits with \`make: *** [sample-db-url] Error 56\` (previously silently exited 0).
- [x] \`make sample-db-adventureworks\` (curl + awk + psql three-stage pipeline) still loads 68 tables successfully.
- [x] \`make sample-db SQL_FILE=titanic.sql\` (single-stage download) still loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)