### PR TITLE
Sync README Usage with actual --[no-]pager help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ Flags:
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
       --version
-      --[no-]pager            Force paging of long output via $PISTA_PAGER,
-                              bypassing the TTY check. Use --no-pager to
-                              disable. PISTA_PAGER must still be set.
+      --[no-]pager            Force paging via $PISTA_PAGER even when stdout is
+                              not a TTY. PISTA_PAGER must be set.
 
 Commands:
   apply <files> ... [flags]


### PR DESCRIPTION
## Summary
- The `## Usage` block in the README is meant to mirror `pista --help` output, but the `--[no-]pager` description had drifted from the actual help text.
- Updated the README to match the current help output verbatim. All other flags/commands already matched.

## Test plan
- [x] `make build`
- [x] Diffed the README `## Usage` block against `pista --help`, `pista apply/plan/dump --help`; only `--[no-]pager` differed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)