### PR TITLE
Add CI job to reject non-ASCII characters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ascii:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check for non-ASCII characters
+        run: |
+          if matches=$(LC_ALL=C git grep -nIP '[^\x00-\x7F]' -- .); then
+            echo "Error: non-ASCII characters found:"
+            echo "$matches"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check for non-ASCII characters
         run: |
-          if matches=$(LC_ALL=C git grep -nIP '[^\x00-\x7F]' -- .); then
+          matches=$(LC_ALL=C git grep -nIP '[^\x00-\x7F]' -- .) && status=0 || status=$?
+          if [ "$status" -eq 0 ]; then
             echo "Error: non-ASCII characters found:"
             echo "$matches"
             exit 1
+          elif [ "$status" -ne 1 ]; then
+            echo "Error: git grep failed with status $status"
+            exit "$status"
           fi
 
   test:

--- a/test/scenario/inline_concurrently.test.sh
+++ b/test/scenario/inline_concurrently.test.sh
@@ -10,7 +10,7 @@ DATA="$SCRIPT_DIR/testdata/inline_concurrently"
 # --- Setup: load initial schema ---
 setup_db "$DATA/init.sql"
 
-# --- Step 1: ADD inline CONCURRENTLY index → no drift after apply ---
+# --- Step 1: ADD inline CONCURRENTLY index -> no drift after apply ---
 step "01 add index (inline CONCURRENTLY)"
 plan_output=$(pista_plan "$DATA/steps/01_add_index.sql") || { fail "plan failed: $plan_output"; true; }
 if ! echo "$plan_output" | grep -qF 'CREATE INDEX CONCURRENTLY'; then
@@ -27,7 +27,7 @@ else
   fi
 fi
 
-# --- Step 2: CHANGE inline CONCURRENTLY index → DROP + CREATE both CONCURRENTLY ---
+# --- Step 2: CHANGE inline CONCURRENTLY index -> DROP + CREATE both CONCURRENTLY ---
 step "02 change index (inline CONCURRENTLY)"
 plan_output=$(pista_plan "$DATA/steps/02_change_index.sql") || { fail "plan failed: $plan_output"; true; }
 if ! echo "$plan_output" | grep -qF 'DROP INDEX CONCURRENTLY'; then

--- a/test/scenario/omit_schema.test.sh
+++ b/test/scenario/omit_schema.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Scenario test: --omit-schema dump → plan round-trip
+# Scenario test: --omit-schema dump -> plan round-trip
 # Verifies that dump --omit-schema output can be fed back to plan
 # with no diff, covering all object types including materialized views.
 set -euo pipefail
@@ -39,8 +39,8 @@ else
   echo "    $dump_output" >&2
 fi
 
-# --- Step 3: dump --omit-schema → plan has no diff ---
-step "03 dump --omit-schema → plan no diff"
+# --- Step 3: dump --omit-schema -> plan has no diff ---
+step "03 dump --omit-schema -> plan no diff"
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 echo "$dump_output" > "$tmp_dir/schema.sql"
@@ -61,8 +61,8 @@ else
   fail "matview index not found in dump"
 fi
 
-# --- Step 5: dump --omit-schema → apply to empty DB → no drift ---
-step "05 dump --omit-schema → apply → no drift"
+# --- Step 5: dump --omit-schema -> apply to empty DB -> no drift ---
+step "05 dump --omit-schema -> apply -> no drift"
 setup_db ""
 if ! apply_output=$("$PISTA" apply "$tmp_dir/schema.sql" 2>&1); then
   fail "apply failed: $apply_output"

--- a/test/scenario/rls.test.sh
+++ b/test/scenario/rls.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Scenario test: row-level security (RLS) and policies
-# Walks the desired schema through enable → policies → modify → recreate
-# (command change) → drop → force → disable, verifying drift-free state at
+# Walks the desired schema through enable -> policies -> modify -> recreate
+# (command change) -> drop -> force -> disable, verifying drift-free state at
 # every step.
 set -euo pipefail
 

--- a/test/scenario/world.test.sh
+++ b/test/scenario/world.test.sh
@@ -18,7 +18,7 @@ run_step "01 add column (city.timezone)" \
   "ADD COLUMN timezone text" \
   "$DATA/steps/01_add_column.sql" || true
 
-# --- Step 2: ALTER COLUMN TYPE (city.population int→bigint) ---
+# --- Step 2: ALTER COLUMN TYPE (city.population int->bigint) ---
 run_step "02 alter column type (city.population)" \
   "SET DATA TYPE bigint" \
   "$DATA/steps/02_alter_column_type.sql" || true
@@ -53,13 +53,13 @@ run_step "08 add view (large_cities)" \
   "CREATE OR REPLACE VIEW public.large_cities" \
   "$DATA/steps/08_add_view.sql" || true
 
-# --- Step 9: ADD FK (city.countrycode → country.code) ---
-run_step "09 add fk (city → country)" \
+# --- Step 9: ADD FK (city.countrycode -> country.code) ---
+run_step "09 add fk (city -> country)" \
   "ADD CONSTRAINT city_countrycode_fkey" \
   "$DATA/steps/09_add_fk.sql" || true
 
-# --- Step 10: RENAME COLUMN (countrylanguage.language → lang) ---
-run_step "10 rename column (language → lang)" \
+# --- Step 10: RENAME COLUMN (countrylanguage.language -> lang) ---
+run_step "10 rename column (language -> lang)" \
   "RENAME COLUMN language TO lang" \
   "$DATA/steps/10_rename_column.sql" || true
 

--- a/testdata/plan/rls_reserved_role.yml
+++ b/testdata/plan/rls_reserved_role.yml
@@ -15,7 +15,7 @@ desired: |
   -- Reserved role specs in TO are emitted verbatim by the parser; PostgreSQL
   -- resolves them at apply time to the actual current/session role, so the
   -- desired SQL cannot round-trip through the catalog. This fixture only
-  -- verifies the parse → emit path, not no-drift.
+  -- verifies the parse -> emit path, not no-drift.
   CREATE POLICY current_user_select ON public.documents FOR SELECT TO current_user USING (owner = current_user);
   CREATE POLICY session_user_select ON public.documents FOR SELECT TO session_user USING (owner = session_user);
 plan: |


### PR DESCRIPTION
## Summary

- Add an `ascii` CI job that fails when any tracked file contains non-ASCII characters, enforcing the ASCII-only writing guideline added in #249. Uses `git grep` (skips binary files via `-I`, locale-independent byte match via `LC_ALL=C`).
- Replace the remaining non-ASCII characters with ASCII equivalents in scenario tests (`test/scenario/*.test.sh`) and a test fixture comment (`testdata/plan/rls_reserved_role.yml`). All occurrences were in comments / display labels, so test output comparisons are unaffected.

## Test plan

- [x] CI `ascii` job passes (no non-ASCII in tracked files).
- [x] `make test` / scenario tests unaffected (changes are comment/label-only).

https://claude.ai/code/session_011JBcS4BeKy3k9khERAJxvk

---
_Generated by [Claude Code](https://claude.ai/code/session_011JBcS4BeKy3k9khERAJxvk)_