### PR TITLE
Cover 3-part qualified type fallback in formatTimeTypeName

### DIFF
--- a/testdata/parser/qualified_time_type.yml
+++ b/testdata/parser/qualified_time_type.yml
@@ -1,0 +1,19 @@
+input: |
+  CREATE TABLE public.records (
+      id integer NOT NULL,
+      a db.public.timestamp NOT NULL,
+      b db.public.timestamptz NOT NULL,
+      c db.public.time NOT NULL,
+      d db.public.timetz NOT NULL,
+      e other.public.timestamp NOT NULL
+  );
+expected: |
+  -- public.records
+  CREATE TABLE public.records (
+      id integer NOT NULL,
+      a db.public."timestamp" NOT NULL,
+      b db.public.timestamptz NOT NULL,
+      c db.public."time" NOT NULL,
+      d db.public.timetz NOT NULL,
+      e other.public."timestamp" NOT NULL
+  );


### PR DESCRIPTION
The formatTimeTypeName helper added in #177 returns false for
TypeName ASTs with more than two name parts so deparseTypeName falls
back to pg_query.Deparse for cross-database references like
db.public.timestamp. That branch was uncovered by tests; the other
defensive guards in the helper protect against AST shapes the
PostgreSQL grammar cannot produce (non-String name nodes, non-A_Const
typmod, non-Integer array bounds) and are intentionally left untested
per the "no unnatural tests for unreachable defensive code"
convention.