### PR TITLE
Remove CI integration section from getting-started

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -265,17 +265,6 @@ $$ LANGUAGE plpgsql;
 
 Execute statements appear in `plan` output. During `apply`, the check SQL is evaluated and the statement is skipped if it returns `false`.
 
-## CI integration
-
-Use `--check` to detect drift. It exits with code 2 when the plan contains executable changes, and 0 when there are none:
-
-```bash
-# Fail the build when the database drifts from schema.sql
-pista plan --check schema.sql
-```
-
-The exit code makes this reliable in CI. Connection and other errors still return a non-zero code, so real failures are not hidden.
-
 ## Tips
 
 - Unnamed constraints are auto-named following PostgreSQL's convention, but pistachio does not emulate PostgreSQL's identifier truncation (63 bytes) or collision suffixing, so generated names may differ. Use explicit `CONSTRAINT <name>` clauses to avoid ambiguity.


### PR DESCRIPTION
## Summary

The `CI integration` section in `getting-started.md` (added in #293) only showed a drift check. The README already documents `--check` more fully (exit codes 2/0/1, `$PISTA_CHECK`), so this section duplicates it. Remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsRas2ethPEPKJx6cFGz3i