### PR TITLE
docs: move Example section above the Usage reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,57 @@ pista dump                  # dump the current schema
 
 The source for the image is under [`demo/`](demo/).
 
+## Example
+
+Create a schema file:
+
+```sql
+CREATE TYPE public.status AS ENUM ('active', 'inactive');
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    status status NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    title text NOT NULL,
+    CONSTRAINT posts_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_posts_user_id ON public.posts USING btree (user_id);
+
+ALTER TABLE ONLY public.posts
+    ADD CONSTRAINT posts_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id);
+```
+
+Preview and apply:
+
+```bash
+pista plan schema.sql                  # review the diff (drops suppressed by default)
+pista plan --allow-drop all schema.sql # review the diff (with drops)
+pista apply schema.sql                 # apply it
+```
+
+Or split the schema across multiple files:
+
+```bash
+pista dump --split ./schema/       # dump per table/view/enum/domain
+pista plan ./schema/*.sql          # review the diff
+pista apply ./schema/*.sql         # apply it
+```
+
+> [!NOTE]
+> Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are auto-named by pistachio following PostgreSQL's convention (`{table}_pkey`, `{table}_{col}_key`, `{table}_{col}_check`, `{table}_{col}_fkey`, `{table}_{col}_excl`). The auto-naming has two limitations:
+> - When multiple constraints would generate the same name, PostgreSQL appends a numeric suffix (e.g. `_1`) that pistachio cannot predict.
+> - PostgreSQL truncates identifier names to 63 bytes (NAMEDATALEN - 1). pistachio does not apply this truncation, so very long table/column names may produce mismatched constraint names.
+>
+> Use explicit `CONSTRAINT <name>` clauses to avoid these issues.
+
 ## Usage
 
 ```
@@ -406,57 +457,6 @@ pista dump --split ./schema/
 # -- Wrote 4 file(s) to ./schema/
 # (writes ./schema/public.status.sql, ./schema/public.users.sql, ./schema/public.orders.sql, ...)
 ```
-
-## Example
-
-Create a schema file:
-
-```sql
-CREATE TYPE public.status AS ENUM ('active', 'inactive');
-
-CREATE TABLE public.users (
-    id integer NOT NULL,
-    name text NOT NULL,
-    status status NOT NULL,
-    CONSTRAINT users_pkey PRIMARY KEY (id)
-);
-
-CREATE TABLE public.posts (
-    id integer NOT NULL,
-    user_id integer NOT NULL,
-    title text NOT NULL,
-    CONSTRAINT posts_pkey PRIMARY KEY (id)
-);
-
-CREATE INDEX idx_posts_user_id ON public.posts USING btree (user_id);
-
-ALTER TABLE ONLY public.posts
-    ADD CONSTRAINT posts_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES users(id);
-```
-
-Preview and apply:
-
-```bash
-pista plan schema.sql                  # review the diff (drops suppressed by default)
-pista plan --allow-drop all schema.sql # review the diff (with drops)
-pista apply schema.sql                 # apply it
-```
-
-Or split the schema across multiple files:
-
-```bash
-pista dump --split ./schema/       # dump per table/view/enum/domain
-pista plan ./schema/*.sql          # review the diff
-pista apply ./schema/*.sql         # apply it
-```
-
-> [!NOTE]
-> Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are auto-named by pistachio following PostgreSQL's convention (`{table}_pkey`, `{table}_{col}_key`, `{table}_{col}_check`, `{table}_{col}_fkey`, `{table}_{col}_excl`). The auto-naming has two limitations:
-> - When multiple constraints would generate the same name, PostgreSQL appends a numeric suffix (e.g. `_1`) that pistachio cannot predict.
-> - PostgreSQL truncates identifier names to 63 bytes (NAMEDATALEN - 1). pistachio does not apply this truncation, so very long table/column names may produce mismatched constraint names.
->
-> Use explicit `CONSTRAINT <name>` clauses to avoid these issues.
 
 ## Supported Objects
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,6 @@ pista plan ./schema/*.sql          # review the diff
 pista apply ./schema/*.sql         # apply it
 ```
 
-> [!NOTE]
-> Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are auto-named by pistachio following PostgreSQL's convention (`{table}_pkey`, `{table}_{col}_key`, `{table}_{col}_check`, `{table}_{col}_fkey`, `{table}_{col}_excl`). The auto-naming has two limitations:
-> - When multiple constraints would generate the same name, PostgreSQL appends a numeric suffix (e.g. `_1`) that pistachio cannot predict.
-> - PostgreSQL truncates identifier names to 63 bytes (NAMEDATALEN - 1). pistachio does not apply this truncation, so very long table/column names may produce mismatched constraint names.
->
-> Use explicit `CONSTRAINT <name>` clauses to avoid these issues.
-
 ## Usage
 
 ```
@@ -457,6 +450,15 @@ pista dump --split ./schema/
 # -- Wrote 4 file(s) to ./schema/
 # (writes ./schema/public.status.sql, ./schema/public.users.sql, ./schema/public.orders.sql, ...)
 ```
+
+## Constraint naming
+
+> [!NOTE]
+> Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are auto-named by pistachio following PostgreSQL's convention (`{table}_pkey`, `{table}_{col}_key`, `{table}_{col}_check`, `{table}_{col}_fkey`, `{table}_{col}_excl`). The auto-naming has two limitations:
+> - When multiple constraints would generate the same name, PostgreSQL appends a numeric suffix (e.g. `_1`) that pistachio cannot predict.
+> - PostgreSQL truncates identifier names to 63 bytes (NAMEDATALEN - 1). pistachio does not apply this truncation, so very long table/column names may produce mismatched constraint names.
+>
+> Use explicit `CONSTRAINT <name>` clauses to avoid these issues.
 
 ## Supported Objects
 


### PR DESCRIPTION
The Example section demonstrated the core schema-file workflow but sat
near the bottom, after the full Usage/flag reference. Move it up between
Demo and Usage so new users see a concrete example before the detailed
flag documentation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DYFtwikhPDZuq3gGSXLZmC