### PR TITLE
Add docker demo image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,85 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
+
+  demo-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository }}-demo
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          file: demo/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=ghcr.io/${{ github.repository }}-demo,push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            PISTA_VERSION=${{ github.ref_name }}
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: demo-digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  demo:
+    runs-on: ubuntu-latest
+    needs:
+      - demo-build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: demo-digests-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository }}-demo
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ github.repository }}-demo@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/${{ github.repository }}-demo:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
 
-  demo-build:
+  docker-demo-build:
     strategy:
       fail-fast: false
       matrix:
@@ -164,10 +164,10 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  demo:
+  docker-demo:
     runs-on: ubuntu-latest
     needs:
-      - demo-build
+      - docker-demo-build
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ brew install winebarrel/pistachio/pistachio
 
 Download the latest binary from [Releases](https://github.com/winebarrel/pistachio/releases).
 
+## Try it out
+
+A self-contained demo image bundles a local PostgreSQL with a sample
+schema pre-loaded, so you can experiment with `pista` without
+installing anything:
+
+```bash
+docker run --rm -it ghcr.io/winebarrel/pistachio-demo
+```
+
+The container drops you into a shell in `/demo` with `pista` and
+`psql` preconfigured. Edit `desired.sql`, then try:
+
+```bash
+pista plan  desired.sql     # show the DDL diff
+pista apply desired.sql     # apply the changes
+pista plan  desired.sql     # ...should now print "No changes"
+pista dump                  # dump the current schema
+```
+
+The source for the image is under [`demo/`](demo/).
+
 ## Usage
 
 ```

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /src
 COPY go.* /src/
 RUN go mod download
 COPY . /src/
-RUN CGO_ENABLED=1 go build -o /out/pista ./cmd/pista
+ARG PISTA_VERSION
+RUN CGO_ENABLED=1 go build -o /out/pista -ldflags "-X main.version=${PISTA_VERSION#v}" ./cmd/pista
 
 FROM postgres:17-alpine
 RUN apk add --no-cache bash

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+#
+# pistachio demo image: PostgreSQL + pista CLI + sample schemas.
+# Build from the repo root:
+#   docker build -f demo/Dockerfile -t pistachio-demo .
+# Run:
+#   docker run --rm -it pistachio-demo
+#
+FROM golang:1.26-alpine AS build
+RUN apk add --no-cache gcc musl-dev
+WORKDIR /src
+COPY go.* /src/
+RUN go mod download
+COPY . /src/
+RUN CGO_ENABLED=1 go build -o /out/pista ./cmd/pista
+
+FROM postgres:17-alpine
+RUN apk add --no-cache bash
+
+COPY --from=build /out/pista /usr/local/bin/pista
+COPY demo/ /demo/
+RUN chmod +x /demo/entrypoint.sh && chown -R postgres:postgres /demo
+
+ENV PGHOST=/var/run/postgresql \
+    PGUSER=postgres \
+    PGDATABASE=demo \
+    PISTA_CONN_STR=postgres://postgres@/demo
+
+WORKDIR /demo
+USER postgres
+
+# Initialise the cluster and pre-load current.sql at build time so
+# every `docker run --rm` starts from the same instant-ready state.
+RUN initdb -D /var/lib/postgresql/data >/dev/null && \
+    pg_ctl -D /var/lib/postgresql/data -l /tmp/init.log start && \
+    until pg_isready -q; do sleep 0.1; done && \
+    createdb demo && \
+    psql -d demo -v ON_ERROR_STOP=1 -f /demo/current.sql && \
+    pg_ctl -D /var/lib/postgresql/data -m fast stop
+
+ENTRYPOINT ["/demo/entrypoint.sh"]
+CMD ["bash"]

--- a/demo/banner.txt
+++ b/demo/banner.txt
@@ -13,6 +13,14 @@ Try the following:
   pista dump                  # dump the current schema
   psql                        # poke around the DB
 
+Destructive changes (DROP COLUMN / DROP TABLE / etc.) are skipped
+by default and shown as '-- skipped:' comments. To allow them,
+pass --allow-drop with the object types you want to permit:
+
+  pista plan  --allow-drop=column        desired.sql
+  pista apply --allow-drop=column,table  desired.sql
+  pista apply --allow-drop=all           desired.sql
+
 Files in this directory (/demo):
   current.sql   - already loaded into 'demo'
   desired.sql   - edit me, then re-run 'pista plan'

--- a/demo/banner.txt
+++ b/demo/banner.txt
@@ -1,0 +1,21 @@
+================================================================
+                       pistachio demo
+================================================================
+
+A local PostgreSQL is running and the schema from current.sql
+is already loaded into the 'demo' database.
+
+Try the following:
+
+  pista plan  desired.sql     # show the DDL diff
+  pista apply desired.sql     # apply the changes
+  pista plan  desired.sql     # ...should now print "No changes"
+  pista dump                  # dump the current schema
+  psql                        # poke around the DB
+
+Files in this directory (/demo):
+  current.sql   - already loaded into 'demo'
+  desired.sql   - edit me, then re-run 'pista plan'
+
+Exit with Ctrl-D.
+================================================================

--- a/demo/current.sql
+++ b/demo/current.sql
@@ -70,10 +70,8 @@ CREATE TABLE post_tags (
 );
 
 -- ---------- view ----------
---  Cast to post_status matches the form PostgreSQL stores back,
---  so re-running 'pista plan' after apply reports no drift.
 CREATE VIEW published_posts AS
     SELECT p.id, p.title, p.body, p.published_at, u.display_name AS author
     FROM posts p
     JOIN users u ON u.id = p.author_id
-    WHERE p.status = 'published'::post_status;
+    WHERE p.status = 'published';

--- a/demo/current.sql
+++ b/demo/current.sql
@@ -1,0 +1,79 @@
+-- ============================================================
+--  pistachio demo: blog/CMS schema (current state)
+--  This file is loaded into the 'demo' database at image build.
+-- ============================================================
+
+-- Enum: post status
+CREATE TYPE post_status AS ENUM ('draft', 'published', 'archived');
+
+-- Domain: simple email validation
+CREATE DOMAIN email_address AS text
+    CHECK (VALUE ~ '^[^@]+@[^@]+\.[^@]+$');
+
+-- ---------- users ----------
+CREATE TABLE users (
+    id           bigserial PRIMARY KEY,
+    email        email_address NOT NULL UNIQUE,
+    display_name text NOT NULL,
+    created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- ---------- posts ----------
+--  foreign key, check constraint, generated column,
+--  partial index, row-level security
+CREATE TABLE posts (
+    id           bigserial PRIMARY KEY,
+    author_id    bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    title        text NOT NULL,
+    body         text NOT NULL,
+    status       post_status NOT NULL DEFAULT 'draft',
+    word_count   integer GENERATED ALWAYS AS (array_length(string_to_array(body, ' '), 1)) STORED,
+    published_at timestamptz,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    CHECK (status <> 'published' OR published_at IS NOT NULL)
+);
+
+CREATE INDEX posts_author_id_idx ON posts (author_id);
+CREATE INDEX posts_published_idx ON posts (published_at DESC) WHERE status = 'published';
+
+ALTER TABLE posts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY posts_visible ON posts
+    FOR SELECT
+    USING (
+        status = 'published'
+        OR author_id = current_setting('app.user_id', true)::bigint
+    );
+
+-- ---------- comments ----------
+CREATE TABLE comments (
+    id         bigserial PRIMARY KEY,
+    post_id    bigint NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    author_id  bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    body       text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX comments_post_id_idx ON comments (post_id);
+
+-- ---------- tags ----------
+CREATE TABLE tags (
+    id   bigserial PRIMARY KEY,
+    name text NOT NULL UNIQUE
+);
+
+-- ---------- post_tags (composite PK, multiple FKs) ----------
+CREATE TABLE post_tags (
+    post_id bigint NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    tag_id  bigint NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (post_id, tag_id)
+);
+
+-- ---------- view ----------
+--  Cast to post_status matches the form PostgreSQL stores back,
+--  so re-running 'pista plan' after apply reports no drift.
+CREATE VIEW published_posts AS
+    SELECT p.id, p.title, p.body, p.published_at, u.display_name AS author
+    FROM posts p
+    JOIN users u ON u.id = p.author_id
+    WHERE p.status = 'published'::post_status;

--- a/demo/desired.sql
+++ b/demo/desired.sql
@@ -82,4 +82,4 @@ CREATE VIEW published_posts AS
     SELECT p.id, p.title, p.body, p.published_at, u.display_name AS author, p.updated_at
     FROM posts p
     JOIN users u ON u.id = p.author_id
-    WHERE p.status = 'published'::post_status;
+    WHERE p.status = 'published';

--- a/demo/desired.sql
+++ b/demo/desired.sql
@@ -1,0 +1,85 @@
+-- ============================================================
+--  pistachio demo: blog/CMS schema (desired state)
+--  Edit this file freely, then run:  pista plan desired.sql
+-- ============================================================
+
+-- Added 'pinned' to the enum
+CREATE TYPE post_status AS ENUM ('draft', 'published', 'archived', 'pinned');
+
+CREATE DOMAIN email_address AS text
+    CHECK (VALUE ~ '^[^@]+@[^@]+\.[^@]+$');
+
+-- ---------- users ----------
+--  +avatar_url
+CREATE TABLE users (
+    id           bigserial PRIMARY KEY,
+    email        email_address NOT NULL UNIQUE,
+    display_name text NOT NULL,
+    avatar_url   text,
+    created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- ---------- posts ----------
+--  -word_count, +updated_at, +posts_created_idx, +posts_modifiable policy
+CREATE TABLE posts (
+    id           bigserial PRIMARY KEY,
+    author_id    bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    title        text NOT NULL,
+    body         text NOT NULL,
+    status       post_status NOT NULL DEFAULT 'draft',
+    published_at timestamptz,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+    CHECK (status <> 'published' OR published_at IS NOT NULL)
+);
+
+CREATE INDEX posts_author_id_idx ON posts (author_id);
+CREATE INDEX posts_published_idx ON posts (published_at DESC) WHERE status = 'published';
+CREATE INDEX posts_created_idx   ON posts (created_at  DESC);
+
+ALTER TABLE posts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY posts_visible ON posts
+    FOR SELECT
+    USING (
+        status IN ('published', 'pinned')
+        OR author_id = current_setting('app.user_id', true)::bigint
+    );
+
+CREATE POLICY posts_modifiable ON posts
+    FOR UPDATE
+    USING (author_id = current_setting('app.user_id', true)::bigint);
+
+-- ---------- comments ----------
+CREATE TABLE comments (
+    id         bigserial PRIMARY KEY,
+    post_id    bigint NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    author_id  bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    body       text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX comments_post_id_idx ON comments (post_id);
+
+-- ---------- tags ----------
+--  +slug
+CREATE TABLE tags (
+    id   bigserial PRIMARY KEY,
+    name text NOT NULL UNIQUE,
+    slug text NOT NULL UNIQUE
+);
+
+-- ---------- post_tags ----------
+CREATE TABLE post_tags (
+    post_id bigint NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    tag_id  bigint NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (post_id, tag_id)
+);
+
+-- ---------- view ----------
+--  include updated_at (appended at the end so CREATE OR REPLACE works)
+CREATE VIEW published_posts AS
+    SELECT p.id, p.title, p.body, p.published_at, u.display_name AS author, p.updated_at
+    FROM posts p
+    JOIN users u ON u.id = p.author_id
+    WHERE p.status = 'published'::post_status;

--- a/demo/entrypoint.sh
+++ b/demo/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+PGDATA=/var/lib/postgresql/data
+
+pg_ctl -D "$PGDATA" -l /tmp/pg.log start
+trap 'pg_ctl -D "$PGDATA" -m fast stop >/dev/null 2>&1 || true' EXIT
+
+until pg_isready -q; do sleep 0.1; done
+
+[ -f /demo/banner.txt ] && cat /demo/banner.txt
+
+exec "$@"


### PR DESCRIPTION
## Summary

A self-contained `pistachio-demo` Docker image that bundles a local PostgreSQL with a sample blog/CMS schema pre-loaded, so users can try `pista` with a single `docker run`.

- `demo/Dockerfile` — multi-stage build (Go builder + `postgres:17-alpine`). Pre-runs `initdb` and loads `current.sql` at build time so each container starts instantly.
- `demo/current.sql` / `demo/desired.sql` — 5-table blog/CMS sample covering enum, domain, FK, CHECK, generated column, partial index, RLS policy, and view.
- `demo/entrypoint.sh` — starts PG in the background, prints the banner, drops into `bash`, stops PG cleanly on exit.
- `demo/banner.txt` — usage hints, including `--allow-drop`.
- `.github/workflows/release.yml` — adds `docker-demo-build` (matrix per platform) and `docker-demo` (manifest merge) jobs that publish `ghcr.io/winebarrel/pistachio-demo` per release tag, parallel to the existing `pistachio` image jobs.
- `README.md` — new "Try it out" section.

## Test plan

- [ ] `docker build -f demo/Dockerfile -t pistachio-demo .` succeeds.
- [ ] `docker run --rm -it pistachio-demo` drops into the demo shell with the banner visible.
- [ ] `pista plan desired.sql` shows the expected diff (enum value add, column adds, index add, policy add/update, view replace, skipped DROP COLUMN).
- [ ] `pista apply desired.sql` succeeds.
- [ ] `pista plan desired.sql` after apply shows only the `-- skipped:` line plus `-- No changes`.
- [ ] On the next release tag push, the new `docker-demo-build` / `docker-demo` workflow jobs publish a multi-arch `ghcr.io/winebarrel/pistachio-demo` image alongside the existing `pistachio` image.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmBvPTABwrhVt3Q1qKRaaK)_