### PR TITLE
Simplify CLI help and convert code to pure ASCII

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -16,11 +16,11 @@ type ApplyOptions struct {
 	Files                    []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQL                   string   `xor:"pre-sql" env:"PISTA_PRE_SQL" help:"SQL to execute before applying changes."`
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PISTA_PRE_SQL_FILE" help:"Path to a SQL file to execute before applying changes."`
-	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index operations (e.g. SET lock_timeout). Only run when the diff includes CONCURRENTLY index DDL; runs outside any transaction."`
-	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to execute before CONCURRENTLY index operations."`
-	WithTx                   bool     `env:"PISTA_WITH_TX" help:"Execute the pre-SQL and schema changes in a transaction."`
-	DisableIndexConcurrently bool     `env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore all CONCURRENTLY opt-ins (both -- pista:concurrently directives and inline CREATE/DROP INDEX CONCURRENTLY) and emit plain CREATE/DROP INDEX."`
-	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs are kept separate."`
+	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index DDL (e.g. SET lock_timeout). Runs outside any transaction, only when the diff contains CONCURRENTLY index DDL."`
+	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to execute before CONCURRENTLY index DDL."`
+	WithTx                   bool     `env:"PISTA_WITH_TX" help:"Execute pre-SQL and schema changes in a transaction."`
+	DisableIndexConcurrently bool     `env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
+	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
 }
 
 // ApplyResult holds the result of an Apply operation.

--- a/apply_test.go
+++ b/apply_test.go
@@ -481,7 +481,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	var buf bytes.Buffer
 	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}}, &buf)
 	require.NoError(t, err)
-	// No check SQL → always execute
+	// No check SQL -> always execute
 	assert.Contains(t, buf.String(), "CREATE OR REPLACE FUNCTION")
 }
 
@@ -672,7 +672,7 @@ func TestApply_ExecError(t *testing.T) {
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );`)
 
-	// Desired has a column with a type that references a nonexistent type → exec error on ALTER TABLE
+	// Desired has a column with a type that references a nonexistent type -> exec error on ALTER TABLE
 	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
 	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
     id integer NOT NULL,

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -15,7 +15,7 @@ var version string
 var cli struct {
 	pistachio.Options
 	Version kong.VersionFlag
-	Pager   *bool `name:"pager" negatable:"" help:"Force paging of long output via $PISTA_PAGER, bypassing the TTY check. Use --no-pager to disable. PISTA_PAGER must still be set."`
+	Pager   *bool `name:"pager" negatable:"" help:"Force paging via $PISTA_PAGER even when stdout is not a TTY. PISTA_PAGER must be set."`
 
 	Apply command.Apply `cmd:"" help:"Apply schema changes to the database."`
 	Plan  command.Plan  `cmd:"" help:"Print the schema diff SQL without applying it."`

--- a/diff/policies.go
+++ b/diff/policies.go
@@ -234,12 +234,12 @@ func exprChanged(a, b *string) bool {
 // in `SELECT <expr>`) are semantically equal under the strict asymmetric
 // cast normalization: parses both via parseSelectExpr, runs
 // normalizeCheckExpr symmetrically (text-like cast strip, paren cleanup,
-// `IN`↔`= ANY(ARRAY[...])`), strips any current-only TypeCast via
+// `IN`<->`= ANY(ARRAY[...])`), strips any current-only TypeCast via
 // alignCurrentCasts, and coerces stripped numeric Sval back to Ival/Fval
 // when the desired side is a bare numeric A_Const.
 //
 // Unlike equalDefault, this does NOT apply a symmetric top-level
-// TypeCast strip and does NOT treat `'0'::bigint` ≡ `'0'::integer` as
+// TypeCast strip and does NOT treat `'0'::bigint` == `'0'::integer` as
 // equal; a non-text top-level cast (e.g. `(...)::numeric`,
 // `(...)::time without time zone`), or a change to a cast's target
 // type, surfaces as a real difference. Text-like casts (`::text`,

--- a/diff/policies_test.go
+++ b/diff/policies_test.go
@@ -268,7 +268,7 @@ func TestEqualSelectExpr_desiredCastCurrentBare(t *testing.T) {
 
 func TestEqualSelectExpr_customNumericNamedTypeNotCoerced(t *testing.T) {
 	// A user-defined type that happens to share a built-in numeric name
-	// (e.g. `myapp.int4`) does NOT gate the Sval→numeric coercion.
+	// (e.g. `myapp.int4`) does NOT gate the Sval->numeric coercion.
 	// alignCurrentCasts still strips the wrapper (unconditional under the
 	// asymmetric rule), but the surviving A_Const{Sval "0"} is left as-is
 	// and compares unequal to the desired bare integer `0`. Same guard as
@@ -280,7 +280,7 @@ func TestEqualSelectExpr_customNumericNamedTypeNotCoerced(t *testing.T) {
 }
 
 func TestNormalizeRoles(t *testing.T) {
-	assert.Equal(t, []string{"public"}, normalizeRoles(nil), "empty → [public]")
+	assert.Equal(t, []string{"public"}, normalizeRoles(nil), "empty -> [public]")
 	assert.Equal(t, []string{"a", "b"}, normalizeRoles([]string{"b", "a"}), "sorted")
 }
 
@@ -336,7 +336,7 @@ func TestDiffPolicies_RenameAndRecreate(t *testing.T) {
 	cur := orderedmap.New[string, *model.Policy]()
 	des := orderedmap.New[string, *model.Policy]()
 	cur.Set("old", newPolicy("old", 'r', withUsing("true")))
-	// Rename old → new AND change command from SELECT to ALL.
+	// Rename old -> new AND change command from SELECT to ALL.
 	des.Set("new", newPolicy("new", '*', withUsing("true"), renameFrom("old")))
 
 	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -453,7 +453,7 @@ func cloneMap[K comparable, V any](m *orderedmap.Map[K, V]) *orderedmap.Map[K, V
 	return clone
 }
 
-// collectColumnRenames returns a map of old column name → new column name
+// collectColumnRenames returns a map of old column name -> new column name
 // for desired columns annotated with -- pista:renamed-from.
 func collectColumnRenames(desired *orderedmap.Map[string, *model.Column]) map[string]string {
 	renames := make(map[string]string)
@@ -468,8 +468,8 @@ func collectColumnRenames(desired *orderedmap.Map[string, *model.Column]) map[st
 // rewriteColumnRefsInExpr walks an expression tree and rewrites each
 // unqualified ColumnRef whose name appears in renames to the mapped new
 // name, mutating the tree in place. Each ColumnRef is matched against the
-// original-name set in a single pass, so chained renames (a→b alongside
-// b→c) cannot cascade.
+// original-name set in a single pass, so chained renames (a->b alongside
+// b->c) cannot cascade.
 func rewriteColumnRefsInExpr(node *pg_query.Node, renames map[string]string) {
 	pgast.WalkExprColumnRefs(node, func(s *pg_query.String) {
 		if newName, ok := renames[s.Sval]; ok {
@@ -479,12 +479,12 @@ func rewriteColumnRefsInExpr(node *pg_query.Node, renames map[string]string) {
 }
 
 // rewriteColumnsInIndexDef returns a new index definition with column
-// references rewritten according to the renames map (old → new). Returns an
+// references rewritten according to the renames map (old -> new). Returns an
 // error (and an empty string) if pg_query parse/deparse fails; callers fall
 // back to the original definition.
 //
-// All renames are applied in a single AST walk, so chained renames (a→b and
-// b→c) do not cascade; each original column name is matched once against
+// All renames are applied in a single AST walk, so chained renames (a->b and
+// b->c) do not cascade; each original column name is matched once against
 // the renames map.
 func rewriteColumnsInIndexDef(def string, renames map[string]string) (string, error) {
 	result, err := pg_query.Parse(def)
@@ -518,7 +518,7 @@ func rewriteColumnsInIndexDef(def string, renames map[string]string) (string, er
 
 // rewriteColumnsInConstraintDef returns a new constraint definition fragment
 // (e.g. "PRIMARY KEY (id)", "CHECK ((x > 0))", "FOREIGN KEY (a) REFERENCES t(b)")
-// with column references rewritten according to the renames map (old → new).
+// with column references rewritten according to the renames map (old -> new).
 // PkAttrs (referenced columns on the foreign side) are intentionally NOT
 // rewritten because they refer to a different table.
 //
@@ -598,7 +598,7 @@ func rewriteColumnRefsInConstraints(cons *orderedmap.Map[string, *model.Constrai
 // renameColumnKeys returns a clone of the columns map where each key in
 // renames is replaced by its mapped new name. Iteration is single-pass
 // (each existing key is matched once against the renames map) so chained
-// renames such as a→b alongside b→c do not cascade. Order is preserved.
+// renames such as a->b alongside b->c do not cascade. Order is preserved.
 func renameColumnKeys(cols *orderedmap.Map[string, *model.Column], renames map[string]string) *orderedmap.Map[string, *model.Column] {
 	out := orderedmap.New[string, *model.Column]()
 	for name, col := range cols.All() {

--- a/diff/rename_test.go
+++ b/diff/rename_test.go
@@ -70,8 +70,8 @@ func TestRewriteColumnsInIndexDef_IncludeClause(t *testing.T) {
 }
 
 func TestRewriteColumnsInIndexDef_NoCascadeOnChain(t *testing.T) {
-	// Renames a→b alongside b→c must rewrite the index's reference to a (the
-	// original) into b; NOT cascade through b→c into c.
+	// Renames a->b alongside b->c must rewrite the index's reference to a (the
+	// original) into b; NOT cascade through b->c into c.
 	got, err := rewriteColumnsInIndexDef(
 		"CREATE INDEX idx ON public.t USING btree (a, b)",
 		map[string]string{"a": "b", "b": "c"},
@@ -220,7 +220,7 @@ func TestRewriteColumnsInConstraintDef_CheckInList(t *testing.T) {
 }
 
 func TestRewriteColumnsInConstraintDef_NoCascadeOnChain(t *testing.T) {
-	// Renames a→b and b→c must not cascade.
+	// Renames a->b and b->c must not cascade.
 	got, err := rewriteColumnsInConstraintDef(
 		"UNIQUE (a, b)",
 		map[string]string{"a": "b", "b": "c"},
@@ -291,7 +291,7 @@ func TestRenameColumnKeys_RemapsAndPreservesOrder(t *testing.T) {
 }
 
 func TestRenameColumnKeys_NoCascadeOnChain(t *testing.T) {
-	// a→b alongside b→c must not cascade through a single column to c.
+	// a->b alongside b->c must not cascade through a single column to c.
 	in := orderedmap.New[string, *model.Column]()
 	in.Set("a", &model.Column{Name: "a"})
 	in.Set("b", &model.Column{Name: "b"})

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -276,7 +276,7 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 				// change as an error so the user explicitly drops/re-adds.
 				// Use exprChanged (strict equalSelectExpr) rather than
 				// equalDefault: equalDefault has DEFAULT-specific semantics
-				// (symmetric top-level cast strip, `'0'::bigint` ≡
+				// (symmetric top-level cast strip, `'0'::bigint` ==
 				// `'0'::integer`) that would silently hide a real top-level
 				// cast change or a cast-target-type change on a GENERATED
 				// expression. equalSelectExpr keeps the asymmetric strip
@@ -363,7 +363,7 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 	// IDENTITY requires the column to have no default and NOT NULL set.
 	switch {
 	case !curIsIdent && desIsIdent:
-		// none → identity: clear default and ensure NOT NULL, then ADD IDENTITY.
+		// none -> identity: clear default and ensure NOT NULL, then ADD IDENTITY.
 		// Catalog reports Default=nil for serial/bigserial/smallserial columns
 		// even though they carry a hidden nextval() default that would block
 		// ADD IDENTITY, so detect those by TypeName as well.
@@ -375,11 +375,11 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 		}
 		stmts = append(stmts, "ALTER TABLE "+fqtn+" ALTER COLUMN "+colIdent+" ADD GENERATED "+identityKind(desired.Identity)+" AS IDENTITY;")
 	case curIsIdent && !desIsIdent:
-		// identity → none: DROP IDENTITY. The column stays NOT NULL afterwards;
+		// identity -> none: DROP IDENTITY. The column stays NOT NULL afterwards;
 		// the NOT NULL diff below will emit DROP NOT NULL if desired is nullable.
 		stmts = append(stmts, "ALTER TABLE "+fqtn+" ALTER COLUMN "+colIdent+" DROP IDENTITY IF EXISTS;")
 	case curIsIdent && desIsIdent && current.Identity != desired.Identity:
-		// always ↔ by default
+		// always <-> by default
 		stmts = append(stmts, "ALTER TABLE "+fqtn+" ALTER COLUMN "+colIdent+" SET GENERATED "+identityKind(desired.Identity)+";")
 	}
 
@@ -503,7 +503,7 @@ func normalizeCheckExpr(node *pg_query.Node) *pg_query.Node {
 			}
 		}
 	case *pg_query.Node_SubLink:
-		// Recurse into the contained SELECT so that IN ↔ ANY(ARRAY[...])
+		// Recurse into the contained SELECT so that IN <-> ANY(ARRAY[...])
 		// rewrites and text-cast strips reach sub-queries inside EXISTS /
 		// IN-subquery / ANY-subquery predicates. CHECK / DEFAULT /
 		// generated-column / index-predicate callers can't actually emit
@@ -542,7 +542,7 @@ func isTextLikeTypeName(tn *pg_query.TypeName) bool {
 // float4 respectively, so both forms are accepted, but only the unqualified
 // keyword (`integer`) and the `pg_catalog`-qualified canonical form
 // (`pg_catalog.int4`) match; a user-defined type that happens to be named
-// e.g. `myapp.int4` does not gate the Sval→numeric coercion below, so a
+// e.g. `myapp.int4` does not gate the Sval->numeric coercion below, so a
 // stripped cast on a custom-type Sval is left as-is rather than rewritten
 // to a built-in numeric A_Const. (The strip itself is unconditional; that
 // is the asymmetric rule from #201; but coercion is narrowed to the
@@ -578,7 +578,7 @@ func isNumericTypeName(tn *pg_query.TypeName) bool {
 }
 
 // desiredIsNumericAConst reports whether a desired-side node is a bare
-// numeric A_Const (Ival or Fval). Used to gate the Sval→numeric coercion
+// numeric A_Const (Ival or Fval). Used to gate the Sval->numeric coercion
 // in the asymmetric cast-strip path so that desired-side quoted literals
 // (`'0'`, `'1'`) keep matching the cast-stripped Sval as before.
 func desiredIsNumericAConst(n *pg_query.Node) bool {
@@ -644,7 +644,7 @@ func numericAConstFromString(s string) *pg_query.Node {
 			},
 		}
 	}
-	// ParseFloat returns ErrRange (with ±Inf as value) for syntactically
+	// ParseFloat returns ErrRange (with +/-Inf as value) for syntactically
 	// valid numerics that exceed float64; but PG's `numeric` carries those
 	// just fine and pg_query's Fval is just a string, so accept ErrRange as
 	// "lexically a number, store the original string verbatim".
@@ -852,7 +852,7 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 	for name, currentCon := range current.All() {
 		desiredCon, ok := desired.GetOk(name)
 		if !ok || !equalConstraintDef(currentCon.Definition, desiredCon.Definition) || currentCon.Validated != desiredCon.Validated {
-			// NOT VALID → validated with same definition can use VALIDATE CONSTRAINT
+			// NOT VALID -> validated with same definition can use VALIDATE CONSTRAINT
 			if ok && equalConstraintDef(currentCon.Definition, desiredCon.Definition) && !currentCon.Validated && desiredCon.Validated {
 				continue
 			}
@@ -873,7 +873,7 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 	for name, desiredCon := range desired.All() {
 		currentCon, ok := current.GetOk(name)
 		if !ok || !equalConstraintDef(currentCon.Definition, desiredCon.Definition) || currentCon.Validated != desiredCon.Validated {
-			// NOT VALID → validated with same definition can use VALIDATE CONSTRAINT
+			// NOT VALID -> validated with same definition can use VALIDATE CONSTRAINT
 			if ok && equalConstraintDef(currentCon.Definition, desiredCon.Definition) && !currentCon.Validated && desiredCon.Validated {
 				stmts = append(stmts, "ALTER TABLE "+fqtn+" VALIDATE CONSTRAINT "+model.Ident(name)+";")
 				continue
@@ -1032,7 +1032,7 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 		}
 		currentFk := current.Get(name)
 		if !equalFKDef(currentFk.Definition, desiredFk.Definition, schema) || currentFk.Validated != desiredFk.Validated {
-			// NOT VALID → validated with same definition can use VALIDATE CONSTRAINT (no recreation needed)
+			// NOT VALID -> validated with same definition can use VALIDATE CONSTRAINT (no recreation needed)
 			if equalFKDef(currentFk.Definition, desiredFk.Definition, schema) && !currentFk.Validated && desiredFk.Validated {
 				continue
 			}
@@ -1063,7 +1063,7 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 		desiredFk, ok := desired.GetOk(name)
 		currentFk := current.Get(name)
 		if !ok || !equalFKDef(currentFk.Definition, desiredFk.Definition, schema) || currentFk.Validated != desiredFk.Validated {
-			// NOT VALID → validated with same definition can use VALIDATE CONSTRAINT
+			// NOT VALID -> validated with same definition can use VALIDATE CONSTRAINT
 			if ok && equalFKDef(currentFk.Definition, desiredFk.Definition, schema) && !currentFk.Validated && desiredFk.Validated {
 				continue
 			}
@@ -1084,7 +1084,7 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 	for name, desiredFk := range desired.All() {
 		currentFk, ok := current.GetOk(name)
 		if !ok || !equalFKDef(currentFk.Definition, desiredFk.Definition, schema) || currentFk.Validated != desiredFk.Validated {
-			// NOT VALID → validated with same definition can use VALIDATE CONSTRAINT
+			// NOT VALID -> validated with same definition can use VALIDATE CONSTRAINT
 			if ok && equalFKDef(currentFk.Definition, desiredFk.Definition, schema) && !currentFk.Validated && desiredFk.Validated {
 				addStmts = append(addStmts, "ALTER TABLE "+fqtn+" VALIDATE CONSTRAINT "+model.Ident(name)+";")
 				continue
@@ -1162,7 +1162,7 @@ func parseIndexDef(def string) (*pg_query.ParseResult, *pg_query.IndexStmt, erro
 // table refs compare equal), canonicalises explicit ASC / NULLS LAST /
 // NULLS FIRST defaults, and runs normalizeCheckExpr over each
 // IndexElem.Expr (expression-index body) and the partial-index
-// WhereClause so symmetric paren / text-cast / `IN`↔`ANY` differences
+// WhereClause so symmetric paren / text-cast / `IN`<->`ANY` differences
 // don't surface as false diffs.
 func normalizeIndexStmt(is *pg_query.IndexStmt) {
 	if is == nil {
@@ -1227,9 +1227,9 @@ func alignIndexCasts(desired, current *pg_query.IndexStmt) {
 
 // equalIndexDef compares two CREATE INDEX definitions by parsing both
 // sides, canonicalising sort / nulls / schema, normalising sub-expression
-// formatting (parens, text-like casts, `IN`↔`= ANY(ARRAY[...])`), and
+// formatting (parens, text-like casts, `IN`<->`= ANY(ARRAY[...])`), and
 // stripping any current-only TypeCast in the partial-index WhereClause
-// and expression-index IndexElem.Expr (with Sval→numeric coercion when
+// and expression-index IndexElem.Expr (with Sval->numeric coercion when
 // the desired side is a bare numeric A_Const); same pipeline as
 // equalConstraintDef.
 func equalIndexDef(current, desired string) bool {
@@ -1356,7 +1356,7 @@ func equalTypeName(a, b string) bool {
 //     is a numeric A_Const, the Sval is coerced to Ival / Fval so the two
 //     deparse identically.
 //  2. normalizeCheckExpr handles symmetric text-like cast strip, paren
-//     cleanup, and `= ANY(ARRAY[...])` ↔ `IN (...)` on both sides.
+//     cleanup, and `= ANY(ARRAY[...])` <-> `IN (...)` on both sides.
 //  3. alignCurrentCasts handles the inner asymmetric strip (current has
 //     `TypeCast` at a position desired doesn't) for expressions like
 //     `now() - '18 years'::interval` where the cast is nested under an
@@ -1392,7 +1392,7 @@ func equalDefault(current, desired *string) bool {
 // stripDefaultTopLevelCast removes a top-level TypeCast wrapper from node,
 // optionally coercing the resulting Sval back to a numeric A_Const when
 // the cast is on a numeric type and peer is itself a numeric (non-string)
-// A_Const. Used by equalDefault to keep `DEFAULT 0::integer` ≡ `DEFAULT 0`
+// A_Const. Used by equalDefault to keep `DEFAULT 0::integer` == `DEFAULT 0`
 // even when the value form on each side parses to a different A_Const
 // kind (Sval vs Ival).
 func stripDefaultTopLevelCast(node, peer *pg_query.Node) *pg_query.Node {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -239,7 +239,7 @@ func TestDiffColumns_generatedToggle(t *testing.T) {
 }
 
 func TestDiffColumns_generatedExpressionChange(t *testing.T) {
-	// Both sides STORED GENERATED but the expression text differs → error,
+	// Both sides STORED GENERATED but the expression text differs -> error,
 	// because PostgreSQL has no in-place `ALTER COLUMN ... SET GENERATED`.
 	current := orderedmap.New[string, *model.Column]()
 	current.Set("total", &model.Column{
@@ -541,7 +541,7 @@ func TestDiffColumns_renameNotNullConstraint_skipsIdentityColumn(t *testing.T) {
 }
 
 func TestDiffColumns_setNotNull_withDesiredName_ignoresName(t *testing.T) {
-	// Nullable → NOT NULL with explicit desired name. v1 emits SET NOT NULL only;
+	// Nullable -> NOT NULL with explicit desired name. v1 emits SET NOT NULL only;
 	// the name is not applied (it would require PG18's standalone ADD CONSTRAINT
 	// NOT NULL syntax).
 	name := "users_name_nn"
@@ -558,7 +558,7 @@ func TestDiffColumns_setNotNull_withDesiredName_ignoresName(t *testing.T) {
 }
 
 func TestDiffColumns_dropNotNull_loseCurrentName(t *testing.T) {
-	// NOT NULL with explicit current name → nullable. DROP NOT NULL implicitly
+	// NOT NULL with explicit current name -> nullable. DROP NOT NULL implicitly
 	// drops the constraint (and the name with it).
 	name := "users_name_nn"
 
@@ -1096,7 +1096,7 @@ func TestDiffForeignKeys_change_denied_alwaysExecutes(t *testing.T) {
 }
 
 func TestDiffForeignKeys_renamedAndChanged_denied_alwaysExecutes(t *testing.T) {
-	// Renamed FK with definition change → DROP (old name) + ADD (new name).
+	// Renamed FK with definition change -> DROP (old name) + ADD (new name).
 	// The new name is in desired so it's not a "pure removal"; deny does not
 	// suppress it.
 	current := orderedmap.New[string, *model.ForeignKey]()
@@ -1241,7 +1241,7 @@ func TestEqualDefault_currentTimestampCastStripped(t *testing.T) {
 
 func TestEqualDefault_currentNegativeIntCastStripped(t *testing.T) {
 	// Negative integer DEFAULT: DB emits `'-40'::integer`, user writes `-40`.
-	// Requires the numeric Sval→Ival coercion alongside the cast strip.
+	// Requires the numeric Sval->Ival coercion alongside the cast strip.
 	assert.True(t, equalDefault(
 		new("'-40'::integer"),
 		new("-40"),
@@ -1275,7 +1275,7 @@ func TestEqualDefault_bothExplicitCastsMatch(t *testing.T) {
 func TestEqualDefault_currentStringCastVsDesiredNumericCast(t *testing.T) {
 	// Asymmetric A_Const kind under matching top-level casts: current's
 	// cast wraps an Sval ("0"), desired's cast wraps an Ival (0). Both
-	// casts get stripped symmetrically; the Sval→numeric coercion must
+	// casts get stripped symmetrically; the Sval->numeric coercion must
 	// look through the peer's still-present TypeCast to decide that the
 	// peer "will be" numeric after its own strip; otherwise the surviving
 	// Sval `'0'` diffs against the desired bare `0`.
@@ -1329,7 +1329,7 @@ func TestEqualDefault_currentLargeNumericCastStripped(t *testing.T) {
 
 func TestEqualDefault_customNumericNamedTypeNotCoerced(t *testing.T) {
 	// Same guard as the CHECK-constraint version: a user-defined type
-	// matching a built-in numeric name does not gate the Sval→numeric
+	// matching a built-in numeric name does not gate the Sval->numeric
 	// coercion, so the surviving Sval still compares unequal to a
 	// desired bare integer.
 	assert.False(t, equalDefault(
@@ -1581,7 +1581,7 @@ func TestDiffForeignKeys_renameAndNotValid(t *testing.T) {
 }
 
 func TestDiffForeignKeys_renameAlreadyAppliedAndNotValid(t *testing.T) {
-	// Rename fk_old→fk_new was already applied in DB (current has fk_new).
+	// Rename fk_old->fk_new was already applied in DB (current has fk_new).
 	// Desired still has RenameFrom but also changes Validated.
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_new", &model.ForeignKey{
@@ -1842,7 +1842,7 @@ func TestEqualConstraintDef_bothExplicitCastsMatch(t *testing.T) {
 }
 
 func TestEqualConstraintDef_castsDifferTypes(t *testing.T) {
-	// Both sides have a cast but the target types differ → not equal.
+	// Both sides have a cast but the target types differ -> not equal.
 	assert.False(t, equalConstraintDef(
 		"CHECK (val > '0'::bigint)",
 		"CHECK (val > '0'::integer)",
@@ -1901,7 +1901,7 @@ func TestEqualConstraintDef_currentCastInArrayLiteralStripped(t *testing.T) {
 func TestEqualConstraintDef_currentNegativeIntCastStripped(t *testing.T) {
 	// pg_get_constraintdef emits negative integer literals as `'-40'::integer`
 	// to dodge the unary-minus precedence trap; user writes bare `-40`.
-	// The cast strip plus Sval→Ival coercion makes them compare equal.
+	// The cast strip plus Sval->Ival coercion makes them compare equal.
 	assert.True(t, equalConstraintDef(
 		"CHECK (vacationhours >= '-40'::integer AND vacationhours <= 240)",
 		"CHECK (vacationhours >= -40 AND vacationhours <= 240)",
@@ -1941,7 +1941,7 @@ func TestEqualConstraintDef_currentNegativeFloatCastStripped(t *testing.T) {
 
 func TestEqualConstraintDef_currentLargeNumericCastStripped(t *testing.T) {
 	// Numeric literals beyond float64 range (PG `numeric` carries arbitrary
-	// precision). The Sval→Fval coercion must accept these so the strip is
+	// precision). The Sval->Fval coercion must accept these so the strip is
 	// not silently undone for very large values.
 	assert.True(t, equalConstraintDef(
 		"CHECK (price <= '1e400'::numeric)",
@@ -1951,7 +1951,7 @@ func TestEqualConstraintDef_currentLargeNumericCastStripped(t *testing.T) {
 
 func TestEqualConstraintDef_customNumericNamedTypeNotCoerced(t *testing.T) {
 	// A user-defined type that happens to share a built-in numeric name
-	// (e.g. `myapp.int4`) should NOT trigger the Sval→numeric coercion.
+	// (e.g. `myapp.int4`) should NOT trigger the Sval->numeric coercion.
 	// alignCurrentCasts still strips the `::myapp.int4` wrapper (the strip
 	// itself is unconditional, per the asymmetric rule from #201), but the
 	// surviving A_Const{Sval "0"} is left as-is; so it deparses to `'0'`
@@ -1984,7 +1984,7 @@ func TestEqualConstraintDef_currentDoublePrecisionCastStripped(t *testing.T) {
 func TestEqualConstraintDef_castsDifferNumericTypesStillDifferent(t *testing.T) {
 	// When both sides carry casts but the target types differ, the asymmetric
 	// rule does not fire and the difference still surfaces; even for numeric
-	// types where the Sval→numeric coercion would otherwise erase the type.
+	// types where the Sval->numeric coercion would otherwise erase the type.
 	assert.False(t, equalConstraintDef(
 		"CHECK (val > '0'::bigint)",
 		"CHECK (val > '0'::integer)",
@@ -2212,7 +2212,7 @@ func TestEqualIndexDef_whereCurrentTimeCastStripped(t *testing.T) {
 
 func TestEqualIndexDef_whereCurrentNegativeIntCastStripped(t *testing.T) {
 	// Negative integer literal: pg_get_indexdef emits `'-40'::integer`,
-	// user writes `-40`. Requires the Sval→Ival coercion alongside the
+	// user writes `-40`. Requires the Sval->Ival coercion alongside the
 	// asymmetric strip.
 	assert.True(t, equalIndexDef(
 		"CREATE INDEX idx ON balances USING btree (id) WHERE (amount >= '-40'::integer)",
@@ -2230,7 +2230,7 @@ func TestEqualIndexDef_whereCurrentCastInsideBoolExpr(t *testing.T) {
 
 func TestEqualIndexDef_whereCustomNumericNamedTypeNotCoerced(t *testing.T) {
 	// Guard: a user-defined type matching a built-in numeric name does NOT
-	// gate the Sval→numeric coercion. The cast is still stripped (asymmetric
+	// gate the Sval->numeric coercion. The cast is still stripped (asymmetric
 	// rule from #201), but the surviving Sval is not rewritten; so the
 	// desired bare integer stays unequal.
 	assert.False(t, equalIndexDef(
@@ -2941,7 +2941,7 @@ func TestParseDefaultExpr_success(t *testing.T) {
 func TestStripDefaultTopLevelCast_stripsWhenPeerHasNoCast(t *testing.T) {
 	// Top-level TypeCast is removed regardless of peer's shape, as long as
 	// the cast is at the root. equalDefault relies on this to collapse
-	// `'hello'::text` ≡ `'hello'`.
+	// `'hello'::text` == `'hello'`.
 	_, target, err := parseSelectExpr("'hello'::text")
 	require.NoError(t, err)
 	result := stripDefaultTopLevelCast(target.Val, nil)

--- a/diff/views.go
+++ b/diff/views.go
@@ -20,7 +20,7 @@ import (
 //     table-qualified columns and omits the default schema, parsed SQL is
 //     the opposite),
 //   - symmetric expression normalization via normalizeSelectExprs:
-//     paren / text-like cast stripping and `= ANY(ARRAY[...])` → `IN (...)`,
+//     paren / text-like cast stripping and `= ANY(ARRAY[...])` -> `IN (...)`,
 //   - asymmetric current-only cast alignment via alignSelectCasts: strips
 //     TypeCasts (notably 'lit'::enum_type) the catalog added but the user
 //     didn't write. Top-level casts at the target list are preserved on
@@ -72,7 +72,7 @@ func equalViewDef(current, desired string) bool {
 // dependent views; strictly better than leaving the bug in place.
 //
 // Known limitation: type-only changes on a same-named column (e.g.
-// `SELECT n FROM t` → `SELECT n::bigint AS n FROM t`) are reported as
+// `SELECT n FROM t` -> `SELECT n::bigint AS n FROM t`) are reported as
 // CREATE-OR-REPLACE-able because the names line up, but PostgreSQL still
 // rejects them with `cannot change data type of view column`. pg_query
 // doesn't perform type inference, so we can't detect this statically;
@@ -240,7 +240,7 @@ func normalizeSelectExprs(node *pg_query.Node) {
 // normalizeTargetExpr is normalizeCheckExpr with a top-level TypeCast
 // preserved. In a SELECT target list the cast type determines the output
 // column type, so symmetric text-cast stripping at that position would
-// hide an intentional `SELECT col` → `SELECT col::text` change.
+// hide an intentional `SELECT col` -> `SELECT col::text` change.
 func normalizeTargetExpr(node *pg_query.Node) *pg_query.Node {
 	if tc := node.GetTypeCast(); tc != nil {
 		tc.Arg = normalizeCheckExpr(tc.Arg)
@@ -269,7 +269,7 @@ func alignTargetCasts(desired, current *pg_query.Node) *pg_query.Node {
 // alignSelectCasts performs the same parallel walk as normalizeSelectExprs but
 // across two trees, applying alignCurrentCasts at each expression position
 // to strip TypeCasts present only on the current side. Used by equalViewDef
-// for the asymmetric current↔desired comparison, and from alignCurrentCasts'
+// for the asymmetric current<->desired comparison, and from alignCurrentCasts'
 // SubLink case for sub-queries inside CHECK / RLS expressions.
 func alignSelectCasts(desired, current *pg_query.Node) {
 	if desired == nil || current == nil {
@@ -389,7 +389,7 @@ func stripQualifications(node *pg_query.Node) {
 	}
 
 	if cr := node.GetColumnRef(); cr != nil {
-		// "table.column" → "column" (remove table prefix)
+		// "table.column" -> "column" (remove table prefix)
 		// Only strip when both parts are plain identifiers (not table.*)
 		if len(cr.Fields) == 2 && cr.Fields[1].GetString_() != nil {
 			cr.Fields = cr.Fields[1:]
@@ -585,7 +585,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 				}
 			}
 		} else if !equalViewDef(currentView.Definition, desiredView.Definition) || currentView.Materialized != desiredView.Materialized {
-			// Materialized views always need DROP+CREATE; VIEW↔MATVIEW
+			// Materialized views always need DROP+CREATE; VIEW<->MATVIEW
 			// switches do too. Regular view definition changes prefer
 			// CREATE OR REPLACE; but PostgreSQL rejects it when the new
 			// query removes, renames, or reorders an existing output
@@ -604,7 +604,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 				if oldKey, renamed := renamedFrom[k]; renamed {
 					dropName = oldKey
 				}
-				// Materialized views or type changes (VIEW ↔ MATERIALIZED VIEW)
+				// Materialized views or type changes (VIEW <-> MATERIALIZED VIEW)
 				// require DROP and recreate. Only proceed if drops are allowed;
 				// otherwise emit a commented DROP for visibility (no CREATE,
 				// since recreation requires the drop).
@@ -682,7 +682,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			continue
 		}
 
-		// If the type changed (VIEW ↔ MATERIALIZED VIEW) but drop was denied,
+		// If the type changed (VIEW <-> MATERIALIZED VIEW) but drop was denied,
 		// the object type hasn't changed yet; skip comment diff.
 		if ok && currentView.Materialized != desiredView.Materialized && !dc.IsDropAllowed("view") {
 			continue

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -295,7 +295,7 @@ func TestEqualViewDef_currentOnlyTypeCast(t *testing.T) {
 }
 
 func TestEqualViewDef_currentOnlyTypeCast_inList(t *testing.T) {
-	// Casts inside an IN list, after the ANY→IN rewrite.
+	// Casts inside an IN list, after the ANY->IN rewrite.
 	assert.True(t, equalViewDef(
 		"SELECT id FROM t WHERE status = ANY (ARRAY['published'::post_status, 'pinned'::post_status])",
 		"SELECT id FROM t WHERE status IN ('published', 'pinned')",
@@ -347,7 +347,7 @@ func TestEqualViewDef_currentOnlyTypeCast_groupBy(t *testing.T) {
 }
 
 func TestEqualViewDef_currentOnlyTypeCast_join(t *testing.T) {
-	// Covers the JoinExpr.Quals position in alignSelectCasts (the IN↔ANY
+	// Covers the JoinExpr.Quals position in alignSelectCasts (the IN<->ANY
 	// variant is already tested in inVsAnyArray_join).
 	assert.True(t, equalViewDef(
 		"SELECT u.id FROM users u JOIN orders o ON o.status = 'paid'::e",
@@ -1117,7 +1117,7 @@ func TestCanCreateOrReplaceView(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "desired uses SELECT * (cannot analyze → safer DROP+CREATE)",
+			name:    "desired uses SELECT * (cannot analyze -> safer DROP+CREATE)",
 			current: "SELECT id FROM t",
 			desired: "SELECT * FROM t",
 			want:    false,

--- a/diff_all.go
+++ b/diff_all.go
@@ -257,7 +257,7 @@ func orderStatements(
 	})
 
 	// Assemble:
-	// FK drops → view drops → creates/alters → table/domain/enum drops → FK adds → view creates
+	// FK drops -> view drops -> creates/alters -> table/domain/enum drops -> FK adds -> view creates
 	var stmts []string
 	for _, ts := range tagStatements(tableDiff.FKDropStmts, dropPosMap) {
 		stmts = append(stmts, ts.sql)
@@ -391,7 +391,7 @@ func extractObjectName(sql string) string {
 		{"COMMENT ON VIEW "},
 		{"COMMENT ON TYPE "},
 		{"COMMENT ON DOMAIN "},
-		{"COMMENT ON COLUMN "}, // schema.table.column → take schema.table
+		{"COMMENT ON COLUMN "}, // schema.table.column -> take schema.table
 	}
 
 	upper := strings.ToUpper(sql)
@@ -407,12 +407,12 @@ func extractObjectName(sql string) string {
 			strings.HasPrefix(upper, "DROP INDEX CONCURRENTLY ") ||
 			strings.HasPrefix(upper, "DROP INDEX ") {
 			// CREATE INDEX ... ON [ONLY] schema.table ...
-			// DROP INDEX returns "" (no ON clause) → pos=-1
+			// DROP INDEX returns "" (no ON clause) -> pos=-1
 			return extractIndexTable(sql)
 		}
 
 		if strings.HasPrefix(upper, "ALTER INDEX ") {
-			// ALTER INDEX schema.idx RENAME TO ... → extract table from idx name context
+			// ALTER INDEX schema.idx RENAME TO ... -> extract table from idx name context
 			// Index statements belong to the table they're on, but ALTER INDEX
 			// doesn't contain the table name directly. Return "" to use pos=-1.
 			return ""
@@ -429,7 +429,7 @@ func extractObjectName(sql string) string {
 		name := extractFirstIdentifier(rest)
 
 		if strings.HasPrefix(upper, "COMMENT ON COLUMN ") {
-			// schema.table.column → schema.table
+			// schema.table.column -> schema.table
 			parts := splitIdentifier(name, 3)
 			if len(parts) >= 2 {
 				return joinIdentifierParts(parts[:2])
@@ -478,7 +478,7 @@ func extractFirstIdentifier(s string) string {
 }
 
 // splitIdentifier splits a possibly-quoted schema-qualified identifier into parts.
-// e.g., `"MySchema"."MyTable".col` → ["\"MySchema\"", "\"MyTable\"", "col"]
+// e.g., `"MySchema"."MyTable".col` -> ["\"MySchema\"", "\"MyTable\"", "col"]
 func splitIdentifier(ident string, maxParts int) []string {
 	var parts []string
 	var part strings.Builder

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -77,7 +77,7 @@ func TestOrderStatements_Fallback(t *testing.T) {
 	desiredDomains := orderedmap.New[string, *model.Domain]()
 	desiredViews := orderedmap.New[string, *model.View]()
 
-	// Create two tables with mutual FK references → cycle
+	// Create two tables with mutual FK references -> cycle
 	refA := "a"
 	refB := "b"
 	schemaPublic := "public"
@@ -175,13 +175,13 @@ func TestOrderStatements_DropUsesCurrentSchema(t *testing.T) {
 	)
 
 	require.Len(t, result, 2)
-	// view_b depends on view_a → view_b must be dropped first (reverse topo order)
+	// view_b depends on view_a -> view_b must be dropped first (reverse topo order)
 	assert.Contains(t, result[0], "view_b", "dependent view dropped first")
 	assert.Contains(t, result[1], "view_a", "dependency dropped second")
 }
 
 func TestOrderStatements_DropFallbackOnCurrentCycle(t *testing.T) {
-	// Current schema has cyclic FK → drop ordering should fall back
+	// Current schema has cyclic FK -> drop ordering should fall back
 	refA := "a"
 	refB := "b"
 	schemaPublic := "public"
@@ -257,9 +257,9 @@ func TestOrderStatements_UnknownPosBeforeKnown(t *testing.T) {
 	domainDiff := &diff.DomainDiffResult{}
 	tableDiff := &diff.TableDiffResult{
 		Stmts: []string{
-			// RENAME uses old name → not in desired posMap → pos=-1
+			// RENAME uses old name -> not in desired posMap -> pos=-1
 			"ALTER TABLE public.users RENAME TO accounts;",
-			// Column change uses new name → in desired posMap
+			// Column change uses new name -> in desired posMap
 			"ALTER TABLE public.accounts ADD COLUMN name text;",
 		},
 	}

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -7,7 +7,7 @@ import "slices"
 // If AllowDrop contains "all", all drops are allowed.
 // Otherwise, only the listed object types are allowed to be dropped.
 type DropPolicy struct {
-	AllowDrop []string `enum:"all,table,view,enum,domain,column,constraint,foreign_key,index,policy" env:"PISTA_ALLOW_DROP" help:"Allow dropping specified object types (can be repeated). Use 'all' to allow all drops."`
+	AllowDrop []string `enum:"all,table,view,enum,domain,column,constraint,foreign_key,index,policy" env:"PISTA_ALLOW_DROP" help:"Allow dropping these object types (repeatable; 'all' allows everything)."`
 }
 
 func (p *DropPolicy) IsDropAllowed(objectType string) bool {

--- a/dump.go
+++ b/dump.go
@@ -131,7 +131,7 @@ func (r *DumpResult) String() string {
 
 // formatSchemaSQL formats enums, domains, tables, and views into canonical SQL
 // output for dump.
-// Order: enums → domains → tables → views (enums first since domains may depend on them).
+// Order: enums -> domains -> tables -> views (enums first since domains may depend on them).
 func formatSchemaSQL(
 	enums *orderedmap.Map[string, *model.Enum],
 	domains *orderedmap.Map[string, *model.Domain],

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -133,7 +133,7 @@ func qualifyRenameFrom(value, defaultSchema string) string {
 }
 
 // unquoteIdent strips surrounding double quotes from a SQL identifier and
-// unescapes doubled double-quotes ("" → "). For unquoted identifiers,
+// unescapes doubled double-quotes ("" -> "). For unquoted identifiers,
 // folds to lowercase to match PostgreSQL's behavior.
 func unquoteIdent(s string) string {
 	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
@@ -156,7 +156,7 @@ func normalizeUnqualifiedDirective(s string) string {
 }
 
 // splitQualifiedName splits a potentially schema-qualified name into parts,
-// respecting quoted identifiers. e.g. `"My Schema"."Old Name"` → [`"My Schema"`, `"Old Name"`]
+// respecting quoted identifiers. e.g. `"My Schema"."Old Name"` -> [`"My Schema"`, `"Old Name"`]
 func splitQualifiedName(s string) []string {
 	var parts []string
 	var current strings.Builder
@@ -268,8 +268,8 @@ func findLeadingCommentEnd(s string) int {
 
 // inlineDirectives holds rename directives for columns and constraints within a CREATE TABLE.
 type inlineDirectives struct {
-	Columns     map[string]string // new column name → old column name
-	Constraints map[string]string // new constraint name → old constraint name
+	Columns     map[string]string // new column name -> old column name
+	Constraints map[string]string // new constraint name -> old constraint name
 }
 
 // extractInlineDirectives scans the raw text of a CREATE TABLE statement for
@@ -347,7 +347,7 @@ func scanQuotedIdent(s string) (string, bool) {
 }
 
 // extractConstraintName extracts the constraint name from a CONSTRAINT line.
-// e.g. "CONSTRAINT users_pkey PRIMARY KEY (id)" → "users_pkey"
+// e.g. "CONSTRAINT users_pkey PRIMARY KEY (id)" -> "users_pkey"
 func extractConstraintName(line string) string {
 	line = strings.TrimSpace(line)
 	upper := strings.ToUpper(line)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -450,11 +450,11 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 // constraints, following the naming convention from PostgreSQL's
 // ChooseConstraintName (src/backend/catalog/pg_constraint.c):
 //
-//	PRIMARY KEY → {table}_pkey
-//	UNIQUE      → {table}_{col}_key  (or {table}_key if colName is empty)
-//	CHECK       → {table}_{col}_check (or {table}_check if colName is empty)
-//	EXCLUSION   → {table}_{col}_excl  (or {table}_excl if colName is empty)
-//	FOREIGN KEY → {table}_{col}_fkey  (or {table}_fkey if colName is empty)
+//	PRIMARY KEY -> {table}_pkey
+//	UNIQUE      -> {table}_{col}_key  (or {table}_key if colName is empty)
+//	CHECK       -> {table}_{col}_check (or {table}_check if colName is empty)
+//	EXCLUSION   -> {table}_{col}_excl  (or {table}_excl if colName is empty)
+//	FOREIGN KEY -> {table}_{col}_fkey  (or {table}_fkey if colName is empty)
 //
 // colName is the first column involved when one is derivable; it may be empty
 // for table-level constraints where no single column name is available.
@@ -1163,7 +1163,7 @@ func deparseTypeName(tn *pg_query.TypeName) (string, error) {
 		return "", fmt.Errorf("unexpected deparse output for type: %s", sql)
 	}
 	typeName := strings.TrimSpace(rest[:lastParen])
-	// pg_query may qualify built-in types with "pg_catalog." (e.g. json → pg_catalog.json).
+	// pg_query may qualify built-in types with "pg_catalog." (e.g. json -> pg_catalog.json).
 	// Strip the prefix so the result matches format_type() output.
 	typeName = strings.TrimPrefix(typeName, "pg_catalog.")
 	return normalizeTypeName(typeName), nil
@@ -1246,7 +1246,7 @@ var typeAliases = map[string]string{
 }
 
 func normalizeTypeName(name string) string {
-	// Handle types with modifiers like "varchar(255)" → "character varying(255)"
+	// Handle types with modifiers like "varchar(255)" -> "character varying(255)"
 	base := name
 	suffix := ""
 	if idx := strings.Index(name, "("); idx != -1 {
@@ -1257,7 +1257,7 @@ func normalizeTypeName(name string) string {
 		suffix = name[idx:]
 	}
 
-	// Normalize spacing in type modifiers: "numeric(10, 2)" → "numeric(10,2)"
+	// Normalize spacing in type modifiers: "numeric(10, 2)" -> "numeric(10,2)"
 	suffix = strings.ReplaceAll(suffix, ", ", ",")
 
 	if canonical, ok := typeAliases[base]; ok {

--- a/parser/policy_test.go
+++ b/parser/policy_test.go
@@ -12,7 +12,7 @@ import (
 // directly (integration tests in pistachio_test do not contribute here).
 
 func TestParseSQL_Policy_DefaultSchemaFallback(t *testing.T) {
-	// Unqualified table reference in CREATE POLICY → schema falls back to
+	// Unqualified table reference in CREATE POLICY -> schema falls back to
 	// defaultSchema (public).
 	sql := `CREATE TABLE public.t (id int);
 ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;

--- a/plan.go
+++ b/plan.go
@@ -14,10 +14,10 @@ type PlanOptions struct {
 	Files                    []string `arg:"" help:"Path to the desired schema SQL file(s)."`
 	PreSQL                   string   `xor:"pre-sql" env:"PISTA_PRE_SQL" help:"SQL to prepend to the plan output."`
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PISTA_PRE_SQL_FILE" help:"Path to a SQL file to prepend to the plan output."`
-	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to run before CONCURRENTLY index operations (e.g. SET lock_timeout). Only emitted when the diff includes CONCURRENTLY index DDL."`
-	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to run before CONCURRENTLY index operations."`
-	DisableIndexConcurrently bool     `env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore all CONCURRENTLY opt-ins (both -- pista:concurrently directives and inline CREATE/DROP INDEX CONCURRENTLY) and emit plain CREATE/DROP INDEX."`
-	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs are kept separate."`
+	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to run before CONCURRENTLY index DDL (e.g. SET lock_timeout). Emitted only when the diff contains CONCURRENTLY index DDL."`
+	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to run before CONCURRENTLY index DDL."`
+	DisableIndexConcurrently bool     `env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
+	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
 }
 
 // ObjectCount holds the number of objects inspected by type.
@@ -91,7 +91,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 		stmts = append(stmts, parser.FormatExecuteStmt(es))
 	}
 
-	// Prefix order matches apply: PreSQL → concurrently-pre-SQL → DDL.
+	// Prefix order matches apply: PreSQL -> concurrently-pre-SQL -> DDL.
 	// Skipped entirely when there is nothing to execute, so an empty plan
 	// stays empty instead of leaking a bare SET / pre-SQL line.
 	if len(stmts) > 0 {

--- a/remap.go
+++ b/remap.go
@@ -8,7 +8,7 @@ import (
 )
 
 // buildDefReplacer builds a strings.Replacer that replaces schema-qualified
-// prefixes in raw SQL definitions (e.g. "staging." → "public.").
+// prefixes in raw SQL definitions (e.g. "staging." -> "public.").
 //
 // All inputs to this replacer come from canonical SQL; pg_get_*def output
 // from the catalog or pg_query deparse output from the parser; so any

--- a/remap_test.go
+++ b/remap_test.go
@@ -53,7 +53,7 @@ func TestBuildDefReplacer_QuotedSchema(t *testing.T) {
 // named `a.b`) would silently rewrite a legitimate three-part column
 // reference `a.b.col` (schema `a`, table `b`, column `col`) by collapsing
 // the schema+table prefix into the dotted-name schema's mapped value. The
-// schema portion may legitimately be rewritten (`a.` → `y.`), but the
+// schema portion may legitimately be rewritten (`a.` -> `y.`), but the
 // table/column segments (`b.col`) must remain intact.
 func TestBuildDefReplacer_PreservesThreePartReference(t *testing.T) {
 	replacer := pistachio.BuildDefReplacer(map[string]string{

--- a/toposort/graph.go
+++ b/toposort/graph.go
@@ -8,7 +8,7 @@ import (
 // graph is a directed acyclic graph for topological sorting.
 type graph struct {
 	nodes map[string]bool
-	edges map[string][]string // from → [to ...] meaning "from depends on to"
+	edges map[string][]string // from -> [to ...] meaning "from depends on to"
 }
 
 // newGraph creates a new empty graph.
@@ -39,7 +39,7 @@ func (g *graph) AddEdge(from, to string) {
 func (g *graph) Sort() ([]string, error) {
 	// Build in-degree map and reverse adjacency list
 	inDegree := make(map[string]int)
-	dependents := make(map[string][]string) // to → [from ...] (who depends on to)
+	dependents := make(map[string][]string) // to -> [from ...] (who depends on to)
 
 	for n := range g.nodes {
 		inDegree[n] = 0
@@ -47,7 +47,7 @@ func (g *graph) Sort() ([]string, error) {
 
 	for from, tos := range g.edges {
 		for _, to := range tos {
-			// "from depends on to" means edge to → from in execution order
+			// "from depends on to" means edge to -> from in execution order
 			inDegree[from]++
 			dependents[to] = append(dependents[to], from)
 		}

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -714,7 +714,7 @@ func TestOrderFromSchema_FKWithDefaultSchema(t *testing.T) {
 	posts.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	posts.ForeignKeys.Set("posts_user_fk", &model.ForeignKey{
 		Constraint: model.Constraint{Name: "posts_user_fk"},
-		RefSchema:  nil, // nil schema → defaults to "public"
+		RefSchema:  nil, // nil schema -> defaults to "public"
 		RefTable:   &refTable,
 	})
 	tables.Set("public.posts", posts)


### PR DESCRIPTION
## Summary
- Tighten verbose flag descriptions on \`--concurrently-pre-sql\`, \`--disable-index-concurrently\`, \`--bulk-alter\`, \`--with-tx\`, \`--allow-drop\`, and \`--pager\`. Phrases like "Only emitted when the diff includes..." and "Force paging of long output via \$PISTA_PAGER, bypassing the TTY check..." become "Emitted only when the diff contains..." and "Force paging via \$PISTA_PAGER even when stdout is not a TTY."
- Replace non-ASCII glyphs used in code comments and test names with ASCII equivalents (\`->\` for \`→\`, \`<->\` for \`↔\`, \`==\` for \`≡\`, \`+/-\` for \`±\`). The Go codebase is now pure ASCII.

User-facing error messages and SQL-style output (e.g. \`-- Plan for ...\`, \`-- No changes\`, \`-- Transaction committed\`) were already concise and ASCII; no change there.

## Test plan
- [x] \`make vet\` / \`make build\` / \`make lint\` pass
- [x] \`make test\` passes across all packages
- [x] \`pista --help\`, \`pista plan --help\`, \`pista apply --help\` render the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)