### PR TITLE
Add qrev to the list of tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,3 +489,4 @@ make test
   schema management for MySQL.
 - [ridgepole](https://github.com/ridgepole/ridgepole): DB schema
   management using a Rails DSL.
+- [qrev](https://github.com/winebarrel/qrev): SQL execution history management tool.


### PR DESCRIPTION
This pull request adds a new tool to the documentation for schema management in MySQL. The most important change is:

Documentation update:

* Added `qrev`, a SQL execution history management tool, to the list of schema management tools for MySQL in `README.md`.