### PR TITLE
Exclude docker-compose from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,13 @@
   ],
   "vulnerabilityAlerts": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchManagers": [
+        "docker-compose"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Disable Renovate updates for the `docker-compose` manager so `compose.yaml` is not tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)