### PR TITLE
Add minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "minimumReleaseAge": "7 days",
   "vulnerabilityAlerts": {
     "enabled": true
   },


### PR DESCRIPTION
This pull request makes a small configuration update to the `renovate.json` file, setting a minimum release age of 7 days for dependencies before Renovate will consider them for updates.