### PR TITLE
Add 1.10.6 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.6] - 2026-05-28
+
+* Replace the em dash in two GENERATED column error messages with a semicolon: `cannot toggle GENERATED; DROP COLUMN + ADD COLUMN is required` and `cannot change GENERATED expression; DROP COLUMN + ADD COLUMN is required`. ([#242](https://github.com/winebarrel/pistachio/pull/242))
+
 ## [1.10.5] - 2026-05-22
 
 * Trim leading / trailing whitespace from each `--include` / `--exclude` pattern in `FilterOptions.AfterApply`. Multi-value env vars like `PISTA_INCLUDE="user*, posts"` were parsed by kong into `["user*", " posts"]`, and the leading space made `path.Match` treat the second pattern as ` posts`, silently matching nothing. The trim runs before `ValidatePatterns`, so the post-trim values are also what gets validated and what `MatchName` compares against.


### PR DESCRIPTION
## Summary
- Add 1.10.6 entry covering the GENERATED error message punctuation change from #242

## Test plan
- [x] CHANGELOG renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)