### PR TITLE
Update image links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![](https://github.com/user-attachments/assets/a17f8c25-ccb3-408b-8062-751c12a92df2#gh-light-mode-only)
-![](https://github.com/user-attachments/assets/495fd93f-9a3a-45c9-af53-28a0f3968412#gh-dark-mode-only)
+![](https://github.com/user-attachments/assets/6d48635e-1d93-4b4b-a7fc-e8f888780575#gh-light-mode-only)
+![](https://github.com/user-attachments/assets/42250c31-d8cd-40a6-954d-77574e959a09#gh-dark-mode-only)
 
 [![CI](https://github.com/winebarrel/pistachio/actions/workflows/ci.yml/badge.svg)](https://github.com/winebarrel/pistachio/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/winebarrel/pistachio/branch/main/graph/badge.svg?token=lWmtTkDrbz)](https://codecov.io/gh/winebarrel/pistachio)


### PR DESCRIPTION
This pull request updates the images displayed at the top of the `README.md` file. The new images likely replace the previous ones for both light and dark modes.