### PR TITLE
Add --force-index-concurrently flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ make fix            # golangci-lint run --fix (auto-fix lint errors)
 - Root-level integration tests use `package pistachio_test`.
 - Test fixtures are YAML files in `testdata/`. Required fields vary by test suite: `apply` uses `init`/`desired`/`applied`, `plan` uses `init`/`desired`/`plan`/`error`, `dump` uses `init`/`dump`, and `parser` uses `input`/`expected`. The plan/apply/dump harnesses also accept optional fields, but **the set differs per suite** (the lists below are not interchangeable):
   - `dump`: `omit_schema`, `include`/`exclude`/`enable`/`disable`.
-  - `plan`: `count`, `drop_policy`, `disallowed_drops`, `disable_index_concurrently`, `include`/`exclude`/`enable`/`disable`, `pre_sql`/`pre_sql_file`/`concurrently_pre_sql`/`concurrently_pre_sql_file`.
+  - `plan`: `count`, `drop_policy`, `disallowed_drops`, `disable_index_concurrently`, `force_index_concurrently`, `include`/`exclude`/`enable`/`disable`, `pre_sql`/`pre_sql_file`/`concurrently_pre_sql`/`concurrently_pre_sql_file`.
   - `apply`: everything `plan` accepts (without the `plan`/`error` fields), plus `applied_sql` and `verify_no_drift`.
 
   The authoritative list is the `planTestCase` / `applyTestCase` / `dumpTestCase` structs at the top of `plan_test.go` / `apply_test.go` / `dump_test.go`. Check the suite-specific struct when writing a new fixture.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ pista plan --disable-index-concurrently schema.sql
 pista apply --disable-index-concurrently --with-tx schema.sql
 ```
 
+Use `--force-index-concurrently` to apply `CONCURRENTLY` to every `CREATE INDEX` and `DROP INDEX` the diff emits, regardless of per-index directives. This also covers pure drops (indexes removed from the desired schema), which the directive cannot reach. Conflicts with `--disable-index-concurrently` and `--with-tx`. Also available as `$PISTA_FORCE_INDEX_CONCURRENTLY`.
+
+```bash
+pista plan --force-index-concurrently schema.sql
+pista apply --force-index-concurrently schema.sql
+```
+
 > [!NOTE]
 > When the generated diff includes `CREATE INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY`, `--with-tx` cannot be used because `CONCURRENTLY` operations cannot run inside a transaction. If there are no index changes, `--with-tx` is allowed even when an index is opted into `CONCURRENTLY`. To run `apply` inside a transaction in spite of the opt-in, combine `--with-tx` with `--disable-index-concurrently`.
 

--- a/apply.go
+++ b/apply.go
@@ -18,8 +18,9 @@ type ApplyOptions struct {
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PISTA_PRE_SQL_FILE" help:"Path to a SQL file to execute before applying changes."`
 	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index DDL (e.g. SET lock_timeout). Runs outside any transaction, only when the diff contains CONCURRENTLY index DDL."`
 	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to execute before CONCURRENTLY index DDL."`
-	WithTx                   bool     `env:"PISTA_WITH_TX" help:"Execute pre-SQL and schema changes in a transaction."`
-	DisableIndexConcurrently bool     `env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
+	WithTx                   bool     `xor:"tx-mode" env:"PISTA_WITH_TX" help:"Execute pre-SQL and schema changes in a transaction."`
+	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
+	ForceIndexConcurrently   bool     `xor:"index-concurrently,tx-mode" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops. Cannot be combined with --with-tx."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
 }
 
@@ -48,6 +49,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		ConcurrentlyPreSQL:       options.ConcurrentlyPreSQL,
 		ConcurrentlyPreSQLFile:   options.ConcurrentlyPreSQLFile,
 		DisableIndexConcurrently: options.DisableIndexConcurrently,
+		ForceIndexConcurrently:   options.ForceIndexConcurrently,
 		BulkAlter:                options.BulkAlter,
 	})
 	if err != nil {

--- a/apply_test.go
+++ b/apply_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/winebarrel/pistachio"
@@ -27,6 +28,7 @@ type applyTestCase struct {
 	DisallowedDrops          string           `yaml:"disallowed_drops,omitempty"`
 	DropPolicy               *applyDropPolicy `yaml:"drop_policy,omitempty"`
 	DisableIndexConcurrently bool             `yaml:"disable_index_concurrently,omitempty"`
+	ForceIndexConcurrently   bool             `yaml:"force_index_concurrently,omitempty"`
 	BulkAlter                bool             `yaml:"bulk_alter,omitempty"`
 	Include                  []string         `yaml:"include,omitempty"`
 	Exclude                  []string         `yaml:"exclude,omitempty"`
@@ -117,6 +119,7 @@ func TestApply(t *testing.T) {
 				},
 				Files:                    []string{desiredFile},
 				DisableIndexConcurrently: tc.DisableIndexConcurrently,
+				ForceIndexConcurrently:   tc.ForceIndexConcurrently,
 				BulkAlter:                tc.BulkAlter,
 				PreSQL:                   tc.PreSQL,
 				PreSQLFile:               preSQLFile,
@@ -146,6 +149,7 @@ func TestApply(t *testing.T) {
 					},
 					Files:                    []string{desiredFile},
 					DisableIndexConcurrently: tc.DisableIndexConcurrently,
+					ForceIndexConcurrently:   tc.ForceIndexConcurrently,
 					PreSQL:                   tc.PreSQL,
 					PreSQLFile:               preSQLFile,
 					ConcurrentlyPreSQL:       tc.ConcurrentlyPreSQL,
@@ -978,4 +982,33 @@ CREATE INDEX idx_mv_n ON public.mv USING btree (n);`), 0o644))
 	}, io.Discard)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "CONCURRENTLY")
+}
+
+func TestApplyOptions_ForceIndexConcurrently_XorEnforcement(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"force_and_disable", []string{"--force-index-concurrently", "--disable-index-concurrently", "schema.sql"}},
+		{"force_and_with_tx", []string{"--force-index-concurrently", "--with-tx", "schema.sql"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var opts pistachio.ApplyOptions
+			parser, err := kong.New(&opts)
+			require.NoError(t, err)
+			_, err = parser.Parse(tc.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--force-index-concurrently")
+		})
+	}
+}
+
+func TestPlanOptions_ForceIndexConcurrently_XorEnforcement(t *testing.T) {
+	var opts pistachio.PlanOptions
+	parser, err := kong.New(&opts)
+	require.NoError(t, err)
+	_, err = parser.Parse([]string{"--force-index-concurrently", "--disable-index-concurrently", "schema.sql"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--force-index-concurrently")
 }

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -913,13 +913,16 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], dc Drop
 	for name, currentIdx := range current.All() {
 		desiredIdx, ok := desired.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
-			// Use CONCURRENTLY only when the desired index (when it exists and
-			// is being changed) has the per-index directive. Pure drops (index
-			// removed from desired) never use CONCURRENTLY because catalog-derived
-			// indexes don't carry the directive.
+			// Use CONCURRENTLY when the desired index (when it exists and is
+			// being changed) has the per-index directive. For pure drops the
+			// desired entry is absent, so fall back to the current entry; that
+			// field is normally false because the catalog doesn't carry it,
+			// but --force-index-concurrently sets it via forceConcurrentlyDirectives.
 			useConcurrently := false
 			if ok {
 				useConcurrently = desiredIdx.Concurrently
+			} else {
+				useConcurrently = currentIdx.Concurrently
 			}
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -905,6 +905,20 @@ func TestDiffIndexes_drop_pureDrop_neverConcurrently(t *testing.T) {
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
 }
 
+func TestDiffIndexes_drop_pureDrop_currentConcurrentlyForced(t *testing.T) {
+	// When forceConcurrentlyDirectives sets Concurrently on the current
+	// index, the pure-drop branch falls back to that flag and emits
+	// DROP INDEX CONCURRENTLY.
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
+	desired := orderedmap.New[string, *model.Index]()
+
+	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, idxResult.Stmts)
+	assert.True(t, idxResult.HasConcurrently)
+}
+
 func TestDiffIndexes_change_perIndexConcurrently(t *testing.T) {
 	current := orderedmap.New[string, *model.Index]()
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})

--- a/diff/views.go
+++ b/diff/views.go
@@ -729,9 +729,14 @@ func diffViewIndexes(current, desired *model.View, dc DropChecker) (stmts []stri
 	for name, currentIdx := range currentIndexes.All() {
 		desiredIdx, ok := desiredIndexes.GetOk(name)
 		if !ok || !equalIndexDef(currentIdx.Definition, desiredIdx.Definition) {
+			// Pure drops have no desired entry. Fall back to the current
+			// entry's flag, which forceConcurrentlyDirectives sets when
+			// --force-index-concurrently is in effect.
 			useConcurrently := false
 			if ok {
 				useConcurrently = desiredIdx.Concurrently
+			} else {
+				useConcurrently = currentIdx.Concurrently
 			}
 			stmt, err := dropIndexSQL(currentIdx.Schema, name, useConcurrently)
 			if err != nil {

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -1053,6 +1053,35 @@ func TestDiffViews_matviewIndexAdd_perIndexDirective(t *testing.T) {
 	assert.Equal(t, "CREATE INDEX idx_mv_n2 ON public.mv USING btree (n);", result.CreateStmts[1])
 }
 
+func TestDiffViews_matviewIndexPureDrop_currentConcurrentlyForced(t *testing.T) {
+	// When forceConcurrentlyDirectives sets Concurrently on the current
+	// matview index, the pure-drop branch falls back to that flag and
+	// emits DROP INDEX CONCURRENTLY.
+	current := orderedmap.New[string, *model.View]()
+	mvCurrent := &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	}
+	mvCurrent.Indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition:   "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+		Concurrently: true,
+	})
+	current.Set("public.mv", mvCurrent)
+
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.mv", &model.View{
+		Schema: "public", Name: "mv", Materialized: true,
+		Definition: "SELECT 1 AS n", Indexes: orderedmap.New[string, *model.Index](),
+	})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.CreateStmts, 1)
+	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_mv_n;", result.CreateStmts[0])
+	assert.True(t, result.HasConcurrently)
+}
+
 func TestDiffViews_modifyMatviewWithIndex_perIndexDirective(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.mv", &model.View{

--- a/diff_all.go
+++ b/diff_all.go
@@ -25,6 +25,7 @@ type diffAllOptions struct {
 	ConcurrentlyPreSQL       string
 	ConcurrentlyPreSQLFile   string
 	DisableIndexConcurrently bool
+	ForceIndexConcurrently   bool
 	BulkAlter                bool
 }
 
@@ -92,8 +93,11 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	desiredTables := options.filterTables(client.reverseRemapTableSchemas(desired.Tables))
 	desiredViews := options.filterViews(client.reverseRemapViewSchemas(desired.Views))
 
-	if options.DisableIndexConcurrently {
+	switch {
+	case options.DisableIndexConcurrently:
 		clearConcurrentlyDirectives(desiredTables, desiredViews)
+	case options.ForceIndexConcurrently:
+		forceConcurrentlyDirectives(filteredTables, filteredViews, desiredTables, desiredViews)
 	}
 
 	enumDiff, err := diff.DiffEnums(filteredEnums, desiredEnums, &options.DropPolicy)
@@ -168,6 +172,39 @@ func clearConcurrentlyDirectives(
 	for _, v := range views.CollectValues() {
 		for _, idx := range v.Indexes.CollectValues() {
 			idx.Concurrently = false
+		}
+	}
+}
+
+// forceConcurrentlyDirectives sets the per-index Concurrently flag on every
+// table and materialized view index in both the current and desired schemas,
+// used to implement --force-index-concurrently. The current side is also
+// flipped so that pure DROP INDEX paths (index absent from desired) can pick
+// up the flag, since catalog-derived indexes don't carry the directive.
+func forceConcurrentlyDirectives(
+	currentTables *orderedmap.Map[string, *model.Table],
+	currentViews *orderedmap.Map[string, *model.View],
+	desiredTables *orderedmap.Map[string, *model.Table],
+	desiredViews *orderedmap.Map[string, *model.View],
+) {
+	for _, t := range currentTables.CollectValues() {
+		for _, idx := range t.Indexes.CollectValues() {
+			idx.Concurrently = true
+		}
+	}
+	for _, v := range currentViews.CollectValues() {
+		for _, idx := range v.Indexes.CollectValues() {
+			idx.Concurrently = true
+		}
+	}
+	for _, t := range desiredTables.CollectValues() {
+		for _, idx := range t.Indexes.CollectValues() {
+			idx.Concurrently = true
+		}
+	}
+	for _, v := range desiredViews.CollectValues() {
+		for _, idx := range v.Indexes.CollectValues() {
+			idx.Concurrently = true
 		}
 	}
 }

--- a/plan.go
+++ b/plan.go
@@ -16,7 +16,8 @@ type PlanOptions struct {
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PISTA_PRE_SQL_FILE" help:"Path to a SQL file to prepend to the plan output."`
 	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to run before CONCURRENTLY index DDL (e.g. SET lock_timeout). Emitted only when the diff contains CONCURRENTLY index DDL."`
 	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to run before CONCURRENTLY index DDL."`
-	DisableIndexConcurrently bool     `env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
+	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
+	ForceIndexConcurrently   bool     `xor:"index-concurrently" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
 }
 
@@ -78,6 +79,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 		ConcurrentlyPreSQL:       options.ConcurrentlyPreSQL,
 		ConcurrentlyPreSQLFile:   options.ConcurrentlyPreSQLFile,
 		DisableIndexConcurrently: options.DisableIndexConcurrently,
+		ForceIndexConcurrently:   options.ForceIndexConcurrently,
 		BulkAlter:                options.BulkAlter,
 	})
 	if err != nil {

--- a/plan_test.go
+++ b/plan_test.go
@@ -23,6 +23,7 @@ type planTestCase struct {
 	DropPolicy               *planDropPolicy `yaml:"drop_policy,omitempty"`
 	DisallowedDrops          string          `yaml:"disallowed_drops,omitempty"`
 	DisableIndexConcurrently bool            `yaml:"disable_index_concurrently,omitempty"`
+	ForceIndexConcurrently   bool            `yaml:"force_index_concurrently,omitempty"`
 	BulkAlter                bool            `yaml:"bulk_alter,omitempty"`
 	Include                  []string        `yaml:"include,omitempty"`
 	Exclude                  []string        `yaml:"exclude,omitempty"`
@@ -292,6 +293,7 @@ func TestPlan(t *testing.T) {
 				},
 				Files:                    []string{desiredFile},
 				DisableIndexConcurrently: tc.DisableIndexConcurrently,
+				ForceIndexConcurrently:   tc.ForceIndexConcurrently,
 				BulkAlter:                tc.BulkAlter,
 				PreSQL:                   tc.PreSQL,
 				PreSQLFile:               preSQLFile,

--- a/testdata/apply/force_index_concurrently_add_index.yml
+++ b/testdata/apply/force_index_concurrently_add_index.yml
@@ -1,0 +1,25 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users USING btree (name);
+applied_sql: |
+  CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users USING btree (name);
+verify_no_drift: true

--- a/testdata/apply/force_index_concurrently_drop_index.yml
+++ b/testdata/apply/force_index_concurrently_drop_index.yml
@@ -1,0 +1,24 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users USING btree (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied_sql: |
+  DROP INDEX CONCURRENTLY public.idx_users_name;
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+verify_no_drift: true

--- a/testdata/plan/force_index_concurrently_add_index.yml
+++ b/testdata/plan/force_index_concurrently_add_index.yml
@@ -1,0 +1,16 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users USING btree (name);
+plan: |
+  CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);

--- a/testdata/plan/force_index_concurrently_change_index.yml
+++ b/testdata/plan/force_index_concurrently_change_index.yml
@@ -1,0 +1,18 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_products_qty ON public.products (qty);
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_products_qty ON public.products (qty) WHERE qty > 0;
+plan: |
+  DROP INDEX CONCURRENTLY public.idx_products_qty;
+  CREATE INDEX CONCURRENTLY idx_products_qty ON public.products USING btree (qty) WHERE qty > 0;

--- a/testdata/plan/force_index_concurrently_drop_index.yml
+++ b/testdata/plan/force_index_concurrently_drop_index.yml
@@ -1,0 +1,16 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users USING btree (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  DROP INDEX CONCURRENTLY public.idx_users_name;

--- a/testdata/plan/force_index_concurrently_matview_add_index.yml
+++ b/testdata/plan/force_index_concurrently_matview_add_index.yml
@@ -1,0 +1,20 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id, name FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names_name ON public.user_names USING btree (name);
+plan: |
+  CREATE INDEX CONCURRENTLY idx_user_names_name ON public.user_names USING btree (name);

--- a/testdata/plan/force_index_concurrently_matview_change_index.yml
+++ b/testdata/plan/force_index_concurrently_matview_change_index.yml
@@ -1,0 +1,22 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names_name ON public.user_names USING btree (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names_name ON public.user_names USING hash (name);
+plan: |
+  DROP INDEX CONCURRENTLY public.idx_user_names_name;
+  CREATE INDEX CONCURRENTLY idx_user_names_name ON public.user_names USING hash (name);

--- a/testdata/plan/force_index_concurrently_matview_drop_index.yml
+++ b/testdata/plan/force_index_concurrently_matview_drop_index.yml
@@ -1,0 +1,20 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names_name ON public.user_names USING btree (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id, name FROM public.users;
+plan: |
+  DROP INDEX CONCURRENTLY public.idx_user_names_name;

--- a/testdata/plan/force_index_concurrently_new_table.yml
+++ b/testdata/plan/force_index_concurrently_new_table.yml
@@ -1,0 +1,16 @@
+force_index_concurrently: true
+init: ""
+desired: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_products_qty ON public.products (qty);
+plan: |
+  CREATE TABLE public.products (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT products_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX CONCURRENTLY idx_products_qty ON public.products USING btree (qty);

--- a/testdata/plan/force_index_concurrently_no_op.yml
+++ b/testdata/plan/force_index_concurrently_no_op.yml
@@ -1,0 +1,15 @@
+force_index_concurrently: true
+concurrently_pre_sql: "SET lock_timeout = '5s';"
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: ""

--- a/testdata/plan/force_index_concurrently_partition_child_drop.yml
+++ b/testdata/plan/force_index_concurrently_partition_child_drop.yml
@@ -1,0 +1,18 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  CREATE INDEX events_2024_id_idx ON public.events_2024 (id);
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+plan: |
+  DROP INDEX CONCURRENTLY public.events_2024_id_idx;

--- a/testdata/plan/force_index_concurrently_pre_sql_pure_drop.yml
+++ b/testdata/plan/force_index_concurrently_pre_sql_pure_drop.yml
@@ -1,0 +1,18 @@
+force_index_concurrently: true
+concurrently_pre_sql: "SET lock_timeout = '5s';"
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users USING btree (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  SET lock_timeout = '5s';
+  DROP INDEX CONCURRENTLY public.idx_users_name;

--- a/testdata/plan/force_index_concurrently_unique_constraint_drop.yml
+++ b/testdata/plan/force_index_concurrently_unique_constraint_drop.yml
@@ -1,0 +1,16 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users DROP CONSTRAINT users_email_key;

--- a/testdata/plan/force_index_concurrently_with_inline_directive.yml
+++ b/testdata/plan/force_index_concurrently_with_inline_directive.yml
@@ -1,0 +1,21 @@
+force_index_concurrently: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:concurrently
+  CREATE INDEX idx_users_name ON public.users USING btree (name);
+  CREATE INDEX CONCURRENTLY idx_users_email ON public.users USING btree (email);
+plan: |
+  CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);
+  CREATE INDEX CONCURRENTLY idx_users_email ON public.users USING btree (email);


### PR DESCRIPTION
## Summary
- Adds `--force-index-concurrently` (env `PISTA_FORCE_INDEX_CONCURRENTLY`) to `plan` and `apply`. Forces CONCURRENTLY on every CREATE/DROP INDEX the diff emits, including pure drops where the per-index directive cannot reach.
- xor with `--disable-index-concurrently` on both subcommands, xor with `--with-tx` on apply.
- README updated.

## Implementation notes
- `forceConcurrentlyDirectives` sets `Concurrently=true` on both current and desired index entries before diffing. The current-side mutation lets the pure-DROP branch in `diffIndexes` / `diffViewIndexes` fall back to `currentIdx.Concurrently` without changing the public diff API.
- UNIQUE/PK constraint-backed indexes are dropped via `ALTER TABLE DROP CONSTRAINT` and are not affected.

## Test plan
- [x] `make lint`
- [x] `make test` (all packages green, coverage 97.8% -> 97.9% in root package; `forceConcurrentlyDirectives` 100%)
- [x] New plan fixtures: add / drop / change / matview add/change/drop / new table / no-op / partition child drop / pre-SQL gating / UNIQUE constraint drop / coexistence with inline+directive
- [x] New apply fixtures: add / drop with `verify_no_drift`
- [x] Diff-layer unit tests for the pure-DROP fallback (tables and views)
- [x] Kong xor enforcement tests for both conflicting combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)