### PR TITLE
Add v1.7.0 breaking-change note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Declarative schema management tool for PostgreSQL. Define your desired schema in
 
 See also: [Getting Started Guide](getting-started.md)
 
+> [!NOTE]
+> **v1.7.0 breaking change:** the CLI binary was renamed from `pist` to `pista`, environment variables from `PIST_*` to `PISTA_*`, and SQL comment directives from `-- pist:` to `-- pista:`. Existing SQL files and shell / CI configurations must be updated before upgrading. See the [1.7.0 changelog entry](CHANGELOG.md#170---2026-05-12) for the full list of renamed names.
+
 <img width="800" alt="demo" src="https://github.com/user-attachments/assets/04dc6e08-96a8-4db9-8a0a-8f9ff4d78928" />
 
 ## Installation


### PR DESCRIPTION
## Summary

- Add a prominent `> [!NOTE]` block near the top of README documenting the v1.7.0 breaking change (`pist` → `pista` binary, `PIST_*` → `PISTA_*` env vars, `-- pist:` → `-- pista:` directives).
- Placed between the description / Getting Started link and the demo image so users see the migration requirement before reading installation instructions.
- Links to the existing 1.7.0 CHANGELOG entry for the full rename list.

## Test plan

- [ ] Confirm the `> [!NOTE]` admonition renders correctly on GitHub.
- [ ] Verify the CHANGELOG.md#170---2026-05-12 anchor resolves.

https://claude.ai/code/session_01QvfVj5gUqRw7bRJPYmaePZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvfVj5gUqRw7bRJPYmaePZ)_