### PR TITLE
Show DDL execution time on apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.12.0] - 2026-06-24
 
-* Print the SQL statement execution time at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It covers the apply phase (statement execution and output), excludes connection setup and diff computation, and is omitted when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
+* Print the apply phase duration at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It covers SQL execution and output, excludes connection setup and diff computation, and is omitted when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
 
 ## [1.11.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.12.0] - 2026-06-24
 
-* Print the SQL statement execution time at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It measures statement execution against the database only, and is omitted when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
+* Print the SQL statement execution time at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It covers the apply phase (statement execution and output), excludes connection setup and diff computation, and is omitted when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
 
 ## [1.11.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.12.0] - 2026-06-24
 
-* Print the SQL statement execution time at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It measures statement execution against the database only, and shows `0s` when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
+* Print the SQL statement execution time at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It measures statement execution against the database only, and is omitted when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
 
 ## [1.11.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.12.0] - 2026-06-24
 
-* Print the DDL execution time at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It measures statement execution against the database only, and shows `0s` when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
+* Print the SQL statement execution time at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It measures statement execution against the database only, and shows `0s` when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
 
 ## [1.11.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.12.0] - 2026-06-24
+
+* Print the DDL execution time at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It measures statement execution against the database only, and shows `0s` when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))
+
 ## [1.11.0] - 2026-05-31
 
 * Add `--force-index-concurrently` (env `$PISTA_FORCE_INDEX_CONCURRENTLY`) to `plan` and `apply`. Forces CONCURRENTLY on every `CREATE INDEX` / `DROP INDEX` the diff emits, including pure drops (indexes removed from desired) that the `-- pista:concurrently` directive cannot reach because catalog-derived indexes do not carry the flag. Conflicts with `--disable-index-concurrently` on both subcommands and with `--with-tx` on apply; both are enforced as kong xor groups. ([#254](https://github.com/winebarrel/pistachio/pull/254))

--- a/apply.go
+++ b/apply.go
@@ -29,11 +29,17 @@ type ApplyOptions struct {
 type ApplyResult struct {
 	Count           ObjectCount
 	DisallowedDrops string
-	// Duration is the elapsed time of the apply phase: executing SQL
-	// statements (pre-SQL, schema DDL, and -- pista:execute statements) and
-	// writing them to the output writer. It excludes connection setup and
-	// diff computation, and is zero when no statements were executed. With a
-	// fast writer this is dominated by database execution time.
+	// Applied reports whether any schema change was actually applied: schema
+	// DDL or an executed -- pista:execute statement. Pre-SQL,
+	// concurrently-pre-SQL, transaction control, search_path setup, and
+	// -- pista:execute directives skipped by their check SQL do not count.
+	Applied bool
+	// Duration is the elapsed time of the apply phase: every statement sent to
+	// the database (transaction BEGIN/COMMIT, pre-SQL, schema DDL, search_path
+	// setup, -- pista:execute check SQL, and execute statements) plus the time
+	// writing them to the output writer. It excludes connection setup and diff
+	// computation, and is zero unless Applied is true. With a fast writer it is
+	// dominated by database execution time.
 	Duration time.Duration
 }
 
@@ -77,6 +83,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	}
 
 	start := time.Now()
+	applied := false
 
 	exec := conn.Exec
 	queryRow := conn.QueryRow
@@ -107,6 +114,10 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		}
 	}
 
+	// Pre-SQL and concurrently-pre-SQL are setup steps (e.g. SET lock_timeout),
+	// not schema changes, so they do not mark the apply as applied. Whether
+	// "-- No changes" is reported depends only on actual schema DDL and
+	// executed -- pista:execute statements.
 	if result.PreSQL != "" {
 		fmt.Fprintln(w, result.PreSQL) //nolint:errcheck
 		if _, err := exec(ctx, result.PreSQL); err != nil {
@@ -129,6 +140,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		if _, err := exec(ctx, stmt); err != nil {
 			return nil, fmt.Errorf("failed to execute SQL: %s: %w", stmt, err)
 		}
+		applied = true
 	}
 
 	// Execute -- pista:execute statements after schema changes.
@@ -158,6 +170,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 			if _, err := exec(ctx, es.SQL); err != nil {
 				return nil, fmt.Errorf("failed to execute SQL: %s: %w", es.SQL, err)
 			}
+			applied = true
 		}
 	}
 
@@ -165,7 +178,10 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return nil, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	applyResult.Duration = time.Since(start)
+	applyResult.Applied = applied
+	if applied {
+		applyResult.Duration = time.Since(start)
+	}
 
 	return applyResult, nil
 }

--- a/apply.go
+++ b/apply.go
@@ -29,7 +29,8 @@ type ApplyOptions struct {
 type ApplyResult struct {
 	Count           ObjectCount
 	DisallowedDrops string
-	// Duration is the time spent executing DDL against the database. It
+	// Duration is the time spent executing SQL statements against the
+	// database (pre-SQL, schema DDL, and -- pista:execute statements). It
 	// excludes connection setup and diff computation, and is zero when no
 	// statements were executed.
 	Duration time.Duration

--- a/apply.go
+++ b/apply.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/parser"
@@ -28,6 +29,10 @@ type ApplyOptions struct {
 type ApplyResult struct {
 	Count           ObjectCount
 	DisallowedDrops string
+	// Duration is the time spent executing DDL against the database. It
+	// excludes connection setup and diff computation, and is zero when no
+	// statements were executed.
+	Duration time.Duration
 }
 
 func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Writer) (*ApplyResult, error) {
@@ -68,6 +73,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if len(result.Stmts) == 0 && len(result.ExecuteStmts) == 0 {
 		return applyResult, nil
 	}
+
+	start := time.Now()
 
 	exec := conn.Exec
 	queryRow := conn.QueryRow
@@ -155,6 +162,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if err := commit(ctx); err != nil {
 		return nil, fmt.Errorf("failed to commit transaction: %w", err)
 	}
+
+	applyResult.Duration = time.Since(start)
 
 	return applyResult, nil
 }

--- a/apply.go
+++ b/apply.go
@@ -29,10 +29,11 @@ type ApplyOptions struct {
 type ApplyResult struct {
 	Count           ObjectCount
 	DisallowedDrops string
-	// Duration is the time spent executing SQL statements against the
-	// database (pre-SQL, schema DDL, and -- pista:execute statements). It
-	// excludes connection setup and diff computation, and is zero when no
-	// statements were executed.
+	// Duration is the elapsed time of the apply phase: executing SQL
+	// statements (pre-SQL, schema DDL, and -- pista:execute statements) and
+	// writing them to the output writer. It excludes connection setup and
+	// diff computation, and is zero when no statements were executed. With a
+	// fast writer this is dominated by database execution time.
 	Duration time.Duration
 }
 

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -31,9 +31,13 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 	fmt.Fprintf(w, "-- Apply to %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
 
 	// Same ordering as Plan: executed SQL (incl. pre-SQL) first, then skipped
-	// DROPs as comments. When nothing was executed, skipped DROPs precede
-	// "-- No changes".
-	if buf.Len() == 0 {
+	// DROPs as comments. When nothing was applied, skipped DROPs precede
+	// "-- No changes". The buffer may still hold output (e.g. --with-tx
+	// transaction comments) even when no schema change was applied, so the
+	// "-- No changes" and timing decisions are driven by result.Applied rather
+	// than the buffer length.
+	if !result.Applied {
+		w.Write(buf.Bytes()) //nolint:errcheck
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/winebarrel/pistachio"
 )
@@ -43,6 +44,8 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}
 	}
+
+	fmt.Fprintf(w, "-- Apply finished in %s\n", result.Duration.Round(time.Millisecond)) //nolint:errcheck
 
 	return nil
 }

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -43,9 +43,10 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}
+		// Only report the execution time when statements were applied. With no
+		// changes there is nothing to time.
+		fmt.Fprintf(w, "-- Apply finished in %s\n", result.Duration.Round(time.Millisecond)) //nolint:errcheck
 	}
-
-	fmt.Fprintf(w, "-- Apply finished in %s\n", result.Duration.Round(time.Millisecond)) //nolint:errcheck
 
 	return nil
 }

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -47,8 +47,8 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}
-		// Only report the execution time when statements were applied. With no
-		// changes there is nothing to time.
+		// Only report the apply phase duration when statements were applied.
+		// With no changes there is nothing to time.
 		fmt.Fprintf(w, "-- Apply finished in %s\n", result.Duration.Round(time.Millisecond)) //nolint:errcheck
 	}
 

--- a/cmd/command/apply_test.go
+++ b/cmd/command/apply_test.go
@@ -202,6 +202,90 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	assert.NotContains(t, got, "-- Apply finished in ")
 }
 
+func TestApply_Run_WithTxExecuteCheckFalse_ShowsNoChanges(t *testing.T) {
+	// --with-tx variant of the case above. The transaction comments fill the
+	// output buffer, but no schema change is applied (the only -- pista:execute
+	// is skipped by its check SQL). The CLI must still print "-- No changes"
+	// and omit the timing line, driven by result.Applied rather than the
+	// buffer length.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pista:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}, WithTx: true}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "-- Transaction started")
+	assert.Contains(t, got, "-- Transaction committed")
+	assert.NotContains(t, got, "CREATE OR REPLACE FUNCTION", "skipped execute must not be printed")
+	assert.Contains(t, got, "-- No changes", "nothing was applied, so No changes is printed even with --with-tx")
+	assert.NotContains(t, got, "-- Apply finished in ")
+}
+
+func TestApply_Run_PreSQLOnly_ShowsNoChanges(t *testing.T) {
+	// pre-SQL is a setup step, not a schema change. With no schema diff and the
+	// only -- pista:execute skipped by its check SQL, the pre-SQL still runs and
+	// is printed, but the apply reports "-- No changes" and omits the timing
+	// line (pre-SQL does not count as applied).
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pista:execute SELECT NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'test_func')
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}, PreSQL: "SET statement_timeout = '5s'"}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "SET statement_timeout", "pre-SQL still runs and is printed")
+	assert.NotContains(t, got, "CREATE OR REPLACE FUNCTION", "skipped execute must not be printed")
+	assert.Contains(t, got, "-- No changes", "pre-SQL is not a schema change, so No changes is printed")
+	assert.NotContains(t, got, "-- Apply finished in ")
+}
+
 func TestApply_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	// Apply CLI counterpart of TestPlan_Run_DropDeniedShowsNoChanges.
 	// When the only diff is a suppressed DROP, the apply prints the skipped

--- a/cmd/command/apply_test.go
+++ b/cmd/command/apply_test.go
@@ -119,8 +119,8 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "-- Apply to schema public (")
 	assert.Contains(t, buf.String(), "-- No changes")
-	// The timing line is always emitted, even when nothing was executed.
-	assert.Contains(t, buf.String(), "-- Apply finished in ")
+	// No timing line when nothing was applied.
+	assert.NotContains(t, buf.String(), "-- Apply finished in ")
 }
 
 func TestApply_Run_ExecuteOnly_NotNoChanges(t *testing.T) {
@@ -198,6 +198,8 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	got := buf.String()
 	assert.NotContains(t, got, "CREATE OR REPLACE FUNCTION", "skipped execute must not be printed")
 	assert.Contains(t, got, "-- No changes", "buffer is empty so CLI prints No changes")
+	// The check SQL ran but nothing was applied, so no timing line is printed.
+	assert.NotContains(t, got, "-- Apply finished in ")
 }
 
 func TestApply_Run_DropDeniedShowsNoChanges(t *testing.T) {

--- a/cmd/command/apply_test.go
+++ b/cmd/command/apply_test.go
@@ -38,6 +38,7 @@ func TestApply_Run(t *testing.T) {
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+	assert.Contains(t, buf.String(), "-- Apply finished in ")
 	assertConnectedCommentFirst(t, buf.String(), conn.Config())
 }
 
@@ -118,6 +119,8 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "-- Apply to schema public (")
 	assert.Contains(t, buf.String(), "-- No changes")
+	// The timing line is always emitted, even when nothing was executed.
+	assert.Contains(t, buf.String(), "-- Apply finished in ")
 }
 
 func TestApply_Run_ExecuteOnly_NotNoChanges(t *testing.T) {

--- a/getting-started.md
+++ b/getting-started.md
@@ -83,6 +83,17 @@ Apply the changes:
 pista apply schema.sql
 ```
 
+Output:
+
+```sql
+-- Apply to schema public (1 table, 0 views, 0 enums, 0 domains)
+ALTER TABLE public.users ADD COLUMN email text;
+-- Apply finished in 12ms
+```
+
+The `-- Apply finished in ...` comment shows the DDL execution time. It is
+printed on every apply, and shows `0s` when there are no changes.
+
 Verify by running plan again:
 
 ```bash

--- a/getting-started.md
+++ b/getting-started.md
@@ -92,7 +92,8 @@ ALTER TABLE public.users ADD COLUMN email text;
 ```
 
 The `-- Apply finished in ...` comment shows the SQL statement execution
-time. It is printed on every apply, and shows `0s` when there are no changes.
+time. It is printed only when changes are applied, not when there are no
+changes.
 
 Verify by running plan again:
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -91,9 +91,9 @@ ALTER TABLE public.users ADD COLUMN email text;
 -- Apply finished in 12ms
 ```
 
-The `-- Apply finished in ...` comment shows the SQL statement execution
-time. It is printed only when changes are applied, not when there are no
-changes.
+The `-- Apply finished in ...` comment shows the apply phase duration (SQL
+execution plus output writing). It is printed only when changes are applied,
+not when there are no changes.
 
 Verify by running plan again:
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -91,8 +91,8 @@ ALTER TABLE public.users ADD COLUMN email text;
 -- Apply finished in 12ms
 ```
 
-The `-- Apply finished in ...` comment shows the DDL execution time. It is
-printed on every apply, and shows `0s` when there are no changes.
+The `-- Apply finished in ...` comment shows the SQL statement execution
+time. It is printed on every apply, and shows `0s` when there are no changes.
 
 Verify by running plan again:
 


### PR DESCRIPTION
## Summary

`pista apply` now appends a trailing `-- Apply finished in <duration>` comment to its output, so users can see how long the schema changes took.

```
-- Apply to schema public (1 table, 0 views, 0 enums, 0 domains)
CREATE TABLE public.demo_timing (...);
-- Apply finished in 60ms
```

- The measured duration covers the apply phase: executing the statements (BEGIN/COMMIT, pre-SQL, schema statements, `-- pista:execute`) and writing them to the output writer. It excludes connection setup and diff computation. With a fast writer (the CLI uses a `bytes.Buffer`) it is dominated by database execution time.
- When there are no changes, the timing line is omitted entirely.
- The line is a SQL comment, so piping the output stays harmless.

## Changes

- `apply.go`: add `Duration time.Duration` to `ApplyResult`, measured around the apply execution block.
- `cmd/command/apply.go`: print `-- Apply finished in <duration>` (rounded to milliseconds) only when statements were applied.
- `cmd/command/apply_test.go`: assert the timing line appears on a normal apply and is absent on the no-changes cases.

## Test

- `make build` / `make vet` pass
- `go test -p 1 ./cmd/command/ ./` pass
- `make lint` -> 0 issues
- Verified against a live database (changes show a duration, no changes omit the line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)