### PR TITLE
Add the -- pista:ignore directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add the `-- pista:ignore` directive. Put it before a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` statement to leave that object unmanaged: pistachio does not create, alter, or drop it. The object is dropped from both the desired and current state before diffing, so it is the in-file equivalent of `--exclude` for a single object. The directive takes no arguments.
+
 ## [1.14.0] - 2026-07-13
 
 * Add a Windows (amd64) release binary, cross-built with mingw-w64. `$PISTA_PAGER` is interpreted by `cmd /c` on Windows. CI builds the binary on windows-latest and runs `make test` against the runner's preinstalled PostgreSQL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Add the `-- pista:ignore` directive. Put it before a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` statement to leave that object unmanaged: pistachio does not create, alter, or drop it. The object is dropped from both the desired and current state before diffing, so it is the in-file equivalent of `--exclude` for a single object. The directive takes no arguments.
+* Add the `-- pista:ignore` directive. Put it before a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` statement to leave that object unmanaged: pistachio does not create, alter, or drop it. The object is dropped from both the desired and current state before diffing, so it is the in-file equivalent of `--exclude` for a single object. Each ignored object is reported as an `-- ignored: <name>` comment in `plan` / `apply` output. The directive takes no arguments.
 
 ## [1.14.0] - 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ CREATE TABLE public.legacy (
 );
 ```
 
-The directive attaches to a statement in the schema file, so it can only ignore an object you have declared. To keep an existing object that would otherwise be dropped, write its `CREATE` statement with the directive.
+Each ignored object is reported as an `-- ignored: <name>` comment in `plan` and `apply` output. The directive attaches to a statement in the schema file, so it can only ignore an object you have declared. To keep an existing object that would otherwise be dropped, write its `CREATE` statement with the directive.
 
 ### Split dump
 

--- a/README.md
+++ b/README.md
@@ -463,6 +463,20 @@ The following references are not auto-rewritten and may produce a redundant `DRO
 - View / materialized view definitions that `SELECT` the renamed column
 - Foreign keys in other tables whose `REFERENCES this_table(renamed_col)` points at the renamed column
 
+### Ignoring objects
+
+Use the `-- pista:ignore` directive to leave an object unmanaged. pistachio does not create, alter, or drop a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` marked with it. This is the in-file equivalent of `--exclude` for a single object, useful for a table managed by another tool or one whose definition intentionally drifts.
+
+```sql
+-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+```
+
+The directive attaches to a statement in the schema file, so it can only ignore an object you have declared. To keep an existing object that would otherwise be dropped, write its `CREATE` statement with the directive.
+
 ### Split dump
 
 Use `--split` to output each table/view/enum/domain as a separate file in the specified directory.

--- a/apply.go
+++ b/apply.go
@@ -29,6 +29,7 @@ type ApplyOptions struct {
 type ApplyResult struct {
 	Count           ObjectCount
 	DisallowedDrops string
+	Ignored         string
 	// Applied reports whether any schema change was actually applied: schema
 	// DDL or an executed -- pista:execute statement. Pre-SQL,
 	// concurrently-pre-SQL, transaction control, search_path setup, and
@@ -76,6 +77,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	applyResult := &ApplyResult{
 		Count:           result.Count,
 		DisallowedDrops: strings.Join(result.DisallowedDrops, "\n"),
+		Ignored:         strings.Join(result.Ignored, "\n"),
 	}
 
 	if len(result.Stmts) == 0 && len(result.ExecuteStmts) == 0 {

--- a/cmd/command/apply.go
+++ b/cmd/command/apply.go
@@ -38,12 +38,18 @@ func (cmd *Apply) Run(ctx context.Context, client *pistachio.Client, w io.Writer
 	// than the buffer length.
 	if !result.Applied {
 		w.Write(buf.Bytes()) //nolint:errcheck
+		if result.Ignored != "" {
+			fmt.Fprintln(w, result.Ignored) //nolint:errcheck
+		}
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {
 		w.Write(buf.Bytes()) //nolint:errcheck
+		if result.Ignored != "" {
+			fmt.Fprintln(w, result.Ignored) //nolint:errcheck
+		}
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}

--- a/cmd/command/apply_test.go
+++ b/cmd/command/apply_test.go
@@ -42,6 +42,83 @@ func TestApply_Run(t *testing.T) {
 	assertConnectedCommentFirst(t, buf.String(), conn.Config())
 }
 
+func TestApply_Run_IgnoredComment(t *testing.T) {
+	// apply reports an ignored object as an -- ignored: comment and leaves it
+	// untouched while applying the managed change.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "CREATE TABLE public.users")
+	assert.Contains(t, got, "-- ignored: public.legacy")
+
+	// The ignored table keeps its extra column.
+	var hasName bool
+	require.NoError(t, conn.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='legacy' AND column_name='name')`).Scan(&hasName))
+	assert.True(t, hasName, "ignored table's column must survive")
+}
+
+func TestApply_Run_IgnoredOnlyShowsNoChanges(t *testing.T) {
+	// When the only object is ignored, apply prints the -- ignored: comment
+	// and reports no changes.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "-- ignored: public.legacy")
+	assert.Contains(t, got, "-- No changes")
+}
+
 func TestApply_Run_Error(t *testing.T) {
 	ctx := context.Background()
 	client := pistachio.NewClient(&pistachio.Options{

--- a/cmd/command/plan.go
+++ b/cmd/command/plan.go
@@ -36,12 +36,18 @@ func (cmd *Plan) Run(ctx context.Context, client *pistachio.Client, w io.Writer)
 	// In the no-SQL case, skipped DROPs come before "-- No changes" so the
 	// summary line reads naturally at the end.
 	if !result.HasChanges {
+		if result.Ignored != "" {
+			fmt.Fprintln(w, result.Ignored) //nolint:errcheck
+		}
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}
 		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
 	} else {
 		fmt.Fprintln(w, result.SQL) //nolint:errcheck
+		if result.Ignored != "" {
+			fmt.Fprintln(w, result.Ignored) //nolint:errcheck
+		}
 		if result.DisallowedDrops != "" {
 			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
 		}

--- a/cmd/command/plan_test.go
+++ b/cmd/command/plan_test.go
@@ -84,6 +84,83 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	assert.Contains(t, buf.String(), "-- No changes")
 }
 
+func TestPlan_Run_IgnoredWithChange(t *testing.T) {
+	// An ignored object is reported as an -- ignored: comment alongside the
+	// executable diff for the managed objects.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    email text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "ADD COLUMN email")
+	assert.Contains(t, got, "-- ignored: public.legacy")
+}
+
+func TestPlan_Run_IgnoredOnlyShowsNoChanges(t *testing.T) {
+	// When the only object is ignored, the plan prints the -- ignored:
+	// comment and still reports no changes.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	err := cmd.Run(ctx, client, &buf)
+	require.NoError(t, err)
+	got := buf.String()
+	assert.Contains(t, got, "-- ignored: public.legacy")
+	assert.Contains(t, got, "-- No changes")
+}
+
 func TestPlan_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	// When the only diff would be a DROP and --allow-drop is not set,
 	// the DROP is emitted as a comment for visibility while the "No changes"

--- a/diff_all.go
+++ b/diff_all.go
@@ -33,6 +33,7 @@ type diffAllOptions struct {
 type diffAllResult struct {
 	Stmts                []string
 	DisallowedDrops      []string
+	Ignored              []string
 	PreSQL               string
 	ConcurrentlyPreSQL   string
 	Count                ObjectCount
@@ -87,10 +88,17 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 
 	// Objects marked -- pista:ignore are unmanaged: drop them from both the
 	// desired and current sides so no create, alter, or drop is generated.
-	removeIgnored(desiredTables, filteredTables, func(t *model.Table) bool { return t.Ignore })
-	removeIgnored(desiredViews, filteredViews, func(v *model.View) bool { return v.Ignore })
-	removeIgnored(desiredEnums, filteredEnums, func(e *model.Enum) bool { return e.Ignore })
-	removeIgnored(desiredDomains, filteredDomains, func(d *model.Domain) bool { return d.Ignore })
+	// Their FQNs are surfaced as -- ignored: comments.
+	var ignored []string
+	ignored = append(ignored, removeIgnored(desiredTables, filteredTables, func(t *model.Table) bool { return t.Ignore })...)
+	ignored = append(ignored, removeIgnored(desiredViews, filteredViews, func(v *model.View) bool { return v.Ignore })...)
+	ignored = append(ignored, removeIgnored(desiredEnums, filteredEnums, func(e *model.Enum) bool { return e.Ignore })...)
+	ignored = append(ignored, removeIgnored(desiredDomains, filteredDomains, func(d *model.Domain) bool { return d.Ignore })...)
+	sort.Strings(ignored)
+	ignoredComments := make([]string, len(ignored))
+	for i, fqn := range ignored {
+		ignoredComments[i] = "-- ignored: " + fqn
+	}
 
 	count := ObjectCount{
 		Schemas: client.Schemas,
@@ -166,6 +174,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	return &diffAllResult{
 		Stmts:                stmts,
 		DisallowedDrops:      disallowed,
+		Ignored:              ignoredComments,
 		PreSQL:               preSQL,
 		ConcurrentlyPreSQL:   concurrentlyPreSQL,
 		Count:                count,
@@ -176,9 +185,9 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 
 // removeIgnored deletes every entry the ignored predicate matches from the
 // desired map and the same key from the current map, so ignored objects
-// produce no create, alter, or drop. Keys are collected first to avoid
-// mutating the map while ranging.
-func removeIgnored[V any](desired, current *orderedmap.Map[string, V], ignored func(V) bool) {
+// produce no create, alter, or drop. It returns the removed keys (the object
+// FQNs). Keys are collected first to avoid mutating the map while ranging.
+func removeIgnored[V any](desired, current *orderedmap.Map[string, V], ignored func(V) bool) []string {
 	var keys []string
 	for k, v := range desired.All() {
 		if ignored(v) {
@@ -189,6 +198,7 @@ func removeIgnored[V any](desired, current *orderedmap.Map[string, V], ignored f
 		desired.Delete(k)
 		current.Delete(k)
 	}
+	return keys
 }
 
 // clearConcurrentlyDirectives wipes the per-index Concurrently flag on every

--- a/diff_all.go
+++ b/diff_all.go
@@ -80,6 +80,18 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	filteredEnums := options.filterEnums(currentEnums)
 	filteredDomains := options.filterDomains(currentDomains)
 
+	desiredEnums := options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums))
+	desiredDomains := options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains))
+	desiredTables := options.filterTables(client.reverseRemapTableSchemas(desired.Tables))
+	desiredViews := options.filterViews(client.reverseRemapViewSchemas(desired.Views))
+
+	// Objects marked -- pista:ignore are unmanaged: drop them from both the
+	// desired and current sides so no create, alter, or drop is generated.
+	removeIgnored(desiredTables, filteredTables, func(t *model.Table) bool { return t.Ignore })
+	removeIgnored(desiredViews, filteredViews, func(v *model.View) bool { return v.Ignore })
+	removeIgnored(desiredEnums, filteredEnums, func(e *model.Enum) bool { return e.Ignore })
+	removeIgnored(desiredDomains, filteredDomains, func(d *model.Domain) bool { return d.Ignore })
+
 	count := ObjectCount{
 		Schemas: client.Schemas,
 		Tables:  filteredTables.Len(),
@@ -87,11 +99,6 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		Enums:   filteredEnums.Len(),
 		Domains: filteredDomains.Len(),
 	}
-
-	desiredEnums := options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums))
-	desiredDomains := options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains))
-	desiredTables := options.filterTables(client.reverseRemapTableSchemas(desired.Tables))
-	desiredViews := options.filterViews(client.reverseRemapViewSchemas(desired.Views))
 
 	switch {
 	case options.DisableIndexConcurrently:
@@ -165,6 +172,23 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		ExecuteStmts:         desired.ExecuteStmts,
 		HasConcurrentlyIndex: tableDiff.HasConcurrently || viewDiff.HasConcurrently,
 	}, nil
+}
+
+// removeIgnored deletes every entry the ignored predicate matches from the
+// desired map and the same key from the current map, so ignored objects
+// produce no create, alter, or drop. Keys are collected first to avoid
+// mutating the map while ranging.
+func removeIgnored[V any](desired, current *orderedmap.Map[string, V], ignored func(V) bool) {
+	var keys []string
+	for k, v := range desired.All() {
+		if ignored(v) {
+			keys = append(keys, k)
+		}
+	}
+	for _, k := range keys {
+		desired.Delete(k)
+		current.Delete(k)
+	}
 }
 
 // clearConcurrentlyDirectives wipes the per-index Concurrently flag on every

--- a/directives.md
+++ b/directives.md
@@ -100,4 +100,6 @@ CREATE TABLE public.legacy (
 );
 ```
 
+Each ignored object is reported as an `-- ignored: <name>` comment in `plan` and `apply` output.
+
 The directive attaches to a statement written in the schema file, so it can only ignore an object you have declared. To keep an existing object that would otherwise be dropped, write its `CREATE` statement with the directive. Because the object is unmanaged, its column references are not validated at parse time.

--- a/directives.md
+++ b/directives.md
@@ -8,6 +8,7 @@ pistachio reads directives from SQL comments in schema files. A directive is a l
 | `execute` | check SQL (optional) | any statement | Run non-managed SQL during apply |
 | `concurrently` | none | `CREATE INDEX` | Create and drop the index with `CONCURRENTLY` |
 | `bulk-alter` | none | `CREATE TABLE` | Merge the table's `ALTER TABLE` actions into one statement |
+| `ignore` | none | tables, views, enums, domains | Leave the object unmanaged |
 
 ## -- pista:renamed-from
 
@@ -86,3 +87,17 @@ ALTER TABLE public.users
 ```
 
 Foreign keys, `RENAME`, `VALIDATE CONSTRAINT`, RLS toggles, and skipped DROPs stay separate statements. The `--bulk-alter` flag merges every table regardless of directives.
+
+## -- pista:ignore
+
+Marks a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` (including materialized views) as unmanaged. pistachio does not create, alter, or drop the object: it is dropped from both the desired and current state before diffing. This is the in-file equivalent of `--exclude` for a single object, useful for a table managed by another tool or one whose definition intentionally drifts.
+
+```sql
+-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+```
+
+The directive attaches to a statement written in the schema file, so it can only ignore an object you have declared. To keep an existing object that would otherwise be dropped, write its `CREATE` statement with the directive. Because the object is unmanaged, its column references are not validated at parse time.

--- a/model/domain.go
+++ b/model/domain.go
@@ -22,6 +22,10 @@ type Domain struct {
 	Collation   *string
 	Constraints []*DomainConstraint
 	Comment     *string
+	// Ignore marks the domain as unmanaged (set by -- pista:ignore). Ignored
+	// objects are not created, altered, or dropped; always false on the
+	// catalog side.
+	Ignore bool
 }
 
 func (d Domain) FQDN() string {

--- a/model/enum.go
+++ b/model/enum.go
@@ -17,6 +17,10 @@ type Enum struct {
 	// value list; always empty on the catalog side.
 	ValueRenameFrom map[string]string
 	Comment         *string
+	// Ignore marks the enum as unmanaged (set by -- pista:ignore). Ignored
+	// objects are not created, altered, or dropped; always false on the
+	// catalog side.
+	Ignore bool
 }
 
 func (e Enum) FQEN() string {

--- a/model/table.go
+++ b/model/table.go
@@ -8,11 +8,15 @@ import (
 )
 
 type Table struct {
-	OID              uint32
-	Schema           string
-	Name             string
-	RenameFrom       *string
-	BulkAlter        bool
+	OID        uint32
+	Schema     string
+	Name       string
+	RenameFrom *string
+	BulkAlter  bool
+	// Ignore marks the table as unmanaged (set by -- pista:ignore). Ignored
+	// objects are not created, altered, or dropped; always false on the
+	// catalog side.
+	Ignore           bool
 	TableSpace       *string
 	Unlogged         bool
 	Partitioned      bool

--- a/model/view.go
+++ b/model/view.go
@@ -15,6 +15,10 @@ type View struct {
 	Materialized bool
 	Indexes      *orderedmap.Map[string, *Index]
 	Comment      *string
+	// Ignore marks the view as unmanaged (set by -- pista:ignore). Ignored
+	// objects are not created, altered, or dropped; always false on the
+	// catalog side.
+	Ignore bool
 }
 
 func (v View) FQVN() string {

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -18,6 +18,9 @@ var (
 	bulkAlterDirectivePattern   = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:bulk-alter[ \t]*$`)
 	// Matches -- pista:bulk-alter with trailing content (invalid usage).
 	bulkAlterWithArgsPattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:bulk-alter[ \t]+\S`)
+	ignoreDirectivePattern   = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:ignore[ \t]*$`)
+	// Matches -- pista:ignore with trailing content (invalid usage).
+	ignoreWithArgsPattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:ignore[ \t]+\S`)
 	// Matches any -- pista: directive, capturing the name (if any) after the colon.
 	anyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:[ \t]*(\S*)`)
 )
@@ -28,6 +31,7 @@ var knownDirectives = map[string]bool{
 	"execute":      true,
 	"concurrently": true,
 	"bulk-alter":   true,
+	"ignore":       true,
 }
 
 // validateDirectives checks for unknown -- pista: directives in the raw SQL
@@ -50,6 +54,10 @@ func validateDirectives(rawSQL string) error {
 
 	if bulkAlterWithArgsPattern.MatchString(rawSQL) {
 		return fmt.Errorf("-- pista:bulk-alter does not accept arguments")
+	}
+
+	if ignoreWithArgsPattern.MatchString(rawSQL) {
+		return fmt.Errorf("-- pista:ignore does not accept arguments")
 	}
 
 	return nil
@@ -242,6 +250,13 @@ func extractConcurrentlyDirectives(rawSQL string, stmts []*pg_query.RawStmt) map
 // Returns a set of StmtLocations that have the directive.
 func extractBulkAlterDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]bool {
 	return extractFlagDirectives(bulkAlterDirectivePattern, rawSQL, stmts)
+}
+
+// extractIgnoreDirectives scans raw SQL for `-- pista:ignore` comments that
+// appear in each statement's leading comment region.
+// Returns a set of StmtLocations that have the directive.
+func extractIgnoreDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]bool {
+	return extractFlagDirectives(ignoreDirectivePattern, rawSQL, stmts)
 }
 
 // extractFlagDirectives scans raw SQL for argument-less directive comments

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -413,7 +413,14 @@ func TestValidateDirectives_Valid(t *testing.T) {
 	assert.NoError(t, validateDirectives("-- pista:execute"))
 	assert.NoError(t, validateDirectives("-- pista:concurrently"))
 	assert.NoError(t, validateDirectives("-- pista:bulk-alter"))
+	assert.NoError(t, validateDirectives("-- pista:ignore"))
 	assert.NoError(t, validateDirectives("SELECT 1; -- no directives"))
+}
+
+func TestValidateDirectives_IgnoreWithArgs(t *testing.T) {
+	err := validateDirectives("-- pista:ignore extra")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-- pista:ignore does not accept arguments")
 }
 
 func TestValidateDirectives_BulkAlterWithArgs(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -78,6 +78,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	stmtDirectives := extractStmtDirectives(sql, result.Stmts)
 	concurrentlyDirectives := extractConcurrentlyDirectives(sql, result.Stmts)
 	bulkAlterDirectives := extractBulkAlterDirectives(sql, result.Stmts)
+	ignoreDirectives := extractIgnoreDirectives(sql, result.Stmts)
 	executeStmts, executeSkipLocations, err := extractExecuteDirectives(sql, result.Stmts)
 	if err != nil {
 		return nil, err
@@ -91,6 +92,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 
 		node := rawStmt.Stmt
 		renameFrom := stmtDirectives[rawStmt.StmtLocation]
+		ignore := ignoreDirectives[rawStmt.StmtLocation]
 
 		switch {
 		case node.GetCreateEnumStmt() != nil:
@@ -122,6 +124,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				}
 			}
 
+			enum.Ignore = ignore
 			if err := setUnique(enums, enum.FQEN(), "enum", enum); err != nil {
 				return nil, err
 			}
@@ -135,6 +138,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 				domain.RenameFrom = &qualified
 			}
+			domain.Ignore = ignore
 			if err := setUnique(domains, domain.FQDN(), "domain", domain); err != nil {
 				return nil, err
 			}
@@ -175,6 +179,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				}
 			}
 
+			table.Ignore = ignore
 			if err := setUnique(tables, table.FQTN(), "table", table); err != nil {
 				return nil, err
 			}
@@ -188,6 +193,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 				view.RenameFrom = &qualified
 			}
+			view.Ignore = ignore
 			if err := setUnique(views, view.FQVN(), "view", view); err != nil {
 				return nil, err
 			}
@@ -203,6 +209,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 					qualified := qualifyRenameFrom(renameFrom, defaultSchema)
 					view.RenameFrom = &qualified
 				}
+				view.Ignore = ignore
 				if err := setUnique(views, view.FQVN(), "materialized view", view); err != nil {
 					return nil, err
 				}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1538,6 +1538,82 @@ func TestParseSQL_RenameDirective_EnumValue_DanglingIgnored(t *testing.T) {
 	assert.Empty(t, e.ValueRenameFrom)
 }
 
+func TestParseSQL_IgnoreDirective_Table(t *testing.T) {
+	sql := `-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	legacy, ok := result.Tables.GetOk("public.legacy")
+	require.True(t, ok)
+	assert.True(t, legacy.Ignore)
+
+	users, ok := result.Tables.GetOk("public.users")
+	require.True(t, ok)
+	assert.False(t, users.Ignore)
+}
+
+func TestParseSQL_IgnoreDirective_View(t *testing.T) {
+	sql := `-- pista:ignore
+CREATE VIEW public.v AS SELECT 1;`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	v, ok := result.Views.GetOk("public.v")
+	require.True(t, ok)
+	assert.True(t, v.Ignore)
+}
+
+func TestParseSQL_IgnoreDirective_Enum(t *testing.T) {
+	sql := `-- pista:ignore
+CREATE TYPE public.status AS ENUM ('active');`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	e, ok := result.Enums.GetOk("public.status")
+	require.True(t, ok)
+	assert.True(t, e.Ignore)
+}
+
+func TestParseSQL_IgnoreDirective_Domain(t *testing.T) {
+	sql := `-- pista:ignore
+CREATE DOMAIN public.email AS text;`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	d, ok := result.Domains.GetOk("public.email")
+	require.True(t, ok)
+	assert.True(t, d.Ignore)
+}
+
+func TestParseSQL_IgnoreDirective_SkipsColumnRefValidation(t *testing.T) {
+	// An ignored table is unmanaged, so a stale column reference in its own
+	// index must not fail parse-time validation.
+	sql := `-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL
+);
+CREATE INDEX legacy_idx ON public.legacy (nonexistent);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	legacy, ok := result.Tables.GetOk("public.legacy")
+	require.True(t, ok)
+	assert.True(t, legacy.Ignore)
+}
+
 func TestParseSQL_RenameDirective_EnumTypeAndValue(t *testing.T) {
 	// A directive above CREATE TYPE renames the type; directives inside the
 	// value list rename values. Both can be combined.

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -25,6 +25,11 @@ import (
 func validateColumnRefs(tables *orderedmap.Map[string, *model.Table]) error {
 	var errs []error
 	for fqtn, t := range tables.All() {
+		// Ignored tables are unmanaged, so their internal consistency is not
+		// checked.
+		if t.Ignore {
+			continue
+		}
 		// Skip both partition children (PartitionOf + PartitionBound set) and
 		// INHERITS-style children (PartitionOf set, PartitionBound nil); both
 		// inherit their columns from the parent rather than declaring their

--- a/plan.go
+++ b/plan.go
@@ -57,6 +57,7 @@ func pluralize(n int, singular string) string {
 type PlanResult struct {
 	SQL             string
 	DisallowedDrops string
+	Ignored         string
 	Count           ObjectCount
 	// HasChanges is true when the plan contains executable statements
 	// (DDL or execute directives). Suppressed drops do not count.
@@ -115,6 +116,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	return &PlanResult{
 		SQL:             strings.Join(stmts, "\n"),
 		DisallowedDrops: strings.Join(result.DisallowedDrops, "\n"),
+		Ignored:         strings.Join(result.Ignored, "\n"),
 		Count:           result.Count,
 		HasChanges:      hasChanges,
 	}, nil

--- a/plan_test.go
+++ b/plan_test.go
@@ -22,6 +22,7 @@ type planTestCase struct {
 	Count                    *expectedCount  `yaml:"count,omitempty"`
 	DropPolicy               *planDropPolicy `yaml:"drop_policy,omitempty"`
 	DisallowedDrops          string          `yaml:"disallowed_drops,omitempty"`
+	Ignored                  string          `yaml:"ignored,omitempty"`
 	DisableIndexConcurrently bool            `yaml:"disable_index_concurrently,omitempty"`
 	ForceIndexConcurrently   bool            `yaml:"force_index_concurrently,omitempty"`
 	BulkAlter                bool            `yaml:"bulk_alter,omitempty"`
@@ -308,6 +309,7 @@ func TestPlan(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.Plan), strings.TrimSpace(got.SQL))
 			assert.Equal(t, strings.TrimSpace(tc.DisallowedDrops), strings.TrimSpace(got.DisallowedDrops))
+			assert.Equal(t, strings.TrimSpace(tc.Ignored), strings.TrimSpace(got.Ignored))
 			assert.Equal(t, got.SQL != "", got.HasChanges, "HasChanges must match presence of executable SQL")
 			assertExpectedCount(t, tc.Count, got.Count)
 		})

--- a/test/scenario/ignore.test.sh
+++ b/test/scenario/ignore.test.sh
@@ -12,11 +12,14 @@ setup_db "$DATA/init.sql"
 # --- Step 1: ignored table produces no DDL for itself ---
 step "01 ignored table is not altered or dropped"
 plan_output=$(pista_plan "$DATA/steps/01_ignore_legacy.sql") || { fail "plan failed: $plan_output"; true; }
-if echo "$plan_output" | grep -q 'legacy'; then
-  fail "plan must not mention the ignored table"
+if echo "$plan_output" | grep -qE '(ALTER|DROP|CREATE) TABLE .*legacy'; then
+  fail "plan must not emit DDL for the ignored table"
   echo "    $plan_output" >&2
 elif ! echo "$plan_output" | grep -qF 'ADD COLUMN email'; then
   fail "expected the managed table to still diff"
+  echo "    $plan_output" >&2
+elif ! echo "$plan_output" | grep -qF -e '-- ignored: public.legacy'; then
+  fail "expected an -- ignored: comment for the ignored table"
   echo "    $plan_output" >&2
 else
   pass

--- a/test/scenario/ignore.test.sh
+++ b/test/scenario/ignore.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Scenario test: -- pista:ignore directive
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/ignore"
+
+setup_db "$DATA/init.sql"
+
+# --- Step 1: ignored table produces no DDL for itself ---
+step "01 ignored table is not altered or dropped"
+plan_output=$(pista_plan "$DATA/steps/01_ignore_legacy.sql") || { fail "plan failed: $plan_output"; true; }
+if echo "$plan_output" | grep -q 'legacy'; then
+  fail "plan must not mention the ignored table"
+  echo "    $plan_output" >&2
+elif ! echo "$plan_output" | grep -qF 'ADD COLUMN email'; then
+  fail "expected the managed table to still diff"
+  echo "    $plan_output" >&2
+else
+  pass
+fi
+
+# --- Step 2: apply leaves the ignored table intact, drift-free ---
+step "02 apply keeps ignored table's column"
+apply_output=$(pista_apply "$DATA/steps/01_ignore_legacy.sql") || { fail "apply failed: $apply_output"; true; }
+name_col=$(psql -X "$PISTA_CONN_STR" -tAc "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='legacy' AND column_name='name')")
+if [ "$name_col" != "t" ]; then
+  fail "ignored table's 'name' column was dropped"
+else
+  drift=$(pista_plan "$DATA/steps/01_ignore_legacy.sql")
+  if echo "$drift" | grep -qF 'No changes'; then
+    pass
+  else
+    fail "expected no drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+summary

--- a/test/scenario/testdata/ignore/init.sql
+++ b/test/scenario/testdata/ignore/init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/ignore/steps/01_ignore_legacy.sql
+++ b/test/scenario/testdata/ignore/steps/01_ignore_legacy.sql
@@ -1,0 +1,12 @@
+-- legacy is ignored: its dropped "name" column must not be touched, and it
+-- must not be dropped even though the desired body differs.
+-- pista:ignore
+CREATE TABLE public.legacy (
+    id integer NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    email text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/testdata/apply/ignore_table.yml
+++ b/testdata/apply/ignore_table.yml
@@ -1,0 +1,30 @@
+init: |
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:ignore
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied: |
+  -- public.legacy
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+verify_no_drift: true

--- a/testdata/plan/ignore_domain.yml
+++ b/testdata/plan/ignore_domain.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE DOMAIN public.age AS integer NOT NULL;
+desired: |
+  -- pista:ignore
+  CREATE DOMAIN public.age AS integer;
+plan: ""

--- a/testdata/plan/ignore_domain.yml
+++ b/testdata/plan/ignore_domain.yml
@@ -4,3 +4,5 @@ desired: |
   -- pista:ignore
   CREATE DOMAIN public.age AS integer;
 plan: ""
+ignored: |
+  -- ignored: public.age

--- a/testdata/plan/ignore_enum_suppresses_error.yml
+++ b/testdata/plan/ignore_enum_suppresses_error.yml
@@ -4,3 +4,5 @@ desired: |
   -- pista:ignore
   CREATE TYPE public.status AS ENUM ('active');
 plan: ""
+ignored: |
+  -- ignored: public.status

--- a/testdata/plan/ignore_enum_suppresses_error.yml
+++ b/testdata/plan/ignore_enum_suppresses_error.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+desired: |
+  -- pista:ignore
+  CREATE TYPE public.status AS ENUM ('active');
+plan: ""

--- a/testdata/plan/ignore_matview.yml
+++ b/testdata/plan/ignore_matview.yml
@@ -1,0 +1,8 @@
+init: |
+  CREATE MATERIALIZED VIEW public.mv AS SELECT 1 AS a;
+desired: |
+  -- pista:ignore
+  CREATE MATERIALIZED VIEW public.mv AS SELECT 2 AS b;
+plan: ""
+ignored: |
+  -- ignored: public.mv

--- a/testdata/plan/ignore_multiple_sorted.yml
+++ b/testdata/plan/ignore_multiple_sorted.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TYPE public.status AS ENUM ('active', 'inactive');
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:ignore
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+  -- pista:ignore
+  CREATE TYPE public.status AS ENUM ('active');
+plan: ""
+ignored: |
+  -- ignored: public.legacy
+  -- ignored: public.status

--- a/testdata/plan/ignore_table_not_altered.yml
+++ b/testdata/plan/ignore_table_not_altered.yml
@@ -11,3 +11,5 @@ desired: |
       CONSTRAINT legacy_pkey PRIMARY KEY (id)
   );
 plan: ""
+ignored: |
+  -- ignored: public.legacy

--- a/testdata/plan/ignore_table_not_altered.yml
+++ b/testdata/plan/ignore_table_not_altered.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:ignore
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+plan: ""

--- a/testdata/plan/ignore_table_not_created.yml
+++ b/testdata/plan/ignore_table_not_created.yml
@@ -1,0 +1,8 @@
+init: ""
+desired: |
+  -- pista:ignore
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+plan: ""

--- a/testdata/plan/ignore_table_not_created.yml
+++ b/testdata/plan/ignore_table_not_created.yml
@@ -6,3 +6,5 @@ desired: |
       CONSTRAINT legacy_pkey PRIMARY KEY (id)
   );
 plan: ""
+ignored: |
+  -- ignored: public.legacy

--- a/testdata/plan/ignore_table_not_dropped.yml
+++ b/testdata/plan/ignore_table_not_dropped.yml
@@ -22,3 +22,5 @@ plan: |
   ALTER TABLE public.users ADD COLUMN name text;
 count:
   tables: 1
+ignored: |
+  -- ignored: public.legacy

--- a/testdata/plan/ignore_table_not_dropped.yml
+++ b/testdata/plan/ignore_table_not_dropped.yml
@@ -1,0 +1,24 @@
+init: |
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  -- pista:ignore
+  CREATE TABLE public.legacy (
+      id integer NOT NULL,
+      CONSTRAINT legacy_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users ADD COLUMN name text;
+count:
+  tables: 1

--- a/testdata/plan/ignore_view.yml
+++ b/testdata/plan/ignore_view.yml
@@ -4,3 +4,5 @@ desired: |
   -- pista:ignore
   CREATE VIEW public.v AS SELECT 2 AS b;
 plan: ""
+ignored: |
+  -- ignored: public.v

--- a/testdata/plan/ignore_view.yml
+++ b/testdata/plan/ignore_view.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE VIEW public.v AS SELECT 1 AS a;
+desired: |
+  -- pista:ignore
+  CREATE VIEW public.v AS SELECT 2 AS b;
+plan: ""


### PR DESCRIPTION
Add a `-- pista:ignore` directive that leaves an object unmanaged.

## Behavior

Put `-- pista:ignore` before a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` (including materialized views) statement. pistachio then does not create, alter, or drop that object: it is removed from both the desired and current state before diffing, so it is the in-file equivalent of `--exclude` for a single object.

```sql
-- pista:ignore
CREATE TABLE public.legacy (
    id integer NOT NULL,
    CONSTRAINT legacy_pkey PRIMARY KEY (id)
);
```

Each ignored object is reported as an `-- ignored: <name>` comment in `plan` / `apply` output, mirroring the existing `-- skipped:` convention:

```
-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
ALTER TABLE public.users ADD COLUMN email text;
-- ignored: public.legacy
```

An ignore-only plan still prints `-- No changes` (ignores are not changes). The directive takes no arguments, and an ignored table's column references are not validated at parse time.

## Changes

- `model`: `Ignore bool` on Table / View / Enum / Domain.
- `parser`: register the directive, reject arguments, set the flag on the parsed object, and skip ignored tables in column-ref validation.
- `diff_all`: `removeIgnored` drops ignored objects from both sides before the count and returns their FQNs, surfaced as `-- ignored:` comments through `PlanResult.Ignored` / `ApplyResult.Ignored`.
- Docs: README (Ignoring objects), directives.md, CHANGELOG.

## Tests

- Parser: flag on each object type, no-args error, column-ref validation skipped.
- Plan fixtures: not created / not altered / not dropped (with count), enum removal-error suppressed, view, domain, each asserting the `-- ignored:` output.
- Apply fixture: ignored table keeps its column, `verify_no_drift`.
- Scenario test at the CLI level.

Full `go test -p 1 ./...`, scenario suite, lint, and the ASCII check pass. Verified end-to-end that `plan` never mutates the database and output is deterministic against a correct DB state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR)_