### PR TITLE
Emit transaction-state comments when --with-tx is used

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -76,10 +76,24 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		if err != nil {
 			return nil, fmt.Errorf("failed to begin transaction: %w", err)
 		}
-		defer tx.Rollback(ctx) //nolint:errcheck
+		fmt.Fprintln(w, "-- Transaction started") //nolint:errcheck
+		committed := false
+		defer func() {
+			tx.Rollback(ctx) //nolint:errcheck
+			if !committed {
+				fmt.Fprintln(w, "-- Transaction rolled back") //nolint:errcheck
+			}
+		}()
 		exec = tx.Exec
 		queryRow = tx.QueryRow
-		commit = tx.Commit
+		commit = func(ctx context.Context) error {
+			if err := tx.Commit(ctx); err != nil {
+				return err
+			}
+			committed = true
+			fmt.Fprintln(w, "-- Transaction committed") //nolint:errcheck
+			return nil
+		}
 	}
 
 	if result.PreSQL != "" {

--- a/apply_test.go
+++ b/apply_test.go
@@ -262,12 +262,18 @@ SELECT * FROM public.missing_table;`), 0o644))
 		Schemas:    []string{"public"},
 	})
 
+	var buf bytes.Buffer
 	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
-	}, io.Discard)
+	}, &buf)
 	require.Error(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "-- Transaction started")
+	assert.Contains(t, out, "-- Transaction rolled back")
+	assert.NotContains(t, out, "-- Transaction committed")
 
 	got, dumpErr := client.Dump(ctx, &pistachio.DumpOptions{})
 	require.NoError(t, dumpErr)
@@ -297,16 +303,79 @@ func TestApply_WithTx_Success(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
+	var buf bytes.Buffer
 	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
-	}, io.Discard)
+	}, &buf)
 	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "-- Transaction started")
+	assert.Contains(t, out, "-- Transaction committed")
+	assert.NotContains(t, out, "-- Transaction rolled back")
 
 	got, dumpErr := client.Dump(ctx, &pistachio.DumpOptions{})
 	require.NoError(t, dumpErr)
 	assert.Contains(t, got.String(), "CREATE TABLE public.users")
+}
+
+func TestApply_WithTx_NoChanges_OmitsTransactionComments(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}, WithTx: true}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotContains(t, out, "-- Transaction started")
+	assert.NotContains(t, out, "-- Transaction committed")
+	assert.NotContains(t, out, "-- Transaction rolled back")
+}
+
+func TestApply_NoWithTx_OmitsTransactionComments(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotContains(t, out, "-- Transaction started")
+	assert.NotContains(t, out, "-- Transaction committed")
+	assert.NotContains(t, out, "-- Transaction rolled back")
 }
 
 func TestApply_ExecuteWithCheck_Executes(t *testing.T) {

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -17,6 +17,9 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 	var buf bytes.Buffer
 	result, err := client.Apply(ctx, &cmd.ApplyOptions, &buf)
 	if err != nil {
+		// Flush any partial output (e.g. transaction-state comments and SQL
+		// that ran before the error) so the user can see what happened.
+		w.Write(buf.Bytes()) //nolint:errcheck
 		return err
 	}
 

--- a/cmd/command/apply_test.go
+++ b/cmd/command/apply_test.go
@@ -57,6 +57,42 @@ func TestApply_Run_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestApply_Run_WithTx_FlushesBufferOnError(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	tmpDir := t.TempDir()
+	desiredFile := filepath.Join(tmpDir, "desired.sql")
+	preSQLFile := filepath.Join(tmpDir, "pre.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+	require.NoError(t, os.WriteFile(preSQLFile, []byte(`SELECT * FROM public.missing_table;`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{
+		Files:      []string{desiredFile},
+		PreSQLFile: preSQLFile,
+		WithTx:     true,
+	}}
+	err := cmd.Run(ctx, client, &buf)
+	require.Error(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "-- Transaction started")
+	assert.Contains(t, out, "-- Transaction rolled back")
+	assert.NotContains(t, out, "-- Transaction committed")
+}
+
 func TestApply_Run_NoChanges(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)


### PR DESCRIPTION
## Summary
- `pista apply --with-tx` の出力に `-- Transaction started` / `-- Transaction committed` / `-- Transaction rolled back` を追加し、トランザクション境界を視認できるようにした
- CLI 側はエラー時にもバッファをフラッシュするように変更。途中まで実行された SQL と `-- Transaction rolled back` がユーザに見える

## Test plan
- [x] `make test` (新規 5 テスト含む)
- [x] `make lint`
- [x] `make test-scenario`

新規/更新テスト:
- `TestApply_WithTx` — pre-SQL 失敗で `started` + `rolled back`
- `TestApply_WithTx_Success` — 正常終了で `started` + `committed`
- `TestApply_WithTx_NoChanges_OmitsTransactionComments` — 差分なしの早期 return では出力なし
- `TestApply_NoWithTx_OmitsTransactionComments` — `--with-tx` なしでは出力なし
- `TestApply_Run_WithTx_FlushesBufferOnError` — CLI のエラー時 flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)