### PR TITLE
Add SQL syntax highlighting with --[no-]color and NO_COLOR support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.7.3] - 2026-05-13
 
 * Print a `-- Connected to ...` comment above the existing header in `plan` / `apply` / `dump` output so it's clear which database the command ran against. TCP connections render as a libpq URI (`postgres://<user>@<host>:<port>/<dbname>`, with IPv6 hosts bracketed and user/dbname URL-escaped); unix-socket connections render as keyword/value form (`host=<path> dbname=<dbname> user=<user>`) to keep the socket path readable. The password (whether embedded in `--conn-string` or passed via `--password` / `PISTA_PASSWORD`) is never included.
+* Colorize SQL output of `plan` / `apply` / `dump` via chroma's PostgreSQL lexer. Enabled by default when stdout is a TTY and `NO_COLOR` (https://no-color.org/) is unset; disable with `--no-color` or by setting `NO_COLOR`. Piped/redirected output is unchanged.
 
 ## [1.7.2] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ Flags:
   -n, --schemas=public,...    Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
-      --[no-]color            Colorize SQL output. Defaults to enabled when
-                              stdout is a TTY and the NO_COLOR environment
-                              variable is unset (see https://no-color.org/).
+      --[no-]color            Colorize SQL output. Auto-detected from
+                              TTY/NO_COLOR (https://no-color.org/).
       --version
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Flags:
   -n, --schemas=public,...    Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
+      --[no-]color            Colorize SQL output. Defaults to enabled when
+                              stdout is a TTY and the NO_COLOR environment
+                              variable is unset (see https://no-color.org/).
       --version
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See also: [Getting Started Guide](getting-started.md)
 > [!NOTE]
 > **v1.7.0 breaking change:** the CLI binary was renamed from `pist` to `pista`, environment variables from `PIST_*` to `PISTA_*`, and SQL comment directives from `-- pist:` to `-- pista:`. Existing SQL files and shell / CI configurations must be updated before upgrading. See the [1.7.0 changelog entry](CHANGELOG.md#170---2026-05-12) for the full list of renamed names.
 
-<img width="800" src="https://github.com/user-attachments/assets/06eee10a-1b1c-41e1-9230-19752eebf1b4" />
+<img width="800" src="https://github.com/user-attachments/assets/89dea160-78fd-46a8-a3ba-fdde10704328" />
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Flags:
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
       --[no-]color            Colorize SQL output. Auto-detected from
-                              TTY/NO_COLOR (https://no-color.org/).
+                              TTY/NO_COLOR.
       --version
 
 Commands:

--- a/cmd/command/color.go
+++ b/cmd/command/color.go
@@ -7,14 +7,19 @@ import (
 	"github.com/alecthomas/chroma/v2/quick"
 )
 
-// SQLWriter is an io.Writer that buffers every Write and, on Flush, emits the
-// buffered text to the underlying writer — optionally through chroma's
-// PostgreSQL lexer. SQL-style comments (e.g. "-- Plan for ...") are colored
-// as comments by the same lexer, so callers can build the entire output
-// (header + DDL + footer) via fmt.Fprintf-style calls and colorize all of it
-// in one shot at the end. Flushing is required because chroma's highlighter
-// needs the full input to tokenize correctly (multi-line strings, comments,
-// etc. span Write boundaries).
+// SQLWriter is an io.Writer that, when color is enabled, buffers every Write
+// and on Flush emits the buffered text to the underlying writer through
+// chroma's PostgreSQL lexer. SQL-style comments (e.g. "-- Plan for ...") are
+// colored as comments by the same lexer, so callers can build the entire
+// output (header + DDL + footer) via fmt.Fprintf-style calls and colorize
+// all of it in one shot at the end. Buffering is required because chroma's
+// highlighter needs the full input to tokenize correctly (multi-line strings,
+// comments, etc. span Write boundaries).
+//
+// When color is disabled, Write passes straight through to the underlying
+// writer and Flush is a no-op, preserving the streaming behavior of
+// pre-color pista output for piped/redirected use (e.g. `pista dump | gzip`
+// must not balloon RSS to buffer a multi-MB schema dump).
 type SQLWriter struct {
 	buf   bytes.Buffer
 	out   io.Writer
@@ -26,13 +31,20 @@ func NewSQLWriter(w io.Writer, color bool) *SQLWriter {
 }
 
 func (s *SQLWriter) Write(p []byte) (int, error) {
+	if !s.color {
+		return s.out.Write(p)
+	}
 	return s.buf.Write(p)
 }
 
+// Flush highlights and emits the buffered text. It also resets the internal
+// buffer so a second Flush is a no-op (rather than duplicating output) and
+// the buffered memory can be reclaimed.
 func (s *SQLWriter) Flush() error {
 	if !s.color {
-		_, err := s.out.Write(s.buf.Bytes())
-		return err
+		return nil
 	}
-	return quick.Highlight(s.out, s.buf.String(), "postgres", "terminal256", "monokai")
+	err := quick.Highlight(s.out, s.buf.String(), "postgres", "terminal256", "monokai")
+	s.buf.Reset()
+	return err
 }

--- a/cmd/command/color.go
+++ b/cmd/command/color.go
@@ -37,9 +37,14 @@ func (s *SQLWriter) Write(p []byte) (int, error) {
 	return s.buf.Write(p)
 }
 
-// Flush highlights and emits the buffered text. It also resets the internal
-// buffer so a second Flush is a no-op (rather than duplicating output) and
-// the buffered memory can be reclaimed.
+// Flush highlights and emits the buffered text, then resets the internal
+// buffer so a second Flush is a no-op and the buffered memory can be
+// reclaimed. quick.Highlight with our hardcoded postgres lexer / terminal256
+// formatter / monokai style never returns an error in practice (the
+// terminal256 formatter drops writer errors, the lexer can't fail
+// tokenising, and quick falls back to defaults for unknown names), so no
+// fallback path is wired here; we still propagate the returned error for
+// forward-compatibility.
 func (s *SQLWriter) Flush() error {
 	if !s.color {
 		return nil

--- a/cmd/command/color.go
+++ b/cmd/command/color.go
@@ -1,0 +1,38 @@
+package command
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/alecthomas/chroma/v2/quick"
+)
+
+// SQLWriter is an io.Writer that buffers every Write and, on Flush, emits the
+// buffered text to the underlying writer — optionally through chroma's
+// PostgreSQL lexer. SQL-style comments (e.g. "-- Plan for ...") are colored
+// as comments by the same lexer, so callers can build the entire output
+// (header + DDL + footer) via fmt.Fprintf-style calls and colorize all of it
+// in one shot at the end. Flushing is required because chroma's highlighter
+// needs the full input to tokenize correctly (multi-line strings, comments,
+// etc. span Write boundaries).
+type SQLWriter struct {
+	buf   bytes.Buffer
+	out   io.Writer
+	color bool
+}
+
+func NewSQLWriter(w io.Writer, color bool) *SQLWriter {
+	return &SQLWriter{out: w, color: color}
+}
+
+func (s *SQLWriter) Write(p []byte) (int, error) {
+	return s.buf.Write(p)
+}
+
+func (s *SQLWriter) Flush() error {
+	if !s.color {
+		_, err := s.out.Write(s.buf.Bytes())
+		return err
+	}
+	return quick.Highlight(s.out, s.buf.String(), "postgres", "terminal256", "monokai")
+}

--- a/cmd/command/color_test.go
+++ b/cmd/command/color_test.go
@@ -16,10 +16,41 @@ func TestSQLWriter_NoColor(t *testing.T) {
 	sql := "-- Plan for schema public\nCREATE TABLE t (id int);\n"
 	_, err := w.Write([]byte(sql))
 	require.NoError(t, err)
-	require.NoError(t, w.Flush())
+	// When color is off, Write streams straight through to the underlying
+	// writer — the data is in buf even before Flush is called.
 	assert.Equal(t, sql, buf.String())
-	// No ANSI escape sequences when color is off.
+	require.NoError(t, w.Flush())
+	// Flush is a no-op in non-color mode, so the output is unchanged.
+	assert.Equal(t, sql, buf.String())
 	assert.NotContains(t, buf.String(), "\x1b[")
+}
+
+func TestSQLWriter_NoColorStreamsAcrossWrites(t *testing.T) {
+	// Each Write must reach the underlying writer immediately when color is
+	// off — required for large outputs (multi-MB `dump`) so we don't buffer
+	// the whole thing in memory.
+	var buf bytes.Buffer
+	w := command.NewSQLWriter(&buf, false)
+	_, err := w.Write([]byte("chunk1\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "chunk1\n", buf.String(), "first chunk must stream immediately")
+	_, err = w.Write([]byte("chunk2\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "chunk1\nchunk2\n", buf.String(), "second chunk must append")
+}
+
+func TestSQLWriter_FlushResetsBuffer(t *testing.T) {
+	// Flush clears the internal buffer so a second Flush emits nothing rather
+	// than duplicating the previous output, and so memory can be reclaimed.
+	var buf bytes.Buffer
+	w := command.NewSQLWriter(&buf, true)
+	_, err := w.Write([]byte("CREATE TABLE t (id int);\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
+	first := buf.String()
+	require.NotEmpty(t, first)
+	require.NoError(t, w.Flush())
+	assert.Equal(t, first, buf.String(), "second Flush must not duplicate output")
 }
 
 func TestSQLWriter_WithColor(t *testing.T) {

--- a/cmd/command/color_test.go
+++ b/cmd/command/color_test.go
@@ -1,0 +1,64 @@
+package command_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/cmd/command"
+)
+
+func TestSQLWriter_NoColor(t *testing.T) {
+	var buf bytes.Buffer
+	w := command.NewSQLWriter(&buf, false)
+	sql := "-- Plan for schema public\nCREATE TABLE t (id int);\n"
+	_, err := w.Write([]byte(sql))
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
+	assert.Equal(t, sql, buf.String())
+	// No ANSI escape sequences when color is off.
+	assert.NotContains(t, buf.String(), "\x1b[")
+}
+
+func TestSQLWriter_WithColor(t *testing.T) {
+	var buf bytes.Buffer
+	w := command.NewSQLWriter(&buf, true)
+	sql := "CREATE TABLE t (id int);\n"
+	_, err := w.Write([]byte(sql))
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
+	// ANSI escape sequences are emitted by the terminal256 formatter.
+	assert.Contains(t, buf.String(), "\x1b[")
+	// The original SQL text is still present in the output.
+	stripped := stripANSI(buf.String())
+	assert.Contains(t, stripped, "CREATE TABLE")
+}
+
+func TestSQLWriter_FlushEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	w := command.NewSQLWriter(&buf, false)
+	require.NoError(t, w.Flush())
+	assert.Empty(t, buf.String())
+}
+
+// stripANSI removes ANSI escape sequences from s.
+func stripANSI(s string) string {
+	var out strings.Builder
+	inEsc := false
+	for _, r := range s {
+		if inEsc {
+			if r == 'm' {
+				inEsc = false
+			}
+			continue
+		}
+		if r == '\x1b' {
+			inEsc = true
+			continue
+		}
+		out.WriteRune(r)
+	}
+	return out.String()
+}

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -23,12 +23,19 @@ var cli struct {
 
 func main() {
 	ctx := context.Background()
-	kctx := kong.Parse(&cli,
-		kong.Vars{"version": version},
-		kong.BindTo(ctx, (*context.Context)(nil)),
-		kong.BindTo(os.Stdout, (*io.Writer)(nil)),
-	)
+	// Parse first so cli.Options.Color is populated (BeforeApply seeds it
+	// from isatty/NO_COLOR, then any explicit --color/--no-color overrides).
+	kctx := kong.Parse(&cli, kong.Vars{"version": version})
+
+	out := command.NewSQLWriter(os.Stdout, cli.Color)
+	kctx.BindTo(ctx, (*context.Context)(nil))
+	kctx.BindTo(out, (*io.Writer)(nil))
+
 	client := pistachio.NewClient(&cli.Options)
-	err := kctx.Run(client)
-	kctx.FatalIfErrorf(err)
+	runErr := kctx.Run(client)
+	flushErr := out.Flush()
+	if runErr != nil {
+		kctx.FatalIfErrorf(runErr)
+	}
+	kctx.FatalIfErrorf(flushErr)
 }

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -33,9 +33,9 @@ func main() {
 
 	client := pistachio.NewClient(&cli.Options)
 	runErr := kctx.Run(client)
-	flushErr := out.Flush()
-	if runErr != nil {
-		kctx.FatalIfErrorf(runErr)
-	}
-	kctx.FatalIfErrorf(flushErr)
+	// Flush write errors (broken pipe when piping to `head`, etc.) are
+	// intentionally ignored — they match the previous per-Fprintf
+	// //nolint:errcheck behavior and make `pista plan | head` exit cleanly.
+	_ = out.Flush()
+	kctx.FatalIfErrorf(runErr)
 }

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -34,8 +34,8 @@ func main() {
 	client := pistachio.NewClient(&cli.Options)
 	runErr := kctx.Run(client)
 	// Flush write errors (broken pipe when piping to `head`, etc.) are
-	// intentionally ignored — they match the previous per-Fprintf
-	// //nolint:errcheck behavior and make `pista plan | head` exit cleanly.
-	_ = out.Flush()
+	// intentionally discarded so `pista plan | head` exits cleanly, matching
+	// the prior behavior where each per-Fprintf write error was ignored.
+	out.Flush() //nolint:errcheck
 	kctx.FatalIfErrorf(runErr)
 }

--- a/demo.tape
+++ b/demo.tape
@@ -6,12 +6,7 @@ Set Width 800
 Set Height 600
 Set Padding 20
 
-Hide
-Type "alias colorize='bat -l sql -p --paging=never' && clear"
-Show
-
 # Create schema file
-Enter
 Type "# Create a desired schema definition file" Enter
 Sleep 2s
 Type "cat <<'EOF' > schema.sql" Enter
@@ -24,46 +19,41 @@ Type@3ms ");" Enter
 Type@3ms "" Enter
 Type@3ms "CREATE INDEX idx_posts_user_id ON public.posts USING btree (user_id);" Enter
 Type@3ms "EOF" Enter
-Sleep 0.5s
-Enter
-Type "colorize schema.sql" Enter
 Sleep 4s
 
 # Plan
 Enter
 Type "# Preview the changes to be applied (like terraform plan)" Enter
 Sleep 2s
-Type "pista plan schema.sql | colorize" Enter
+Type "pista plan schema.sql" Enter
 Sleep 4s
 
 # Apply
 Enter
 Type "# Apply the schema to the database" Enter
 Sleep 2s
-Type "pista apply schema.sql | colorize" Enter
+Type "pista apply schema.sql" Enter
 Sleep 4s
 
 # Verify no remaining diff
 Enter
 Type "# Verify that the schema is now in sync" Enter
 Sleep 2s
-Type "pista plan schema.sql | colorize" Enter
+Type "pista plan schema.sql" Enter
 Sleep 4s
 
 # Dump
 Enter
 Type "# Dump the current database schema" Enter
 Sleep 2s
-Type "pista dump | colorize" Enter
+Type "pista dump" Enter
 Sleep 4s
 
 # Backup and modify schema: add a column
 Enter
 Type "# Modify the schema file: add an body column to posts" Enter
 Sleep 2s
-Type "cp schema.sql schema.sql.bak" Enter
-Sleep 0.5s
-Type "sed -i '' 's/title text NOT NULL,/title text NOT NULL,\n    body text NOT NULL,/' schema.sql" Enter
+Type "sed -i.bak 's/title text NOT NULL,/title text NOT NULL,\n    body text NOT NULL,/' schema.sql" Enter
 Sleep 0.5s
 
 # Show diff
@@ -77,26 +67,26 @@ Sleep 4s
 Enter
 Type "# Plan again to see the incremental changes" Enter
 Sleep 2s
-Type "pista plan schema.sql | colorize" Enter
+Type "pista plan schema.sql" Enter
 Sleep 4s
 
 # Apply the diff
 Enter
 Type "# Apply the incremental changes" Enter
 Sleep 2s
-Type "pista apply schema.sql | colorize" Enter
+Type "pista apply schema.sql" Enter
 Sleep 4s
 
 # Verify no remaining diff
 Enter
 Type "# Verify that the schema is now in sync" Enter
 Sleep 2s
-Type "pista plan schema.sql | colorize" Enter
+Type "pista plan schema.sql" Enter
 Sleep 4s
 
 # Dump
 Enter
 Type "# Dump the current database schema" Enter
 Sleep 2s
-Type "pista dump | colorize" Enter
+Type "pista dump" Enter
 Sleep 4s

--- a/demo.tape
+++ b/demo.tape
@@ -51,7 +51,7 @@ Sleep 4s
 
 # Backup and modify schema: add a column
 Enter
-Type "# Modify the schema file: add an body column to posts" Enter
+Type "# Modify the schema file: add a body column to posts" Enter
 Sleep 2s
 Type "sed -i.bak 's/title text NOT NULL,/title text NOT NULL,\n    body text NOT NULL,/' schema.sql" Enter
 Sleep 0.5s

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/winebarrel/pistachio
 go 1.26
 
 require (
+	github.com/alecthomas/chroma/v2 v2.24.1
 	github.com/alecthomas/kong v1.15.0
 	github.com/jackc/pgx/v5 v5.9.1
+	github.com/mattn/go-isatty v0.0.22
 	github.com/pganalyze/pg_query_go/v6 v6.2.2
 	github.com/stretchr/testify v1.11.1
 	github.com/winebarrel/orderedmap v1.7.0
@@ -13,13 +15,11 @@ require (
 )
 
 require (
-	github.com/alecthomas/chroma/v2 v2.24.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/mod v0.36.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,13 @@ require (
 )
 
 require (
+	github.com/alecthomas/chroma/v2 v2.24.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/mod v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/winebarrel/orderedmap v1.7.0 h1:SWe+CApXxqqWiXT+G9KoSy15YMNzgJbBMNU4I
 github.com/winebarrel/orderedmap v1.7.0/go.mod h1:/LvVD4ZrMGgzoV9UkbzWSTy1yGVjnBImC6SmJvH1eeM=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6DfZJQM=
+github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/kong v1.15.0 h1:BVJstKbpO73zKpmIu+m/aLRrNmWwxXPIGTNin9VmLVI=
 github.com/alecthomas/kong v1.15.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
@@ -8,6 +10,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -24,6 +28,8 @@ github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
+github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/pganalyze/pg_query_go/v6 v6.2.2 h1:O0L6zMC226R82RF3X5n0Ki6HjytDsoAzuzp4ATVAHNo=
 github.com/pganalyze/pg_query_go/v6 v6.2.2/go.mod h1:Cn6+j4870kJz3iYNsb0VsNG04vpSWgEvBwc590J4qD0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/options.go
+++ b/options.go
@@ -20,9 +20,12 @@ type Options struct {
 // BeforeApply seeds Options.Color from the runtime environment so the
 // --color / --no-color flag has a sensible default. Kong invokes this before
 // flag values are applied, so an explicit flag still wins. NO_COLOR is honored
-// per https://no-color.org/ — presence (regardless of value) disables color.
+// per https://no-color.org/ — presence (regardless of value, including empty)
+// disables color, so os.LookupEnv is used to distinguish "unset" from
+// "set to empty".
 func (o *Options) BeforeApply() error {
-	o.Color = isatty.IsTerminal(os.Stdout.Fd()) && os.Getenv("NO_COLOR") == ""
+	_, noColor := os.LookupEnv("NO_COLOR")
+	o.Color = isatty.IsTerminal(os.Stdout.Fd()) && !noColor
 	return nil
 }
 

--- a/options.go
+++ b/options.go
@@ -14,7 +14,7 @@ type Options struct {
 	Password   string            `env:"PISTA_PASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PISTA_SCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
-	Color      bool              `negatable:"" help:"Colorize SQL output. Defaults to enabled when stdout is a TTY and the NO_COLOR environment variable is unset (see https://no-color.org/)."`
+	Color      bool              `negatable:"" help:"Colorize SQL output. Auto-detected from TTY/NO_COLOR (https://no-color.org/)."`
 }
 
 // BeforeApply seeds Options.Color from the runtime environment so the

--- a/options.go
+++ b/options.go
@@ -2,7 +2,10 @@ package pistachio
 
 import (
 	"fmt"
+	"os"
 	"path"
+
+	"github.com/mattn/go-isatty"
 )
 
 type Options struct {
@@ -11,6 +14,16 @@ type Options struct {
 	Password   string            `env:"PISTA_PASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PISTA_SCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
+	Color      bool              `negatable:"" help:"Colorize SQL output. Defaults to enabled when stdout is a TTY and the NO_COLOR environment variable is unset (see https://no-color.org/)."`
+}
+
+// BeforeApply seeds Options.Color from the runtime environment so the
+// --color / --no-color flag has a sensible default. Kong invokes this before
+// flag values are applied, so an explicit flag still wins. NO_COLOR is honored
+// per https://no-color.org/ — presence (regardless of value) disables color.
+func (o *Options) BeforeApply() error {
+	o.Color = isatty.IsTerminal(os.Stdout.Fd()) && os.Getenv("NO_COLOR") == ""
+	return nil
 }
 
 type FilterOptions struct {

--- a/options.go
+++ b/options.go
@@ -14,7 +14,7 @@ type Options struct {
 	Password   string            `env:"PISTA_PASSWORD" help:"PostgreSQL password."`
 	Schemas    []string          `short:"n" env:"PISTA_SCHEMAS" default:"public" help:"Schemas to inspect and modify."`
 	SchemaMap  map[string]string `short:"m" help:"Schema name mapping (e.g. -m old=new)."`
-	Color      bool              `negatable:"" help:"Colorize SQL output. Auto-detected from TTY/NO_COLOR (https://no-color.org/)."`
+	Color      bool              `negatable:"" help:"Colorize SQL output. Auto-detected from TTY/NO_COLOR."`
 }
 
 // BeforeApply seeds Options.Color from the runtime environment so the

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,32 @@
+package pistachio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptions_BeforeApply_NoColorEnvDisablesColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	o := &Options{}
+	require.NoError(t, o.BeforeApply())
+	assert.False(t, o.Color, "NO_COLOR must disable Color regardless of TTY state")
+}
+
+func TestOptions_BeforeApply_NoColorAnyValueDisables(t *testing.T) {
+	// Per https://no-color.org/, any non-empty value disables color.
+	t.Setenv("NO_COLOR", "0")
+	o := &Options{}
+	require.NoError(t, o.BeforeApply())
+	assert.False(t, o.Color, "NO_COLOR=0 still disables color per spec")
+}
+
+func TestOptions_BeforeApply_NoTTYDisablesColor(t *testing.T) {
+	// `go test` runs with stdout piped (not a TTY), so isatty returns false
+	// and BeforeApply must leave Color disabled even when NO_COLOR is unset.
+	t.Setenv("NO_COLOR", "")
+	o := &Options{}
+	require.NoError(t, o.BeforeApply())
+	assert.False(t, o.Color, "non-TTY stdout must disable Color")
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,6 +1,7 @@
 package pistachio
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,19 +15,54 @@ func TestOptions_BeforeApply_NoColorEnvDisablesColor(t *testing.T) {
 	assert.False(t, o.Color, "NO_COLOR must disable Color regardless of TTY state")
 }
 
-func TestOptions_BeforeApply_NoColorAnyValueDisables(t *testing.T) {
-	// Per https://no-color.org/, any non-empty value disables color.
+func TestOptions_BeforeApply_NoColorZeroValueDisables(t *testing.T) {
+	// Per https://no-color.org/, presence regardless of value disables color.
+	// "0" is intentionally not a magic "off" value.
 	t.Setenv("NO_COLOR", "0")
 	o := &Options{}
 	require.NoError(t, o.BeforeApply())
 	assert.False(t, o.Color, "NO_COLOR=0 still disables color per spec")
 }
 
-func TestOptions_BeforeApply_NoTTYDisablesColor(t *testing.T) {
-	// `go test` runs with stdout piped (not a TTY), so isatty returns false
-	// and BeforeApply must leave Color disabled even when NO_COLOR is unset.
+func TestOptions_BeforeApply_NoColorEmptyValueDisables(t *testing.T) {
+	// Spec: presence regardless of value disables color, including the empty
+	// string. os.Getenv cannot distinguish "unset" from "set to empty", so the
+	// implementation uses os.LookupEnv.
 	t.Setenv("NO_COLOR", "")
 	o := &Options{}
 	require.NoError(t, o.BeforeApply())
+	assert.False(t, o.Color, "NO_COLOR set to empty must still disable color")
+}
+
+func TestOptions_BeforeApply_NoTTYDisablesColor(t *testing.T) {
+	// Exercise the !TTY branch deterministically: unset NO_COLOR (so the
+	// TTY check is what decides), and replace os.Stdout with the write end
+	// of a pipe so isatty.IsTerminal returns false regardless of how the
+	// test was launched (CI vs. interactive `go test`).
+	unsetNoColor(t)
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		r.Close()
+		w.Close()
+	})
+	orig := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = orig })
+
+	o := &Options{}
+	require.NoError(t, o.BeforeApply())
 	assert.False(t, o.Color, "non-TTY stdout must disable Color")
+}
+
+// unsetNoColor removes NO_COLOR for the duration of a single test, restoring
+// any pre-existing value on cleanup. t.Setenv has no "unset" counterpart, so
+// we manage it manually here.
+func unsetNoColor(t *testing.T) {
+	t.Helper()
+	prev, had := os.LookupEnv("NO_COLOR")
+	if had {
+		require.NoError(t, os.Unsetenv("NO_COLOR"))
+		t.Cleanup(func() { _ = os.Setenv("NO_COLOR", prev) })
+	}
 }


### PR DESCRIPTION
Based on #189 (feat/conn-info-comment).

## Summary

- Colorize `plan` / `apply` / `dump` output via chroma's PostgreSQL lexer.
- `--[no-]color` flag with auto-detection from TTY + `NO_COLOR` (https://no-color.org/).
- `SQLWriter` in `cmd/command` buffers writes and flushes through chroma on demand; `main.go` wraps `os.Stdout` and triggers Flush after the command runs. Run methods stay color-agnostic — they just write to `io.Writer`.
- Simplify `demo.tape`: drop the external `bat`-based `colorize` alias since pista now colorizes its own output.
- CHANGELOG updated for 1.7.3 (alongside the conn-info comment entry from #189).

## Test plan

- [x] `go test -run 'TestSQLWriter|TestOptions_BeforeApply' ./...` — passes
- [x] 100% coverage on `NewSQLWriter`, `Write`, `Flush`, `BeforeApply`
- [x] `make lint` — clean
- [x] `go run ./cmd/pista --help` — `--[no-]color` shows
- [ ] Verify on a real PostgreSQL instance (plan / apply / dump with both `--color` / `--no-color` / piped output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)