### PR TITLE
Trim whitespace from --include/--exclude patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.5] - 2026-05-22
+
+* Trim leading / trailing whitespace from each `--include` / `--exclude` pattern in `FilterOptions.AfterApply`. Multi-value env vars like `PISTA_INCLUDE="user*, posts"` were parsed by kong into `["user*", " posts"]`, and the leading space made `path.Match` treat the second pattern as ` posts` — silently matching nothing. The trim runs before `ValidatePatterns`, so the post-trim values are also what gets validated and what `MatchName` compares against.
+
 ## [1.10.4] - 2026-05-17
 
 * Bind `apply --with-tx` to the `$PISTA_WITH_TX` environment variable so it can be enabled from CI / shell config without passing the flag on every invocation. Aligns with the existing `$PISTA_BULK_ALTER` / `$PISTA_DISABLE_INDEX_CONCURRENTLY` env-tag pattern on the other apply bool flags.

--- a/filter_test.go
+++ b/filter_test.go
@@ -46,6 +46,16 @@ func TestFilterOptions_AfterApply_Invalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "--include")
 }
 
+func TestFilterOptions_AfterApply_TrimsWhitespace(t *testing.T) {
+	o := &pistachio.FilterOptions{
+		Include: []string{" user* ", "\tposts\n"},
+		Exclude: []string{"  tmp_* "},
+	}
+	require.NoError(t, o.AfterApply())
+	assert.Equal(t, []string{"user*", "posts"}, o.Include)
+	assert.Equal(t, []string{"tmp_*"}, o.Exclude)
+}
+
 func TestMatchName(t *testing.T) {
 	t.Run("no filters", func(t *testing.T) {
 		o := &pistachio.FilterOptions{}

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package pistachio
 import (
 	"fmt"
 	"path"
+	"strings"
 )
 
 type Options struct {
@@ -63,6 +64,12 @@ func (f *FilterOptions) MatchName(name string) bool {
 }
 
 func (f *FilterOptions) AfterApply() error {
+	for i, pattern := range f.Include {
+		f.Include[i] = strings.TrimSpace(pattern)
+	}
+	for i, pattern := range f.Exclude {
+		f.Exclude[i] = strings.TrimSpace(pattern)
+	}
 	return f.ValidatePatterns()
 }
 


### PR DESCRIPTION
## Summary
- `FilterOptions.AfterApply` now `strings.TrimSpace`es each `Include` / `Exclude` entry before validation, so multi-value env vars like `PISTA_INCLUDE="user*, posts"` (kong parses to `["user*", " posts"]`) no longer silently fail to match.
- Added `TestFilterOptions_AfterApply_TrimsWhitespace` covering spaces, tabs, and newlines on both fields.
- Added a 1.10.5 entry to `CHANGELOG.md`.

## Test plan
- [x] `go test ./...` (filter unit tests)
- [x] `make vet`
- [x] `make lint`