### PR TITLE
Rename job from dependabot to auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,7 +6,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  auto-merge:
     runs-on: ubuntu-latest
     if: github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]'
     steps:


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/auto-merge.yml` workflow file, renaming the `dependabot` job to `auto-merge` for clarity.