### PR TITLE
Fix timestamp/time typmod placement in deparsed SQL

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1173,11 +1173,18 @@ func formatTimeTypeName(tn *pg_query.TypeName) (string, bool) {
 	if len(tn.Names) == 0 || len(tn.Names) > 2 {
 		return "", false
 	}
-	if len(tn.Names) == 2 && tn.Names[0].GetString_().GetSval() != "pg_catalog" {
+	if len(tn.Names) == 2 {
+		q := tn.Names[0].GetString_()
+		if q == nil || q.GetSval() != "pg_catalog" {
+			return "", false
+		}
+	}
+	last := tn.Names[len(tn.Names)-1].GetString_()
+	if last == nil {
 		return "", false
 	}
 	var bare, zone string
-	switch tn.Names[len(tn.Names)-1].GetString_().GetSval() {
+	switch last.GetSval() {
 	case "timestamp":
 		bare, zone = "timestamp", "without time zone"
 	case "timestamptz":
@@ -1191,7 +1198,11 @@ func formatTimeTypeName(tn *pg_query.TypeName) (string, bool) {
 	}
 	prec := ""
 	if len(tn.Typmods) > 0 {
-		ival := tn.Typmods[0].GetAConst().GetIval()
+		c := tn.Typmods[0].GetAConst()
+		if c == nil {
+			return "", false
+		}
+		ival := c.GetIval()
 		if ival == nil {
 			return "", false
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1191,13 +1191,28 @@ func formatTimeTypeName(tn *pg_query.TypeName) (string, bool) {
 	}
 	prec := ""
 	if len(tn.Typmods) > 0 {
-		c := tn.Typmods[0].GetAConst()
-		if c == nil {
+		ival := tn.Typmods[0].GetAConst().GetIval()
+		if ival == nil {
 			return "", false
 		}
-		prec = fmt.Sprintf("(%d)", c.GetIval().GetIval())
+		prec = fmt.Sprintf("(%d)", ival.GetIval())
 	}
-	return bare + prec + " " + zone + strings.Repeat("[]", len(tn.ArrayBounds)), true
+	var arr strings.Builder
+	for _, b := range tn.ArrayBounds {
+		// pg_query encodes "[]" as Ival=-1; positive values are explicit
+		// array bounds like "[3]". Anything else (e.g. a non-Integer node)
+		// means we don't know how to format it — fall back to deparse.
+		i := b.GetInteger()
+		if i == nil {
+			return "", false
+		}
+		if i.GetIval() < 0 {
+			arr.WriteString("[]")
+		} else {
+			fmt.Fprintf(&arr, "[%d]", i.GetIval())
+		}
+	}
+	return bare + prec + " " + zone + arr.String(), true
 }
 
 var typeAliases = map[string]string{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1126,6 +1126,13 @@ func parseInlineForeignKey(con *pg_query.Constraint, schema, table, defaultSchem
 // Deparse helpers
 
 func deparseTypeName(tn *pg_query.TypeName) (string, error) {
+	// pg_query's deparse places typmod after "with/without time zone" for
+	// timestamp/time variants, producing invalid SQL like
+	// "timestamp without time zone(6)". Format these four types directly
+	// from the AST so the precision lands in the right spot.
+	if s, ok := formatTimeTypeName(tn); ok {
+		return s, nil
+	}
 	result := &pg_query.ParseResult{
 		Stmts: []*pg_query.RawStmt{{
 			Stmt: &pg_query.Node{
@@ -1160,6 +1167,37 @@ func deparseTypeName(tn *pg_query.TypeName) (string, error) {
 	// Strip the prefix so the result matches format_type() output.
 	typeName = strings.TrimPrefix(typeName, "pg_catalog.")
 	return normalizeTypeName(typeName), nil
+}
+
+func formatTimeTypeName(tn *pg_query.TypeName) (string, bool) {
+	if len(tn.Names) == 0 || len(tn.Names) > 2 {
+		return "", false
+	}
+	if len(tn.Names) == 2 && tn.Names[0].GetString_().GetSval() != "pg_catalog" {
+		return "", false
+	}
+	var bare, zone string
+	switch tn.Names[len(tn.Names)-1].GetString_().GetSval() {
+	case "timestamp":
+		bare, zone = "timestamp", "without time zone"
+	case "timestamptz":
+		bare, zone = "timestamp", "with time zone"
+	case "time":
+		bare, zone = "time", "without time zone"
+	case "timetz":
+		bare, zone = "time", "with time zone"
+	default:
+		return "", false
+	}
+	prec := ""
+	if len(tn.Typmods) > 0 {
+		c := tn.Typmods[0].GetAConst()
+		if c == nil {
+			return "", false
+		}
+		prec = fmt.Sprintf("(%d)", c.GetIval().GetIval())
+	}
+	return bare + prec + " " + zone + strings.Repeat("[]", len(tn.ArrayBounds)), true
 }
 
 var typeAliases = map[string]string{

--- a/testdata/parser/timestamp_precision.yml
+++ b/testdata/parser/timestamp_precision.yml
@@ -17,7 +17,10 @@ input: |
       tstz_arr timestamptz(3)[] NOT NULL,
       t_arr time(2)[] NOT NULL,
       ttz_arr timetz[] NOT NULL,
-      ts_arr_explicit timestamp(1) without time zone[] NOT NULL
+      ts_arr_explicit timestamp(1) without time zone[] NOT NULL,
+      ts_arr_bounded timestamp(6)[3] NOT NULL,
+      tstz_arr_bounded timestamptz(3)[3][5] NOT NULL,
+      ttz_arr_bounded timetz[7] NOT NULL
   );
 expected: |
   -- public.records
@@ -39,5 +42,8 @@ expected: |
       tstz_arr timestamp(3) with time zone[] NOT NULL,
       t_arr time(2) without time zone[] NOT NULL,
       ttz_arr time with time zone[] NOT NULL,
-      ts_arr_explicit timestamp(1) without time zone[] NOT NULL
+      ts_arr_explicit timestamp(1) without time zone[] NOT NULL,
+      ts_arr_bounded timestamp(6) without time zone[3] NOT NULL,
+      tstz_arr_bounded timestamp(3) with time zone[3][5] NOT NULL,
+      ttz_arr_bounded time with time zone[7] NOT NULL
   );

--- a/testdata/parser/timestamp_precision.yml
+++ b/testdata/parser/timestamp_precision.yml
@@ -1,0 +1,43 @@
+input: |
+  CREATE TABLE public.records (
+      id integer NOT NULL,
+      ts_default timestamp(6) without time zone DEFAULT now() NOT NULL,
+      ts_short timestamp(3) NOT NULL,
+      tstz_long timestamp(2) with time zone NOT NULL,
+      tstz_short timestamptz(1) NOT NULL,
+      t_default time(4) without time zone NOT NULL,
+      t_short time(3) NOT NULL,
+      ttz_long time(0) with time zone NOT NULL,
+      ttz_short timetz(5) NOT NULL,
+      ts_bare timestamp NOT NULL,
+      tstz_bare timestamptz NOT NULL,
+      t_bare time NOT NULL,
+      ttz_bare timetz NOT NULL,
+      ts_arr timestamp(6)[] NOT NULL,
+      tstz_arr timestamptz(3)[] NOT NULL,
+      t_arr time(2)[] NOT NULL,
+      ttz_arr timetz[] NOT NULL,
+      ts_arr_explicit timestamp(1) without time zone[] NOT NULL
+  );
+expected: |
+  -- public.records
+  CREATE TABLE public.records (
+      id integer NOT NULL,
+      ts_default timestamp(6) without time zone DEFAULT now() NOT NULL,
+      ts_short timestamp(3) without time zone NOT NULL,
+      tstz_long timestamp(2) with time zone NOT NULL,
+      tstz_short timestamp(1) with time zone NOT NULL,
+      t_default time(4) without time zone NOT NULL,
+      t_short time(3) without time zone NOT NULL,
+      ttz_long time(0) with time zone NOT NULL,
+      ttz_short time(5) with time zone NOT NULL,
+      ts_bare timestamp without time zone NOT NULL,
+      tstz_bare timestamp with time zone NOT NULL,
+      t_bare time without time zone NOT NULL,
+      ttz_bare time with time zone NOT NULL,
+      ts_arr timestamp(6) without time zone[] NOT NULL,
+      tstz_arr timestamp(3) with time zone[] NOT NULL,
+      t_arr time(2) without time zone[] NOT NULL,
+      ttz_arr time with time zone[] NOT NULL,
+      ts_arr_explicit timestamp(1) without time zone[] NOT NULL
+  );

--- a/testdata/plan/alter_column_type_timestamp_precision.yml
+++ b/testdata/plan/alter_column_type_timestamp_precision.yml
@@ -1,0 +1,12 @@
+init: |
+  CREATE TABLE public.records (
+      id integer NOT NULL,
+      at timestamp without time zone NOT NULL
+  );
+desired: |
+  CREATE TABLE public.records (
+      id integer NOT NULL,
+      at timestamp(6) with time zone NOT NULL
+  );
+plan: |
+  ALTER TABLE public.records ALTER COLUMN at SET DATA TYPE timestamp(6) with time zone;

--- a/testdata/plan/no_diff_domain_timestamp_precision.yml
+++ b/testdata/plan/no_diff_domain_timestamp_precision.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE DOMAIN public.precise_ts AS timestamp(6) without time zone;
+  CREATE DOMAIN public.precise_ttz AS time(3) with time zone;
+desired: |
+  CREATE DOMAIN public.precise_ts AS timestamp(6) without time zone;
+  CREATE DOMAIN public.precise_ttz AS timetz(3);
+plan: ""

--- a/testdata/plan/no_diff_timestamp_precision.yml
+++ b/testdata/plan/no_diff_timestamp_precision.yml
@@ -1,0 +1,29 @@
+init: |
+  CREATE TABLE public.records (
+      id integer NOT NULL,
+      ts6 timestamp(6) without time zone NOT NULL,
+      ts3 timestamp(3) with time zone NOT NULL,
+      ts_bare timestamp NOT NULL,
+      tstz_bare timestamp with time zone NOT NULL,
+      t2 time(2) without time zone NOT NULL,
+      t0 time(0) with time zone NOT NULL,
+      t_bare time NOT NULL,
+      ttz_bare time with time zone NOT NULL,
+      ts_arr timestamp(6) without time zone[] NOT NULL,
+      ttz_arr time(3) with time zone[] NOT NULL
+  );
+desired: |
+  CREATE TABLE public.records (
+      id integer NOT NULL,
+      ts6 timestamp(6) without time zone NOT NULL,
+      ts3 timestamptz(3) NOT NULL,
+      ts_bare timestamp NOT NULL,
+      tstz_bare timestamptz NOT NULL,
+      t2 time(2) without time zone NOT NULL,
+      t0 timetz(0) NOT NULL,
+      t_bare time NOT NULL,
+      ttz_bare timetz NOT NULL,
+      ts_arr timestamp(6) without time zone[] NOT NULL,
+      ttz_arr timetz(3)[] NOT NULL
+  );
+plan: ""


### PR DESCRIPTION
## Summary
- `deparseTypeName` short-circuits the four time-zone-aware types (`timestamp`, `timestamptz`, `time`, `timetz`) and builds the canonical form directly from the `TypeName` AST (Names / Typmods / ArrayBounds), instead of round-tripping through `pg_query.Deparse` which misplaces the precision and emits invalid SQL like `timestamp without time zone(6)`.
- Adds parser/plan fixtures covering the four types × short/long form × bare/precision × array form, plus a `CREATE DOMAIN` base type case and an `ALTER COLUMN TYPE` precision-add case. Each fixture was verified to fail against `main` without the fix.

Fixes #176

## Test plan
- [x] `make test` — all packages green
- [x] `make lint` — 0 issues
- [x] `make test-scenario` — 11/11 green
- [x] Parser package coverage holds at 90.2% (unchanged vs `main`)
- [x] Reverse-verified: temporarily reverting `parser/parser.go` causes the four new fixtures to fail
- [x] Manual `pist plan` against the exact `records.created_at timestamp(6) without time zone DEFAULT now() NOT NULL` case from the issue produces correct SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)