### PR TITLE
Use SET statement_timeout in --pre-sql examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pista plan schema.sql
 pista plan tables.sql views.sql
 
 # Include pre-SQL in the output
-pista plan schema.sql --pre-sql "SET search_path TO myschema;"
+pista plan schema.sql --pre-sql "SET statement_timeout = '5s';"
 pista plan schema.sql --pre-sql-file pre.sql
 ```
 
@@ -111,7 +111,7 @@ Use `--pre-sql` or `--pre-sql-file` to run SQL before applying changes (mutually
 
 ```bash
 # Inline SQL
-pista apply schema.sql --pre-sql "SET search_path TO myschema;" --with-tx
+pista apply schema.sql --pre-sql "SET statement_timeout = '5s';" --with-tx
 
 # From file
 pista apply schema.sql --pre-sql-file pre.sql --with-tx

--- a/getting-started.md
+++ b/getting-started.md
@@ -218,10 +218,10 @@ pista apply schema.sql --with-tx
 
 ### Running pre-migration SQL
 
-Execute SQL before applying schema changes (e.g. installing extensions). Use `--pre-sql` for inline SQL or `--pre-sql-file` for a file (mutually exclusive):
+Execute SQL before applying schema changes (e.g. setting a statement timeout). Use `--pre-sql` for inline SQL or `--pre-sql-file` for a file (mutually exclusive):
 
 ```bash
-pista apply schema.sql --pre-sql "CREATE EXTENSION IF NOT EXISTS pgcrypto;" --with-tx
+pista apply schema.sql --pre-sql "SET statement_timeout = '5s';" --with-tx
 pista apply schema.sql --pre-sql-file pre.sql --with-tx
 ```
 


### PR DESCRIPTION
## Summary
- Replace the generic `SET search_path` / `CREATE EXTENSION` snippets in the `--pre-sql` examples with `SET statement_timeout = '5s';`, which better represents a typical pre-migration use case (guarding against long-running statements).
- Picked `statement_timeout` so the example doesn't overlap with the existing `--concurrently-pre-sql` example that already uses `SET lock_timeout`.
- Updated the surrounding prose in getting-started.md to match (\"installing extensions\" → \"setting a statement timeout\").

## Test plan
- [x] Docs-only change — visual review of README.md and getting-started.md diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)