### PR TITLE
Place demo entrypoint at image root

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -19,8 +19,9 @@ FROM postgres:17-alpine
 RUN apk add --no-cache bash
 
 COPY --from=build /out/pista /usr/local/bin/pista
-COPY demo/ /demo/
-RUN chmod +x /demo/entrypoint.sh && chown -R postgres:postgres /demo
+COPY demo/entrypoint.sh /entrypoint.sh
+COPY demo/manual.txt demo/current.sql demo/desired.sql /demo/
+RUN chmod +x /entrypoint.sh && chown -R postgres:postgres /demo
 
 ENV PGHOST=/var/run/postgresql \
     PGUSER=postgres \
@@ -39,5 +40,5 @@ RUN initdb -D /var/lib/postgresql/data >/dev/null && \
     psql -d demo -v ON_ERROR_STOP=1 -f /demo/current.sql && \
     pg_ctl -D /var/lib/postgresql/data -m fast stop
 
-ENTRYPOINT ["/demo/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
## Summary

Stacks on top of #213. Switches the demo image's bulk `COPY demo/ /demo/` to per-file copies so that:

- `entrypoint.sh` lands at the image root (`/entrypoint.sh`) rather than under `/demo`.
- `/demo` inside the image contains only the user-facing files (`manual.txt`, `current.sql`, `desired.sql`).
- The `Dockerfile` itself is no longer baked into the published image (it was incidentally copied by the bulk `COPY`).

## Test plan

- [ ] `docker build -f demo/Dockerfile -t pistachio-demo .` succeeds.
- [ ] `docker run --rm -it pistachio-demo ls /` shows `entrypoint.sh` at the root.
- [ ] `docker run --rm -it pistachio-demo ls /demo` shows only `manual.txt`, `current.sql`, `desired.sql` (no `Dockerfile`, no `entrypoint.sh`).
- [ ] The banner still prints on container start and the existing plan / apply / dump flow works unchanged.