### PR TITLE
Update stale equalPolicyExpr reference in TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -119,9 +119,11 @@ without that qualification, so even semantically-identical USING /
 WITH CHECK expressions produce a spurious `ALTER POLICY` when subqueries
 are involved.
 
-`equalPolicyExpr` reuses `normalizeCheckExpr` from constraint diffs, which
-strips text-like casts and canonicalises `= ANY(ARRAY[...])` → `IN (...)`,
-but does not walk into subqueries and rewrite ColumnRef qualifications.
+`equalSelectExpr` (formerly `equalPolicyExpr`, renamed in #207 for shared
+use across policy / generated-column expressions) reuses `normalizeCheckExpr`
+from constraint diffs, which strips text-like casts and canonicalises
+`= ANY(ARRAY[...])` → `IN (...)`, but does not walk into subqueries and
+rewrite ColumnRef qualifications.
 
 Fix would be to walk `SubLink` / `RangeSubselect` nodes and strip column
 qualifiers that match the FROM-clause table alias. The same approach


### PR DESCRIPTION
## Summary

PR #207 renamed `equalPolicyExpr` to `equalSelectExpr` (the helper is shared between RLS policy USING / WITH CHECK comparison and stored-generated-column expression comparison; the body was never policy-specific). One TODO entry — "Policy USING / WITH CHECK normalization for subquery column refs" — still points at the old name. Update the reference and note the rename inline so future readers grepping for the symbol find it.

Audited the rest of TODO.md while I was there. All other entries are still relevant:

- column-rename cross-object rewrite (#123), ValidateColumnRefs for GENERATED/DEFAULT (#124), INHERITS plan/apply (#125), TableSpace silent drift, Unlogged toggle silent drift, `Column.StorageType` dead code (verified still declared-only in `model/column.go:45`), Constraint Deferrable/Deferred granularity, standalone Sequences, table-rename cross-table dependents, `TO CURRENT_USER` reserved-role spec round-trip, Named NOT NULL constraints on PG18, forgotten-dependent-reference plan-time error promotion.

No removals — the "no fix planned" entries (`TO CURRENT_USER`, forgotten-dependent-reference) double as known-limitation documentation and are kept in place.

## Test plan

- [x] TODO.md edit only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)