### PR TITLE
Add connection info comment to plan/apply/dump output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.7.3] - 2026-05-13
+
+* Print a `-- Connected to postgres://<user>@<host>:<port>/<dbname>` comment above the existing header in `plan` / `apply` / `dump` output so it's clear which database the command ran against. The password (whether embedded in `--conn-string` or passed via `--password` / `PISTA_PASSWORD`) is never included.
+
 ## [1.7.2] - 2026-05-13
 
 * Add `-d` / `--dbname` flag (env `PISTA_DBNAME`) that overrides the dbname embedded in `--conn-string`. Lets users keep host/user/port constant in `-c postgres://user@host:port/` while selecting the database name ad hoc per invocation, mirroring the `psql -d` convention. If `-d` is omitted, existing behavior is unchanged: pgx parses dbname from `--conn-string`, falling back to the connecting user name when absent. ([#188](https://github.com/winebarrel/pistachio/pull/188))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.7.3] - 2026-05-13
 
-* Print a `-- Connected to postgres://<user>@<host>:<port>/<dbname>` comment above the existing header in `plan` / `apply` / `dump` output so it's clear which database the command ran against. The password (whether embedded in `--conn-string` or passed via `--password` / `PISTA_PASSWORD`) is never included.
+* Print a `-- Connected to ...` comment above the existing header in `plan` / `apply` / `dump` output so it's clear which database the command ran against. TCP connections render as a libpq URI (`postgres://<user>@<host>:<port>/<dbname>`, with IPv6 hosts bracketed and user/dbname URL-escaped); unix-socket connections render as keyword/value form (`host=<path> dbname=<dbname> user=<user>`) to keep the socket path readable. The password (whether embedded in `--conn-string` or passed via `--password` / `PISTA_PASSWORD`) is never included.
 
 ## [1.7.2] - 2026-05-13
 

--- a/client.go
+++ b/client.go
@@ -68,11 +68,13 @@ func (client *Client) buildConnConfig() (*pgx.ConnConfig, error) {
 //
 // TCP connections render as a libpq URI (postgres://user@host:port/dbname).
 // IPv6 hosts are bracketed via net.JoinHostPort; user and dbname are
-// URL-escaped via net/url so identifiers with special characters round-trip
-// safely. libpq unix-socket connections (host starts with "/") render as a
-// keyword/value string ("host=/path dbname=db user=u") instead — percent-
-// encoding the socket path into the URI host component would be unreadable
-// in a comment.
+// URL-escaped via net/url so identifiers with URI-meaningful characters
+// (including '/' in the dbname) round-trip safely — Path holds the decoded
+// form and RawPath the encoded form, so url.URL.String() uses RawPath when
+// the default encoding would differ. libpq unix-socket connections (host
+// starts with "/") render as a keyword/value string ("host=/path dbname=db
+// user=u") instead — percent-encoding the socket path into the URI host
+// component would be unreadable in a comment.
 func (client *Client) ConnInfoComment() (string, error) {
 	cfg, err := client.buildConnConfig()
 	if err != nil {
@@ -84,10 +86,11 @@ func (client *Client) ConnInfoComment() (string, error) {
 	}
 
 	u := url.URL{
-		Scheme: "postgres",
-		User:   url.User(cfg.User),
-		Host:   net.JoinHostPort(cfg.Host, strconv.Itoa(int(cfg.Port))),
-		Path:   "/" + cfg.Database,
+		Scheme:  "postgres",
+		User:    url.User(cfg.User),
+		Host:    net.JoinHostPort(cfg.Host, strconv.Itoa(int(cfg.Port))),
+		Path:    "/" + cfg.Database,
+		RawPath: "/" + url.PathEscape(cfg.Database),
 	}
 	return "-- Connected to " + u.String(), nil
 }

--- a/client.go
+++ b/client.go
@@ -59,6 +59,15 @@ func (client *Client) buildConnConfig() (*pgx.ConnConfig, error) {
 	return cfg, nil
 }
 
+func (client *Client) ConnInfoComment() (string, error) {
+	cfg, err := client.buildConnConfig()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("-- Connected to postgres://%s@%s:%d/%s", cfg.User, cfg.Host, cfg.Port, cfg.Database), nil
+}
+
 func (client *Client) connect(ctx context.Context) (*pgx.Conn, error) {
 	cfg, err := client.buildConnConfig()
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -59,13 +62,34 @@ func (client *Client) buildConnConfig() (*pgx.ConnConfig, error) {
 	return cfg, nil
 }
 
+// ConnInfoComment returns a SQL comment describing the connection target
+// (host/port/dbname/user) for inclusion at the top of plan/apply/dump output.
+// The password is intentionally never included.
+//
+// TCP connections render as a libpq URI (postgres://user@host:port/dbname).
+// IPv6 hosts are bracketed via net.JoinHostPort; user and dbname are
+// URL-escaped via net/url so identifiers with special characters round-trip
+// safely. libpq unix-socket connections (host starts with "/") render as a
+// keyword/value string ("host=/path dbname=db user=u") instead — percent-
+// encoding the socket path into the URI host component would be unreadable
+// in a comment.
 func (client *Client) ConnInfoComment() (string, error) {
 	cfg, err := client.buildConnConfig()
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("-- Connected to postgres://%s@%s:%d/%s", cfg.User, cfg.Host, cfg.Port, cfg.Database), nil
+	if strings.HasPrefix(cfg.Host, "/") {
+		return fmt.Sprintf("-- Connected to host=%s dbname=%s user=%s", cfg.Host, cfg.Database, cfg.User), nil
+	}
+
+	u := url.URL{
+		Scheme: "postgres",
+		User:   url.User(cfg.User),
+		Host:   net.JoinHostPort(cfg.Host, strconv.Itoa(int(cfg.Port))),
+		Path:   "/" + cfg.Database,
+	}
+	return "-- Connected to " + u.String(), nil
 }
 
 func (client *Client) connect(ctx context.Context) (*pgx.Conn, error) {

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -20,6 +20,10 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 		return err
 	}
 
+	if connInfo, err := client.ConnInfoComment(); err == nil {
+		fmt.Fprintln(w, connInfo) //nolint:errcheck
+	}
+
 	fmt.Fprintf(w, "-- Apply to %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 
 	// Same ordering as Plan: executed SQL (incl. pre-SQL) first, then skipped

--- a/cmd/command/command_test.go
+++ b/cmd/command/command_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/winebarrel/pistachio"
@@ -39,6 +40,7 @@ func TestPlan_Run(t *testing.T) {
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+	assertConnectedCommentFirst(t, buf.String(), conn.Config())
 }
 
 func TestDump_Run(t *testing.T) {
@@ -62,6 +64,7 @@ func TestDump_Run(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "-- Dump of schema public (1 table, 0 views, 0 enums, 0 domains)")
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+	assertConnectedCommentFirst(t, buf.String(), conn.Config())
 }
 
 func TestDump_Run_Split(t *testing.T) {
@@ -667,6 +670,25 @@ func TestApply_Run(t *testing.T) {
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+	assertConnectedCommentFirst(t, buf.String(), conn.Config())
+}
+
+// assertConnectedCommentFirst verifies plan/apply/dump prepend a
+// "-- Connected to ..." comment as the first output line, and that the
+// password from the test connection (if any) does not appear in the output.
+func assertConnectedCommentFirst(t *testing.T, out string, cfg *pgx.ConnConfig) {
+	t.Helper()
+	assert.True(t, strings.HasPrefix(out, "-- Connected to "), "first line must be '-- Connected to ...', got: %q", firstLine(out))
+	if cfg.Password != "" {
+		assert.NotContains(t, out, cfg.Password, "password must not appear in output")
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 func TestApply_Run_ExecutedWithSkippedDrops(t *testing.T) {

--- a/cmd/command/dump.go
+++ b/cmd/command/dump.go
@@ -21,7 +21,12 @@ func (cmd *Dump) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return err
 	}
 
+	connInfo, _ := client.ConnInfoComment()
+
 	if cmd.Split == "" {
+		if connInfo != "" {
+			fmt.Fprintln(w, connInfo) //nolint:errcheck
+		}
 		fmt.Fprintf(w, "-- Dump of %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 		fmt.Fprintln(w, result)                                                                    //nolint:errcheck
 		return nil
@@ -31,6 +36,9 @@ func (cmd *Dump) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
+	if connInfo != "" {
+		fmt.Fprintln(w, connInfo) //nolint:errcheck
+	}
 	fmt.Fprintf(w, "-- Dump of %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 
 	count, err := writeDumpFiles(cmd.Split, result.Files())

--- a/cmd/command/dump.go
+++ b/cmd/command/dump.go
@@ -21,10 +21,8 @@ func (cmd *Dump) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return err
 	}
 
-	connInfo, _ := client.ConnInfoComment()
-
 	if cmd.Split == "" {
-		if connInfo != "" {
+		if connInfo, err := client.ConnInfoComment(); err == nil {
 			fmt.Fprintln(w, connInfo) //nolint:errcheck
 		}
 		fmt.Fprintf(w, "-- Dump of %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
@@ -36,7 +34,7 @@ func (cmd *Dump) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	if connInfo != "" {
+	if connInfo, err := client.ConnInfoComment(); err == nil {
 		fmt.Fprintln(w, connInfo) //nolint:errcheck
 	}
 	fmt.Fprintf(w, "-- Dump of %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -18,6 +18,10 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		return err
 	}
 
+	if connInfo, err := client.ConnInfoComment(); err == nil {
+		fmt.Fprintln(w, connInfo) //nolint:errcheck
+	}
+
 	fmt.Fprintf(w, "-- Plan for %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 
 	// Order: executable SQL (incl. pre-SQL) first so it can be piped/copied

--- a/connect_test.go
+++ b/connect_test.go
@@ -76,6 +76,46 @@ func TestBuildConnConfig_InvalidConnStringReturnsError(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "failed to parse connection string"))
 }
 
+func TestConnInfoComment(t *testing.T) {
+	client := NewClient(&Options{
+		ConnString: "postgres://myuser:secret@myhost:5433/mydb",
+	})
+
+	comment, err := client.ConnInfoComment()
+	require.NoError(t, err)
+	assert.Equal(t, "-- Connected to postgres://myuser@myhost:5433/mydb", comment)
+	assert.NotContains(t, comment, "secret")
+}
+
+func TestConnInfoComment_WithDBNameOverride(t *testing.T) {
+	client := NewClient(&Options{
+		ConnString: "postgres://myuser@myhost/origdb",
+		DBName:     "overridden",
+	})
+
+	comment, err := client.ConnInfoComment()
+	require.NoError(t, err)
+	assert.Contains(t, comment, "/overridden")
+}
+
+func TestConnInfoComment_OptionsPasswordNotIncluded(t *testing.T) {
+	client := NewClient(&Options{
+		ConnString: "postgres://myuser@myhost:5432/mydb",
+		Password:   "topsecret",
+	})
+
+	comment, err := client.ConnInfoComment()
+	require.NoError(t, err)
+	assert.NotContains(t, comment, "topsecret")
+}
+
+func TestConnInfoComment_InvalidConnString(t *testing.T) {
+	client := NewClient(&Options{ConnString: "::not-valid::"})
+
+	_, err := client.ConnInfoComment()
+	require.Error(t, err)
+}
+
 func TestConnect_InvalidConnStringPropagatesBuildError(t *testing.T) {
 	client := NewClient(&Options{ConnString: "::not-a-valid-conn-string::"})
 

--- a/connect_test.go
+++ b/connect_test.go
@@ -109,6 +109,46 @@ func TestConnInfoComment_OptionsPasswordNotIncluded(t *testing.T) {
 	assert.NotContains(t, comment, "topsecret")
 }
 
+func TestConnInfoComment_IPv6HostBracketed(t *testing.T) {
+	// libpq URIs require IPv6 hosts to be bracketed; net.JoinHostPort handles
+	// this. Without brackets the "::1:5432" string is ambiguous.
+	client := NewClient(&Options{
+		ConnString: "postgres://myuser@[::1]:5433/mydb",
+	})
+
+	comment, err := client.ConnInfoComment()
+	require.NoError(t, err)
+	assert.Equal(t, "-- Connected to postgres://myuser@[::1]:5433/mydb", comment)
+}
+
+func TestConnInfoComment_UnixSocketHost(t *testing.T) {
+	// pgx accepts unix-socket hosts via the libpq URI's host= query parameter.
+	// We surface them as keyword/value form because percent-encoding the
+	// socket path into the URI host component is unreadable in a comment.
+	client := NewClient(&Options{
+		ConnString: "postgres://myuser@/mydb?host=/var/run/postgresql",
+	})
+
+	comment, err := client.ConnInfoComment()
+	require.NoError(t, err)
+	assert.Equal(t, "-- Connected to host=/var/run/postgresql dbname=mydb user=myuser", comment)
+}
+
+func TestConnInfoComment_URLEscapesSpecialChars(t *testing.T) {
+	// User / dbname with characters that have URI meaning must be escaped so
+	// the comment stays a parseable libpq URI. Round-tripping through url.URL
+	// gives us this for free.
+	client := NewClient(&Options{
+		ConnString: "postgres://my%2Fuser@myhost:5432/my%20db",
+	})
+
+	comment, err := client.ConnInfoComment()
+	require.NoError(t, err)
+	// The user "my/user" and dbname "my db" must reappear escaped.
+	assert.Contains(t, comment, "my%2Fuser")
+	assert.Contains(t, comment, "my%20db")
+}
+
 func TestConnInfoComment_InvalidConnString(t *testing.T) {
 	client := NewClient(&Options{ConnString: "::not-valid::"})
 

--- a/connect_test.go
+++ b/connect_test.go
@@ -149,6 +149,21 @@ func TestConnInfoComment_URLEscapesSpecialChars(t *testing.T) {
 	assert.Contains(t, comment, "my%20db")
 }
 
+func TestConnInfoComment_DBNameWithSlashEscaped(t *testing.T) {
+	// url.URL.Path does NOT escape '/' by default — without setting RawPath a
+	// dbname like "team/db" would render as multiple path segments
+	// ("postgres://...:5432/team/db") and break URI round-trip. RawPath plus
+	// url.PathEscape forces the '/' to be encoded as %2F.
+	client := NewClient(&Options{
+		ConnString: "postgres://myuser@myhost:5432/postgres",
+		DBName:     "team/db",
+	})
+
+	comment, err := client.ConnInfoComment()
+	require.NoError(t, err)
+	assert.Equal(t, "-- Connected to postgres://myuser@myhost:5432/team%2Fdb", comment)
+}
+
 func TestConnInfoComment_InvalidConnString(t *testing.T) {
 	client := NewClient(&Options{ConnString: "::not-valid::"})
 


### PR DESCRIPTION
## Summary

- Print a `-- Connected to postgres://<user>@<host>:<port>/<dbname>` comment above the existing header in `plan` / `apply` / `dump` output so it's clear which database the command ran against.
- Password is excluded — neither the password embedded in `--conn-string` nor `--password` / `PISTA_PASSWORD` appears in the output.
- CHANGELOG updated for 1.7.3.

Example output:

```
-- Connected to postgres://postgres@localhost:5432/mydb
-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
...
```

## Test plan

- [x] `go test -run 'TestConnInfoComment' .` — 4 new tests pass (URL format, dbname override, Options.Password not leaked, invalid conn string error)
- [x] `ConnInfoComment` / `buildConnConfig` coverage at 100%
- [x] `make lint` — clean
- [ ] Verify `pista plan` / `pista apply` / `pista dump` output against a real PostgreSQL instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)