### PR TITLE
Fix DROP COLUMN ordering when dependent objects are also dropped

### DIFF
--- a/diff/tables.go
+++ b/diff/tables.go
@@ -162,7 +162,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		return result, nil
 	}
 
-	colStmts, colDisallowed, err := diffColumns(fqtn, current.Columns, desired.Columns, dc)
+	colStmts, colDropStmts, colDisallowed, err := diffColumns(fqtn, current.Columns, desired.Columns, dc)
 	if err != nil {
 		return nil, err
 	}
@@ -222,16 +222,33 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 
 	result.Stmts = append(result.Stmts, diffComments(current, desired)...)
 
+	// Column drops go last so dependent objects (UNIQUE/CHECK constraints,
+	// indexes, policies) are dropped first. PostgreSQL silently cascades
+	// single-column UNIQUE/CHECK constraints and dependent indexes when a
+	// column is dropped, which would make a later explicit DROP
+	// CONSTRAINT/INDEX fail with "does not exist". Policies referencing a
+	// dropped column block the DROP COLUMN entirely.
+	result.Stmts = append(result.Stmts, colDropStmts...)
+
 	return result, nil
 }
 
-func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column], dc DropChecker) (stmts []string, disallowed []string, err error) {
+// diffColumns returns (stmts, dropStmts, disallowed, err). Adds, alters, and
+// renames go into stmts; pure drops (columns absent from desired) go into
+// dropStmts so the caller can sequence them after constraint/index/policy
+// drops on the same table — PostgreSQL auto-cascades single-column
+// UNIQUE/CHECK constraints and dependent indexes during DROP COLUMN, which
+// makes a later explicit DROP CONSTRAINT/INDEX fail with "does not exist".
+// Within dropStmts, generated columns are emitted before their potential
+// source columns so a paired drop (e.g. dropping both `body` and a stored
+// `word_count GENERATED ALWAYS AS (length(body))`) succeeds without CASCADE.
+func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Column], dc DropChecker) (stmts []string, dropStmts []string, disallowed []string, err error) {
 	dc = normalizeDropChecker(dc)
 
 	// Detect renames
 	renameStmts, current, err := detectColumnRenames(fqtn, current, desired)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	stmts = append(stmts, renameStmts...)
 
@@ -248,7 +265,7 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 			cur := currentCol.Generated.IsStoredGeneratedColumn()
 			des := desiredCol.Generated.IsStoredGeneratedColumn()
 			if cur != des {
-				return nil, nil, fmt.Errorf("column %s.%s: cannot toggle GENERATED — DROP COLUMN + ADD COLUMN is required",
+				return nil, nil, nil, fmt.Errorf("column %s.%s: cannot toggle GENERATED — DROP COLUMN + ADD COLUMN is required",
 					fqtn, model.Ident(name))
 			}
 			if cur && des && exprChanged(currentCol.Default, desiredCol.Default) {
@@ -264,7 +281,7 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 				// cast change or a cast-target-type change on a GENERATED
 				// expression. equalSelectExpr keeps the asymmetric strip
 				// from #201 / #203 but no DEFAULT-style softening.
-				return nil, nil, fmt.Errorf("column %s.%s: cannot change GENERATED expression — DROP COLUMN + ADD COLUMN is required",
+				return nil, nil, nil, fmt.Errorf("column %s.%s: cannot change GENERATED expression — DROP COLUMN + ADD COLUMN is required",
 					fqtn, model.Ident(name))
 			}
 			stmts = append(stmts, alterColumnSQL(fqtn, currentCol, desiredCol)...)
@@ -272,19 +289,27 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 	}
 
 	// Drop removed columns. When the column-drop policy disallows it, emit
-	// the same DROP as a comment for visibility.
+	// the same DROP as a comment for visibility. Two passes: generated
+	// columns first so dropping them doesn't fail when their source column
+	// is also being dropped in the same batch.
 	colAllowed := dc.IsDropAllowed("column")
-	for name := range current.Keys() {
-		if _, ok := desired.GetOk(name); !ok {
+	for _, pass := range []bool{true, false} {
+		for name, col := range current.All() {
+			if _, ok := desired.GetOk(name); ok {
+				continue
+			}
+			if col.Generated.IsStoredGeneratedColumn() != pass {
+				continue
+			}
 			if colAllowed {
-				stmts = append(stmts, "ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
+				dropStmts = append(dropStmts, "ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
 			} else {
 				disallowed = append(disallowed, "-- skipped: ALTER TABLE "+fqtn+" DROP COLUMN "+model.Ident(name)+";")
 			}
 		}
 	}
 
-	return stmts, disallowed, nil
+	return stmts, dropStmts, disallowed, nil
 }
 
 func addColumnSQL(fqtn string, col *model.Column) string {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -193,9 +193,10 @@ func TestDiffColumns_dropColumn_denied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, disallowed, err := diffColumns("public.users", current, desired, denyAllDrops{})
+	stmts, drops, disallowed, err := diffColumns("public.users", current, desired, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
+	assert.Empty(t, drops)
 	assert.Equal(t, []string{"-- skipped: ALTER TABLE public.users DROP COLUMN name;"}, disallowed)
 }
 
@@ -233,7 +234,7 @@ func TestDiffColumns_generatedExpressionChange(t *testing.T) {
 		Generated: 's',
 		Default:   new("price * quantity * 2"),
 	})
-	_, _, err := diffColumns("public.products", current, desired, allowAllDrops{})
+	_, _, _, err := diffColumns("public.products", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot change GENERATED expression")
 }
@@ -257,7 +258,7 @@ func TestDiffColumns_generatedExpressionTopLevelCastAdded(t *testing.T) {
 		Generated: 's',
 		Default:   new("(price * quantity)::numeric(10,2)"),
 	})
-	_, _, err := diffColumns("public.products", current, desired, allowAllDrops{})
+	_, _, _, err := diffColumns("public.products", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot change GENERATED expression")
 }
@@ -280,7 +281,7 @@ func TestDiffColumns_generatedExpressionEqualCastAsymmetric(t *testing.T) {
 		Generated: 's',
 		Default:   new("price * quantity"),
 	})
-	_, _, err := diffColumns("public.products", current, desired, allowAllDrops{})
+	_, _, _, err := diffColumns("public.products", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 }
 
@@ -292,7 +293,7 @@ func TestDiffColumns_addColumn(t *testing.T) {
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ADD COLUMN name text NOT NULL;", stmts[0])
@@ -306,10 +307,10 @@ func TestDiffColumns_dropColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, drops, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, stmts, 1)
-	assert.Equal(t, "ALTER TABLE public.users DROP COLUMN name;", stmts[0])
+	assert.Empty(t, stmts)
+	assert.Equal(t, []string{"ALTER TABLE public.users DROP COLUMN name;"}, drops)
 }
 
 func TestDiffColumns_alterType(t *testing.T) {
@@ -319,7 +320,7 @@ func TestDiffColumns_alterType(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;", stmts[0])
@@ -332,7 +333,7 @@ func TestDiffColumns_alterType_withCollation(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0], `COLLATE "en_US"`)
@@ -345,7 +346,7 @@ func TestDiffColumns_alterCollation_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("fr_FR")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{`ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text COLLATE "fr_FR";`}, stmts)
 }
@@ -357,7 +358,7 @@ func TestDiffColumns_alterCollation_add(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{`ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text COLLATE "en_US";`}, stmts)
 }
@@ -369,7 +370,7 @@ func TestDiffColumns_alterCollation_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;"}, stmts)
 }
@@ -381,7 +382,7 @@ func TestDiffColumns_alterCollation_unchanged(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -393,7 +394,7 @@ func TestDiffColumns_alterDefault_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer", Default: new("0")})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age SET DEFAULT 0;", stmts[0])
@@ -406,7 +407,7 @@ func TestDiffColumns_alterDefault_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("age", &model.Column{Name: "age", TypeName: "integer"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN age DROP DEFAULT;", stmts[0])
@@ -419,7 +420,7 @@ func TestDiffColumns_alterNotNull_set(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;", stmts[0])
@@ -432,7 +433,7 @@ func TestDiffColumns_alterNotNull_drop(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, stmts, 1)
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;", stmts[0])
@@ -448,7 +449,7 @@ func TestDiffColumns_renameNotNullConstraint(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &newName})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME CONSTRAINT users_name_nn_old TO users_name_nn_new;"}, stmts)
 }
@@ -462,7 +463,7 @@ func TestDiffColumns_notNullName_sameName_isNoOp(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -477,7 +478,7 @@ func TestDiffColumns_notNullName_addOrDrop_isNoOp(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 
@@ -488,7 +489,7 @@ func TestDiffColumns_notNullName_addOrDrop_isNoOp(t *testing.T) {
 	desired = orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true})
 
-	stmts, _, err = diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err = diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -513,7 +514,7 @@ func TestDiffColumns_renameNotNullConstraint_skipsIdentityColumn(t *testing.T) {
 		NotNullName: &newName, Identity: model.ColumnIdentity('a'),
 	})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -530,7 +531,7 @@ func TestDiffColumns_setNotNull_withDesiredName_ignoresName(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text", NotNull: true, NotNullName: &name})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;"}, stmts)
 }
@@ -546,7 +547,7 @@ func TestDiffColumns_dropNotNull_loseCurrentName(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ALTER COLUMN name DROP NOT NULL;"}, stmts)
 }
@@ -558,7 +559,7 @@ func TestDiffColumns_addColumn_withNotNullName(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("email", &model.Column{Name: "email", TypeName: "text", NotNull: true, NotNullName: &name})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users ADD COLUMN email text CONSTRAINT users_email_nn NOT NULL;"}, stmts)
 }
@@ -570,7 +571,7 @@ func TestDiffColumns_identitySkipsNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -2412,7 +2413,7 @@ func TestDiffColumns_renameColumn_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -2571,7 +2572,7 @@ func TestDiffColumns_renameColumn_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	_, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	_, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }
@@ -2603,7 +2604,7 @@ func TestDiffColumns_renameColumn(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER TABLE public.users RENAME COLUMN name TO display_name;"}, stmts)
 }
@@ -2616,7 +2617,7 @@ func TestDiffColumns_renameColumn_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	stmts, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }
@@ -2850,7 +2851,7 @@ func TestDiffColumns_renameColumn_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("display_name", &model.Column{Name: "display_name", RenameFrom: &oldName, TypeName: "text"})
 
-	_, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
+	_, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source column")
 }
@@ -3000,7 +3001,7 @@ func TestDiffColumns_addIdentity_fromNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY;",
@@ -3014,7 +3015,7 @@ func TestDiffColumns_addIdentity_fromNullable(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('d')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id SET NOT NULL;",
@@ -3032,7 +3033,7 @@ func TestDiffColumns_addIdentity_fromSerial(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id DROP DEFAULT;",
@@ -3047,7 +3048,7 @@ func TestDiffColumns_addIdentity_fromColumnWithDefault(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id DROP DEFAULT;",
@@ -3062,7 +3063,7 @@ func TestDiffColumns_dropIdentity_keepNotNull(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id DROP IDENTITY IF EXISTS;",
@@ -3076,7 +3077,7 @@ func TestDiffColumns_dropIdentity_toNullable(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id DROP IDENTITY IF EXISTS;",
@@ -3091,7 +3092,7 @@ func TestDiffColumns_changeIdentityKind_alwaysToByDefault(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('d')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id SET GENERATED BY DEFAULT;",
@@ -3105,7 +3106,7 @@ func TestDiffColumns_changeIdentityKind_byDefaultToAlways(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ALTER TABLE public.items ALTER COLUMN id SET GENERATED ALWAYS;",
@@ -3119,7 +3120,7 @@ func TestDiffColumns_identityUnchanged(t *testing.T) {
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 
-	stmts, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
+	stmts, _, _, err := diffColumns("public.items", current, desired, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, stmts)
 }

--- a/test/scenario/bulk_alter.test.sh
+++ b/test/scenario/bulk_alter.test.sh
@@ -29,11 +29,11 @@ if ! echo "$plan_output" | grep -qE '^ALTER TABLE public\.users$'; then
 elif ! echo "$plan_output" | grep -qE '^  ADD COLUMN name text NOT NULL,$'; then
   fail "expected indented action lines with trailing comma"
   echo "    $plan_output" >&2
-elif ! echo "$plan_output" | grep -qE '^  DROP COLUMN legacy,$'; then
-  fail "expected DROP COLUMN to be merged"
+elif ! echo "$plan_output" | grep -qE '^  ADD CONSTRAINT users_id_pos CHECK \(id > 0\),$'; then
+  fail "expected ADD CONSTRAINT to be merged before DROP COLUMN"
   echo "    $plan_output" >&2
-elif ! echo "$plan_output" | grep -qE '^  ADD CONSTRAINT users_id_pos CHECK \(id > 0\);$'; then
-  fail "expected ADD CONSTRAINT as final merged action"
+elif ! echo "$plan_output" | grep -qE '^  DROP COLUMN legacy;$'; then
+  fail "expected DROP COLUMN as final merged action (after dependent-object drops)"
   echo "    $plan_output" >&2
 else
   apply_output=$(pista_apply_bulk "$DATA/steps/01_multi_action.sql") || { fail "apply failed: $apply_output"; true; }

--- a/testdata/apply/bulk_alter_drop_column_with_constraint.yml
+++ b/testdata/apply/bulk_alter_drop_column_with_constraint.yml
@@ -1,0 +1,25 @@
+bulk_alter: true
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT tags_pkey PRIMARY KEY (id),
+      CONSTRAINT tags_slug_key UNIQUE (slug)
+  );
+desired: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      CONSTRAINT tags_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.tags
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      CONSTRAINT tags_pkey PRIMARY KEY (id)
+  );
+applied_sql: |
+  ALTER TABLE public.tags
+    DROP CONSTRAINT tags_slug_key,
+    DROP COLUMN slug;

--- a/testdata/apply/bulk_alter_mixed_actions.yml
+++ b/testdata/apply/bulk_alter_mixed_actions.yml
@@ -29,5 +29,5 @@ applied_sql: |
   ALTER TABLE public.users
     ADD COLUMN email text,
     ALTER COLUMN name SET NOT NULL,
-    DROP COLUMN legacy,
-    ADD CONSTRAINT users_id_pos CHECK (id > 0);
+    ADD CONSTRAINT users_id_pos CHECK (id > 0),
+    DROP COLUMN legacy;

--- a/testdata/apply/drop_column_referenced_by_fk.yml
+++ b/testdata/apply/drop_column_referenced_by_fk.yml
@@ -1,0 +1,36 @@
+init: |
+  CREATE TABLE public.parents (
+      id integer NOT NULL,
+      slug text NOT NULL,
+      CONSTRAINT parents_pkey PRIMARY KEY (id),
+      CONSTRAINT parents_slug_key UNIQUE (slug)
+  );
+  CREATE TABLE public.children (
+      id integer NOT NULL,
+      parent_slug text NOT NULL,
+      CONSTRAINT children_pkey PRIMARY KEY (id),
+      CONSTRAINT children_parent_slug_fkey FOREIGN KEY (parent_slug) REFERENCES public.parents (slug)
+  );
+desired: |
+  CREATE TABLE public.parents (
+      id integer NOT NULL,
+      CONSTRAINT parents_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.children (
+      id integer NOT NULL,
+      CONSTRAINT children_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.children
+  CREATE TABLE public.children (
+      id integer NOT NULL,
+      CONSTRAINT children_pkey PRIMARY KEY (id)
+  );
+
+  -- public.parents
+  CREATE TABLE public.parents (
+      id integer NOT NULL,
+      CONSTRAINT parents_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop: [all]

--- a/testdata/apply/drop_column_with_check_constraint.yml
+++ b/testdata/apply/drop_column_with_check_constraint.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      qty integer,
+      CONSTRAINT items_pkey PRIMARY KEY (id),
+      CONSTRAINT items_qty_check CHECK (qty > 0)
+  );
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop: [all]

--- a/testdata/apply/drop_column_with_composite_index.yml
+++ b/testdata/apply/drop_column_with_composite_index.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      ts timestamp NOT NULL,
+      level text NOT NULL,
+      CONSTRAINT logs_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX logs_ts_level_idx ON public.logs (ts, level);
+desired: |
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      ts timestamp NOT NULL,
+      CONSTRAINT logs_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.logs
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      ts timestamp without time zone NOT NULL,
+      CONSTRAINT logs_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop: [all]

--- a/testdata/apply/drop_column_with_generated_column.yml
+++ b/testdata/apply/drop_column_with_generated_column.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      price numeric(10,2) NOT NULL,
+      quantity integer NOT NULL,
+      total numeric(10,2) GENERATED ALWAYS AS ((price * (quantity)::numeric)) STORED,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      price numeric(10,2) NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.products
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      price numeric(10,2) NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop: [all]

--- a/testdata/apply/drop_column_with_index.yml
+++ b/testdata/apply/drop_column_with_index.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      occurred_at timestamp,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX events_occurred_idx ON public.events (occurred_at);
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop: [all]

--- a/testdata/apply/drop_column_with_multi_column_unique.yml
+++ b/testdata/apply/drop_column_with_multi_column_unique.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE TABLE public.assignments (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      role text NOT NULL,
+      CONSTRAINT assignments_pkey PRIMARY KEY (id),
+      CONSTRAINT assignments_user_role_key UNIQUE (user_id, role)
+  );
+desired: |
+  CREATE TABLE public.assignments (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT assignments_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.assignments
+  CREATE TABLE public.assignments (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT assignments_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop: [all]

--- a/testdata/apply/drop_column_with_policy.yml
+++ b/testdata/apply/drop_column_with_policy.yml
@@ -1,0 +1,24 @@
+init: |
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      owner_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.posts ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY posts_owner ON public.posts USING (owner_id = current_setting('app.user_id', true)::integer);
+desired: |
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.posts ENABLE ROW LEVEL SECURITY;
+applied: |
+  -- public.posts
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE public.posts ENABLE ROW LEVEL SECURITY;
+drop_policy:
+  allow_drop: [all]

--- a/testdata/apply/drop_column_with_unique_constraint.yml
+++ b/testdata/apply/drop_column_with_unique_constraint.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT tags_pkey PRIMARY KEY (id),
+      CONSTRAINT tags_slug_key UNIQUE (slug)
+  );
+desired: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      CONSTRAINT tags_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.tags
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      CONSTRAINT tags_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop: [all]

--- a/testdata/plan/bulk_alter_drop_column_with_constraint.yml
+++ b/testdata/plan/bulk_alter_drop_column_with_constraint.yml
@@ -1,0 +1,19 @@
+bulk_alter: true
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT tags_pkey PRIMARY KEY (id),
+      CONSTRAINT tags_slug_key UNIQUE (slug)
+  );
+desired: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      CONSTRAINT tags_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.tags
+    DROP CONSTRAINT tags_slug_key,
+    DROP COLUMN slug;

--- a/testdata/plan/bulk_alter_mixed_actions.yml
+++ b/testdata/plan/bulk_alter_mixed_actions.yml
@@ -18,5 +18,5 @@ plan: |
   ALTER TABLE public.users
     ADD COLUMN email text,
     ALTER COLUMN name SET NOT NULL,
-    DROP COLUMN legacy,
-    ADD CONSTRAINT users_id_pos CHECK (id > 0);
+    ADD CONSTRAINT users_id_pos CHECK (id > 0),
+    DROP COLUMN legacy;

--- a/testdata/plan/drop_column_disallowed_constraint_allowed.yml
+++ b/testdata/plan/drop_column_disallowed_constraint_allowed.yml
@@ -1,0 +1,18 @@
+drop_policy:
+  allow_drop: [constraint]
+init: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT tags_pkey PRIMARY KEY (id),
+      CONSTRAINT tags_slug_key UNIQUE (slug)
+  );
+desired: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      CONSTRAINT tags_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.tags DROP CONSTRAINT tags_slug_key;
+disallowed_drops: |
+  -- skipped: ALTER TABLE public.tags DROP COLUMN slug;

--- a/testdata/plan/drop_column_with_check_constraint.yml
+++ b/testdata/plan/drop_column_with_check_constraint.yml
@@ -1,0 +1,17 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      qty integer,
+      CONSTRAINT items_pkey PRIMARY KEY (id),
+      CONSTRAINT items_qty_check CHECK (qty > 0)
+  );
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.items DROP CONSTRAINT items_qty_check;
+  ALTER TABLE public.items DROP COLUMN qty;

--- a/testdata/plan/drop_column_with_generated_column.yml
+++ b/testdata/plan/drop_column_with_generated_column.yml
@@ -1,0 +1,19 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      price numeric(10,2) NOT NULL,
+      quantity integer NOT NULL,
+      total numeric(10,2) GENERATED ALWAYS AS ((price * (quantity)::numeric)) STORED,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      price numeric(10,2) NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.products DROP COLUMN total;
+  ALTER TABLE public.products DROP COLUMN quantity;

--- a/testdata/plan/drop_column_with_index.yml
+++ b/testdata/plan/drop_column_with_index.yml
@@ -1,0 +1,17 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      occurred_at timestamp,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX events_occurred_idx ON public.events (occurred_at);
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+plan: |
+  DROP INDEX public.events_occurred_idx;
+  ALTER TABLE public.events DROP COLUMN occurred_at;

--- a/testdata/plan/drop_column_with_policy.yml
+++ b/testdata/plan/drop_column_with_policy.yml
@@ -1,0 +1,19 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      owner_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.posts ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY posts_owner ON public.posts USING (owner_id = current_setting('app.user_id', true)::integer);
+desired: |
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.posts ENABLE ROW LEVEL SECURITY;
+plan: |
+  DROP POLICY posts_owner ON public.posts;
+  ALTER TABLE public.posts DROP COLUMN owner_id;

--- a/testdata/plan/drop_column_with_unique_constraint.yml
+++ b/testdata/plan/drop_column_with_unique_constraint.yml
@@ -1,0 +1,17 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT tags_pkey PRIMARY KEY (id),
+      CONSTRAINT tags_slug_key UNIQUE (slug)
+  );
+desired: |
+  CREATE TABLE public.tags (
+      id integer NOT NULL,
+      CONSTRAINT tags_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.tags DROP CONSTRAINT tags_slug_key;
+  ALTER TABLE public.tags DROP COLUMN slug;

--- a/testdata/plan/partition_child_concurrent_index.yml
+++ b/testdata/plan/partition_child_concurrent_index.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  -- pista:concurrently
+  CREATE INDEX events_2024_id_idx ON public.events_2024 (id);
+plan: |
+  CREATE INDEX CONCURRENTLY events_2024_id_idx ON public.events_2024 USING btree (id);


### PR DESCRIPTION
## Summary

When a column is dropped together with a dependent object on the same table, pistachio currently emits `DROP COLUMN` before `DROP CONSTRAINT` / `DROP INDEX` / `DROP POLICY`. PostgreSQL silently cascades single-column `UNIQUE` / `CHECK` constraints and dependent indexes during `DROP COLUMN`, so the subsequent explicit drop fails with `"... does not exist"`. RLS policies and stored-generated columns referencing the dropped column block `DROP COLUMN` outright.

Example before this PR (PG errors out on the second statement):
```sql
ALTER TABLE public.tags DROP COLUMN slug;
ALTER TABLE public.tags DROP CONSTRAINT tags_slug_key;  -- ERROR: does not exist
```

After:
```sql
ALTER TABLE public.tags DROP CONSTRAINT tags_slug_key;
ALTER TABLE public.tags DROP COLUMN slug;
```

## Changes

- `diff/tables.go::diffColumns` now returns column drops in a separate slice. Within that slice, stored-generated columns are emitted before non-generated ones so a `generated_col → source_col` pair drops cleanly.
- `diff/tables.go::diffTable` appends `colDropStmts` at the end of `result.Stmts`, after policy / index / constraint / comment / RLS handling. FK drops already emit first via `FKDropStmts`, so dependents are gone before the column itself goes.
- Bulk-alter merge naturally inherits the new order, so a single `ALTER TABLE` lists `DROP CONSTRAINT` before `DROP COLUMN`.

## Coverage

| Function | Before | After |
|---|---|---|
| `diffTable` | 80.0% | 98.4% |
| `diffColumns` | 42.9% | 100.0% |

## Test plan

- [x] Plan + apply fixtures for: single-col UNIQUE, multi-col UNIQUE, CHECK, single-col index, composite index, FK from another table, RLS policy, stored-generated column
- [x] Bulk-alter fixture for the merged `DROP CONSTRAINT, DROP COLUMN` form
- [x] Disallowed-drop interaction (`allow_drop: [constraint]` skips DROP COLUMN, the constraint drop still runs)
- [x] Existing `bulk_alter_mixed_actions` plan/apply fixtures updated to the new (correct) action order — `DROP COLUMN` now appears last in the merged `ALTER TABLE`
- [x] Partition-child + concurrent index plan fixture (raises `diffTable` coverage)
- [x] `make test` + `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)