### PR TITLE
Add -d/--dbname flag to override database name from --conn-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.7.2] - 2026-05-13
+
+* Add `-d` / `--dbname` flag (env `PISTA_DBNAME`) that overrides the dbname embedded in `--conn-string`. Lets users keep host/user/port constant in `-c postgres://user@host:port/` while selecting the database name ad hoc per invocation, mirroring the `psql -d` convention. If `-d` is omitted, existing behavior is unchanged: pgx parses dbname from `--conn-string`, falling back to the connecting user name when absent. ([#188](https://github.com/winebarrel/pistachio/pull/188))
+
 ## [1.7.1] - 2026-05-13
 
 * Reject `dump --split` filenames that would escape the target directory or alias other entries on disk. PostgreSQL quoted identifiers may contain `/`, `..`, or absolute paths (`CREATE TABLE "../escape" (...)` parses), and the existing `fileNameReplacer` only stripped `"` and substituted `_` for spaces before passing the result to `filepath.Join`, which does not prevent traversal. A hostile DB object name could therefore land a file outside the directory passed to `--split`, and even a non-escaping but non-canonical name like `foo/../bar.sql` could silently overwrite a sibling `bar.sql` since `DumpResult.Files()`' dedup runs on the original map key. Each name is now required to be a flat basename: any path separator (`/` or `\`) is refused outright, `filepath.IsLocal` rejects `..` path elements / absolute paths / empty strings / Windows-reserved names, and a canonical-form check (`name == filepath.Clean(name)`) refuses any `./`, `foo/../bar`, double-slash, or trailing-slash shapes. Identifiers that legitimately contain literal dots (`foo..bar`, `..leading`, `public.v1.0`) still write through. Realistic exploit conditions are narrow (requires `CREATE` privilege on the target database) but the guard closes the traversal and symlink-redirect paths and keeps the on-disk filename equal to the map key. ([#186](https://github.com/winebarrel/pistachio/pull/186))

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Flags:
                               PostgreSQL connection string. See
                               https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
                               ($PISTA_CONN_STR)
+  -d, --dbname=STRING         PostgreSQL database name. Overrides the dbname in
+                              --conn-string ($PISTA_DBNAME).
       --password=STRING       PostgreSQL password ($PISTA_PASSWORD).
   -n, --schemas=public,...    Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...

--- a/client.go
+++ b/client.go
@@ -42,14 +42,27 @@ func (client *Client) validateSchemas() error {
 	return nil
 }
 
-func (client *Client) connect(ctx context.Context) (*pgx.Conn, error) {
+func (client *Client) buildConnConfig() (*pgx.ConnConfig, error) {
 	cfg, err := pgx.ParseConfig(client.ConnString)
 	if err != nil {
 		return nil, fmt.Errorf("pistachio: failed to parse connection string: %w", err)
 	}
 
+	if client.Dbname != "" {
+		cfg.Database = client.Dbname
+	}
+
 	if client.Password != "" {
 		cfg.Password = client.Password
+	}
+
+	return cfg, nil
+}
+
+func (client *Client) connect(ctx context.Context) (*pgx.Conn, error) {
+	cfg, err := client.buildConnConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	conn, err := pgx.ConnectConfig(ctx, cfg)

--- a/client.go
+++ b/client.go
@@ -48,8 +48,8 @@ func (client *Client) buildConnConfig() (*pgx.ConnConfig, error) {
 		return nil, fmt.Errorf("pistachio: failed to parse connection string: %w", err)
 	}
 
-	if client.Dbname != "" {
-		cfg.Database = client.Dbname
+	if client.DBName != "" {
+		cfg.Database = client.DBName
 	}
 
 	if client.Password != "" {

--- a/connect_test.go
+++ b/connect_test.go
@@ -3,6 +3,7 @@ package pistachio
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,4 +23,63 @@ func TestConnect_PropagatesCancelledContext(t *testing.T) {
 	_, err := client.connect(ctx)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBuildConnConfig_DbnameOverridesConnString(t *testing.T) {
+	client := NewClient(&Options{
+		ConnString: "postgres://postgres@localhost/postgres",
+		Dbname:     "mydb",
+	})
+
+	cfg, err := client.buildConnConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "mydb", cfg.Database)
+}
+
+func TestBuildConnConfig_DbnameWorksWithEmptyDbnameInConnString(t *testing.T) {
+	client := NewClient(&Options{
+		ConnString: "postgres://postgres@localhost:5432/",
+		Dbname:     "mydb",
+	})
+
+	cfg, err := client.buildConnConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "mydb", cfg.Database)
+}
+
+func TestBuildConnConfig_DbnameEmptyKeepsConnStringDatabase(t *testing.T) {
+	client := NewClient(&Options{
+		ConnString: "postgres://postgres@localhost/origdb",
+	})
+
+	cfg, err := client.buildConnConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "origdb", cfg.Database)
+}
+
+func TestBuildConnConfig_PasswordOverride(t *testing.T) {
+	client := NewClient(&Options{
+		ConnString: "postgres://postgres@localhost/postgres",
+		Password:   "secret",
+	})
+
+	cfg, err := client.buildConnConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "secret", cfg.Password)
+}
+
+func TestBuildConnConfig_InvalidConnStringReturnsError(t *testing.T) {
+	client := NewClient(&Options{ConnString: "::not-a-valid-conn-string::"})
+
+	_, err := client.buildConnConfig()
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "failed to parse connection string"))
+}
+
+func TestConnect_InvalidConnStringPropagatesBuildError(t *testing.T) {
+	client := NewClient(&Options{ConnString: "::not-a-valid-conn-string::"})
+
+	_, err := client.connect(context.Background())
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "failed to parse connection string"))
 }

--- a/connect_test.go
+++ b/connect_test.go
@@ -28,7 +28,7 @@ func TestConnect_PropagatesCancelledContext(t *testing.T) {
 func TestBuildConnConfig_DbnameOverridesConnString(t *testing.T) {
 	client := NewClient(&Options{
 		ConnString: "postgres://postgres@localhost/postgres",
-		Dbname:     "mydb",
+		DBName:     "mydb",
 	})
 
 	cfg, err := client.buildConnConfig()
@@ -39,7 +39,7 @@ func TestBuildConnConfig_DbnameOverridesConnString(t *testing.T) {
 func TestBuildConnConfig_DbnameWorksWithEmptyDbnameInConnString(t *testing.T) {
 	client := NewClient(&Options{
 		ConnString: "postgres://postgres@localhost:5432/",
-		Dbname:     "mydb",
+		DBName:     "mydb",
 	})
 
 	cfg, err := client.buildConnConfig()

--- a/options.go
+++ b/options.go
@@ -7,7 +7,7 @@ import (
 
 type Options struct {
 	ConnString string            `short:"c" env:"PISTA_CONN_STR" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
-	Dbname     string            `short:"d" env:"PISTA_DBNAME" help:"PostgreSQL database name. Overrides the dbname in --conn-string."`
+	DBName     string            `name:"dbname" short:"d" env:"PISTA_DBNAME" help:"PostgreSQL database name. Overrides the dbname in --conn-string."`
 	Password   string            `env:"PISTA_PASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PISTA_SCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`

--- a/options.go
+++ b/options.go
@@ -7,6 +7,7 @@ import (
 
 type Options struct {
 	ConnString string            `short:"c" env:"PISTA_CONN_STR" default:"postgres://postgres@localhost/postgres" help:"PostgreSQL connection string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"`
+	Dbname     string            `short:"d" env:"PISTA_DBNAME" help:"PostgreSQL database name. Overrides the dbname in --conn-string."`
 	Password   string            `env:"PISTA_PASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PISTA_SCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`


### PR DESCRIPTION
## Summary
- Add psql-style `-d/--dbname` flag (env `PISTA_DBNAME`) that overrides the dbname embedded in `--conn-string`, enabling the `-c postgres://user@host:port/` + `-d $DB_NAME` pattern requested in #187.
- Extract `buildConnConfig` from `connect` for testability; `connect` delegates to it and propagates any parse error.
- All branches covered by unit tests; pistachio package coverage stays at 98%.

Closes #187.

## Test plan
- [x] `make lint` (0 issues)
- [x] `make vet`
- [x] `go test .` — all pass, coverage 98.0%; `client.go` functions all 100% covered
- [x] Built the binary and verified `--help` output matches the README Usage block
- [x] Reviewer: try `pista plan -c postgres://postgres@localhost/ -d postgres schema.sql` against a local Postgres