### PR TITLE
Make --no-pager negatable and add --pager force-on flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.1] - 2026-05-17
+
+* Make `--no-pager` negatable: the flag is now `--[no-]pager`, and `--pager` forces paging on even when stdout is not a TTY. Useful when stdout is piped into a tool that itself expects pager-style output (syntax highlighter, etc.) where the auto TTY check would otherwise short-circuit. `PISTA_PAGER` is still the source of truth for *which* command to run, so `--pager` with an unset `PISTA_PAGER` remains a no-op. Internally `command.StartPager` now takes `*bool` (`nil` = auto / TTY check, `true` = force, `false` = disable) instead of a plain `bool`.
+
 ## [1.10.0] - 2026-05-17
 
 * Fix `DROP COLUMN` ordering when dependent objects (UNIQUE / CHECK constraints, dependent indexes, RLS policies, stored-generated columns) are dropped in the same plan. PostgreSQL silently cascades single-column UNIQUE/CHECK constraints and dependent indexes during `DROP COLUMN`, so a subsequent explicit `DROP CONSTRAINT` / `DROP INDEX` fails with `... does not exist`; RLS policies and same-table stored-generated columns block `DROP COLUMN` outright. `diff.diffColumns` now returns column drops in a separate slice (emitting stored-generated columns before non-generated ones so a paired `generated_col → source_col` drop succeeds without `CASCADE`) and `diff.diffTable` appends `colDropStmts` at the tail of `result.Stmts`, after policy / index / constraint / comment / RLS handling. FK drops continue to emit first via `FKDropStmts`, so dependents are gone before the column itself goes. The bulk-alter merge naturally inherits the new order, so a single `ALTER TABLE` lists `DROP CONSTRAINT` before `DROP COLUMN`. ([#223](https://github.com/winebarrel/pistachio/pull/223))

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Flags:
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
       --version
-      --no-pager              Disable paging of long output via $PISTA_PAGER.
+      --[no-]pager            Force paging of long output via $PISTA_PAGER,
+                              bypassing the TTY check. Use --no-pager to
+                              disable. PISTA_PAGER must still be set.
 
 Commands:
   apply <files> ... [flags]
@@ -220,7 +222,7 @@ pista dump
 
 ### Paging long output
 
-Set `$PISTA_PAGER` to forward `plan` / `apply` / `dump` output through an external command when stdout is a TTY. The command is interpreted by `sh -c`, so quoting and arguments work as in the shell. Pipes and redirects (`pista dump > file.sql`, `pista dump | grep ...`) are unaffected — the pager only kicks in for interactive use. Use `--no-pager` to disable it for a single invocation.
+Set `$PISTA_PAGER` to forward `plan` / `apply` / `dump` output through an external command when stdout is a TTY. The command is interpreted by `sh -c`, so quoting and arguments work as in the shell. Pipes and redirects (`pista dump > file.sql`, `pista dump | grep ...`) are unaffected — the pager only kicks in for interactive use. Use `--no-pager` to disable it for a single invocation, or `--pager` to force it on when stdout is not a TTY (e.g. when piping into another pager-aware tool); `PISTA_PAGER` must still be set for `--pager` to do anything.
 
 ```bash
 # Page with less, keeping ANSI colors
@@ -231,6 +233,9 @@ PISTA_PAGER='source-highlight -s sql -f esc | less -R' pista plan schema.sql
 
 # One-off override
 pista --no-pager plan schema.sql
+
+# Force the pager even when stdout is not a TTY
+PISTA_PAGER='source-highlight -s sql -f esc' pista --pager dump
 ```
 
 ### Schema name mapping

--- a/cmd/command/pager.go
+++ b/cmd/command/pager.go
@@ -9,24 +9,34 @@ import (
 )
 
 // StartPager wraps w with a pager subprocess when all of the following hold:
-//   - paging hasn't been disabled by --no-pager,
-//   - w is a TTY (so the user is actually viewing the output interactively),
+//   - paging hasn't been disabled by --no-pager (pager != nil && *pager == false),
+//   - either pager was explicitly forced via --pager (*pager == true) or w is a
+//     TTY (so the user is actually viewing the output interactively),
 //   - PISTA_PAGER is set to a non-empty command line.
+//
+// pager == nil means the user passed neither --pager nor --no-pager, so the
+// TTY check decides. Otherwise *pager explicitly turns paging on or off, but
+// an unset PISTA_PAGER still gates everything (matching the convention that
+// the env var is the source of truth for *which* pager to run).
 //
 // Otherwise it returns w unchanged with a no-op close. The returned close
 // function tears down the pager and waits for it to exit, so callers should
 // always invoke it (typically via defer).
-func StartPager(w io.Writer, noPager bool) (io.Writer, func(), error) {
+func StartPager(w io.Writer, pager *bool) (io.Writer, func(), error) {
 	noop := func() {}
-	if noPager {
-		return w, noop, nil
-	}
-	f, ok := w.(*os.File)
-	if !ok || !isTerminalFn(f) {
+	if pager != nil && !*pager {
 		return w, noop, nil
 	}
 	cmdline := os.Getenv("PISTA_PAGER")
 	if cmdline == "" {
+		return w, noop, nil
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return w, noop, nil
+	}
+	forced := pager != nil && *pager
+	if !forced && !isTerminalFn(f) {
 		return w, noop, nil
 	}
 

--- a/cmd/command/pager_test.go
+++ b/cmd/command/pager_test.go
@@ -21,13 +21,14 @@ func TestStartPager_NoPagerFlag(t *testing.T) {
 	}
 	t.Cleanup(func() { f.Close() })
 
-	w, closer, err := command.StartPager(f, true)
+	disabled := false
+	w, closer, err := command.StartPager(f, &disabled)
 	if err != nil {
 		t.Fatalf("StartPager: %v", err)
 	}
 	defer closer()
 	if w != io.Writer(f) {
-		t.Fatalf("noPager=true should return writer unchanged, got %T", w)
+		t.Fatalf("pager=false should return writer unchanged, got %T", w)
 	}
 }
 
@@ -37,7 +38,7 @@ func TestStartPager_NonFileWriter(t *testing.T) {
 	defer restore()
 
 	var buf bytes.Buffer
-	w, closer, err := command.StartPager(&buf, false)
+	w, closer, err := command.StartPager(&buf, nil)
 	if err != nil {
 		t.Fatalf("StartPager: %v", err)
 	}
@@ -58,13 +59,59 @@ func TestStartPager_NotATerminal(t *testing.T) {
 	}
 	t.Cleanup(func() { f.Close() })
 
-	w, closer, err := command.StartPager(f, false)
+	w, closer, err := command.StartPager(f, nil)
 	if err != nil {
 		t.Fatalf("StartPager: %v", err)
 	}
 	defer closer()
 	if w != io.Writer(f) {
 		t.Fatalf("non-TTY writer should be returned unchanged")
+	}
+}
+
+func TestStartPager_ForcedSkipsTTYCheck(t *testing.T) {
+	// --pager forces paging even when stdout is not a TTY.
+	t.Setenv("PISTA_PAGER", "cat")
+	restore := command.SetIsTerminalForTest(func(*os.File) bool { return false })
+	defer restore()
+
+	f, err := os.CreateTemp(t.TempDir(), "out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+
+	forced := true
+	w, closer, err := command.StartPager(f, &forced)
+	if err != nil {
+		t.Fatalf("StartPager: %v", err)
+	}
+	defer closer()
+	if w == io.Writer(f) {
+		t.Fatalf("forced pager should wrap writer even when not a TTY")
+	}
+}
+
+func TestStartPager_ForcedButEnvUnset(t *testing.T) {
+	// --pager with PISTA_PAGER unset still does nothing — env gates everything.
+	t.Setenv("PISTA_PAGER", "")
+	restore := command.SetIsTerminalForTest(func(*os.File) bool { return false })
+	defer restore()
+
+	f, err := os.CreateTemp(t.TempDir(), "out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+
+	forced := true
+	w, closer, err := command.StartPager(f, &forced)
+	if err != nil {
+		t.Fatalf("StartPager: %v", err)
+	}
+	defer closer()
+	if w != io.Writer(f) {
+		t.Fatalf("empty PISTA_PAGER should disable paging even when forced, got %T", w)
 	}
 }
 
@@ -79,7 +126,7 @@ func TestStartPager_EnvUnset(t *testing.T) {
 	}
 	t.Cleanup(func() { f.Close() })
 
-	w, closer, err := command.StartPager(f, false)
+	w, closer, err := command.StartPager(f, nil)
 	if err != nil {
 		t.Fatalf("StartPager: %v", err)
 	}
@@ -100,7 +147,7 @@ func TestStartPager_SpawnsAndPipesThrough(t *testing.T) {
 	}
 	t.Cleanup(func() { f.Close() })
 
-	w, closer, err := command.StartPager(f, false)
+	w, closer, err := command.StartPager(f, nil)
 	if err != nil {
 		t.Fatalf("StartPager: %v", err)
 	}
@@ -138,7 +185,7 @@ func TestStartPager_CloserIsIdempotent(t *testing.T) {
 	}
 	t.Cleanup(func() { f.Close() })
 
-	w, closer, err := command.StartPager(f, false)
+	w, closer, err := command.StartPager(f, nil)
 	if err != nil {
 		t.Fatalf("StartPager: %v", err)
 	}
@@ -213,7 +260,7 @@ func TestStartPager_FailsOnBadCommand(t *testing.T) {
 	// `sh -c` will start successfully and the missing binary surfaces as
 	// a non-zero exit on Wait, not an error from Start. Verify StartPager
 	// still returns a usable writer and tolerates the pager exiting early.
-	w, closer, err := command.StartPager(f, false)
+	w, closer, err := command.StartPager(f, nil)
 	if err != nil {
 		t.Fatalf("StartPager unexpectedly errored: %v", err)
 	}

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -15,7 +15,7 @@ var version string
 var cli struct {
 	pistachio.Options
 	Version kong.VersionFlag
-	NoPager bool `name:"no-pager" help:"Disable paging of long output via $PISTA_PAGER."`
+	Pager   *bool `name:"pager" negatable:"" help:"Force paging of long output via $PISTA_PAGER, bypassing the TTY check. Use --no-pager to disable. PISTA_PAGER must still be set."`
 
 	Apply command.Apply `cmd:"" help:"Apply schema changes to the database."`
 	Plan  command.Plan  `cmd:"" help:"Print the schema diff SQL without applying it."`
@@ -30,7 +30,7 @@ func main() {
 		kong.BindTo(os.Stdout, (*io.Writer)(nil)),
 	)
 
-	w, closePager, err := command.StartPager(os.Stdout, cli.NoPager)
+	w, closePager, err := command.StartPager(os.Stdout, cli.Pager)
 	kctx.FatalIfErrorf(err)
 	// Defer covers panics; the explicit closePager() below covers the
 	// os.Exit path inside FatalIfErrorf so the pager always finishes


### PR DESCRIPTION
## Summary

- Replace the boolean `--no-pager` flag with a negatable `--[no-]pager`. Passing `--pager` forces the pager subprocess to start even when stdout is not a TTY (useful when piping into another pager-aware tool); an unset `PISTA_PAGER` still gates everything, so `--pager` with no env var remains a no-op.
- `command.StartPager` now takes `*bool` (`nil` = auto / TTY check, `true` = force, `false` = disable) instead of a plain `bool`.
- Note: tools like `bat` / `less` auto-disable color when their own stdout is not a TTY. If you want highlighting to survive a downstream pipe, pass the tool's force flag (e.g. `bat --color=always`) inside `PISTA_PAGER` — same convention as `git` etc.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all packages ok
- [x] New unit tests cover `--pager` skipping the TTY check and the `--pager` + unset `PISTA_PAGER` no-op path
- [x] Manual: `PISTA_PAGER='tr a-z A-Z' ./pista dump --pager | cat` upper-cases output (pager runs through the pipe); without `--pager` it auto-disables on non-TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)