### PR TITLE
Add a supported OS/arch table to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ brew install winebarrel/pistachio/pistachio
 
 Download the latest binary from [Releases](https://github.com/winebarrel/pistachio/releases).
 
+| OS      | Arch         |
+|---------|--------------|
+| macOS   | amd64, arm64 |
+| Linux   | amd64, arm64 |
+| Windows | amd64        |
+
 ## Demo
 
 A demo image bundles PostgreSQL with a sample schema for trying `pista` without a local install:


### PR DESCRIPTION
Add a compact OS/arch table under the "Download binary" heading so the Windows binary is easy to spot among the release assets, which are otherwise sorted alphabetically with the Windows zip last.

| OS      | Arch         |
|---------|--------------|
| macOS   | amd64, arm64 |
| Linux   | amd64, arm64 |
| Windows | amd64        |

Matches the actual release assets (both architectures for macOS/Linux, amd64 for Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR)_