### PR TITLE
Add -- pista:bulk-alter directive for per-table ALTER TABLE merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add the `-- pista:bulk-alter` directive. Put it before a `CREATE TABLE` statement to combine that table's consecutive `ALTER TABLE` actions into a single statement. Other tables keep one statement per action. The `--bulk-alter` flag (env `$PISTA_BULK_ALTER`) is unchanged and merges every table. Like `-- pista:concurrently`, the directive takes no arguments and is ignored on statements other than `CREATE TABLE`.
+
 ## [1.12.1] - 2026-06-27
 
 * Fix `dump --omit-schema` leaving the schema name in indexes on partitioned tables. `pg_get_indexdef` emits `ON ONLY <schema>.<table>` for such indexes, which the schema-stripping replacement did not match, so `public.` stayed in the output.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Declarative schema management tool for PostgreSQL. Define the desired schema in SQL; pistachio generates the DDL diff.
 
-See also: [Getting Started Guide](getting-started.md)
+See also: [Getting Started Guide](getting-started.md) / [Directives](directives.md)
 
 ![](https://github.com/user-attachments/assets/f280336b-52c2-409e-a8ba-f9a2ec71f950)
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ ALTER TABLE public.users
   ADD CONSTRAINT users_id_pos CHECK (id > 0);
 ```
 
+To merge `ALTER TABLE` actions for individual tables only, put the `-- pista:bulk-alter` directive before the `CREATE TABLE` statement. Other tables keep one statement per action. `--bulk-alter` merges every table regardless of the directive.
+
+```sql
+-- pista:bulk-alter
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+```
+
 By default, `plan` and `apply` do not drop tables, views, enums, domains, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `foreign_key`, `index`). Also available as `$PISTA_ALLOW_DROP`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately.
 
 ```bash

--- a/bulk_alter.go
+++ b/bulk_alter.go
@@ -4,6 +4,8 @@ import "strings"
 
 // mergeAlterTable collapses consecutive `ALTER TABLE <fqtn> <action>;` statements
 // that target the same table into a single statement with comma-separated actions.
+// shouldMerge decides per table (by fqtn) whether its statements are merged;
+// tables it rejects pass through unchanged.
 //
 // Only a small whitelist of action prefixes is mergeable; everything else
 // (renames, VALIDATE CONSTRAINT, RLS toggles, "-- skipped:" comments, non-ALTER
@@ -14,7 +16,7 @@ import "strings"
 // Caller must only invoke this on statements that are sequenced per-table
 // (i.e. diff.TableDiffResult.Stmts), since merging relies on the natural
 // per-table contiguity that DiffTables produces.
-func mergeAlterTable(stmts []string) []string {
+func mergeAlterTable(stmts []string, shouldMerge func(fqtn string) bool) []string {
 	result := make([]string, 0, len(stmts))
 
 	var groupFQTN string
@@ -50,7 +52,7 @@ func mergeAlterTable(stmts []string) []string {
 
 	for _, stmt := range stmts {
 		fqtn, action, ok := parseMergeableAlterTable(stmt)
-		if !ok {
+		if !ok || !shouldMerge(fqtn) {
 			flush()
 			result = append(result, stmt)
 			continue

--- a/bulk_alter_test.go
+++ b/bulk_alter_test.go
@@ -259,7 +259,7 @@ func TestMergeAlterTable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mergeAlterTable(tt.in)
+			got := mergeAlterTable(tt.in, func(string) bool { return true })
 			if tt.want == nil {
 				assert.Empty(t, got)
 				return
@@ -267,6 +267,24 @@ func TestMergeAlterTable(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMergeAlterTable_ShouldMergePerTable(t *testing.T) {
+	in := []string{
+		"ALTER TABLE public.users ADD COLUMN email text;",
+		"ALTER TABLE public.users ADD COLUMN age integer;",
+		"ALTER TABLE public.posts ADD COLUMN title text;",
+		"ALTER TABLE public.posts ADD COLUMN body text;",
+	}
+
+	got := mergeAlterTable(in, func(fqtn string) bool { return fqtn == "public.users" })
+
+	want := []string{
+		"ALTER TABLE public.users\n  ADD COLUMN email text,\n  ADD COLUMN age integer;",
+		"ALTER TABLE public.posts ADD COLUMN title text;",
+		"ALTER TABLE public.posts ADD COLUMN body text;",
+	}
+	assert.Equal(t, want, got)
 }
 
 func TestParseMergeableAlterTable_Negatives(t *testing.T) {

--- a/diff_all.go
+++ b/diff_all.go
@@ -115,8 +115,18 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
 	}
 
-	if options.BulkAlter {
-		tableDiff.Stmts = mergeAlterTable(tableDiff.Stmts)
+	// --bulk-alter merges every table; the -- pista:bulk-alter directive
+	// opts in individual tables.
+	bulkAlterTables := make(map[string]bool)
+	for _, t := range desiredTables.CollectValues() {
+		if t.BulkAlter {
+			bulkAlterTables[t.FQTN()] = true
+		}
+	}
+	if options.BulkAlter || len(bulkAlterTables) > 0 {
+		tableDiff.Stmts = mergeAlterTable(tableDiff.Stmts, func(fqtn string) bool {
+			return options.BulkAlter || bulkAlterTables[fqtn]
+		})
 	}
 
 	viewDiff, err := diff.DiffViews(filteredViews, desiredViews, &options.DropPolicy)

--- a/directives.md
+++ b/directives.md
@@ -1,0 +1,78 @@
+# Directives
+
+pistachio reads directives from SQL comments in schema files. A directive is a line comment of the form `-- pista:<name>` placed on its own line immediately before the target statement. Unknown directive names are rejected at parse time. A directive placed before a statement it does not apply to is ignored.
+
+| Directive | Arguments | Applies to | Purpose |
+|---|---|---|---|
+| `renamed-from` | old name (required) | tables, views, enums, domains, columns, constraints, foreign keys, indexes, policies | Rename instead of drop and create |
+| `execute` | check SQL (optional) | any statement | Run non-managed SQL during apply |
+| `concurrently` | none | `CREATE INDEX` | Create and drop the index with `CONCURRENTLY` |
+| `bulk-alter` | none | `CREATE TABLE` | Merge the table's `ALTER TABLE` actions into one statement |
+
+## -- pista:renamed-from
+
+Renames an object instead of dropping and recreating it. The argument is the old name. For tables, views, enums, and domains, the old name may be schema-qualified; without a schema it defaults to the default schema. For columns, constraints, foreign keys, indexes, and policies, the old name is unqualified.
+
+```sql
+-- pista:renamed-from public.old_users
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    -- pista:renamed-from name
+    display_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    -- pista:renamed-from users_name_key
+    CONSTRAINT users_display_name_key UNIQUE (display_name)
+);
+
+-- pista:renamed-from idx_users_name
+CREATE INDEX idx_users_display_name ON public.users (display_name);
+
+-- pista:renamed-from fk_old_name
+ALTER TABLE public.orders ADD CONSTRAINT fk_new_name FOREIGN KEY (user_id) REFERENCES public.users(id);
+```
+
+For columns and constraints, write the directive inside `CREATE TABLE` on the line before the definition. Directives that have already been applied are silently skipped, so leave them in place until cleanup.
+
+See [Renaming objects](README.md#renaming-objects) in the README for column rename caveats.
+
+## -- pista:execute
+
+Includes non-managed SQL (functions, triggers, grants) in schema files. The marked statement is excluded from schema diffing. The optional argument is a check SQL expression evaluated during `apply`: when it returns `true` the statement is executed, otherwise skipped. Without a check, the statement always runs.
+
+```sql
+-- pista:execute SELECT to_regprocedure('public.my_func()') IS NULL
+CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ ... $$ LANGUAGE plpgsql;
+```
+
+See [Executing arbitrary SQL](README.md#executing-arbitrary-sql) in the README for versioning patterns.
+
+## -- pista:concurrently
+
+Opts an index into `CONCURRENTLY` for `CREATE INDEX` and `DROP INDEX`. Writing `CREATE INDEX CONCURRENTLY` inline is equivalent.
+
+```sql
+-- pista:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);
+```
+
+`--disable-index-concurrently` ignores all opt-ins; `--force-index-concurrently` applies `CONCURRENTLY` to every index change. `CONCURRENTLY` operations cannot run inside a transaction, so a plan containing them conflicts with `apply --with-tx`.
+
+## -- pista:bulk-alter
+
+Combines the table's consecutive `ALTER TABLE` actions into a single statement with comma-separated actions. Tables without the directive keep one statement per action.
+
+```sql
+-- pista:bulk-alter
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+```
+
+```sql
+ALTER TABLE public.users
+  ADD COLUMN email text,
+  ALTER COLUMN name SET NOT NULL;
+```
+
+Foreign keys, `RENAME`, `VALIDATE CONSTRAINT`, RLS toggles, and skipped DROPs stay separate statements. The `--bulk-alter` flag merges every table regardless of directives.

--- a/model/table.go
+++ b/model/table.go
@@ -12,6 +12,7 @@ type Table struct {
 	Schema           string
 	Name             string
 	RenameFrom       *string
+	BulkAlter        bool
 	TableSpace       *string
 	Unlogged         bool
 	Partitioned      bool

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -15,6 +15,9 @@ var (
 	concurrentlyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:concurrently[ \t]*$`)
 	// Matches -- pista:concurrently with trailing content (invalid usage).
 	concurrentlyWithArgsPattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:concurrently[ \t]+\S`)
+	bulkAlterDirectivePattern   = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:bulk-alter[ \t]*$`)
+	// Matches -- pista:bulk-alter with trailing content (invalid usage).
+	bulkAlterWithArgsPattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:bulk-alter[ \t]+\S`)
 	// Matches any -- pista: directive, capturing the name (if any) after the colon.
 	anyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:[ \t]*(\S*)`)
 )
@@ -24,6 +27,7 @@ var knownDirectives = map[string]bool{
 	"renamed-from": true,
 	"execute":      true,
 	"concurrently": true,
+	"bulk-alter":   true,
 }
 
 // validateDirectives checks for unknown -- pista: directives in the raw SQL
@@ -42,6 +46,10 @@ func validateDirectives(rawSQL string) error {
 
 	if concurrentlyWithArgsPattern.MatchString(rawSQL) {
 		return fmt.Errorf("-- pista:concurrently does not accept arguments")
+	}
+
+	if bulkAlterWithArgsPattern.MatchString(rawSQL) {
+		return fmt.Errorf("-- pista:bulk-alter does not accept arguments")
 	}
 
 	return nil
@@ -226,6 +234,20 @@ func extractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]s
 // that appear in each statement's leading comment region.
 // Returns a set of StmtLocations that have the directive.
 func extractConcurrentlyDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]bool {
+	return extractFlagDirectives(concurrentlyDirectivePattern, rawSQL, stmts)
+}
+
+// extractBulkAlterDirectives scans raw SQL for `-- pista:bulk-alter` comments
+// that appear in each statement's leading comment region.
+// Returns a set of StmtLocations that have the directive.
+func extractBulkAlterDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]bool {
+	return extractFlagDirectives(bulkAlterDirectivePattern, rawSQL, stmts)
+}
+
+// extractFlagDirectives scans raw SQL for argument-less directive comments
+// matching pattern in each statement's leading comment region.
+// Returns a set of StmtLocations that have the directive.
+func extractFlagDirectives(pattern *regexp.Regexp, rawSQL string, stmts []*pg_query.RawStmt) map[int32]bool {
 	directives := make(map[int32]bool)
 
 	for _, stmt := range stmts {
@@ -239,7 +261,7 @@ func extractConcurrentlyDirectives(rawSQL string, stmts []*pg_query.RawStmt) map
 		leadingEnd := findLeadingCommentEnd(region)
 		leading := region[:leadingEnd]
 
-		if concurrentlyDirectivePattern.MatchString(leading) {
+		if pattern.MatchString(leading) {
 			directives[loc] = true
 		}
 	}

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -372,12 +372,54 @@ func TestExtractConcurrentlyDirectives_noDirective(t *testing.T) {
 	assert.Empty(t, directives)
 }
 
+func TestExtractBulkAlterDirectives(t *testing.T) {
+	sql := `-- pista:bulk-alter
+CREATE TABLE public.users (id integer NOT NULL);
+CREATE TABLE public.posts (id integer NOT NULL);`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	directives := extractBulkAlterDirectives(sql, result.Stmts)
+	assert.True(t, directives[result.Stmts[0].StmtLocation])
+	assert.False(t, directives[result.Stmts[1].StmtLocation])
+}
+
+func TestExtractBulkAlterDirectives_withRenamedFrom(t *testing.T) {
+	sql := `-- pista:renamed-from public.old_users
+-- pista:bulk-alter
+CREATE TABLE public.users (id integer NOT NULL);`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	directives := extractBulkAlterDirectives(sql, result.Stmts)
+	assert.True(t, directives[result.Stmts[0].StmtLocation])
+}
+
+func TestExtractBulkAlterDirectives_noDirective(t *testing.T) {
+	sql := `CREATE TABLE public.users (id integer NOT NULL);`
+
+	result, err := pg_query.Parse(sql)
+	require.NoError(t, err)
+
+	directives := extractBulkAlterDirectives(sql, result.Stmts)
+	assert.Empty(t, directives)
+}
+
 func TestValidateDirectives_Valid(t *testing.T) {
 	assert.NoError(t, validateDirectives("-- pista:renamed-from old"))
 	assert.NoError(t, validateDirectives("-- pista:execute SELECT true"))
 	assert.NoError(t, validateDirectives("-- pista:execute"))
 	assert.NoError(t, validateDirectives("-- pista:concurrently"))
+	assert.NoError(t, validateDirectives("-- pista:bulk-alter"))
 	assert.NoError(t, validateDirectives("SELECT 1; -- no directives"))
+}
+
+func TestValidateDirectives_BulkAlterWithArgs(t *testing.T) {
+	err := validateDirectives("-- pista:bulk-alter extra")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-- pista:bulk-alter does not accept arguments")
 }
 
 func TestValidateDirectives_ConcurrentlyWithArgs(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -77,6 +77,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 
 	stmtDirectives := extractStmtDirectives(sql, result.Stmts)
 	concurrentlyDirectives := extractConcurrentlyDirectives(sql, result.Stmts)
+	bulkAlterDirectives := extractBulkAlterDirectives(sql, result.Stmts)
 	executeStmts, executeSkipLocations, err := extractExecuteDirectives(sql, result.Stmts)
 	if err != nil {
 		return nil, err
@@ -126,6 +127,9 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if renameFrom != "" {
 				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 				table.RenameFrom = &qualified
+			}
+			if bulkAlterDirectives[rawStmt.StmtLocation] {
+				table.BulkAlter = true
 			}
 
 			// Extract column/constraint-level directives from raw SQL

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1850,6 +1850,74 @@ CREATE INDEX CONCURRENTLY idx_name ON public.users (name);`
 	assert.True(t, idx.Concurrently)
 }
 
+func TestParseSQL_BulkAlterDirective_Table(t *testing.T) {
+	sql := `-- pista:bulk-alter
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	users, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	assert.True(t, users.BulkAlter)
+
+	posts, ok := result.Tables.GetOk("public.posts")
+	require.True(t, ok)
+	assert.False(t, posts.BulkAlter)
+}
+
+func TestParseSQL_BulkAlterDirective_WithRenamed(t *testing.T) {
+	sql := `-- pista:renamed-from public.old_users
+-- pista:bulk-alter
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	assert.True(t, tbl.BulkAlter)
+	require.NotNil(t, tbl.RenameFrom)
+	assert.Equal(t, "public.old_users", *tbl.RenameFrom)
+}
+
+func TestParseSQL_BulkAlterDirective_IgnoredOnNonTable(t *testing.T) {
+	// -- pista:bulk-alter before a CREATE INDEX should be silently ignored
+	// and should NOT leak to the following CREATE TABLE
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pista:bulk-alter
+CREATE INDEX idx_name ON public.users (name);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	users, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	assert.False(t, users.BulkAlter)
+
+	posts, ok := result.Tables.GetOk("public.posts")
+	require.True(t, ok)
+	assert.False(t, posts.BulkAlter)
+}
+
 func TestParseSQL_ConcurrentlyDirective_IgnoredOnNonIndex(t *testing.T) {
 	// -- pista:concurrently before a CREATE TABLE should be silently ignored
 	// and should NOT leak to the following CREATE INDEX

--- a/testdata/apply/bulk_alter_directive.yml
+++ b/testdata/apply/bulk_alter_directive.yml
@@ -1,0 +1,43 @@
+verify_no_drift: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:bulk-alter
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      age integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.posts
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      age integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied_sql: |
+  ALTER TABLE public.posts ADD COLUMN title text;
+  ALTER TABLE public.users
+    ADD COLUMN email text,
+    ADD COLUMN age integer;

--- a/testdata/plan/bulk_alter_directive.yml
+++ b/testdata/plan/bulk_alter_directive.yml
@@ -1,0 +1,29 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:bulk-alter
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      age integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text,
+      body text,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.posts ADD COLUMN title text;
+  ALTER TABLE public.posts ADD COLUMN body text;
+  ALTER TABLE public.users
+    ADD COLUMN email text,
+    ADD COLUMN age integer;

--- a/testdata/plan/bulk_alter_directive_args_error.yml
+++ b/testdata/plan/bulk_alter_directive_args_error.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:bulk-alter extra
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+error: "-- pista:bulk-alter does not accept arguments"

--- a/testdata/plan/bulk_alter_directive_quoted_ident.yml
+++ b/testdata/plan/bulk_alter_directive_quoted_ident.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public."Users" (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:bulk-alter
+  CREATE TABLE public."Users" (
+      id integer NOT NULL,
+      email text,
+      age integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public."Users"
+    ADD COLUMN email text,
+    ADD COLUMN age integer;

--- a/testdata/plan/bulk_alter_directive_rename.yml
+++ b/testdata/plan/bulk_alter_directive_rename.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.old_users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:renamed-from public.old_users
+  -- pista:bulk-alter
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      age integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.old_users RENAME TO users;
+  ALTER TABLE public.users
+    ADD COLUMN email text,
+    ADD COLUMN age integer;

--- a/testdata/plan/bulk_alter_directive_with_flag.yml
+++ b/testdata/plan/bulk_alter_directive_with_flag.yml
@@ -1,0 +1,28 @@
+bulk_alter: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:bulk-alter
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      title text,
+      body text,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.posts
+    ADD COLUMN title text,
+    ADD COLUMN body text;
+  ALTER TABLE public.users ADD COLUMN email text;


### PR DESCRIPTION
## Summary

Add the `-- pista:bulk-alter` directive to opt individual tables into ALTER TABLE merging. Put it before a `CREATE TABLE` statement to combine that table's consecutive `ALTER TABLE` actions into a single statement. Other tables keep one statement per action.

```sql
-- pista:bulk-alter
CREATE TABLE public.users (
    id integer NOT NULL,
    CONSTRAINT users_pkey PRIMARY KEY (id)
);
```

The `--bulk-alter` flag (env `$PISTA_BULK_ALTER`) is unchanged and merges every table regardless of directives. Like `-- pista:concurrently`, the directive takes no arguments and is ignored on statements other than `CREATE TABLE`.

## Changes

- `parser/directive.go`: add the directive pattern, register it in `knownDirectives`, reject arguments, and extract per-statement locations via a shared `extractFlagDirectives` helper (also reused by `-- pista:concurrently`)
- `parser/parser.go`: set `Table.BulkAlter` when the directive appears in a `CREATE TABLE` statement's leading comments
- `model/table.go`: add the `BulkAlter` field
- `bulk_alter.go`: `mergeAlterTable` takes a `shouldMerge func(fqtn string) bool` predicate
- `diff_all.go`: build the opt-in table set from the desired schema and merge when the flag or a directive requests it

## Tests

- Parser unit tests: directive extraction, no leakage to adjacent statements, `renamed-from` combination, ignored on non-table statements, argument error
- Plan fixtures: selective merge, flag + directive, table rename, quoted identifiers, argument error
- Apply fixture with `verify_no_drift: true`
- Coverage: root package 97.9% -> 98.0%, parser unchanged at 91.1%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdZDTzmzaZw5pNyGj3Lb8k