### PR TITLE
Re-apply demo entrypoint layout from #215 to main

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -19,8 +19,9 @@ FROM postgres:18-alpine
 RUN apk add --no-cache bash
 
 COPY --from=build /out/pista /usr/local/bin/pista
-COPY demo/ /demo/
-RUN chmod +x /demo/entrypoint.sh && chown -R postgres:postgres /demo
+COPY demo/entrypoint.sh /entrypoint.sh
+COPY demo/banner.txt demo/current.sql demo/desired.sql /demo/
+RUN chmod +x /entrypoint.sh && chown -R postgres:postgres /demo
 
 ENV PGHOST=/var/run/postgresql \
     PGUSER=postgres \
@@ -39,5 +40,5 @@ RUN initdb -D /var/lib/postgresql/data >/dev/null && \
     psql -d demo -v ON_ERROR_STOP=1 -f /demo/current.sql && \
     pg_ctl -D /var/lib/postgresql/data -m fast stop
 
-ENTRYPOINT ["/demo/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
## Summary
- PR #215 was merged into the intermediate branch `claude/create-online-demo-MEZKd` *after* PR #213 had already merged that branch into `main`, so its changes never reached `main`.
- This re-applies #215's commit (entrypoint moved to `/entrypoint.sh`, explicit file COPY) on top of the current `main`.
- One adjustment: #215 referenced `demo/manual.txt`, but `main` still uses `demo/banner.txt`. Updated the COPY to `banner.txt` to match the actual file (and what `entrypoint.sh` reads).

## Test plan
- [x] `docker build -f demo/Dockerfile -t pistachio-demo .` succeeds.
- [x] Inside the container: `/entrypoint.sh` exists at image root, `/demo/` contains only `banner.txt`, `current.sql`, `desired.sql` (no `Dockerfile`/`entrypoint.sh`).
- [x] Banner is printed at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)