### PR TITLE
Use DROP+CREATE for view changes that remove or rename columns

### DIFF
--- a/diff/rename.go
+++ b/diff/rename.go
@@ -151,9 +151,10 @@ func updateIndexTableName(def string, newTableName string) (string, error) {
 }
 
 // detectViewRenames finds desired views with RenameFrom that match a current view.
-func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([]string, *orderedmap.Map[string, *model.View], error) {
+func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([]string, *orderedmap.Map[string, *model.View], map[string]string, error) {
 	var stmts []string
 	adjusted := cloneMap(current)
+	renamedFrom := map[string]string{}
 
 	for newKey, desiredView := range desired.All() {
 		if desiredView.RenameFrom == nil {
@@ -170,21 +171,21 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 			if _, exists := adjusted.GetOk(newKey); exists {
 				continue
 			}
-			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+			return nil, nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
 		}
 
 		if oldKey != newKey {
 			if _, exists := adjusted.GetOk(newKey); exists {
-				return nil, nil, fmt.Errorf("cannot rename %s to %s: destination already exists", oldKey, newKey)
+				return nil, nil, nil, fmt.Errorf("cannot rename %s to %s: destination already exists", oldKey, newKey)
 			}
 		}
 
 		if oldView.Schema != desiredView.Schema {
-			return nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
+			return nil, nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
 		}
 
 		if oldView.Materialized != desiredView.Materialized {
-			return nil, nil, fmt.Errorf("cannot rename %s to %s: view type mismatch (cannot rename between VIEW and MATERIALIZED VIEW)", oldKey, newKey)
+			return nil, nil, nil, fmt.Errorf("cannot rename %s to %s: view type mismatch (cannot rename between VIEW and MATERIALIZED VIEW)", oldKey, newKey)
 		}
 
 		objType := "VIEW"
@@ -197,9 +198,10 @@ func detectViewRenames(current, desired *orderedmap.Map[string, *model.View]) ([
 		renamed := *oldView
 		renamed.Name = desiredView.Name
 		adjusted.Set(newKey, &renamed)
+		renamedFrom[newKey] = oldKey
 	}
 
-	return stmts, adjusted, nil
+	return stmts, adjusted, renamedFrom, nil
 }
 
 // detectColumnRenames finds desired columns with RenameFrom that match a current column.

--- a/diff/views.go
+++ b/diff/views.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"fmt"
+	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap"
@@ -54,6 +55,110 @@ func equalViewDef(current, desired string) bool {
 		return current == desired
 	}
 	return curStr == desStr
+}
+
+// canCreateOrReplaceView reports whether a view definition change can be
+// expressed as CREATE OR REPLACE VIEW. PostgreSQL requires the new query to
+// produce columns with the same names in the same order as the existing
+// view; only appending new columns at the end is allowed. Removing,
+// renaming, reordering, or replacing a column makes CREATE OR REPLACE fail
+// with `cannot drop columns from view` (or a similar error), so the caller
+// must use DROP + CREATE in that case.
+//
+// Returns false when either side's output columns can't be determined
+// statically (SELECT *, target-list expressions without an alias, parse
+// error). That conservatively routes uncertain cases through DROP +
+// CREATE, which always works at the cost of briefly dropping privileges /
+// dependent views — strictly better than leaving the bug in place.
+//
+// Known limitation: type-only changes on a same-named column (e.g.
+// `SELECT n FROM t` → `SELECT n::bigint AS n FROM t`) are reported as
+// CREATE-OR-REPLACE-able because the names line up, but PostgreSQL still
+// rejects them with `cannot change data type of view column`. pg_query
+// doesn't perform type inference, so we can't detect this statically;
+// users who hit it can resolve manually by adjusting the source DDL or
+// dropping the view in a pre-step.
+func canCreateOrReplaceView(current, desired string) bool {
+	curCols, curOK := viewOutputColumns(current)
+	desCols, desOK := viewOutputColumns(desired)
+	if !curOK || !desOK {
+		return false
+	}
+	if len(desCols) < len(curCols) {
+		return false
+	}
+	for i, name := range curCols {
+		if desCols[i] != name {
+			return false
+		}
+	}
+	return true
+}
+
+// viewOutputColumns parses a view definition's SELECT body and returns the
+// ordered list of output column names. Returns ok=false when any column
+// can't be named statically (SELECT *, t.*, or an expression target
+// without an alias) or when parsing fails.
+func viewOutputColumns(definition string) (cols []string, ok bool) {
+	def := strings.TrimSpace(definition)
+	def = strings.TrimSuffix(def, ";")
+	result, err := pg_query.Parse("CREATE VIEW _v AS " + def)
+	if err != nil || len(result.Stmts) != 1 {
+		return nil, false
+	}
+	vs := result.Stmts[0].Stmt.GetViewStmt()
+	if vs == nil || vs.Query == nil {
+		return nil, false
+	}
+	return selectOutputColumns(vs.Query)
+}
+
+// selectOutputColumns walks a SelectStmt and returns the ordered names of
+// its top-level target list. For UNION / INTERSECT / EXCEPT it recurses
+// into the left arm, since PostgreSQL inherits set-operation result names
+// from the first SELECT.
+func selectOutputColumns(node *pg_query.Node) ([]string, bool) {
+	ss := node.GetSelectStmt()
+	if ss == nil {
+		return nil, false
+	}
+	if ss.Op != pg_query.SetOperation_SETOP_NONE {
+		if ss.Larg == nil {
+			return nil, false
+		}
+		return selectOutputColumns(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Larg}})
+	}
+	if len(ss.TargetList) == 0 {
+		return nil, false
+	}
+	names := make([]string, 0, len(ss.TargetList))
+	for _, t := range ss.TargetList {
+		rt := t.GetResTarget()
+		if rt == nil {
+			return nil, false
+		}
+		if rt.Name != "" {
+			names = append(names, rt.Name)
+			continue
+		}
+		if rt.Val == nil {
+			return nil, false
+		}
+		cr := rt.Val.GetColumnRef()
+		if cr == nil || len(cr.Fields) == 0 {
+			return nil, false
+		}
+		last := cr.Fields[len(cr.Fields)-1]
+		if last.GetAStar() != nil {
+			return nil, false
+		}
+		s := last.GetString_()
+		if s == nil {
+			return nil, false
+		}
+		names = append(names, s.Sval)
+	}
+	return names, true
 }
 
 // normalizeSelectExprs walks a SELECT statement (and any nested
@@ -443,7 +548,15 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 				}
 			}
 		} else if !equalViewDef(currentView.Definition, desiredView.Definition) || currentView.Materialized != desiredView.Materialized {
+			// Materialized views always need DROP+CREATE; VIEW↔MATVIEW
+			// switches do too. Regular view definition changes prefer
+			// CREATE OR REPLACE — but PostgreSQL rejects it when the new
+			// query removes, renames, or reorders an existing output
+			// column, so detect that case and fall back to DROP+CREATE.
 			needsDropCreate := desiredView.Materialized || currentView.Materialized != desiredView.Materialized
+			if !needsDropCreate && !canCreateOrReplaceView(currentView.Definition, desiredView.Definition) {
+				needsDropCreate = true
+			}
 			if needsDropCreate {
 				// Materialized views or type changes (VIEW ↔ MATERIALIZED VIEW)
 				// require DROP and recreate. Only proceed if drops are allowed;

--- a/diff/views.go
+++ b/diff/views.go
@@ -595,18 +595,20 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 				needsDropCreate = true
 			}
 			if needsDropCreate {
+				// When the view was also renamed, drop the old name —
+				// the database still has it because the ALTER RENAME
+				// was suppressed above. Computed before the drop-policy
+				// branch so the skipped-DROP comment matches the
+				// relation that actually exists.
+				dropName := k
+				if oldKey, renamed := renamedFrom[k]; renamed {
+					dropName = oldKey
+				}
 				// Materialized views or type changes (VIEW ↔ MATERIALIZED VIEW)
 				// require DROP and recreate. Only proceed if drops are allowed;
 				// otherwise emit a commented DROP for visibility (no CREATE,
 				// since recreation requires the drop).
 				if dc.IsDropAllowed("view") {
-					// When the view was also renamed, drop the old name —
-					// the database still has it because the ALTER RENAME
-					// was suppressed above.
-					dropName := k
-					if oldKey, renamed := renamedFrom[k]; renamed {
-						dropName = oldKey
-					}
 					if currentView.Materialized {
 						result.DropStmts = append(result.DropStmts, "DROP MATERIALIZED VIEW "+dropName+";")
 					} else {
@@ -628,9 +630,9 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 					recreated[k] = true
 				} else {
 					if currentView.Materialized {
-						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP MATERIALIZED VIEW "+k+";")
+						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP MATERIALIZED VIEW "+dropName+";")
 					} else {
-						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP VIEW "+k+";")
+						result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP VIEW "+dropName+";")
 					}
 					recreateDenied[k] = true
 				}

--- a/diff/views.go
+++ b/diff/views.go
@@ -515,11 +515,10 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 	result := &ViewDiffResult{}
 
 	// Detect renames
-	renameStmts, current, err := detectViewRenames(current, desired)
+	renameStmts, current, renamedFrom, err := detectViewRenames(current, desired)
 	if err != nil {
 		return nil, err
 	}
-	result.CreateStmts = append(result.CreateStmts, renameStmts...)
 
 	// Track views that are recreated (DROP+CREATE) so comments can be re-applied.
 	recreated := make(map[string]bool)
@@ -527,6 +526,44 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 	// skip the executable comment diff too, so the output reflects "nothing
 	// executable" rather than emitting half of the intended change.
 	recreateDenied := make(map[string]bool)
+	// A renamed view that ALSO needs DROP+CREATE (e.g. its column list is
+	// changing) must not go through the ALTER ... RENAME path: that
+	// statement is sequenced with CreateStmts, after DropStmts, so by
+	// the time it runs the executable DROP has already failed against
+	// the old name. Track these so the rename statement is dropped
+	// and the DROP statement uses the old name instead.
+	needsRecreateRenamed := map[string]bool{}
+	for newKey := range renamedFrom {
+		desiredView, dok := desired.GetOk(newKey)
+		currentView, cok := current.GetOk(newKey)
+		if !dok || !cok {
+			continue
+		}
+		if currentView.Materialized != desiredView.Materialized {
+			needsRecreateRenamed[newKey] = true
+			continue
+		}
+		if !equalViewDef(currentView.Definition, desiredView.Definition) {
+			if desiredView.Materialized || !canCreateOrReplaceView(currentView.Definition, desiredView.Definition) {
+				needsRecreateRenamed[newKey] = true
+			}
+		}
+	}
+	for _, stmt := range renameStmts {
+		skip := false
+		for newKey := range needsRecreateRenamed {
+			oldKey := renamedFrom[newKey]
+			desiredView, _ := desired.GetOk(newKey)
+			needle := oldKey + " RENAME TO " + model.Ident(desiredView.Name) + ";"
+			if strings.Contains(stmt, needle) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			result.CreateStmts = append(result.CreateStmts, stmt)
+		}
+	}
 
 	// New or modified views (CREATE OR REPLACE / recreate for materialized)
 	for k, desiredView := range desired.All() {
@@ -563,10 +600,17 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 				// otherwise emit a commented DROP for visibility (no CREATE,
 				// since recreation requires the drop).
 				if dc.IsDropAllowed("view") {
+					// When the view was also renamed, drop the old name —
+					// the database still has it because the ALTER RENAME
+					// was suppressed above.
+					dropName := k
+					if oldKey, renamed := renamedFrom[k]; renamed {
+						dropName = oldKey
+					}
 					if currentView.Materialized {
-						result.DropStmts = append(result.DropStmts, "DROP MATERIALIZED VIEW "+k+";")
+						result.DropStmts = append(result.DropStmts, "DROP MATERIALIZED VIEW "+dropName+";")
 					} else {
-						result.DropStmts = append(result.DropStmts, "DROP VIEW "+k+";")
+						result.DropStmts = append(result.DropStmts, "DROP VIEW "+dropName+";")
 					}
 					result.CreateStmts = append(result.CreateStmts, desiredView.SQL())
 					if desiredView.Materialized && desiredView.Indexes != nil {

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -1215,6 +1215,82 @@ func TestViewOutputColumns_NegativePaths(t *testing.T) {
 	}
 }
 
+func TestDiffViews_renamePlusRecreateDropsOldNameAndSkipsRename(t *testing.T) {
+	// A view that is both renamed AND has a column-shape change needs
+	// DROP+CREATE. The DROP has to target the old name (the DB hasn't
+	// renamed yet) and the ALTER RENAME must be suppressed — otherwise
+	// the apply runs `DROP VIEW <new name>` first (no such view) and
+	// fails before the rename can move the row.
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v_old", &model.View{
+		Schema: "public", Name: "v_old",
+		Definition: "SELECT id, slug FROM t",
+	})
+	oldKey := "public.v_old"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v_new", &model.View{
+		Schema: "public", Name: "v_new", RenameFrom: &oldKey,
+		Definition: "SELECT id FROM t",
+	})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.DropStmts, 1)
+	assert.Equal(t, "DROP VIEW public.v_old;", result.DropStmts[0])
+	require.Len(t, result.CreateStmts, 1)
+	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v_new")
+	// Sanity: no stray ALTER VIEW ... RENAME in the plan.
+	for _, s := range result.CreateStmts {
+		assert.NotContains(t, s, "RENAME TO")
+	}
+}
+
+func TestDiffViews_renameWithoutDefinitionChangeKeepsRename(t *testing.T) {
+	// Pure rename (definition unchanged) must still emit ALTER RENAME —
+	// the new behavior only suppresses the rename when DROP+CREATE is
+	// also required.
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v_old", &model.View{
+		Schema: "public", Name: "v_old",
+		Definition: "SELECT id FROM t",
+	})
+	oldKey := "public.v_old"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v_new", &model.View{
+		Schema: "public", Name: "v_new", RenameFrom: &oldKey,
+		Definition: "SELECT id FROM t",
+	})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	require.Len(t, result.CreateStmts, 1)
+	assert.Equal(t, "ALTER VIEW public.v_old RENAME TO v_new;", result.CreateStmts[0])
+}
+
+func TestDiffViews_renameWithAppendOnlyChangeKeepsRename(t *testing.T) {
+	// Rename + append-only change uses CREATE OR REPLACE (not DROP+CREATE).
+	// The rename has to survive, then the in-place replace updates the body.
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v_old", &model.View{
+		Schema: "public", Name: "v_old",
+		Definition: "SELECT id FROM t",
+	})
+	oldKey := "public.v_old"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v_new", &model.View{
+		Schema: "public", Name: "v_new", RenameFrom: &oldKey,
+		Definition: "SELECT id, name FROM t",
+	})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	require.Len(t, result.CreateStmts, 2)
+	assert.Equal(t, "ALTER VIEW public.v_old RENAME TO v_new;", result.CreateStmts[0])
+	assert.Contains(t, result.CreateStmts[1], "CREATE OR REPLACE VIEW public.v_new")
+}
+
 func TestDiffViews_columnRemovedTriggersDropCreate(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.v", &model.View{

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -1185,6 +1185,36 @@ func TestCanCreateOrReplaceView(t *testing.T) {
 	}
 }
 
+func TestViewOutputColumns_NegativePaths(t *testing.T) {
+	// Direct table-driven coverage for viewOutputColumns /
+	// selectOutputColumns input forms that canCreateOrReplaceView only
+	// hits incidentally — locking the ok=false branches against future
+	// refactors and trimming the patch's uncovered-line count.
+	tests := []struct {
+		name string
+		body string
+	}{
+		// pg_query accepts a bare `SELECT` (no target list) without
+		// reporting a syntax error, producing a SelectStmt with an
+		// empty TargetList. The function must reject it so callers
+		// fall back to DROP+CREATE.
+		{"empty TargetList", "SELECT"},
+		// SELECT * is unanalyzable: until the catalog expands the star
+		// to real column names there's no list to compare against.
+		{"SELECT *", "SELECT * FROM t"},
+		// Computed expression with no alias has no stable output name.
+		{"bare expression target", "SELECT a + b FROM t"},
+		// Parse failures short-circuit early.
+		{"parse error", "this is not SQL"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := viewOutputColumns(tc.body)
+			assert.False(t, ok)
+		})
+	}
+}
+
 func TestDiffViews_columnRemovedTriggersDropCreate(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.v", &model.View{

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -1078,3 +1078,167 @@ func TestDiffViews_modifyMatviewWithIndex_perIndexDirective(t *testing.T) {
 	assert.Contains(t, result.CreateStmts[0], "CREATE MATERIALIZED VIEW")
 	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_mv_n ON public.mv USING btree (n);", result.CreateStmts[1])
 }
+
+func TestCanCreateOrReplaceView(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		desired string
+		want    bool
+	}{
+		{
+			name:    "identical column list",
+			current: "SELECT id, name FROM t",
+			desired: "SELECT id, name FROM t WHERE active",
+			want:    true,
+		},
+		{
+			name:    "append column at end (allowed by PG)",
+			current: "SELECT id, name FROM t",
+			desired: "SELECT id, name, email FROM t",
+			want:    true,
+		},
+		{
+			name:    "remove column",
+			current: "SELECT id, name FROM t",
+			desired: "SELECT id FROM t",
+			want:    false,
+		},
+		{
+			name:    "rename column via alias",
+			current: "SELECT id, name FROM t",
+			desired: "SELECT id, name AS display FROM t",
+			want:    false,
+		},
+		{
+			name:    "reorder columns",
+			current: "SELECT id, name FROM t",
+			desired: "SELECT name, id FROM t",
+			want:    false,
+		},
+		{
+			name:    "desired uses SELECT * (cannot analyze → safer DROP+CREATE)",
+			current: "SELECT id FROM t",
+			desired: "SELECT * FROM t",
+			want:    false,
+		},
+		{
+			name:    "current is a UNION (first SELECT decides column names)",
+			current: "SELECT id, name FROM t1 UNION SELECT id, name FROM t2",
+			desired: "SELECT id, name FROM t1 UNION SELECT id, name FROM t2 WHERE active",
+			want:    true,
+		},
+		{
+			name:    "expression without alias (unanalyzable)",
+			current: "SELECT id, length(name) FROM t",
+			desired: "SELECT id, upper(name) FROM t",
+			want:    false,
+		},
+		{
+			name:    "parse error on one side",
+			current: "SELECT id FROM t",
+			desired: "NOT A VIEW",
+			want:    false,
+		},
+		{
+			name:    "CTE in view body (outer SELECT decides)",
+			current: "WITH c AS (SELECT id FROM t) SELECT id FROM c",
+			desired: "WITH c AS (SELECT id, name FROM t) SELECT id FROM c",
+			want:    true,
+		},
+		{
+			name:    "INTERSECT (first SELECT decides)",
+			current: "SELECT id FROM t INTERSECT SELECT id FROM u",
+			desired: "SELECT id FROM t WHERE active INTERSECT SELECT id FROM u",
+			want:    true,
+		},
+		{
+			name:    "EXCEPT (first SELECT decides)",
+			current: "SELECT id FROM t EXCEPT SELECT id FROM u",
+			desired: "SELECT id, name FROM t EXCEPT SELECT id, name FROM u",
+			want:    true,
+		},
+		{
+			name:    "aliased expression keeps the alias as the column name",
+			current: "SELECT a + b AS sum FROM t",
+			desired: "SELECT a + b + 1 AS sum FROM t",
+			want:    true,
+		},
+		{
+			name:    "table-qualified column resolves to bare name",
+			current: "SELECT t.id, name FROM t",
+			desired: "SELECT id, name FROM t",
+			want:    true,
+		},
+		{
+			name:    "t.* (unanalyzable)",
+			current: "SELECT id FROM t",
+			desired: "SELECT t.* FROM t",
+			want:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := canCreateOrReplaceView(tc.current, tc.desired)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDiffViews_columnRemovedTriggersDropCreate(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v", &model.View{
+		Schema: "public", Name: "v",
+		Definition: "SELECT id, slug FROM t",
+	})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v", &model.View{
+		Schema: "public", Name: "v",
+		Definition: "SELECT id FROM t",
+	})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.DropStmts, 1)
+	assert.Equal(t, "DROP VIEW public.v;", result.DropStmts[0])
+	require.Len(t, result.CreateStmts, 1)
+	assert.Contains(t, result.CreateStmts[0], "SELECT id FROM t")
+}
+
+func TestDiffViews_columnAppendedKeepsCreateOrReplace(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v", &model.View{
+		Schema: "public", Name: "v",
+		Definition: "SELECT id FROM t",
+	})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v", &model.View{
+		Schema: "public", Name: "v",
+		Definition: "SELECT id, name FROM t",
+	})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	require.Len(t, result.CreateStmts, 1)
+	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW")
+}
+
+func TestDiffViews_columnRemovedDropDeniedFallsBackToCommented(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v", &model.View{
+		Schema: "public", Name: "v",
+		Definition: "SELECT id, slug FROM t",
+	})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v", &model.View{
+		Schema: "public", Name: "v",
+		Definition: "SELECT id FROM t",
+	})
+
+	result, err := DiffViews(current, desired, denyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	assert.Empty(t, result.CreateStmts)
+	assert.Equal(t, []string{"-- skipped: DROP VIEW public.v;"}, result.DisallowedDropStmts)
+}

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -1268,6 +1268,31 @@ func TestDiffViews_renameWithoutDefinitionChangeKeepsRename(t *testing.T) {
 	assert.Equal(t, "ALTER VIEW public.v_old RENAME TO v_new;", result.CreateStmts[0])
 }
 
+func TestDiffViews_renamePlusRecreateDropDeniedSkipsOldName(t *testing.T) {
+	// Mirror of the executable-drop fix for the denied-drop branch:
+	// when --allow-drop forbids the view drop, the `-- skipped:` comment
+	// has to point at the relation that actually exists (the old name),
+	// not the renamed-but-not-yet-applied new name.
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v_old", &model.View{
+		Schema: "public", Name: "v_old",
+		Definition: "SELECT id, slug FROM t",
+	})
+	oldKey := "public.v_old"
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v_new", &model.View{
+		Schema: "public", Name: "v_new", RenameFrom: &oldKey,
+		Definition: "SELECT id FROM t",
+	})
+
+	result, err := DiffViews(current, desired, denyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	assert.Empty(t, result.CreateStmts)
+	require.Len(t, result.DisallowedDropStmts, 1)
+	assert.Equal(t, "-- skipped: DROP VIEW public.v_old;", result.DisallowedDropStmts[0])
+}
+
 func TestDiffViews_renameWithAppendOnlyChangeKeepsRename(t *testing.T) {
 	// Rename + append-only change uses CREATE OR REPLACE (not DROP+CREATE).
 	// The rename has to survive, then the in-place replace updates the body.

--- a/testdata/apply/drop_column_referenced_by_view.yml
+++ b/testdata/apply/drop_column_referenced_by_view.yml
@@ -1,0 +1,32 @@
+init: |
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text NOT NULL,
+      updated_at timestamp NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.posts_summary AS
+      SELECT id, title, updated_at FROM public.posts;
+desired: |
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.posts_summary AS
+      SELECT id, title FROM public.posts;
+applied: |
+  -- public.posts
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  -- public.posts_summary
+  CREATE OR REPLACE VIEW public.posts_summary AS
+  SELECT posts.id,
+      posts.title
+     FROM posts;
+drop_policy:
+  allow_drop: [all]

--- a/testdata/apply/drop_column_referenced_by_view.yml
+++ b/testdata/apply/drop_column_referenced_by_view.yml
@@ -28,5 +28,20 @@ applied: |
   SELECT posts.id,
       posts.title
      FROM posts;
+applied_pg16: &applied_pg16plus |
+  -- public.posts
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  -- public.posts_summary
+  CREATE OR REPLACE VIEW public.posts_summary AS
+  SELECT id,
+      title
+     FROM posts;
+applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus
 drop_policy:
   allow_drop: [all]

--- a/testdata/apply/view_rename_with_column_removal.yml
+++ b/testdata/apply/view_rename_with_column_removal.yml
@@ -1,0 +1,41 @@
+init: |
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT t_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.v_old AS SELECT id, slug FROM public.t;
+desired: |
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT t_pkey PRIMARY KEY (id)
+  );
+  -- pista:renamed-from public.v_old
+  CREATE VIEW public.v_new AS SELECT id FROM public.t;
+applied: |
+  -- public.t
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT t_pkey PRIMARY KEY (id)
+  );
+
+  -- public.v_new
+  CREATE OR REPLACE VIEW public.v_new AS
+  SELECT t.id
+     FROM t;
+applied_pg16: &applied_pg16plus |
+  -- public.t
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      slug text,
+      CONSTRAINT t_pkey PRIMARY KEY (id)
+  );
+
+  -- public.v_new
+  CREATE OR REPLACE VIEW public.v_new AS
+  SELECT id
+     FROM t;
+applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/plan/drop_column_referenced_by_view.yml
+++ b/testdata/plan/drop_column_referenced_by_view.yml
@@ -1,0 +1,24 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text NOT NULL,
+      updated_at timestamp NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.posts_summary AS
+      SELECT id, title, updated_at FROM public.posts;
+desired: |
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.posts_summary AS
+      SELECT id, title FROM public.posts;
+plan: |
+  DROP VIEW public.posts_summary;
+  ALTER TABLE public.posts DROP COLUMN updated_at;
+  CREATE OR REPLACE VIEW public.posts_summary AS
+  SELECT id, title FROM public.posts;

--- a/testdata/plan/view_column_append_stays_replace.yml
+++ b/testdata/plan/view_column_append_stays_replace.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.users_view AS SELECT id, name FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.users_view AS SELECT id, name, email FROM public.users;
+plan: |
+  CREATE OR REPLACE VIEW public.users_view AS
+  SELECT id, name, email FROM public.users;

--- a/testdata/plan/view_column_rename_forces_recreate.yml
+++ b/testdata/plan/view_column_rename_forces_recreate.yml
@@ -1,0 +1,20 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.users_view AS SELECT id, name FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.users_view AS SELECT id, name AS display_name FROM public.users;
+plan: |
+  DROP VIEW public.users_view;
+  CREATE OR REPLACE VIEW public.users_view AS
+  SELECT id, name AS display_name FROM public.users;

--- a/testdata/plan/view_mixed_recreate_and_replace.yml
+++ b/testdata/plan/view_mixed_recreate_and_replace.yml
@@ -1,0 +1,26 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      name text,
+      legacy text,
+      CONSTRAINT t_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.v_shrink AS SELECT id, name, legacy FROM public.t;
+  CREATE VIEW public.v_extend AS SELECT id FROM public.t;
+desired: |
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      name text,
+      legacy text,
+      CONSTRAINT t_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.v_shrink AS SELECT id, name FROM public.t;
+  CREATE VIEW public.v_extend AS SELECT id, name FROM public.t;
+plan: |
+  DROP VIEW public.v_shrink;
+  CREATE OR REPLACE VIEW public.v_extend AS
+  SELECT id, name FROM public.t;
+  CREATE OR REPLACE VIEW public.v_shrink AS
+  SELECT id, name FROM public.t;

--- a/testdata/plan/view_recreate_reapplies_comment.yml
+++ b/testdata/plan/view_recreate_reapplies_comment.yml
@@ -1,0 +1,25 @@
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      legacy text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_users AS SELECT id, name, legacy FROM public.users;
+  COMMENT ON VIEW public.active_users IS 'Active users only';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_users AS SELECT id, name FROM public.users;
+  COMMENT ON VIEW public.active_users IS 'Active users only';
+plan: |
+  DROP VIEW public.active_users;
+  ALTER TABLE public.users DROP COLUMN legacy;
+  CREATE OR REPLACE VIEW public.active_users AS
+  SELECT id, name FROM public.users;
+  COMMENT ON VIEW public.active_users IS 'Active users only';


### PR DESCRIPTION
## Summary

PostgreSQL's `CREATE OR REPLACE VIEW` only accepts changes that keep the same column names in the same order; appending columns at the end is allowed, but removing, renaming, or reordering raises `cannot drop columns from view`. The same change also blocks an accompanying `DROP COLUMN` on a referenced table because the view's dependency on that column hasn't been cleared yet.

PR #223 fixed the in-table drop ordering but didn't help when a view was in the picture — running the demo end-to-end (`desired.sql` → `current.sql`) still failed at `DROP COLUMN updated_at` because the `published_posts` view depended on it.

This PR extracts the output column names from each view's SELECT body and, when the desired column list is not a prefix-extension of the current one, falls back to `DROP VIEW` + `CREATE VIEW`. View drops already run ahead of table changes via `viewDiff.DropStmts`, so the subsequent `DROP COLUMN` succeeds.

Views whose output columns can't be determined statically (`SELECT *`, target-list expressions without an alias) are conservatively routed through DROP+CREATE — strictly better than the prior `CREATE OR REPLACE` that PostgreSQL would have rejected.

## Demo verification

```sh
psql demo_test -f demo/desired.sql
pista plan --allow-drop=all --disable=enum -d demo_test demo/current.sql
```

Generates (and applies cleanly):
```sql
DROP VIEW public.published_posts;
DROP INDEX public.posts_created_idx;
ALTER TABLE public.tags DROP CONSTRAINT tags_slug_key;
ALTER TABLE public.tags DROP COLUMN slug;
...
ALTER TABLE public.posts DROP COLUMN updated_at;
CREATE OR REPLACE VIEW public.published_posts AS ...;
```

A subsequent `plan` reports `No changes` (no drift).

## Known limitation

`canCreateOrReplaceView` only inspects column names, not types. A type-only change on a same-named column (e.g. `SELECT n FROM t` → `SELECT n::bigint AS n FROM t`) is still routed through `CREATE OR REPLACE` and PostgreSQL will reject it with `cannot change data type of view column`. pg_query doesn't perform type inference, so we can't detect this statically. Documented in the helper's doc comment.

## Coverage

| Function | Coverage |
|---|---|
| `canCreateOrReplaceView` | 100.0% |
| `viewOutputColumns` | 88.9% |
| `selectOutputColumns` | 80.0% |
| `DiffViews` | 96.2% (+0.1pt) |

Residual gaps are defensive paths (pg_query producing unexpected AST shapes) per the CLAUDE.md guidance.

## Test plan

- [x] 15-case unit test for `canCreateOrReplaceView`: identical / append / remove / rename / reorder / `SELECT *` / UNION / INTERSECT / EXCEPT / CTE / table-qualified column / aliased expression / `t.*` / expression without alias / parse error
- [x] 3 `DiffViews` unit tests: column removed (DROP+CREATE), column appended (CREATE OR REPLACE), column removed + drop denied (commented)
- [x] Apply + plan fixtures: `drop_column_referenced_by_view`, `view_column_rename_forces_recreate`, `view_column_append_stays_replace`, `view_recreate_reapplies_comment`, `view_mixed_recreate_and_replace`
- [x] `make test` + `make lint` clean
- [x] `make test-scenario` — all 11 scenarios pass
- [x] `demo/desired.sql` → `demo/current.sql` end-to-end apply succeeds with no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)