### PR TITLE
Fix deparse dropping key column named "value" in UNIQUE/PK constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.16.1] - 2026-07-18
+
+* Fix invalid DDL for a single-column `UNIQUE` / `PRIMARY KEY` constraint on a column named `value`. libpg_query dropped the column from the deparsed definition, so `plan` / `apply` produced a broken `ADD CONSTRAINT ... UNIQUE` and reported false drift. The key columns are now restored from the parse tree. ([#291](https://github.com/winebarrel/pistachio/pull/291))
+
 ## [1.16.0] - 2026-07-13
 
 * Open the `plan` and `dump` connections in read-only mode, so those commands cannot write to the database even by accident. `apply` still applies DDL. Pass `--no-read-only` (env `$PISTA_NO_READ_ONLY`) for a read-write connection.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1329,6 +1329,35 @@ func deparseConstraintDef(con *pg_query.Constraint) (string, error) {
 	con.SkipValidation = false
 	defer func() { con.SkipValidation = origSkipValidation }()
 
+	// Work around a libpg_query deparse bug: a single key column named "value"
+	// is dropped from the deparsed column list, even though the parse tree
+	// keeps it. Swap each key column name for a collision-free placeholder that
+	// deparses reliably, then substitute the real identifiers back into the
+	// output. Only UNIQUE/PRIMARY KEY constraints populate Keys, so other
+	// constraint types are unaffected.
+	swapped := make([]*pg_query.String, 0, len(con.Keys))
+	origKeys := make([]string, 0, len(con.Keys))
+	repl := make(map[string]string, len(con.Keys))
+	for i, k := range con.Keys {
+		s := k.GetString_()
+		if s == nil {
+			continue
+		}
+		// The trailing "_e" delimits the index so one placeholder is never a
+		// substring of another (e.g. "..._1_e" vs "..._10_e"), which would
+		// corrupt replacement for constraints with ten or more key columns.
+		placeholder := fmt.Sprintf("pistachio_key_placeholder_%d_e", i)
+		swapped = append(swapped, s)
+		origKeys = append(origKeys, s.Sval)
+		repl[placeholder] = model.Ident(s.Sval)
+		s.Sval = placeholder
+	}
+	defer func() {
+		for i, s := range swapped {
+			s.Sval = origKeys[i]
+		}
+	}()
+
 	alterCmd := &pg_query.AlterTableCmd{
 		Subtype: pg_query.AlterTableType_AT_AddConstraint,
 		Def:     &pg_query.Node{Node: &pg_query.Node_Constraint{Constraint: con}},
@@ -1353,18 +1382,25 @@ func deparseConstraintDef(con *pg_query.Constraint) (string, error) {
 		return "", fmt.Errorf("failed to deparse constraint: %w", err)
 	}
 
+	restorePlaceholders := func(def string) string {
+		for placeholder, ident := range repl {
+			def = strings.ReplaceAll(def, placeholder, ident)
+		}
+		return def
+	}
+
 	if con.Conname != "" {
 		marker := "CONSTRAINT " + model.Ident(con.Conname) + " "
 		idx := strings.Index(sql, marker)
 		if idx != -1 {
-			return strings.TrimSpace(sql[idx+len(marker):]), nil
+			return restorePlaceholders(strings.TrimSpace(sql[idx+len(marker):])), nil
 		}
 	}
 
 	const fallbackMarker = " ADD "
 	idx := strings.LastIndex(sql, fallbackMarker)
 	if idx != -1 {
-		return strings.TrimSpace(sql[idx+len(fallbackMarker):]), nil
+		return restorePlaceholders(strings.TrimSpace(sql[idx+len(fallbackMarker):])), nil
 	}
 
 	return "", fmt.Errorf("could not extract constraint definition from: %s", sql)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1335,6 +1335,9 @@ func deparseConstraintDef(con *pg_query.Constraint) (string, error) {
 	// deparses reliably, then substitute the real identifiers back into the
 	// output. Only UNIQUE/PRIMARY KEY constraints populate Keys, so other
 	// constraint types are unaffected.
+	//
+	// Upstream: https://github.com/pganalyze/pg_query_go/issues/148
+	// Revert this workaround once that bug is fixed.
 	swapped := make([]*pg_query.String, 0, len(con.Keys))
 	origKeys := make([]string, 0, len(con.Keys))
 	repl := make(map[string]string, len(con.Keys))

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -483,6 +483,39 @@ func TestParseSQL_PrimaryKeyOnValueColumn(t *testing.T) {
 	assert.Equal(t, "PRIMARY KEY (value)", con.Definition)
 }
 
+func TestParseSQL_ColumnLevelUniqueOnValueColumn(t *testing.T) {
+	// Column-level UNIQUE fills con.Keys from the column name (parser.go:539),
+	// so it hits the same deparse workaround as a table-level constraint.
+	sql := `CREATE TABLE public.api_keys (
+    id bigint PRIMARY KEY,
+    value text UNIQUE
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.api_keys")
+	require.True(t, ok)
+	con, ok := tbl.Constraints.GetOk("api_keys_value_key")
+	require.True(t, ok)
+	assert.Equal(t, "UNIQUE (value)", con.Definition)
+}
+
+func TestParseSQL_ColumnLevelPrimaryKeyOnValueColumn(t *testing.T) {
+	sql := `CREATE TABLE public.settings (
+    value text PRIMARY KEY
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.settings")
+	require.True(t, ok)
+	con, ok := tbl.Constraints.GetOk("settings_pkey")
+	require.True(t, ok)
+	assert.Equal(t, "PRIMARY KEY (value)", con.Definition)
+}
+
 func TestParseSQL_UniqueConstraintManyKeysWithValue(t *testing.T) {
 	// A composite key with ten or more columns exercises the placeholder
 	// substitution: "..._1_e" must not corrupt "..._10_e". "value" is included

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -446,6 +446,63 @@ func TestParseSQL_ColumnLevelNamedPrimaryKey(t *testing.T) {
 	assert.Contains(t, con.Definition, "PRIMARY KEY")
 }
 
+func TestParseSQL_UniqueConstraintOnValueColumn(t *testing.T) {
+	// A single-column UNIQUE/PRIMARY KEY on a column named "value" trips a
+	// libpg_query deparse bug that drops the column list. The parse tree keeps
+	// the key, so the constraint Definition must still carry "(value)".
+	sql := `CREATE TABLE public.api_keys (
+    id bigint NOT NULL,
+    value text NOT NULL,
+    CONSTRAINT api_keys_pkey PRIMARY KEY (id),
+    CONSTRAINT api_keys_value_key UNIQUE (value)
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.api_keys")
+	require.True(t, ok)
+	con, ok := tbl.Constraints.GetOk("api_keys_value_key")
+	require.True(t, ok)
+	assert.Equal(t, "UNIQUE (value)", con.Definition)
+}
+
+func TestParseSQL_PrimaryKeyOnValueColumn(t *testing.T) {
+	sql := `CREATE TABLE public.settings (
+    value text NOT NULL,
+    CONSTRAINT settings_pkey PRIMARY KEY (value)
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.settings")
+	require.True(t, ok)
+	con, ok := tbl.Constraints.GetOk("settings_pkey")
+	require.True(t, ok)
+	assert.Equal(t, "PRIMARY KEY (value)", con.Definition)
+}
+
+func TestParseSQL_UniqueConstraintManyKeysWithValue(t *testing.T) {
+	// A composite key with ten or more columns exercises the placeholder
+	// substitution: "..._1_e" must not corrupt "..._10_e". "value" is included
+	// so the deparse workaround is engaged.
+	sql := `CREATE TABLE public.wide (
+    c0 int, c1 int, c2 int, c3 int, c4 int, c5 int,
+    c6 int, c7 int, c8 int, c9 int, value int,
+    CONSTRAINT wide_key UNIQUE (c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, value)
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.wide")
+	require.True(t, ok)
+	con, ok := tbl.Constraints.GetOk("wide_key")
+	require.True(t, ok)
+	assert.Equal(t, "UNIQUE (c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, value)", con.Definition)
+}
+
 func TestParseSQL_ColumnLevelMixedConstraints(t *testing.T) {
 	// Multiple named column-level constraints on different columns
 	sql := `CREATE TABLE public.groups (

--- a/testdata/plan/add_unique_value_column.yml
+++ b/testdata/plan/add_unique_value_column.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.api_keys (
+      id bigint NOT NULL,
+      value text NOT NULL,
+      CONSTRAINT api_keys_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.api_keys (
+      id bigint NOT NULL,
+      value text NOT NULL,
+      CONSTRAINT api_keys_pkey PRIMARY KEY (id),
+      CONSTRAINT api_keys_value_key UNIQUE (value)
+  );
+plan: |
+  ALTER TABLE public.api_keys ADD CONSTRAINT api_keys_value_key UNIQUE (value);

--- a/testdata/plan/primary_key_value_column_no_drift.yml
+++ b/testdata/plan/primary_key_value_column_no_drift.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TABLE public.settings (
+      value text NOT NULL,
+      CONSTRAINT settings_pkey PRIMARY KEY (value)
+  );
+desired: |
+  CREATE TABLE public.settings (
+      value text NOT NULL,
+      CONSTRAINT settings_pkey PRIMARY KEY (value)
+  );
+plan: ""

--- a/testdata/plan/unique_value_column_no_drift.yml
+++ b/testdata/plan/unique_value_column_no_drift.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.api_keys (
+      id bigint NOT NULL,
+      value text NOT NULL,
+      CONSTRAINT api_keys_pkey PRIMARY KEY (id),
+      CONSTRAINT api_keys_value_key UNIQUE (value)
+  );
+desired: |
+  CREATE TABLE public.api_keys (
+      id bigint NOT NULL,
+      value text NOT NULL,
+      CONSTRAINT api_keys_pkey PRIMARY KEY (id),
+      CONSTRAINT api_keys_value_key UNIQUE (value)
+  );
+plan: ""


### PR DESCRIPTION
## Problem

libpg_query drops a single key column named `value` from the deparsed
column list of a UNIQUE/PRIMARY KEY constraint, even though the parse
tree keeps it (upstream [pganalyze/pg_query_go#148](https://github.com/pganalyze/pg_query_go/issues/148)).

This produced a broken constraint `Definition` (`UNIQUE` with no columns), causing:

- invalid `CREATE TABLE` / `ALTER TABLE ... ADD CONSTRAINT` DDL that fails on apply with a syntax error, and
- false drift: a table already carrying `UNIQUE (value)` was reported as changed on every `plan`.

```
-- desired schema
CREATE TABLE api_keys (
    id bigint PRIMARY KEY,
    value text NOT NULL,
    CONSTRAINT api_keys_value_unique UNIQUE (value)
);

-- before: pista plan (broken)
ALTER TABLE public.api_keys ADD CONSTRAINT api_keys_value_unique UNIQUE;
--> ERROR: syntax error at or near ";"
```

It affects single-column `UNIQUE`/`PRIMARY KEY` on a column named `value` (table- and column-level). Multi-column keys, other column names, and `pista dump` (which reads `pg_get_constraintdef`) are unaffected.

## Fix

`deparseConstraintDef` now swaps each key column name for a collision-free
placeholder that deparses reliably, then substitutes the real identifiers
back into the output. The parse tree keeps the correct keys, so this
restores the column list without depending on the upstream fix. Only
UNIQUE/PRIMARY KEY constraints populate `Keys`, so other constraint types
are unaffected.

## Tests

- Parser unit tests: `Definition` for `UNIQUE (value)` and `PRIMARY KEY (value)`.
- Regression test for an 11-column composite key including `value`, guarding against placeholder substring collisions (`_1` vs `_10`).
- Plan fixtures: ALTER ADD, UNIQUE no-drift, PK no-drift.

Verified with `make lint` (0 issues), `make vet`, the full test suite, and end-to-end `pista plan`/`apply` across the create, drift, and alter paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)