### PR TITLE
Open plan and dump connections in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Open the `plan` and `dump` connections in read-only mode (`SET default_transaction_read_only = on`), so those commands cannot write to the database even by accident. `apply` is unchanged and still applies DDL. Pass `--no-read-only` (env `$PISTA_NO_READ_ONLY`) to open a read-write connection instead.
+* Open the `plan` and `dump` connections in read-only mode, so those commands cannot write to the database even by accident. `apply` still applies DDL. Pass `--no-read-only` (env `$PISTA_NO_READ_ONLY`) for a read-write connection.
 
 ## [1.15.0] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Open the `plan` and `dump` connections in read-only mode (`SET default_transaction_read_only = on`), so those commands cannot write to the database even by accident. `apply` is unchanged and still applies DDL.
+
 ## [1.15.0] - 2026-07-13
 
 * Add the `-- pista:ignore` directive. Put it before a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` statement to leave that object unmanaged: pistachio does not create, alter, or drop it. The object is dropped from both the desired and current state before diffing, so it is the in-file equivalent of `--exclude` for a single object. Each ignored object is reported as an `-- ignored: <name>` comment in `plan` / `apply` output. The directive takes no arguments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Open the `plan` and `dump` connections in read-only mode (`SET default_transaction_read_only = on`), so those commands cannot write to the database even by accident. `apply` is unchanged and still applies DDL.
+* Open the `plan` and `dump` connections in read-only mode (`SET default_transaction_read_only = on`), so those commands cannot write to the database even by accident. `apply` is unchanged and still applies DDL. Pass `--no-read-only` (env `$PISTA_NO_READ_ONLY`) to open a read-write connection instead.
 
 ## [1.15.0] - 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ pista plan --check schema.sql
 echo $?  # 0: no changes, 2: changes, 1: error
 ```
 
+`plan` and `dump` open a read-only connection, so they cannot write to the database. Pass `--no-read-only` (env `$PISTA_NO_READ_ONLY`) to use a read-write connection.
+
 ### apply
 
 Apply the diff to the database.

--- a/apply.go
+++ b/apply.go
@@ -48,7 +48,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if err := client.validateSchemas(); err != nil {
 		return nil, err
 	}
-	conn, err := client.connect(ctx)
+	conn, err := client.connect(ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -95,7 +95,10 @@ func (client *Client) ConnInfoComment() (string, error) {
 	return "-- Connected to " + u.String(), nil
 }
 
-func (client *Client) connect(ctx context.Context) (*pgx.Conn, error) {
+// connect opens a database connection. When readOnly is true, the session is
+// set to reject writes, so read-only operations (plan, dump) cannot modify the
+// database even by accident. apply passes false because it applies DDL.
+func (client *Client) connect(ctx context.Context, readOnly bool) (*pgx.Conn, error) {
 	cfg, err := client.buildConnConfig()
 	if err != nil {
 		return nil, err
@@ -106,5 +109,12 @@ func (client *Client) connect(ctx context.Context) (*pgx.Conn, error) {
 		return nil, fmt.Errorf("pistachio: failed to connect database: %w", err)
 	}
 
-	return conn, err
+	if readOnly {
+		if _, err := conn.Exec(ctx, "SET default_transaction_read_only = on"); err != nil {
+			conn.Close(ctx) //nolint:errcheck
+			return nil, fmt.Errorf("pistachio: failed to set read-only mode: %w", err)
+		}
+	}
+
+	return conn, nil
 }

--- a/client.go
+++ b/client.go
@@ -95,25 +95,24 @@ func (client *Client) ConnInfoComment() (string, error) {
 	return "-- Connected to " + u.String(), nil
 }
 
-// connect opens a database connection. When readOnly is true, the session is
-// set to reject writes, so read-only operations (plan, dump) cannot modify the
+// connect opens a database connection. When readOnly is true, the session
+// rejects writes, so read-only operations (plan, dump) cannot modify the
 // database even by accident. apply passes false because it applies DDL.
+// The read-only flag is set as a startup parameter, so it is in effect for the
+// whole connection with no extra round-trip.
 func (client *Client) connect(ctx context.Context, readOnly bool) (*pgx.Conn, error) {
 	cfg, err := client.buildConnConfig()
 	if err != nil {
 		return nil, err
 	}
 
+	if readOnly {
+		cfg.RuntimeParams["default_transaction_read_only"] = "on"
+	}
+
 	conn, err := pgx.ConnectConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("pistachio: failed to connect database: %w", err)
-	}
-
-	if readOnly {
-		if _, err := conn.Exec(ctx, "SET default_transaction_read_only = on"); err != nil {
-			conn.Close(ctx) //nolint:errcheck
-			return nil, fmt.Errorf("pistachio: failed to set read-only mode: %w", err)
-		}
 	}
 
 	return conn, nil

--- a/connect_test.go
+++ b/connect_test.go
@@ -20,9 +20,47 @@ func TestConnect_PropagatesCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := client.connect(ctx)
+	_, err := client.connect(ctx, false)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestConnect_ReadOnly(t *testing.T) {
+	connStr := os.Getenv("TEST_PISTA_CONN_STR")
+	if connStr == "" {
+		connStr = "postgres://postgres@localhost/postgres"
+	}
+	client := NewClient(&Options{ConnString: connStr})
+
+	ctx := context.Background()
+	conn, err := client.connect(ctx, true)
+	require.NoError(t, err)
+	defer conn.Close(ctx) //nolint:errcheck
+
+	var ro string
+	require.NoError(t, conn.QueryRow(ctx, "SHOW default_transaction_read_only").Scan(&ro))
+	assert.Equal(t, "on", ro)
+
+	// A write must be rejected by the read-only transaction.
+	_, err = conn.Exec(ctx, "CREATE TABLE pista_ro_probe (id integer)")
+	require.Error(t, err)
+}
+
+func TestConnect_Writable(t *testing.T) {
+	connStr := os.Getenv("TEST_PISTA_CONN_STR")
+	if connStr == "" {
+		connStr = "postgres://postgres@localhost/postgres"
+	}
+	client := NewClient(&Options{ConnString: connStr})
+
+	ctx := context.Background()
+	conn, err := client.connect(ctx, false)
+	require.NoError(t, err)
+	defer conn.Close(ctx) //nolint:errcheck
+
+	var ro string
+	require.NoError(t, conn.QueryRow(ctx, "SHOW default_transaction_read_only").Scan(&ro))
+	assert.Equal(t, "off", ro)
 }
 
 func TestBuildConnConfig_DbnameOverridesConnString(t *testing.T) {
@@ -174,7 +212,7 @@ func TestConnInfoComment_InvalidConnString(t *testing.T) {
 func TestConnect_InvalidConnStringPropagatesBuildError(t *testing.T) {
 	client := NewClient(&Options{ConnString: "::not-a-valid-conn-string::"})
 
-	_, err := client.connect(context.Background())
+	_, err := client.connect(context.Background(), false)
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "failed to parse connection string"))
 }

--- a/dump.go
+++ b/dump.go
@@ -14,6 +14,7 @@ type DumpOptions struct {
 	FilterOptions
 	Split      string `help:"Output each table/view/enum/domain as a separate file in the specified directory."`
 	OmitSchema bool   `help:"Omit schema name from the dump output."`
+	NoReadOnly bool   `env:"PISTA_NO_READ_ONLY" help:"Open the database connection read-write. By default dump uses a read-only connection."`
 }
 
 type DumpResult struct {
@@ -227,7 +228,7 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 		return nil, fmt.Errorf("--omit-schema cannot be used with multiple schemas")
 	}
 
-	conn, err := client.connect(ctx, true)
+	conn, err := client.connect(ctx, !options.NoReadOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/dump.go
+++ b/dump.go
@@ -227,7 +227,7 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 		return nil, fmt.Errorf("--omit-schema cannot be used with multiple schemas")
 	}
 
-	conn, err := client.connect(ctx)
+	conn, err := client.connect(ctx, true)
 	if err != nil {
 		return nil, err
 	}

--- a/dump_test.go
+++ b/dump_test.go
@@ -134,6 +134,28 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
 	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain", got.Count.Summary())
 }
 
+func TestDump_NoReadOnly(t *testing.T) {
+	// With NoReadOnly the connection is opened read-write. Dump never writes,
+	// so the output is the same; this just exercises the plumbing.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{NoReadOnly: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Count.Tables)
+}
+
 func TestDump_Count_Empty(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/plan.go
+++ b/plan.go
@@ -19,6 +19,7 @@ type PlanOptions struct {
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
+	NoReadOnly               bool     `env:"PISTA_NO_READ_ONLY" help:"Open the database connection read-write. By default plan uses a read-only connection."`
 }
 
 // ObjectCount holds the number of objects inspected by type.
@@ -68,7 +69,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	if err := client.validateSchemas(); err != nil {
 		return nil, err
 	}
-	conn, err := client.connect(ctx, true)
+	conn, err := client.connect(ctx, !options.NoReadOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/plan.go
+++ b/plan.go
@@ -68,7 +68,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	if err := client.validateSchemas(); err != nil {
 		return nil, err
 	}
-	conn, err := client.connect(ctx)
+	conn, err := client.connect(ctx, true)
 	if err != nil {
 		return nil, err
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -111,6 +111,31 @@ func TestPlan_WithPassword(t *testing.T) {
 	assert.Contains(t, got.SQL, "CREATE TABLE public.users")
 }
 
+func TestPlan_NoReadOnly(t *testing.T) {
+	// With NoReadOnly the connection is opened read-write. Plan never writes,
+	// so the output is the same; this just exercises the plumbing.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{NoReadOnly: true, Files: []string{desiredFile}})
+	require.NoError(t, err)
+	assert.Contains(t, got.SQL, "CREATE TABLE public.users")
+}
+
 func TestPlan_InvalidDesiredFile(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)


### PR DESCRIPTION
Make `plan` and `dump` use a read-only database connection so they cannot write, even by accident. `apply` is unchanged and still applies DDL.

## Behavior

- `plan` and `dump` open the connection with `default_transaction_read_only = on`, set as a startup parameter (no extra round-trip). Any write is rejected by PostgreSQL.
- `apply` opens a read-write connection.
- `--no-read-only` (env `$PISTA_NO_READ_ONLY`) opens a read-write connection for `plan` / `dump` when needed.

The setting is session-scoped: it affects only pistachio's own connection, not other connections, and does not change any cluster, database, or role default.

## Changes

- `client.go`: `connect` takes a `readOnly` flag and sets the startup parameter when true.
- `plan.go` / `dump.go`: pass read-only by default; add the `NoReadOnly` option (opt-out, so the zero value keeps read-only on for both the CLI and the library API).
- `apply.go`: passes read-write.
- README, CHANGELOG.

## Tests

- `connect` read-only rejects writes; read-write does not.
- `--no-read-only` plumbing for `plan` and `dump`.
- Full suite passes with plan/dump read-only and apply read-write. Coverage unchanged (connect stays at 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR)_