### PR TITLE
Add make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 
 .PHONY: install
 install:
-	go install .
+	go install ./cmd/pista
 
 .PHONY: vet
 vet:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ all: vet test build
 build:
 	go build ./cmd/pista
 
+.PHONY: install
+install:
+	go install .
+
 .PHONY: vet
 vet:
 	go vet ./...


### PR DESCRIPTION
This pull request adds a new `install` target to the `Makefile`, allowing developers to easily install the Go module using `go install .`.

Build and installation improvements:

* Added an `.PHONY` declaration and an `install` target to the `Makefile`, which runs `go install .` for streamlined module installation.