### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash -xeo pipefail {0}


### PR DESCRIPTION
Potential fix for [https://github.com/winebarrel/pistachio/security/code-scanning/1](https://github.com/winebarrel/pistachio/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
Best minimal fix without changing functionality is:

- `permissions:`
  - `contents: read`

This satisfies CodeQL’s recommendation and enforces least privilege for the `GITHUB_TOKEN` in this workflow.  
Edit location: insert this block between the `on:` section and existing `defaults:` (or any other top-level position).

No imports, methods, or definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
