### PR TITLE
Bump up version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [1.16.0] - 2026-07-13
 
 * Open the `plan` and `dump` connections in read-only mode, so those commands cannot write to the database even by accident. `apply` still applies DDL. Pass `--no-read-only` (env `$PISTA_NO_READ_ONLY`) for a read-write connection.
 


### PR DESCRIPTION
Release 1.16.0. Move the Unreleased CHANGELOG entry to `## [1.16.0] - 2026-07-13`.

- Open the `plan` and `dump` connections in read-only mode, with `--no-read-only` to opt out (#286)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGhirQAJiGDwwbNhQX8WWR)_