### PR TITLE
Use external test package for model tests

### DIFF
--- a/model/column_test.go
+++ b/model/column_test.go
@@ -1,45 +1,46 @@
-package model
+package model_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/pistachio/model"
 )
 
 func TestColumnIdentity_IsIdentityColumn(t *testing.T) {
-	assert.True(t, ColumnIdentity('a').IsIdentityColumn())
-	assert.True(t, ColumnIdentity('d').IsIdentityColumn())
-	assert.False(t, ColumnIdentity(0).IsIdentityColumn())
+	assert.True(t, model.ColumnIdentity('a').IsIdentityColumn())
+	assert.True(t, model.ColumnIdentity('d').IsIdentityColumn())
+	assert.False(t, model.ColumnIdentity(0).IsIdentityColumn())
 }
 
 func TestColumnIdentity_IsGeneratedAlways(t *testing.T) {
-	assert.True(t, ColumnIdentity('a').IsGeneratedAlways())
-	assert.False(t, ColumnIdentity('d').IsGeneratedAlways())
+	assert.True(t, model.ColumnIdentity('a').IsGeneratedAlways())
+	assert.False(t, model.ColumnIdentity('d').IsGeneratedAlways())
 }
 
 func TestColumnIdentity_IsGeneratedByDefault(t *testing.T) {
-	assert.True(t, ColumnIdentity('d').IsGeneratedByDefault())
-	assert.False(t, ColumnIdentity('a').IsGeneratedByDefault())
+	assert.True(t, model.ColumnIdentity('d').IsGeneratedByDefault())
+	assert.False(t, model.ColumnIdentity('a').IsGeneratedByDefault())
 }
 
 func TestColumnGenerated_IsGeneratedColumn(t *testing.T) {
-	assert.True(t, ColumnGenerated('s').IsGeneratedColumn())
-	assert.True(t, ColumnGenerated('v').IsGeneratedColumn())
-	assert.False(t, ColumnGenerated(0).IsGeneratedColumn())
+	assert.True(t, model.ColumnGenerated('s').IsGeneratedColumn())
+	assert.True(t, model.ColumnGenerated('v').IsGeneratedColumn())
+	assert.False(t, model.ColumnGenerated(0).IsGeneratedColumn())
 }
 
 func TestColumnGenerated_IsStoredGeneratedColumn(t *testing.T) {
-	assert.True(t, ColumnGenerated('s').IsStoredGeneratedColumn())
-	assert.False(t, ColumnGenerated('v').IsStoredGeneratedColumn())
+	assert.True(t, model.ColumnGenerated('s').IsStoredGeneratedColumn())
+	assert.False(t, model.ColumnGenerated('v').IsStoredGeneratedColumn())
 }
 
 func TestColumnGenerated_IsVirtualGeneratedColumn(t *testing.T) {
-	assert.True(t, ColumnGenerated('v').IsVirtualGeneratedColumn())
-	assert.False(t, ColumnGenerated('s').IsVirtualGeneratedColumn())
+	assert.True(t, model.ColumnGenerated('v').IsVirtualGeneratedColumn())
+	assert.False(t, model.ColumnGenerated('s').IsVirtualGeneratedColumn())
 }
 
 func TestColumn_String(t *testing.T) {
-	col := &Column{Name: "id", TypeName: "integer", NotNull: true}
+	col := &model.Column{Name: "id", TypeName: "integer", NotNull: true}
 	s := col.String()
 	assert.Contains(t, s, "id")
 	assert.Contains(t, s, "integer")

--- a/model/constraint_test.go
+++ b/model/constraint_test.go
@@ -1,33 +1,34 @@
-package model
+package model_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/pistachio/model"
 )
 
 func TestConstraintType(t *testing.T) {
-	assert.True(t, ConstraintType('c').IsCheckConstraint())
-	assert.True(t, ConstraintType('f').IsForeignKeyConstraint())
-	assert.True(t, ConstraintType('n').IsNotNullConstraint())
-	assert.True(t, ConstraintType('p').IsPrimaryKeyConstraint())
-	assert.True(t, ConstraintType('u').IsUniqueConstraint())
-	assert.True(t, ConstraintType('t').IsConstraintTrigger())
-	assert.True(t, ConstraintType('x').IsExclusionConstraint())
+	assert.True(t, model.ConstraintType('c').IsCheckConstraint())
+	assert.True(t, model.ConstraintType('f').IsForeignKeyConstraint())
+	assert.True(t, model.ConstraintType('n').IsNotNullConstraint())
+	assert.True(t, model.ConstraintType('p').IsPrimaryKeyConstraint())
+	assert.True(t, model.ConstraintType('u').IsUniqueConstraint())
+	assert.True(t, model.ConstraintType('t').IsConstraintTrigger())
+	assert.True(t, model.ConstraintType('x').IsExclusionConstraint())
 
-	assert.False(t, ConstraintType('c').IsPrimaryKeyConstraint())
-	assert.False(t, ConstraintType('p').IsCheckConstraint())
+	assert.False(t, model.ConstraintType('c').IsPrimaryKeyConstraint())
+	assert.False(t, model.ConstraintType('p').IsCheckConstraint())
 }
 
 func TestConstraint_String(t *testing.T) {
-	con := &Constraint{Name: "pk", Type: ConstraintType('p'), Definition: "PRIMARY KEY (id)"}
+	con := &model.Constraint{Name: "pk", Type: model.ConstraintType('p'), Definition: "PRIMARY KEY (id)"}
 	s := con.String()
 	assert.Contains(t, s, "pk")
 }
 
 func TestForeignKey_String(t *testing.T) {
-	fk := &ForeignKey{
-		Constraint: Constraint{Name: "fk_user", Type: ConstraintType('f'), Definition: "FOREIGN KEY (user_id) REFERENCES users(id)"},
+	fk := &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Type: model.ConstraintType('f'), Definition: "FOREIGN KEY (user_id) REFERENCES users(id)"},
 		Schema:     "public",
 		Table:      "orders",
 	}
@@ -36,10 +37,10 @@ func TestForeignKey_String(t *testing.T) {
 }
 
 func TestForeignKey_SQL(t *testing.T) {
-	fk := ForeignKey{
-		Constraint: Constraint{
+	fk := model.ForeignKey{
+		Constraint: model.Constraint{
 			Name:       "fk_user",
-			Type:       ConstraintType('f'),
+			Type:       model.ConstraintType('f'),
 			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
 			Validated:  true,
 		},
@@ -50,10 +51,10 @@ func TestForeignKey_SQL(t *testing.T) {
 }
 
 func TestForeignKey_SQL_NotValid(t *testing.T) {
-	fk := ForeignKey{
-		Constraint: Constraint{
+	fk := model.ForeignKey{
+		Constraint: model.Constraint{
 			Name:       "fk_user",
-			Type:       ConstraintType('f'),
+			Type:       model.ConstraintType('f'),
 			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
 			Validated:  false,
 		},

--- a/model/index_test.go
+++ b/model/index_test.go
@@ -1,17 +1,18 @@
-package model
+package model_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/pistachio/model"
 )
 
 func TestIndex_FQTN(t *testing.T) {
-	idx := Index{Schema: "public", Name: "users_pkey", Table: "users"}
+	idx := model.Index{Schema: "public", Name: "users_pkey", Table: "users"}
 	assert.Equal(t, "public.users", idx.FQTN())
 }
 
 func TestIndex_SQL(t *testing.T) {
-	idx := Index{Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"}
+	idx := model.Index{Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"}
 	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING btree (name);", idx.SQL())
 }

--- a/model/policy_test.go
+++ b/model/policy_test.go
@@ -1,53 +1,54 @@
-package model
+package model_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/pistachio/model"
 )
 
 func TestPolicyCommand_String(t *testing.T) {
-	assert.Equal(t, "ALL", PolicyCommand('*').String())
-	assert.Equal(t, "SELECT", PolicyCommand('r').String())
-	assert.Equal(t, "INSERT", PolicyCommand('a').String())
-	assert.Equal(t, "UPDATE", PolicyCommand('w').String())
-	assert.Equal(t, "DELETE", PolicyCommand('d').String())
-	assert.Equal(t, "", PolicyCommand(0).String())
+	assert.Equal(t, "ALL", model.PolicyCommand('*').String())
+	assert.Equal(t, "SELECT", model.PolicyCommand('r').String())
+	assert.Equal(t, "INSERT", model.PolicyCommand('a').String())
+	assert.Equal(t, "UPDATE", model.PolicyCommand('w').String())
+	assert.Equal(t, "DELETE", model.PolicyCommand('d').String())
+	assert.Equal(t, "", model.PolicyCommand(0).String())
 }
 
 func TestPolicyCommand_IsAll(t *testing.T) {
-	assert.True(t, PolicyCommand('*').IsAll())
-	assert.False(t, PolicyCommand('r').IsAll())
+	assert.True(t, model.PolicyCommand('*').IsAll())
+	assert.False(t, model.PolicyCommand('r').IsAll())
 }
 
 func TestPolicy_String(t *testing.T) {
-	p := &Policy{Name: "p", Schema: "public", Table: "t", Command: '*', Permissive: true}
+	p := &model.Policy{Name: "p", Schema: "public", Table: "t", Command: '*', Permissive: true}
 	s := p.String()
 	assert.Contains(t, s, "p")
 }
 
 func TestPolicy_SQL_minimal(t *testing.T) {
 	using := "true"
-	p := Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*', Using: &using}
+	p := model.Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*', Using: &using}
 	assert.Equal(t, "CREATE POLICY p ON public.t USING (true);", p.SQL())
 }
 
 func TestPolicy_SQL_restrictive(t *testing.T) {
 	using := "owner = current_user"
-	p := Policy{Name: "p", Schema: "public", Table: "t", Permissive: false, Command: '*', Using: &using}
+	p := model.Policy{Name: "p", Schema: "public", Table: "t", Permissive: false, Command: '*', Using: &using}
 	assert.Equal(t, "CREATE POLICY p ON public.t AS RESTRICTIVE USING (owner = current_user);", p.SQL())
 }
 
 func TestPolicy_SQL_specific_command(t *testing.T) {
 	using := "true"
-	p := Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: 'r', Using: &using}
+	p := model.Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: 'r', Using: &using}
 	assert.Equal(t, "CREATE POLICY p ON public.t FOR SELECT USING (true);", p.SQL())
 }
 
 func TestPolicy_SQL_with_check(t *testing.T) {
 	using := "true"
 	wc := "owner = current_user"
-	p := Policy{
+	p := model.Policy{
 		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
 		Using: &using, WithCheck: &wc,
 	}
@@ -58,13 +59,13 @@ func TestPolicy_SQL_with_check(t *testing.T) {
 
 func TestPolicy_SQL_with_check_only(t *testing.T) {
 	wc := "owner = current_user"
-	p := Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: 'a', WithCheck: &wc}
+	p := model.Policy{Name: "p", Schema: "public", Table: "t", Permissive: true, Command: 'a', WithCheck: &wc}
 	assert.Equal(t, "CREATE POLICY p ON public.t FOR INSERT WITH CHECK (owner = current_user);", p.SQL())
 }
 
 func TestPolicy_SQL_role_named(t *testing.T) {
 	using := "true"
-	p := Policy{
+	p := model.Policy{
 		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
 		Roles: []string{"app_user"}, Using: &using,
 	}
@@ -73,7 +74,7 @@ func TestPolicy_SQL_role_named(t *testing.T) {
 
 func TestPolicy_SQL_role_reserved(t *testing.T) {
 	using := "true"
-	p := Policy{
+	p := model.Policy{
 		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
 		Roles: []string{"current_user"}, Using: &using,
 	}
@@ -82,7 +83,7 @@ func TestPolicy_SQL_role_reserved(t *testing.T) {
 
 func TestPolicy_SQL_role_multiple(t *testing.T) {
 	using := "true"
-	p := Policy{
+	p := model.Policy{
 		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
 		Roles: []string{"a", "b"}, Using: &using,
 	}
@@ -96,7 +97,7 @@ func TestPolicy_SQL_role_multiple(t *testing.T) {
 // takes in practice when no TO is specified.
 func TestPolicy_SQL_role_public_only(t *testing.T) {
 	using := "true"
-	p := Policy{
+	p := model.Policy{
 		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
 		Roles: []string{"public"}, Using: &using,
 	}
@@ -110,7 +111,7 @@ func TestPolicy_SQL_role_public_only(t *testing.T) {
 // instead. Reachable only via direct construction.
 func TestPolicy_SQL_role_empty(t *testing.T) {
 	using := "true"
-	p := Policy{
+	p := model.Policy{
 		Name: "p", Schema: "public", Table: "t", Permissive: true, Command: '*',
 		Using: &using,
 	}

--- a/model/sequence_test.go
+++ b/model/sequence_test.go
@@ -1,13 +1,14 @@
-package model
+package model_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/pistachio/model"
 )
 
 func TestSequence_String(t *testing.T) {
-	seq := &Sequence{Schema: "public", Name: "users_id_seq", DataType: "bigint"}
+	seq := &model.Sequence{Schema: "public", Name: "users_id_seq", DataType: "bigint"}
 	s := seq.String()
 	assert.Contains(t, s, "users_id_seq")
 }

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -1,21 +1,22 @@
-package model
+package model_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
 )
 
-func newTable(schema, name string) *Table {
-	return &Table{
+func newTable(schema, name string) *model.Table {
+	return &model.Table{
 		Schema:      schema,
 		Name:        name,
-		Columns:     orderedmap.New[string, *Column](),
-		Constraints: orderedmap.New[string, *Constraint](),
-		ForeignKeys: orderedmap.New[string, *ForeignKey](),
-		Indexes:     orderedmap.New[string, *Index](),
-		Policies:    orderedmap.New[string, *Policy](),
+		Columns:     orderedmap.New[string, *model.Column](),
+		Constraints: orderedmap.New[string, *model.Constraint](),
+		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+		Indexes:     orderedmap.New[string, *model.Index](),
+		Policies:    orderedmap.New[string, *model.Policy](),
 	}
 }
 
@@ -44,7 +45,7 @@ func TestTable_RLSSQL_WithPolicies(t *testing.T) {
 	tbl := newTable("public", "users")
 	tbl.RowSecurity = true
 	using := "owner = current_user"
-	tbl.Policies.Set("p", &Policy{
+	tbl.Policies.Set("p", &model.Policy{
 		Name: "p", Schema: "public", Table: "users",
 		Permissive: true, Command: 'r', Using: &using,
 	})
@@ -56,15 +57,15 @@ func TestTable_RLSSQL_WithPolicies(t *testing.T) {
 // nil-Policies guard: an older Table built without orderedmap-init must not
 // panic on RLSSQL even though the parser/catalog now always initialize it.
 func TestTable_RLSSQL_NilPolicies(t *testing.T) {
-	tbl := &Table{Schema: "public", Name: "users"}
+	tbl := &model.Table{Schema: "public", Name: "users"}
 	assert.Empty(t, tbl.RLSSQL())
 }
 
 func TestTableToSQL_IncludesRLS(t *testing.T) {
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 	tbl.RowSecurity = true
-	out := TableToSQL(tbl)
+	out := model.TableToSQL(tbl)
 	assert.Contains(t, out, "CREATE TABLE public.users")
 	assert.Contains(t, out, "ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;")
 }
@@ -76,8 +77,8 @@ func TestTable_FQTN(t *testing.T) {
 
 func TestTable_SQL_simple(t *testing.T) {
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true})
-	tbl.Constraints.Set("users_pkey", &Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.Constraints.Set("users_pkey", &model.Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
 
 	expected := `CREATE TABLE public.users (
     id integer NOT NULL,
@@ -89,7 +90,7 @@ func TestTable_SQL_simple(t *testing.T) {
 func TestTable_SQL_namedNotNull(t *testing.T) {
 	name := "users_email_nn"
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("email", &Column{Name: "email", TypeName: "text", NotNull: true, NotNullName: &name})
+	tbl.Columns.Set("email", &model.Column{Name: "email", TypeName: "text", NotNull: true, NotNullName: &name})
 
 	assert.Contains(t, tbl.SQL(), "email text CONSTRAINT users_email_nn NOT NULL")
 }
@@ -99,7 +100,7 @@ func TestTable_SQL_namedNotNull_identityColumnSuppresses(t *testing.T) {
 	// either the "NOT NULL" tail or the CONSTRAINT name on identity columns.
 	name := "users_id_nn"
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true, NotNullName: &name, Identity: ColumnIdentity('a')})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, NotNullName: &name, Identity: model.ColumnIdentity('a')})
 
 	out := tbl.SQL()
 	assert.Contains(t, out, "GENERATED ALWAYS AS IDENTITY")
@@ -110,7 +111,7 @@ func TestTable_SQL_namedNotNull_identityColumnSuppresses(t *testing.T) {
 func TestTable_SQL_unlogged(t *testing.T) {
 	tbl := newTable("public", "temp_data")
 	tbl.Unlogged = true
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer"})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
 	assert.Contains(t, tbl.SQL(), "CREATE UNLOGGED TABLE")
 }
@@ -118,7 +119,7 @@ func TestTable_SQL_unlogged(t *testing.T) {
 func TestTable_SQL_withDefault(t *testing.T) {
 	tbl := newTable("public", "users")
 	def := "0"
-	tbl.Columns.Set("age", &Column{Name: "age", TypeName: "integer", Default: &def})
+	tbl.Columns.Set("age", &model.Column{Name: "age", TypeName: "integer", Default: &def})
 
 	assert.Contains(t, tbl.SQL(), "DEFAULT 0")
 }
@@ -126,21 +127,21 @@ func TestTable_SQL_withDefault(t *testing.T) {
 func TestTable_SQL_withCollation(t *testing.T) {
 	tbl := newTable("public", "users")
 	coll := "en_US"
-	tbl.Columns.Set("name", &Column{Name: "name", TypeName: "text", Collation: &coll})
+	tbl.Columns.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: &coll})
 
 	assert.Contains(t, tbl.SQL(), `COLLATE "en_US"`)
 }
 
 func TestTable_SQL_identityAlways(t *testing.T) {
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", Identity: ColumnIdentity('a')})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", Identity: model.ColumnIdentity('a')})
 
 	assert.Contains(t, tbl.SQL(), "GENERATED ALWAYS AS IDENTITY")
 }
 
 func TestTable_SQL_identityByDefault(t *testing.T) {
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", Identity: ColumnIdentity('d')})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", Identity: model.ColumnIdentity('d')})
 
 	assert.Contains(t, tbl.SQL(), "GENERATED BY DEFAULT AS IDENTITY")
 }
@@ -148,10 +149,10 @@ func TestTable_SQL_identityByDefault(t *testing.T) {
 func TestTable_SQL_generatedStored(t *testing.T) {
 	tbl := newTable("public", "users")
 	def := "first_name || ' ' || last_name"
-	tbl.Columns.Set("full_name", &Column{
+	tbl.Columns.Set("full_name", &model.Column{
 		Name:      "full_name",
 		TypeName:  "text",
-		Generated: ColumnGenerated('s'),
+		Generated: model.ColumnGenerated('s'),
 		Default:   &def,
 	})
 
@@ -161,7 +162,7 @@ func TestTable_SQL_generatedStored(t *testing.T) {
 
 func TestTable_SQL_identityNotNull(t *testing.T) {
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true, Identity: ColumnIdentity('a')})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true, Identity: model.ColumnIdentity('a')})
 	// Identity columns should NOT emit NOT NULL
 	assert.NotContains(t, tbl.SQL(), "NOT NULL")
 }
@@ -171,7 +172,7 @@ func TestTable_SQL_partitioned(t *testing.T) {
 	tbl.Partitioned = true
 	partDef := "RANGE (created_at)"
 	tbl.PartitionDef = &partDef
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer"})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
 	sql := tbl.SQL()
 	assert.Contains(t, sql, "PARTITION BY RANGE (created_at)")
@@ -206,7 +207,7 @@ func TestTable_SQL_partitionOf_inherits(t *testing.T) {
 	tbl := newTable("public", "child")
 	parent := "public.parent"
 	tbl.PartitionOf = &parent
-	tbl.Constraints.Set("child_pkey", &Constraint{Name: "child_pkey", Definition: "PRIMARY KEY (id)"})
+	tbl.Constraints.Set("child_pkey", &model.Constraint{Name: "child_pkey", Definition: "PRIMARY KEY (id)"})
 
 	sql := tbl.SQL()
 	assert.Contains(t, sql, "INHERITS (public.parent)")
@@ -217,14 +218,14 @@ func TestTable_SQL_tablespace(t *testing.T) {
 	tbl := newTable("public", "users")
 	ts := "my_ts"
 	tbl.TableSpace = &ts
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer"})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 
 	assert.Contains(t, tbl.SQL(), "TABLESPACE my_ts")
 }
 
 func TestTable_IdxSQL(t *testing.T) {
 	tbl := newTable("public", "users")
-	tbl.Indexes.Set("idx_name", &Index{Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
+	tbl.Indexes.Set("idx_name", &model.Index{Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING btree (name);", tbl.IdxSQL())
 }
 
@@ -235,8 +236,8 @@ func TestTable_IdxSQL_empty(t *testing.T) {
 
 func TestTable_FkSQL(t *testing.T) {
 	tbl := newTable("public", "orders")
-	tbl.ForeignKeys.Set("fk_user", &ForeignKey{
-		Constraint: Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true},
+	tbl.ForeignKeys.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true},
 		Schema:     "public",
 		Table:      "orders",
 	})
@@ -248,7 +249,7 @@ func TestTable_CommentSQL(t *testing.T) {
 	comment := "Main users table"
 	tbl.Comment = &comment
 	colComment := "User name"
-	tbl.Columns.Set("name", &Column{Name: "name", TypeName: "text", Comment: &colComment})
+	tbl.Columns.Set("name", &model.Column{Name: "name", TypeName: "text", Comment: &colComment})
 
 	sql := tbl.CommentSQL()
 	assert.Contains(t, sql, "COMMENT ON TABLE public.users IS 'Main users table';")
@@ -257,29 +258,29 @@ func TestTable_CommentSQL(t *testing.T) {
 
 func TestTable_CommentSQL_noComments(t *testing.T) {
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer"})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	assert.Equal(t, "", tbl.CommentSQL())
 }
 
 func TestTablesToSQL(t *testing.T) {
-	tables := orderedmap.New[string, *Table]()
+	tables := orderedmap.New[string, *model.Table]()
 	tbl := newTable("public", "users")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true})
-	tbl.Constraints.Set("users_pkey", &Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.Constraints.Set("users_pkey", &model.Constraint{Name: "users_pkey", Definition: "PRIMARY KEY (id)"})
 	tables.Set("public.users", tbl)
 
-	got := TablesToSQL(tables)
+	got := model.TablesToSQL(tables)
 	assert.Contains(t, got, "-- public.users")
 	assert.Contains(t, got, "CREATE TABLE public.users")
 }
 
 func TestTablesToSQL_withIndexAndFK(t *testing.T) {
-	tables := orderedmap.New[string, *Table]()
+	tables := orderedmap.New[string, *model.Table]()
 	tbl := newTable("public", "orders")
-	tbl.Columns.Set("id", &Column{Name: "id", TypeName: "integer", NotNull: true})
-	tbl.Indexes.Set("idx_user", &Index{Definition: "CREATE INDEX idx_user ON public.orders USING btree (user_id)"})
-	tbl.ForeignKeys.Set("fk_user", &ForeignKey{
-		Constraint: Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true},
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.Indexes.Set("idx_user", &model.Index{Definition: "CREATE INDEX idx_user ON public.orders USING btree (user_id)"})
+	tbl.ForeignKeys.Set("fk_user", &model.ForeignKey{
+		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true},
 		Schema:     "public",
 		Table:      "orders",
 	})
@@ -287,7 +288,7 @@ func TestTablesToSQL_withIndexAndFK(t *testing.T) {
 	tbl.Comment = &comment
 	tables.Set("public.orders", tbl)
 
-	got := TablesToSQL(tables)
+	got := model.TablesToSQL(tables)
 	assert.Contains(t, got, "-- public.orders")
 	assert.Contains(t, got, "CREATE TABLE public.orders")
 	assert.Contains(t, got, "CREATE INDEX idx_user")
@@ -296,15 +297,15 @@ func TestTablesToSQL_withIndexAndFK(t *testing.T) {
 }
 
 func TestTablesToSQL_multipleTables(t *testing.T) {
-	tables := orderedmap.New[string, *Table]()
+	tables := orderedmap.New[string, *model.Table]()
 	t1 := newTable("public", "a")
-	t1.Columns.Set("id", &Column{Name: "id", TypeName: "integer"})
+	t1.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	tables.Set("public.a", t1)
 	t2 := newTable("public", "b")
-	t2.Columns.Set("id", &Column{Name: "id", TypeName: "integer"})
+	t2.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	tables.Set("public.b", t2)
 
-	got := TablesToSQL(tables)
+	got := model.TablesToSQL(tables)
 	assert.Contains(t, got, "-- public.a")
 	assert.Contains(t, got, "-- public.b")
 }

--- a/model/view_test.go
+++ b/model/view_test.go
@@ -1,46 +1,47 @@
-package model
+package model_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
 )
 
 func TestView_FQVN(t *testing.T) {
-	v := View{Schema: "public", Name: "active_users"}
+	v := model.View{Schema: "public", Name: "active_users"}
 	assert.Equal(t, "public.active_users", v.FQVN())
 }
 
 func TestView_SQL(t *testing.T) {
-	v := View{Schema: "public", Name: "active_users", Definition: "SELECT id, name FROM users WHERE active = true"}
+	v := model.View{Schema: "public", Name: "active_users", Definition: "SELECT id, name FROM users WHERE active = true"}
 	expected := "CREATE OR REPLACE VIEW public.active_users AS\nSELECT id, name FROM users WHERE active = true;"
 	assert.Equal(t, expected, v.SQL())
 }
 
 func TestView_SQL_trims(t *testing.T) {
-	v := View{Schema: "public", Name: "v1", Definition: "  SELECT 1;  "}
+	v := model.View{Schema: "public", Name: "v1", Definition: "  SELECT 1;  "}
 	assert.Equal(t, "CREATE OR REPLACE VIEW public.v1 AS\nSELECT 1;", v.SQL())
 }
 
 func TestView_CommentSQL(t *testing.T) {
 	comment := "Active users view"
-	v := View{Schema: "public", Name: "active_users", Comment: &comment}
+	v := model.View{Schema: "public", Name: "active_users", Comment: &comment}
 	assert.Equal(t, "COMMENT ON VIEW public.active_users IS 'Active users view';", v.CommentSQL())
 }
 
 func TestView_CommentSQL_nil(t *testing.T) {
-	v := View{Schema: "public", Name: "active_users"}
+	v := model.View{Schema: "public", Name: "active_users"}
 	assert.Equal(t, "", v.CommentSQL())
 }
 
 func TestViewsToSQL(t *testing.T) {
 	comment := "my view"
-	views := orderedmap.New[string, *View]()
-	views.Set("public.v1", &View{Schema: "public", Name: "v1", Definition: "SELECT 1", Comment: &comment})
-	views.Set("public.v2", &View{Schema: "public", Name: "v2", Definition: "SELECT 2"})
+	views := orderedmap.New[string, *model.View]()
+	views.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", Comment: &comment})
+	views.Set("public.v2", &model.View{Schema: "public", Name: "v2", Definition: "SELECT 2"})
 
-	got := ViewsToSQL(views)
+	got := model.ViewsToSQL(views)
 	expected := `-- public.v1
 CREATE OR REPLACE VIEW public.v1 AS
 SELECT 1;
@@ -53,25 +54,25 @@ SELECT 2;`
 }
 
 func TestView_SQL_materialized(t *testing.T) {
-	v := View{Schema: "public", Name: "mv", Materialized: true, Definition: "SELECT count(*) AS cnt FROM users"}
+	v := model.View{Schema: "public", Name: "mv", Materialized: true, Definition: "SELECT count(*) AS cnt FROM users"}
 	expected := "CREATE MATERIALIZED VIEW public.mv AS\nSELECT count(*) AS cnt FROM users;"
 	assert.Equal(t, expected, v.SQL())
 }
 
 func TestView_CommentSQL_materialized(t *testing.T) {
 	comment := "stats"
-	v := View{Schema: "public", Name: "mv", Materialized: true, Comment: &comment}
+	v := model.View{Schema: "public", Name: "mv", Materialized: true, Comment: &comment}
 	assert.Equal(t, "COMMENT ON MATERIALIZED VIEW public.mv IS 'stats';", v.CommentSQL())
 }
 
 func TestViewToSQL_materializedWithIndex(t *testing.T) {
-	indexes := orderedmap.New[string, *Index]()
-	indexes.Set("idx_mv_n", &Index{
+	indexes := orderedmap.New[string, *model.Index]()
+	indexes.Set("idx_mv_n", &model.Index{
 		Schema: "public", Name: "idx_mv_n", Table: "mv",
 		Definition: "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
 	})
-	v := &View{Schema: "public", Name: "mv", Materialized: true, Definition: "SELECT 1 AS n", Indexes: indexes}
-	got := ViewToSQL(v)
+	v := &model.View{Schema: "public", Name: "mv", Materialized: true, Definition: "SELECT 1 AS n", Indexes: indexes}
+	got := model.ViewToSQL(v)
 	assert.Contains(t, got, "CREATE MATERIALIZED VIEW")
 	assert.Contains(t, got, "CREATE INDEX idx_mv_n")
 }


### PR DESCRIPTION
## Summary
- Switch `model/{column,constraint,index,policy,sequence,table,view}_test.go` from same-package tests to `model_test`, aligning with the existing `domain_test.go` / `enum_test.go` and the project convention ("Use same-package tests only when access to unexported identifiers is required").
- These seven files reference only exported identifiers, so the same-package declaration was unnecessary.
- `util_test.go` stays in `package model` because it tests the unexported `quoteIdent` helper.

## Test plan
- [x] \`go vet ./model/...\`
- [x] \`go test ./model/...\`
- [x] \`make lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)