### PR TITLE
Add --color=always to bat in demo PISTA_PAGER

### DIFF
--- a/demo.tape
+++ b/demo.tape
@@ -6,7 +6,7 @@ Set Width 800
 Set Height 600
 Set Padding 20
 
-Type@3ms "export PISTA_PAGER='bat -l sql -p --paging=never'" Enter
+Type@3ms "export PISTA_PAGER='bat -l sql -p --paging=never --color=always'" Enter
 Sleep 2s
 
 # Create schema file

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -32,7 +32,7 @@ ENV PGHOST=/var/run/postgresql \
     PGUSER=postgres \
     PGDATABASE=demo \
     PISTA_CONN_STR=postgres://postgres@/demo \
-    PISTA_PAGER="bat -l sql -p --paging=never"
+    PISTA_PAGER="bat -l sql -p --paging=never --color=always"
 
 WORKDIR /demo
 USER postgres


### PR DESCRIPTION
## Summary

- `bat` auto-disables ANSI colors when its own stdout is not a TTY. In the demo container and the VHS recording, `bat` is invoked as the `PISTA_PAGER` subprocess and its stdout points at the parent process's pipe, so highlighting was being suppressed.
- Add `--color=always` to both `demo.tape` and `demo/Dockerfile` so the demo output stays colorized regardless of how `bat` is launched.

## Test plan

- [ ] Rebuild the demo image and confirm `pista plan` / `pista dump` output is syntax-highlighted in the container shell.
- [ ] Re-record `demo.gif` via VHS and confirm the captured frames show colored SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)