### PR TITLE
Cover ParseSQLFilesWithSchema happy path and missing-file error

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,17 +100,23 @@ func TestParseSQLFilesWithSchema(t *testing.T) {
 	dir := t.TempDir()
 	a := filepath.Join(dir, "a.sql")
 	b := filepath.Join(dir, "b.sql")
-	require.NoError(t, os.WriteFile(a, []byte("CREATE TABLE public.t1 (id integer NOT NULL);"), 0o644))
+	// One unqualified, one explicitly qualified: verifies both the file-join
+	// behavior and that defaultSchema is applied to unqualified names.
+	require.NoError(t, os.WriteFile(a, []byte("CREATE TABLE t1 (id integer NOT NULL);"), 0o644))
 	require.NoError(t, os.WriteFile(b, []byte("CREATE TABLE public.t2 (id integer NOT NULL);"), 0o644))
 
 	result, err := parser.ParseSQLFilesWithSchema([]string{a, b}, "public")
 	require.NoError(t, err)
-	assert.Equal(t, 2, result.Tables.Len())
+	_, ok := result.Tables.GetOk("public.t1")
+	assert.True(t, ok, "unqualified t1 should be schema-qualified to public.t1")
+	_, ok = result.Tables.GetOk("public.t2")
+	assert.True(t, ok, "qualified public.t2 should be preserved")
 }
 
 func TestParseSQLFilesWithSchema_MissingFile(t *testing.T) {
 	_, err := parser.ParseSQLFilesWithSchema([]string{filepath.Join(t.TempDir(), "missing.sql")}, "public")
 	require.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 	assert.Contains(t, err.Error(), "failed to read SQL file")
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -95,6 +95,24 @@ func TestParseSQL_InvalidSQL(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseSQLFilesWithSchema(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.sql")
+	b := filepath.Join(dir, "b.sql")
+	require.NoError(t, os.WriteFile(a, []byte("CREATE TABLE public.t1 (id integer NOT NULL);"), 0o644))
+	require.NoError(t, os.WriteFile(b, []byte("CREATE TABLE public.t2 (id integer NOT NULL);"), 0o644))
+
+	result, err := parser.ParseSQLFilesWithSchema([]string{a, b}, "public")
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Tables.Len())
+}
+
+func TestParseSQLFilesWithSchema_MissingFile(t *testing.T) {
+	_, err := parser.ParseSQLFilesWithSchema([]string{filepath.Join(t.TempDir(), "missing.sql")}, "public")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read SQL file")
+}
+
 func TestParseSQL_View(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,


### PR DESCRIPTION
## Summary
- The public `ParseSQLFilesWithSchema` entry point had 0% direct coverage; only the unexported `parseSQLWithSchema` and `readSQLFile` helpers were exercised by tests.
- Adds a happy-path test that joins two files into a single parse result, and an error-path test that asserts the wrapped read failure when a listed path is absent.
- `parser` package coverage: 90.2% → 91.1% (`ParseSQLFilesWithSchema` 0% → 100%, `readSQLFile` 70% → 90% transitively).

The rest of the sub-100% functions in `parser`/`model`/`diff` were audited and confirmed to be either defensive guards against AST shapes the PostgreSQL grammar cannot produce (`pg_query.Deparse` on synthetic-valid AST, nil checks on fields populated by the grammar) or invariant-protected dead branches (`findFollowingExisting` `return ""` given `working ⊆ desired`, `parsePolicyCommand` default, etc.) — left untouched per the "no unnatural tests for unreachable defensive code" convention in CLAUDE.md.

## Test plan
- [x] `go test ./parser/` — green, 91.1% coverage
- [x] `TestParseSQLFilesWithSchema` and `TestParseSQLFilesWithSchema_MissingFile` pass

https://claude.ai/code/session_013jTTPaRvtTuq76yEPNxHkN

---
_Generated by [Claude Code](https://claude.ai/code/session_013jTTPaRvtTuq76yEPNxHkN)_