### PR TITLE
Use bat for demo less coloring instead of source-highlight

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -16,10 +16,10 @@ ARG PISTA_VERSION
 RUN CGO_ENABLED=1 go build -o /out/pista -ldflags "-X main.version=${PISTA_VERSION#v}" ./cmd/pista
 
 FROM postgres:18-alpine
-RUN apk add --no-cache bash sudo vim less source-highlight bat && \
+RUN apk add --no-cache bash sudo vim less bat && \
     echo 'postgres ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/postgres-nopasswd && \
     chmod 0440 /etc/sudoers.d/postgres-nopasswd && \
-    printf "alias ll='ls -lF'\nalias vi='vim'\nexport LESSOPEN='| /usr/bin/src-hilite-lesspipe.sh %%s'\nexport LESS='-R'\n" > /var/lib/postgresql/.bashrc && \
+    printf "alias ll='ls -lF'\nalias vi='vim'\nexport LESSOPEN='| bat --color=always -pp %%s'\nexport LESS='-R'\n" > /var/lib/postgresql/.bashrc && \
     printf "syntax on\n" > /var/lib/postgresql/.vimrc && \
     chown postgres:postgres /var/lib/postgresql/.bashrc /var/lib/postgresql/.vimrc
 


### PR DESCRIPTION
Switch the demo image's `less` colorizer from `source-highlight` to `bat`, so file viewing matches the `bat`-based `PISTA_PAGER` already used for `pista` output.

- Drop the `source-highlight` package from `apk add` (`bat` is already installed).
- Point `LESSOPEN` at `bat --color=always -pp %s` instead of `src-hilite-lesspipe.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)