### PR TITLE
Fix dump --omit-schema leaving schema on partitioned-table indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Fix `dump --omit-schema` leaving the schema name in indexes on partitioned tables. `pg_get_indexdef` emits `ON ONLY <schema>.<table>` for such indexes, which the schema-stripping replacement did not match, so `public.` stayed in the output.
+
 ## [1.12.0] - 2026-06-24
 
 * Print the apply phase duration at the end of `pista apply` as a `-- Apply finished in <duration>` comment. It covers SQL execution and output, excludes connection setup and diff computation, and is omitted when there are no changes. ([#260](https://github.com/winebarrel/pistachio/pull/260))

--- a/TODO.md
+++ b/TODO.md
@@ -182,6 +182,26 @@ be documented as such if it ever surfaces in user-facing docs.
 
 Origin: [#157](https://github.com/winebarrel/pistachio/pull/157).
 
+## CREATE OR REPLACE VIEW: type-only change on a same-named column
+
+`canCreateOrReplaceView` (`diff/views.go`) decides between
+`CREATE OR REPLACE VIEW` and `DROP`+`CREATE` by comparing the output
+column *names* in order. When only a column's *type* changes but the name
+stays (e.g. `SELECT n FROM t` -> `SELECT n::bigint AS n FROM t`), the names
+still line up, so the plan emits `CREATE OR REPLACE VIEW`. PostgreSQL then
+rejects it at apply time with `cannot change data type of view column`,
+so a clean-looking plan fails on execution.
+
+`pg_query` does not perform type inference, so the type change can't be
+detected statically from the SELECT alone. Resolving it would require
+either type resolution against the desired schema or always routing view
+definition changes through `DROP`+`CREATE` (which costs dependent objects
+and privileges). Workaround: adjust the source DDL or drop the view in a
+pre-step.
+
+Origin: known limitation documented inline at `diff/views.go`
+(`canCreateOrReplaceView`).
+
 ## Plan-time error promotion: forgotten dependent reference
 
 When desired SQL references the new column name in a dependent

--- a/dump.go
+++ b/dump.go
@@ -25,6 +25,18 @@ type DumpResult struct {
 	Count      ObjectCount
 }
 
+// stripIndexSchemaPrefix removes the schema qualification from the relation an
+// index targets, for --omit-schema. pg_get_indexdef emits
+// "... ON <schema>.<rel> ..." for ordinary indexes and
+// "... ON ONLY <schema>.<rel> ..." for indexes on partitioned-table parents,
+// so both forms are rewritten. The two patterns are mutually exclusive per
+// occurrence (the ONLY form has "ONLY " between "ON " and the relation), so
+// applying both replacers never double-processes a match.
+func stripIndexSchemaPrefix(definition, fqrn, relName string) string {
+	definition = strings.ReplaceAll(definition, " ON ONLY "+fqrn+" ", " ON ONLY "+relName+" ")
+	return strings.ReplaceAll(definition, " ON "+fqrn+" ", " ON "+relName+" ")
+}
+
 func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 	if !r.OmitSchema {
 		return r.Tables
@@ -49,7 +61,7 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 			for _, idx := range copied.Indexes.CollectValues() {
 				idxCopied := *idx
 				idxCopied.Schema = ""
-				idxCopied.Definition = strings.ReplaceAll(idx.Definition, " ON "+fqtn+" ", " ON "+tableName+" ")
+				idxCopied.Definition = stripIndexSchemaPrefix(idx.Definition, fqtn, tableName)
 				idxs.Set(idx.Name, &idxCopied)
 			}
 			copied.Indexes = idxs
@@ -83,7 +95,7 @@ func (r *DumpResult) views() *orderedmap.Map[string, *model.View] {
 			for _, idx := range copied.Indexes.CollectValues() {
 				idxCopied := *idx
 				idxCopied.Schema = ""
-				idxCopied.Definition = strings.ReplaceAll(idx.Definition, " ON "+fqvn+" ", " ON "+viewName+" ")
+				idxCopied.Definition = stripIndexSchemaPrefix(idx.Definition, fqvn, viewName)
 				idxs.Set(idx.Name, &idxCopied)
 			}
 			copied.Indexes = idxs

--- a/testdata/dump/omit_schema_partitioned_index.yml
+++ b/testdata/dump/omit_schema_partitioned_index.yml
@@ -1,0 +1,15 @@
+omit_schema: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at date NOT NULL
+  ) PARTITION BY RANGE (created_at);
+  CREATE INDEX idx_events_id ON public.events (id);
+dump: |
+  -- events
+  CREATE TABLE events (
+      id integer NOT NULL,
+      created_at date NOT NULL
+  )
+  PARTITION BY RANGE (created_at);
+  CREATE INDEX idx_events_id ON ONLY events USING btree (id);


### PR DESCRIPTION
## Problem

`pg_get_indexdef` emits `CREATE INDEX ... ON ONLY <schema>.<table> ...` for indexes on partitioned-table parents. The `dump --omit-schema` schema-stripping replacement only matched `" ON <schema>.<table> "`, so the `ON ONLY` form did not match and the schema name (`public.`) stayed in the output.

## Fix

Add a shared `stripIndexSchemaPrefix` helper that rewrites both `ON <rel>` and `ON ONLY <rel>`, used by the table and view index paths. `ON ONLY` is preserved (it is part of the index definition); only the schema prefix is removed. These are the only two ON forms `pg_get_indexdef` produces, so all of its output is covered.

FK references already strip the schema structurally (via `RefSchema`), so this string-replacement gap was limited to the index definition.

## Tests

* New fixture `testdata/dump/omit_schema_partitioned_index.yml`: fails before the fix (`ON ONLY public.events`), passes after (`ON ONLY events`).
* `dump.go` coverage stays at 100%; full suite, `vet`, and `lint` pass.

## Also

Document the known `CREATE OR REPLACE VIEW` type-only-change limitation in `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)