### PR TITLE
chore: Fix demo PISTA_PAGER env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Declarative schema management tool for PostgreSQL. Define the desired schema in 
 
 See also: [Getting Started Guide](getting-started.md)
 
-<img width="800" alt="demo" src="https://github.com/user-attachments/assets/e8471dca-3451-422c-b935-90f0c9819618" />
+![](https://github.com/user-attachments/assets/f280336b-52c2-409e-a8ba-f9a2ec71f950)
 
 ## Installation
 

--- a/demo.tape
+++ b/demo.tape
@@ -6,7 +6,7 @@ Set Width 800
 Set Height 600
 Set Padding 20
 
-Type@3ms "export PISTA_PAGER='bat -l sql -p --paging=never --color=always'" Enter
+Type@3ms "export PISTA_PAGER='bat -l sql -pp --color=always'" Enter
 Sleep 2s
 
 # Create schema file


### PR DESCRIPTION
This pull request makes a minor update to the `demo.tape` file to adjust the pager command used for displaying SQL output. The change modifies the `PISTA_PAGER` environment variable to use the `-pp` option instead of `-p --paging=never` for the `bat` command.