### PR TITLE
Bind --with-tx to $PISTA_WITH_TX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.3] - 2026-05-17
+
+* Bind `apply --with-tx` to the `$PISTA_WITH_TX` environment variable so it can be enabled from CI / shell config without passing the flag on every invocation. Aligns with the existing `$PISTA_BULK_ALTER` / `$PISTA_DISABLE_INDEX_CONCURRENTLY` env-tag pattern on the other apply bool flags.
+
 ## [1.10.2] - 2026-05-17
 
 * Emit `-- Transaction started` / `-- Transaction committed` / `-- Transaction rolled back` comments in `apply --with-tx` output so the transaction boundary is visible in the SQL stream. The CLI now also flushes buffered apply output when `client.Apply` returns an error, so partial DDL that ran before the failure plus the `-- Transaction rolled back` marker are surfaced to the user instead of being discarded with the error. Plain SQL keywords (`BEGIN` / `COMMIT` / `ROLLBACK`) were considered but rejected because they look like skipped statements; the comments are prose to disambiguate from emitted DDL. ([#229](https://github.com/winebarrel/pistachio/pull/229))

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pista apply schema.sql
 pista apply tables.sql views.sql
 ```
 
-Use `--pre-sql` or `--pre-sql-file` to run SQL before applying changes (mutually exclusive). Also available as `$PISTA_PRE_SQL` / `$PISTA_PRE_SQL_FILE`. Use `--with-tx` to wrap everything in a transaction.
+Use `--pre-sql` or `--pre-sql-file` to run SQL before applying changes (mutually exclusive). Also available as `$PISTA_PRE_SQL` / `$PISTA_PRE_SQL_FILE`. Use `--with-tx` to wrap everything in a transaction (also available as `$PISTA_WITH_TX`).
 
 ```bash
 # Inline SQL

--- a/apply.go
+++ b/apply.go
@@ -18,7 +18,7 @@ type ApplyOptions struct {
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PISTA_PRE_SQL_FILE" help:"Path to a SQL file to execute before applying changes."`
 	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index operations (e.g. SET lock_timeout). Only run when the diff includes CONCURRENTLY index DDL; runs outside any transaction."`
 	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to execute before CONCURRENTLY index operations."`
-	WithTx                   bool     `help:"Execute the pre-SQL and schema changes in a transaction."`
+	WithTx                   bool     `env:"PISTA_WITH_TX" help:"Execute the pre-SQL and schema changes in a transaction."`
 	DisableIndexConcurrently bool     `env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore all CONCURRENTLY opt-ins (both -- pista:concurrently directives and inline CREATE/DROP INDEX CONCURRENTLY) and emit plain CREATE/DROP INDEX."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs are kept separate."`
 }


### PR DESCRIPTION
## Summary
- Add `env:"PISTA_WITH_TX"` to `ApplyOptions.WithTx` so the flag can be set via environment, mirroring `PISTA_BULK_ALTER` / `PISTA_DISABLE_INDEX_CONCURRENTLY`.
- README updated to mention the env var alongside `--with-tx`.
- CHANGELOG entry added as 1.10.3.

## Test plan
- [x] `make build` / `make lint`
- [x] `pista apply --help` shows `($PISTA_WITH_TX)` next to `--with-tx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)