### PR TITLE
Add plan --check for drift detection via exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Add `--check` (env `$PISTA_CHECK`) to `plan` for drift detection in CI. The exit code is 2 if the plan contains executable changes, 0 if not, and 1 on error. The output does not change. Suppressed drops alone exit 0 because they generate no executable DDL.
+* Add `--check` (env `$PISTA_CHECK`) to `plan` for drift detection in CI. The exit code is 2 if the plan contains executable changes, 0 if not, and 1 on error. The output does not change. Suppressed drops alone exit 0 because they generate no executable DDL. `PlanResult` gains a `HasChanges` field, and the CLI uses it instead of checking `SQL` for emptiness.
 
 ## [1.13.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Add `--check` (env `$PISTA_CHECK`) to `plan`. Exits with code 2 when the plan contains executable changes, 0 when there are none, and 1 on error, so schema drift can be detected from the exit code in CI. The plan output is printed as usual. Drops suppressed by the drop policy exit 0, consistent with the `-- No changes` output.
+* Add `--check` (env `$PISTA_CHECK`) to `plan` for drift detection in CI. The exit code is 2 if the plan contains executable changes, 0 if not, and 1 on error. The output does not change. Suppressed drops alone exit 0 because they generate no executable DDL.
 
 ## [1.13.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add `--check` (env `$PISTA_CHECK`) to `plan`. Exits with code 2 when the plan contains executable changes, 0 when there are none, and 1 on error, so schema drift can be detected from the exit code in CI. The plan output is printed as usual. Drops suppressed by the drop policy exit 0, consistent with the `-- No changes` output.
+
 ## [1.13.0] - 2026-07-03
 
 * Add the `-- pista:bulk-alter` directive. Put it before a `CREATE TABLE` statement to combine that table's consecutive `ALTER TABLE` actions into a single statement. Other tables keep one statement per action. The `--bulk-alter` flag (env `$PISTA_BULK_ALTER`) is unchanged and merges every table. Like `-- pista:concurrently`, the directive takes no arguments and is ignored on statements other than `CREATE TABLE`.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ pista plan schema.sql --pre-sql-file pre.sql
 
 `--pre-sql` / `--pre-sql-file` are also available as `$PISTA_PRE_SQL` / `$PISTA_PRE_SQL_FILE`.
 
-Use `--check` to detect schema drift from the exit code (e.g. in CI). The plan output is printed as usual, and the exit code is 2 when the plan contains executable changes, 0 when there are none, and 1 on error. Drops suppressed by the drop policy (`-- skipped:` comments) produce no executable DDL and exit 0, consistent with the `-- No changes` output. Also available as `$PISTA_CHECK`.
+Use `--check` to detect schema drift from the exit code. The exit code is 2 if the plan contains executable changes, 0 if not, and 1 on error. The output does not change. Suppressed drops alone exit 0 because they generate no executable DDL. Also available as `$PISTA_CHECK`.
 
 ```bash
 pista plan --check schema.sql

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ pista plan schema.sql --pre-sql-file pre.sql
 
 `--pre-sql` / `--pre-sql-file` are also available as `$PISTA_PRE_SQL` / `$PISTA_PRE_SQL_FILE`.
 
+Use `--check` to detect schema drift from the exit code (e.g. in CI). The plan output is printed as usual, and the exit code is 2 when the plan contains executable changes, 0 when there are none, and 1 on error. Drops suppressed by the drop policy (`-- skipped:` comments) produce no executable DDL and exit 0, consistent with the `-- No changes` output. Also available as `$PISTA_CHECK`.
+
+```bash
+pista plan --check schema.sql
+echo $?  # 0: no changes, 2: changes, 1: error
+```
+
 ### apply
 
 Apply the diff to the database.

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -2,14 +2,21 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/winebarrel/pistachio"
 )
 
+// ErrPlanDiff is returned by Plan.Run when --check is set and the plan
+// contains executable DDL. main maps it to exit code 2. Suppressed drops
+// alone do not trigger it, consistent with the "-- No changes" output.
+var ErrPlanDiff = errors.New("plan contains changes")
+
 type Plan struct {
 	pistachio.PlanOptions
+	Check bool `env:"PISTA_CHECK" help:"Exit with code 2 when the plan contains executable changes."`
 }
 
 func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer) error {
@@ -38,6 +45,10 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}
+	}
+
+	if cmd.Check && result.SQL != "" {
+		return ErrPlanDiff
 	}
 
 	return nil

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -11,7 +11,7 @@ import (
 
 // ErrPlanDiff is returned by Plan.Run when --check is set and the plan
 // contains executable DDL. main maps it to exit code 2. Suppressed drops
-// alone do not trigger it, consistent with the "-- No changes" output.
+// alone do not trigger it.
 var ErrPlanDiff = errors.New("plan contains changes")
 
 type Plan struct {

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -35,7 +35,7 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 	// as a runnable script; skipped DROPs follow as informational comments.
 	// In the no-SQL case, skipped DROPs come before "-- No changes" so the
 	// summary line reads naturally at the end.
-	if result.SQL == "" {
+	if !result.HasChanges {
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}
@@ -47,7 +47,7 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 		}
 	}
 
-	if cmd.Check && result.SQL != "" {
+	if cmd.Check && result.HasChanges {
 		return ErrPlanDiff
 	}
 

--- a/cmd/command/plan_test.go
+++ b/cmd/command/plan_test.go
@@ -252,6 +252,69 @@ func TestPlan_Run_CheckSkippedDropOnly(t *testing.T) {
 	assert.Contains(t, got, "-- No changes")
 }
 
+func TestPlan_Run_CheckExecuteOnly(t *testing.T) {
+	// A -- pista:execute statement is executable SQL, so --check returns
+	// ErrPlanDiff even without a schema diff.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL+`
+-- pista:execute
+CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.ErrorIs(t, err, command.ErrPlanDiff)
+}
+
+func TestPlan_Run_CheckPreSQLNoChanges(t *testing.T) {
+	// Pre-SQL is prepended only when the plan has statements, so it does
+	// not turn an empty plan into a diff.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{
+		Files:  []string{desiredFile},
+		PreSQL: "SELECT 1;",
+	}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "-- No changes")
+	assert.NotContains(t, got, "SELECT 1;")
+}
+
 func TestPlan_Run_CheckError(t *testing.T) {
 	// Connection failures must surface as ordinary errors, not ErrPlanDiff.
 	ctx := context.Background()

--- a/cmd/command/plan_test.go
+++ b/cmd/command/plan_test.go
@@ -169,6 +169,107 @@ func TestPlan_Run_PreSQLBeforeSkippedDrops(t *testing.T) {
 	assert.Less(t, addColPos, skippedPos, "skipped comments must follow executable SQL")
 }
 
+func TestPlan_Run_CheckWithDiff(t *testing.T) {
+	// --check returns ErrPlanDiff when the plan contains executable DDL.
+	// The normal plan output is still written before the error is returned.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.ErrorIs(t, err, command.ErrPlanDiff)
+	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+}
+
+func TestPlan_Run_CheckNoChanges(t *testing.T) {
+	// --check returns nil when the schema is already in the desired state.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(initSQL), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "-- No changes")
+}
+
+func TestPlan_Run_CheckSkippedDropOnly(t *testing.T) {
+	// Suppressed drops produce no executable DDL, so --check treats them as
+	// no changes (consistent with the "-- No changes" output).
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(""), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "-- skipped: DROP TABLE public.users;")
+	assert.Contains(t, got, "-- No changes")
+}
+
+func TestPlan_Run_CheckError(t *testing.T) {
+	// Connection failures must surface as ordinary errors, not ErrPlanDiff.
+	ctx := context.Background()
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: "invalid://connection",
+		Schemas:    []string{"public"},
+	})
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, command.ErrPlanDiff)
+}
+
 func TestPlan_Run_ExecuteOnly_NotNoChanges(t *testing.T) {
 	// When the only diff is a -- pista:execute statement (no schema diff),
 	// the plan must surface the execute SQL and must NOT print "-- No changes".

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 
@@ -43,5 +44,10 @@ func main() {
 	client := pistachio.NewClient(&cli.Options)
 	err = kctx.Run(client)
 	closePager()
+	// plan --check: diffs are reported via exit code 2, not as a fatal
+	// error. The plan output has already been written at this point.
+	if errors.Is(err, command.ErrPlanDiff) {
+		kctx.Exit(2)
+	}
 	kctx.FatalIfErrorf(err)
 }

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -44,8 +44,8 @@ func main() {
 	client := pistachio.NewClient(&cli.Options)
 	err = kctx.Run(client)
 	closePager()
-	// plan --check: diffs are reported via exit code 2, not as a fatal
-	// error. The plan output has already been written at this point.
+	// plan --check reports diffs as exit code 2 instead of a fatal error.
+	// The plan output has already been written.
 	if errors.Is(err, command.ErrPlanDiff) {
 		kctx.Exit(2)
 	}

--- a/plan.go
+++ b/plan.go
@@ -58,6 +58,9 @@ type PlanResult struct {
 	SQL             string
 	DisallowedDrops string
 	Count           ObjectCount
+	// HasChanges is true when the plan contains executable statements
+	// (DDL or execute directives). Suppressed drops do not count.
+	HasChanges bool
 }
 
 func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResult, error) {
@@ -93,10 +96,12 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 		stmts = append(stmts, parser.FormatExecuteStmt(es))
 	}
 
+	hasChanges := len(stmts) > 0
+
 	// Prefix order matches apply: PreSQL -> concurrently-pre-SQL -> DDL.
 	// Skipped entirely when there is nothing to execute, so an empty plan
 	// stays empty instead of leaking a bare SET / pre-SQL line.
-	if len(stmts) > 0 {
+	if hasChanges {
 		var prefix []string
 		if result.PreSQL != "" {
 			prefix = append(prefix, result.PreSQL)
@@ -111,5 +116,6 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 		SQL:             strings.Join(stmts, "\n"),
 		DisallowedDrops: strings.Join(result.DisallowedDrops, "\n"),
 		Count:           result.Count,
+		HasChanges:      hasChanges,
 	}, nil
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -308,6 +308,7 @@ func TestPlan(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.Plan), strings.TrimSpace(got.SQL))
 			assert.Equal(t, strings.TrimSpace(tc.DisallowedDrops), strings.TrimSpace(got.DisallowedDrops))
+			assert.Equal(t, got.SQL != "", got.HasChanges, "HasChanges must match presence of executable SQL")
 			assertExpectedCount(t, tc.Count, got.Count)
 		})
 	}

--- a/test/scenario/check.test.sh
+++ b/test/scenario/check.test.sh
@@ -68,8 +68,18 @@ else
   fail "expected exit code 2, got $rc"
 fi
 
-# --- Step 6: error -> exit 1 ---
-step "06 check exits 1 on error"
+# --- Step 6: PISTA_CHECK env -> exit 2 ---
+step "06 PISTA_CHECK env exits 2 on diff"
+rc=0
+PISTA_CHECK=true "$PISTA" plan --allow-drop all "$DATA/steps/02_drop_table.sql" >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "2" ]; then
+  pass
+else
+  fail "expected exit code 2, got $rc"
+fi
+
+# --- Step 7: error -> exit 1 ---
+step "07 check exits 1 on error"
 rc=0
 "$PISTA" -c postgres://invalid@localhost:1/none plan --check "$DATA/steps/01_add_column.sql" >/dev/null 2>&1 || rc=$?
 if [ "$rc" = "1" ]; then

--- a/test/scenario/check.test.sh
+++ b/test/scenario/check.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Scenario test: plan --check exit codes
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/check"
+
+# Run pista plan --check and echo the exit code. Never fails the script
+# itself; callers assert on the echoed code.
+plan_check_rc() {
+  local rc=0
+  "$PISTA" plan --check "$@" >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+# --- Setup: load initial schema ---
+setup_db "$DATA/init.sql"
+
+# --- Step 1: diff present -> exit 2 ---
+step "01 check exits 2 on diff"
+rc=$(plan_check_rc "$DATA/steps/01_add_column.sql")
+if [ "$rc" = "2" ]; then
+  pass
+else
+  fail "expected exit code 2, got $rc"
+fi
+
+# --- Step 2: plan output is still printed with --check ---
+step "02 check still prints the plan"
+plan_output=$("$PISTA" plan --check "$DATA/steps/01_add_column.sql" 2>&1) && rc=0 || rc=$?
+if [ "$rc" != "2" ]; then
+  fail "expected exit code 2, got $rc"
+elif echo "$plan_output" | grep -qF 'ADD COLUMN name'; then
+  pass
+else
+  fail "expected ADD COLUMN name in plan output"
+  echo "    $plan_output" >&2
+fi
+
+# --- Step 3: no diff -> exit 0 ---
+step "03 check exits 0 after apply"
+apply_output=$(pista_apply "$DATA/steps/01_add_column.sql") || { fail "apply failed: $apply_output"; true; }
+rc=$(plan_check_rc "$DATA/steps/01_add_column.sql")
+if [ "$rc" = "0" ]; then
+  pass
+else
+  fail "expected exit code 0, got $rc"
+fi
+
+# --- Step 4: suppressed drop only -> exit 0 ---
+step "04 check exits 0 on skipped drop only"
+rc=$(plan_check_rc "$DATA/steps/02_drop_table.sql")
+if [ "$rc" = "0" ]; then
+  pass
+else
+  fail "expected exit code 0, got $rc"
+fi
+
+# --- Step 5: suppressed drop allowed -> exit 2 ---
+step "05 check exits 2 when drop is allowed"
+rc=0
+"$PISTA" plan --check --allow-drop all "$DATA/steps/02_drop_table.sql" >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "2" ]; then
+  pass
+else
+  fail "expected exit code 2, got $rc"
+fi
+
+# --- Step 6: error -> exit 1 ---
+step "06 check exits 1 on error"
+rc=0
+"$PISTA" -c postgres://invalid@localhost:1/none plan --check "$DATA/steps/01_add_column.sql" >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "1" ]; then
+  pass
+else
+  fail "expected exit code 1, got $rc"
+fi
+
+summary

--- a/test/scenario/testdata/check/init.sql
+++ b/test/scenario/testdata/check/init.sql
@@ -1,0 +1,4 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/check/steps/01_add_column.sql
+++ b/test/scenario/testdata/check/steps/01_add_column.sql
@@ -1,0 +1,5 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/check/steps/02_drop_table.sql
+++ b/test/scenario/testdata/check/steps/02_drop_table.sql
@@ -1,2 +1,2 @@
--- Desired schema removes public.users entirely. Without --allow-drop the
--- DROP is suppressed, so --check must exit 0 (no executable DDL).
+-- Empty desired schema. Without --allow-drop the DROP of public.users is
+-- suppressed and --check exits 0.

--- a/test/scenario/testdata/check/steps/02_drop_table.sql
+++ b/test/scenario/testdata/check/steps/02_drop_table.sql
@@ -1,0 +1,2 @@
+-- Desired schema removes public.users entirely. Without --allow-drop the
+-- DROP is suppressed, so --check must exit 0 (no executable DDL).


### PR DESCRIPTION
pista plan --check (env $PISTA_CHECK) exits with code 2 when the plan
contains executable changes, 0 when there are none, and 1 on error, so
CI can detect schema drift without grepping the output. The plan output
is printed as usual before the exit.

Drops suppressed by the drop policy produce no executable DDL and exit
0, consistent with the existing "-- No changes" output.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR