### PR TITLE
Add declarative management of standalone sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.17.0] - 2026-07-21
+
+* Manage standalone sequences. `plan`, `apply`, and `dump` handle `CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`, `COMMENT ON SEQUENCE`, and rename via `-- pista:renamed-from`. Only standalone sequences are managed. A sequence owned by a `serial` or identity column stays with that column and is excluded from the diff, classified by `pg_depend.deptype`. A sequence referenced by a column default via `nextval` is created before that table and dropped after. `--enable`, `--disable`, `--include`, `--exclude`, and `--allow-drop` accept `sequence`. The `UNLOGGED` attribute is not tracked. ([#296](https://github.com/winebarrel/pistachio/pull/296))
+
 ## [1.16.1] - 2026-07-18
 
 * Fix invalid DDL for a single-column `UNIQUE` / `PRIMARY KEY` constraint on a column named `value`. libpg_query dropped the column from the deparsed definition, so `plan` / `apply` produced a broken `ADD CONSTRAINT ... UNIQUE` and reported false drift. The key columns are now restored from the parse tree. ([#291](https://github.com/winebarrel/pistachio/pull/291))

--- a/README.md
+++ b/README.md
@@ -502,15 +502,16 @@ pista dump --split ./schema/
 
 - Domain types (`CREATE DOMAIN`, `ALTER DOMAIN SET/DROP DEFAULT`, `SET/DROP NOT NULL`, `ADD/DROP CONSTRAINT`)
 - Enum types (`CREATE TYPE ... AS ENUM`, `ALTER TYPE ... ADD VALUE`)
+- Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables)
 - Views
 - Materialized views
 - Columns (serial/bigserial/smallserial, identity, generated)
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
-- Comments (on tables, columns, views, types, domains)
+- Comments (on tables, columns, views, types, domains, sequences)
 - Row-level security (`ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY`, policies via `CREATE POLICY` / `ALTER POLICY` / `DROP POLICY`)
-- Renaming (tables, views, enums, enum values, domains, columns, constraints, foreign keys, indexes, policies via `-- pista:renamed-from` directive)
+- Renaming (tables, views, enums, enum values, domains, sequences, columns, constraints, foreign keys, indexes, policies via `-- pista:renamed-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 

--- a/TODO.md
+++ b/TODO.md
@@ -86,17 +86,6 @@ for in-place changes; using it would avoid the round-trip.
 Origin: post-[#125](https://github.com/winebarrel/pistachio/pull/125) audit. Optimisation rather than a bug; current
 behaviour is correct, just heavier than necessary.
 
-## Standalone Sequences are not first-class
-
-`catalog/sequences.go` reads sequences (used for SERIAL/IDENTITY
-metadata), but parser and diff don't handle `CREATE SEQUENCE` /
-`ALTER SEQUENCE` / `DROP SEQUENCE` as schema operations. Standalone
-sequences in desired SQL therefore round-trip via execute directives
-only. Decide whether sequence is in scope; if yes, add parser/diff
-support; if no, document the limitation.
-
-Origin: post-[#125](https://github.com/winebarrel/pistachio/pull/125) audit.
-
 ## Table rename: cross-table dependents
 
 `detectTableRenames` rewrites the renamed table's own indexes and FKs

--- a/TODO.md
+++ b/TODO.md
@@ -215,3 +215,16 @@ similar name exists in desired") but the heuristic has false positives
 and is not pursued.
 
 Origin: discussion during [#124](https://github.com/winebarrel/pistachio/pull/124). No current plan to implement.
+
+## UNLOGGED sequence support
+
+Standalone sequence management does not track the `UNLOGGED` attribute. An
+`UNLOGGED SEQUENCE` is read and dumped as a plain `CREATE SEQUENCE` (as if
+`LOGGED`), and a `LOGGED` <-> `UNLOGGED` change produces no diff. Closing
+this would follow the existing table pattern: add an `Unlogged` field to
+`model.Sequence`, read `pg_class.relpersistence = 'u'` in the catalog,
+emit `CREATE UNLOGGED SEQUENCE`, and emit `ALTER SEQUENCE ... SET
+LOGGED/UNLOGGED` for transitions. `TEMPORARY` sequences stay out of scope
+(session-local, never dumped).
+
+Origin: [#296](https://github.com/winebarrel/pistachio/pull/296).

--- a/catalog/sequences.go
+++ b/catalog/sequences.go
@@ -5,18 +5,34 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
 )
 
-// Sequences returns all sequences in the filtered schemas.
-//
-// Currently this method has no production callers; sequences are not yet
-// consumed by the diff/apply pipeline. It is intentionally kept as the
-// foundation for future sequence-aware schema management; do not delete
-// it as dead code.
-//
-//deadcode:keep
-func (c *Catalog) Sequences(ctx context.Context) ([]model.Sequence, error) {
+// Sequences returns the standalone sequences in the filtered schemas, keyed by
+// FQN. Sequences owned by a table column (serial or identity) are excluded:
+// they are managed as column attributes, not as standalone objects.
+func (c *Catalog) Sequences(ctx context.Context) (*orderedmap.Map[string, *model.Sequence], error) {
+	seqs, err := c.ListSequences(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	seqByKey := orderedmap.New[string, *model.Sequence]()
+	for _, s := range seqs {
+		if s.Owned() {
+			continue
+		}
+		seqByKey.Set(s.FQN(), s)
+	}
+
+	return seqByKey, nil
+}
+
+// ListSequences returns all sequences in the filtered schemas, including those
+// owned by serial/identity columns. OwnerTable/OwnerColumn identify the owning
+// column (nil for standalone sequences).
+func (c *Catalog) ListSequences(ctx context.Context) ([]*model.Sequence, error) {
 	q := `
 		WITH
 			dependency_extension AS (
@@ -38,8 +54,13 @@ func (c *Catalog) Sequences(ctx context.Context) ([]model.Sequence, error) {
 			s.seqincrement,
 			s.seqcache,
 			s.seqcycle,
+			-- deptype 'a' covers serial columns, 'i' covers identity
+			-- columns. Both mark auto-created sequences owned by a table
+			-- column, so owner_table is non-null only for those; standalone
+			-- CREATE SEQUENCE objects leave it null.
 			d.refobjid::regclass::text AS owner_table,
-			a.attname AS owner_column
+			a.attname AS owner_column,
+			descr.description AS comment
 		FROM
 			pg_catalog.pg_class c
 			JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
@@ -47,9 +68,12 @@ func (c *Catalog) Sequences(ctx context.Context) ([]model.Sequence, error) {
 			LEFT JOIN pg_catalog.pg_depend d ON d.objid = c.oid
 			AND d.classid = 'pg_class'::regclass
 			AND d.refclassid = 'pg_class'::regclass
-			AND d.deptype = 'a'
+			AND d.deptype IN ('a', 'i')
 			LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = d.refobjid
 			AND a.attnum = d.refobjsubid
+			LEFT JOIN pg_catalog.pg_description descr ON descr.objoid = c.oid
+			AND descr.classoid = 'pg_class'::regclass
+			AND descr.objsubid = 0
 			LEFT JOIN dependency_extension de ON de.objid = c.oid
 		WHERE
 			c.relkind = 'S'
@@ -70,7 +94,7 @@ func (c *Catalog) Sequences(ctx context.Context) ([]model.Sequence, error) {
 	}
 	defer rows.Close()
 
-	var seqs []model.Sequence
+	var seqs []*model.Sequence
 	for rows.Next() {
 		var s model.Sequence
 		err := rows.Scan(
@@ -86,11 +110,12 @@ func (c *Catalog) Sequences(ctx context.Context) ([]model.Sequence, error) {
 			&s.Cycle,
 			&s.OwnerTable,
 			&s.OwnerColumn,
+			&s.Comment,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan sequence info: %w", err)
 		}
-		seqs = append(seqs, s)
+		seqs = append(seqs, &s)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/catalog/sequences_test.go
+++ b/catalog/sequences_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/winebarrel/pistachio/internal/testutil"
 )
 
-func TestSequences(t *testing.T) {
+func TestListSequences(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)
@@ -24,12 +24,12 @@ func TestSequences(t *testing.T) {
 		`)
 		cat, err := catalog.NewCatalog(conn, []string{"public"})
 		require.NoError(t, err)
-		seqs, err := cat.Sequences(ctx)
+		seqs, err := cat.ListSequences(ctx)
 		require.NoError(t, err)
 		assert.Empty(t, seqs)
 	})
 
-	t.Run("serial sequence", func(t *testing.T) {
+	t.Run("serial sequence has owner", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE TABLE public.users (
 				id serial NOT NULL,
@@ -38,7 +38,7 @@ func TestSequences(t *testing.T) {
 		`)
 		cat, err := catalog.NewCatalog(conn, []string{"public"})
 		require.NoError(t, err)
-		seqs, err := cat.Sequences(ctx)
+		seqs, err := cat.ListSequences(ctx)
 		require.NoError(t, err)
 		require.Len(t, seqs, 1)
 		assert.Equal(t, "users_id_seq", seqs[0].Name)
@@ -48,17 +48,49 @@ func TestSequences(t *testing.T) {
 		assert.Equal(t, "id", *seqs[0].OwnerColumn)
 	})
 
-	t.Run("standalone sequence", func(t *testing.T) {
+	t.Run("identity sequence has owner", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.users (
+				id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+				CONSTRAINT users_pkey PRIMARY KEY (id)
+			);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		seqs, err := cat.ListSequences(ctx)
+		require.NoError(t, err)
+		require.Len(t, seqs, 1)
+		require.NotNil(t, seqs[0].OwnerTable)
+		assert.Contains(t, *seqs[0].OwnerTable, "users")
+		require.NotNil(t, seqs[0].OwnerColumn)
+		assert.Equal(t, "id", *seqs[0].OwnerColumn)
+	})
+
+	t.Run("standalone sequence has no owner", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE SEQUENCE public.my_seq;
 		`)
 		cat, err := catalog.NewCatalog(conn, []string{"public"})
 		require.NoError(t, err)
-		seqs, err := cat.Sequences(ctx)
+		seqs, err := cat.ListSequences(ctx)
 		require.NoError(t, err)
 		require.Len(t, seqs, 1)
 		assert.Equal(t, "my_seq", seqs[0].Name)
-		assert.Equal(t, "public", seqs[0].Schema)
+		assert.Nil(t, seqs[0].OwnerTable)
+	})
+
+	t.Run("sequence with comment", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE SEQUENCE public.my_seq;
+			COMMENT ON SEQUENCE public.my_seq IS 'id generator';
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		seqs, err := cat.ListSequences(ctx)
+		require.NoError(t, err)
+		require.Len(t, seqs, 1)
+		require.NotNil(t, seqs[0].Comment)
+		assert.Equal(t, "id generator", *seqs[0].Comment)
 	})
 
 	t.Run("sequence with options", func(t *testing.T) {
@@ -73,7 +105,7 @@ func TestSequences(t *testing.T) {
 		`)
 		cat, err := catalog.NewCatalog(conn, []string{"public"})
 		require.NoError(t, err)
-		seqs, err := cat.Sequences(ctx)
+		seqs, err := cat.ListSequences(ctx)
 		require.NoError(t, err)
 		require.Len(t, seqs, 1)
 
@@ -86,4 +118,30 @@ func TestSequences(t *testing.T) {
 		assert.Equal(t, int64(10), seq.Cache)
 		assert.True(t, seq.Cycle)
 	})
+}
+
+// TestSequences verifies the map getter returns only standalone sequences,
+// excluding serial/identity-owned ones.
+func TestSequences(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+		CREATE TABLE public.users (
+			id serial NOT NULL,
+			code integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+			CONSTRAINT users_pkey PRIMARY KEY (id)
+		);
+		CREATE SEQUENCE public.standalone_seq;
+	`)
+	cat, err := catalog.NewCatalog(conn, []string{"public"})
+	require.NoError(t, err)
+	seqs, err := cat.Sequences(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, seqs.Len())
+	seq, ok := seqs.GetOk("public.standalone_seq")
+	require.True(t, ok)
+	assert.Equal(t, "standalone_seq", seq.Name)
+	assert.Nil(t, seq.OwnerTable)
 }

--- a/cmd/command/dump_test.go
+++ b/cmd/command/dump_test.go
@@ -34,7 +34,7 @@ func TestDump_Run(t *testing.T) {
 	cmd := &command.Dump{}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- Dump of schema public (1 table, 0 views, 0 enums, 0 domains)")
+	assert.Contains(t, buf.String(), "-- Dump of schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)")
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
 	assertConnectedCommentFirst(t, buf.String(), conn.Config())
 }
@@ -74,7 +74,7 @@ CREATE TABLE public.posts (
 	assert.Contains(t, string(postsData), "CREATE TABLE public.posts")
 
 	out := buf.String()
-	assert.Contains(t, out, "-- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains)")
+	assert.Contains(t, out, "-- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains, 0 sequences)")
 	assert.Contains(t, out, fmt.Sprintf("-- Wrote 2 file(s) to %s", splitDir))
 	assert.NotContains(t, out, "public.users.sql")
 	assert.NotContains(t, out, "public.posts.sql")
@@ -96,7 +96,7 @@ func TestDump_Run_Empty(t *testing.T) {
 	cmd := &command.Dump{}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains)")
+	assert.Contains(t, buf.String(), "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains, 0 sequences)")
 }
 
 func TestDump_Run_Split_WithView(t *testing.T) {
@@ -153,7 +153,7 @@ func TestDump_Run_Split_Empty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, entries)
 	out := buf.String()
-	assert.Contains(t, out, "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains)")
+	assert.Contains(t, out, "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains, 0 sequences)")
 	assert.Contains(t, out, fmt.Sprintf("-- Wrote 0 file(s) to %s", splitDir))
 }
 

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -53,6 +53,50 @@ func detectEnumRenames(current, desired *orderedmap.Map[string, *model.Enum]) ([
 	return stmts, adjusted, nil
 }
 
+// detectSequenceRenames finds desired sequences with RenameFrom that match a current sequence.
+func detectSequenceRenames(current, desired *orderedmap.Map[string, *model.Sequence]) ([]string, *orderedmap.Map[string, *model.Sequence], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newKey, desiredSeq := range desired.All() {
+		if desiredSeq.RenameFrom == nil {
+			continue
+		}
+		oldKey := *desiredSeq.RenameFrom
+
+		if oldKey == newKey {
+			continue
+		}
+
+		oldSeq, ok := adjusted.GetOk(oldKey)
+		if !ok {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+		}
+
+		if oldKey != newKey {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				return nil, nil, fmt.Errorf("cannot rename %s to %s: destination already exists", oldKey, newKey)
+			}
+		}
+
+		if oldSeq.Schema != desiredSeq.Schema {
+			return nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
+		}
+
+		stmts = append(stmts, "ALTER SEQUENCE "+oldKey+" RENAME TO "+model.Ident(desiredSeq.Name)+";")
+
+		adjusted.Delete(oldKey)
+		renamed := *oldSeq
+		renamed.Name = desiredSeq.Name
+		adjusted.Set(newKey, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}
+
 // detectTableRenames finds desired tables with RenameFrom that match a current table.
 //
 // NOTE: After a table rename, other objects that reference the old table name

--- a/diff/sequences.go
+++ b/diff/sequences.go
@@ -1,0 +1,107 @@
+package diff
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+type SequenceDiffResult struct {
+	Stmts               []string
+	DropStmts           []string
+	DisallowedDropStmts []string
+}
+
+func DiffSequences(current, desired *orderedmap.Map[string, *model.Sequence], dc DropChecker) (*SequenceDiffResult, error) {
+	dc = normalizeDropChecker(dc)
+	result := &SequenceDiffResult{}
+
+	// Detect renames
+	renameStmts, current, err := detectSequenceRenames(current, desired)
+	if err != nil {
+		return nil, err
+	}
+	result.Stmts = append(result.Stmts, renameStmts...)
+
+	// New sequences
+	for k, desiredSeq := range desired.All() {
+		if _, ok := current.GetOk(k); !ok {
+			result.Stmts = append(result.Stmts, desiredSeq.SQL())
+			if commentSQL := desiredSeq.CommentSQL(); commentSQL != "" {
+				result.Stmts = append(result.Stmts, commentSQL)
+			}
+		}
+	}
+
+	// Modified sequences
+	for k, desiredSeq := range desired.All() {
+		currentSeq, ok := current.GetOk(k)
+		if !ok {
+			continue
+		}
+		result.Stmts = append(result.Stmts, diffSequence(k, currentSeq, desiredSeq)...)
+	}
+
+	// Dropped sequences. When the sequence-drop policy disallows it, emit a commented DROP.
+	seqAllowed := dc.IsDropAllowed("sequence")
+	for k := range current.Keys() {
+		if _, ok := desired.GetOk(k); !ok {
+			if seqAllowed {
+				result.DropStmts = append(result.DropStmts, "DROP SEQUENCE "+k+";")
+			} else {
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP SEQUENCE "+k+";")
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// diffSequence emits a single ALTER SEQUENCE combining every changed option,
+// plus a separate COMMENT statement when the comment changed.
+func diffSequence(fqn string, current, desired *model.Sequence) []string {
+	var clauses []string
+
+	if current.DataType != desired.DataType {
+		clauses = append(clauses, "AS "+desired.DataType)
+	}
+	if current.Increment != desired.Increment {
+		clauses = append(clauses, "INCREMENT BY "+strconv.FormatInt(desired.Increment, 10))
+	}
+	if current.Min != desired.Min {
+		clauses = append(clauses, "MINVALUE "+strconv.FormatInt(desired.Min, 10))
+	}
+	if current.Max != desired.Max {
+		clauses = append(clauses, "MAXVALUE "+strconv.FormatInt(desired.Max, 10))
+	}
+	if current.Start != desired.Start {
+		clauses = append(clauses, "START WITH "+strconv.FormatInt(desired.Start, 10))
+	}
+	if current.Cache != desired.Cache {
+		clauses = append(clauses, "CACHE "+strconv.FormatInt(desired.Cache, 10))
+	}
+	if current.Cycle != desired.Cycle {
+		if desired.Cycle {
+			clauses = append(clauses, "CYCLE")
+		} else {
+			clauses = append(clauses, "NO CYCLE")
+		}
+	}
+
+	var stmts []string
+	if len(clauses) > 0 {
+		stmts = append(stmts, "ALTER SEQUENCE "+fqn+" "+strings.Join(clauses, " ")+";")
+	}
+
+	if !equalPtr(current.Comment, desired.Comment) {
+		if desired.Comment != nil {
+			stmts = append(stmts, "COMMENT ON SEQUENCE "+fqn+" IS "+model.QuoteLiteral(*desired.Comment)+";")
+		} else {
+			stmts = append(stmts, "COMMENT ON SEQUENCE "+fqn+" IS NULL;")
+		}
+	}
+
+	return stmts
+}

--- a/diff/sequences_test.go
+++ b/diff/sequences_test.go
@@ -1,0 +1,128 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/diff"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func newSeqMap(seqs ...*model.Sequence) *orderedmap.Map[string, *model.Sequence] {
+	m := orderedmap.New[string, *model.Sequence]()
+	for _, s := range seqs {
+		m.Set(s.FQN(), s)
+	}
+	return m
+}
+
+func baseSeq() *model.Sequence {
+	return &model.Sequence{
+		Schema:    "public",
+		Name:      "s",
+		DataType:  "bigint",
+		Start:     1,
+		Min:       1,
+		Max:       9223372036854775807,
+		Increment: 1,
+		Cache:     1,
+	}
+}
+
+func TestDiffSequences_CreateNew(t *testing.T) {
+	result, err := diff.DiffSequences(newSeqMap(), newSeqMap(baseSeq()), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.Stmts, 1)
+	assert.Contains(t, result.Stmts[0], "CREATE SEQUENCE public.s")
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffSequences_DropExisting(t *testing.T) {
+	result, err := diff.DiffSequences(newSeqMap(baseSeq()), newSeqMap(), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	require.Len(t, result.DropStmts, 1)
+	assert.Equal(t, "DROP SEQUENCE public.s;", result.DropStmts[0])
+}
+
+func TestDiffSequences_DropDenied(t *testing.T) {
+	result, err := diff.DiffSequences(newSeqMap(baseSeq()), newSeqMap(), diff.DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	require.Len(t, result.DisallowedDropStmts, 1)
+	assert.Contains(t, result.DisallowedDropStmts[0], "-- skipped: DROP SEQUENCE public.s;")
+}
+
+func TestDiffSequences_NoDiff(t *testing.T) {
+	result, err := diff.DiffSequences(newSeqMap(baseSeq()), newSeqMap(baseSeq()), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffSequences_AlterOptions(t *testing.T) {
+	desired := baseSeq()
+	desired.Increment = 2
+	desired.Max = 5000
+	desired.Cache = 10
+	desired.Cycle = true
+	result, err := diff.DiffSequences(newSeqMap(baseSeq()), newSeqMap(desired), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.Stmts, 1)
+	assert.Equal(t, "ALTER SEQUENCE public.s INCREMENT BY 2 MAXVALUE 5000 CACHE 10 CYCLE;", result.Stmts[0])
+}
+
+func TestDiffSequences_NoCycle(t *testing.T) {
+	current := baseSeq()
+	current.Cycle = true
+	result, err := diff.DiffSequences(newSeqMap(current), newSeqMap(baseSeq()), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.Stmts, 1)
+	assert.Equal(t, "ALTER SEQUENCE public.s NO CYCLE;", result.Stmts[0])
+}
+
+func TestDiffSequences_AddComment(t *testing.T) {
+	desired := baseSeq()
+	comment := "id generator"
+	desired.Comment = &comment
+	result, err := diff.DiffSequences(newSeqMap(baseSeq()), newSeqMap(desired), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.Stmts, 1)
+	assert.Equal(t, "COMMENT ON SEQUENCE public.s IS 'id generator';", result.Stmts[0])
+}
+
+func TestDiffSequences_RemoveComment(t *testing.T) {
+	current := baseSeq()
+	comment := "id generator"
+	current.Comment = &comment
+	result, err := diff.DiffSequences(newSeqMap(current), newSeqMap(baseSeq()), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.Stmts, 1)
+	assert.Equal(t, "COMMENT ON SEQUENCE public.s IS NULL;", result.Stmts[0])
+}
+
+func TestDiffSequences_Rename(t *testing.T) {
+	current := baseSeq()
+	current.Name = "old"
+	desired := baseSeq()
+	desired.Name = "new"
+	renameFrom := "public.old"
+	desired.RenameFrom = &renameFrom
+	result, err := diff.DiffSequences(newSeqMap(current), newSeqMap(desired), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Stmts)
+	assert.Equal(t, "ALTER SEQUENCE public.old RENAME TO new;", result.Stmts[0])
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffSequences_RenameCrossSchemaError(t *testing.T) {
+	current := &model.Sequence{Schema: "other", Name: "old", DataType: "bigint", Max: 1, Cache: 1, Increment: 1}
+	desired := &model.Sequence{Schema: "public", Name: "new", DataType: "bigint", Max: 1, Cache: 1, Increment: 1}
+	renameFrom := "other.old"
+	desired.RenameFrom = &renameFrom
+	_, err := diff.DiffSequences(newSeqMap(current), newSeqMap(desired), diff.AllowAllDrops{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-schema rename")
+}

--- a/diff/sequences_test.go
+++ b/diff/sequences_test.go
@@ -130,6 +130,22 @@ func TestDiffSequences_Rename(t *testing.T) {
 	assert.Empty(t, result.DropStmts)
 }
 
+func TestDiffSequences_RenameAlreadyApplied(t *testing.T) {
+	// After a rename is applied, re-planning still carries the renamed-from
+	// directive: the source is gone but the destination exists, so the rename
+	// is skipped and no diff is produced (idempotent).
+	current := baseSeq()
+	current.Name = "new"
+	desired := baseSeq()
+	desired.Name = "new"
+	renameFrom := "public.old"
+	desired.RenameFrom = &renameFrom
+	result, err := diff.DiffSequences(newSeqMap(current), newSeqMap(desired), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+}
+
 func TestDiffSequences_RenameCrossSchemaError(t *testing.T) {
 	current := &model.Sequence{Schema: "other", Name: "old", DataType: "bigint", Max: 1, Cache: 1, Increment: 1}
 	desired := &model.Sequence{Schema: "public", Name: "new", DataType: "bigint", Max: 1, Cache: 1, Increment: 1}

--- a/diff/sequences_test.go
+++ b/diff/sequences_test.go
@@ -74,6 +74,19 @@ func TestDiffSequences_AlterOptions(t *testing.T) {
 	assert.Equal(t, "ALTER SEQUENCE public.s INCREMENT BY 2 MAXVALUE 5000 CACHE 10 CYCLE;", result.Stmts[0])
 }
 
+func TestDiffSequences_AlterType(t *testing.T) {
+	current := baseSeq()
+	current.DataType = "smallint"
+	current.Max = 100
+	desired := baseSeq()
+	desired.DataType = "integer"
+	desired.Max = 100
+	result, err := diff.DiffSequences(newSeqMap(current), newSeqMap(desired), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.Stmts, 1)
+	assert.Equal(t, "ALTER SEQUENCE public.s AS integer;", result.Stmts[0])
+}
+
 func TestDiffSequences_NoCycle(t *testing.T) {
 	current := baseSeq()
 	current.Cycle = true

--- a/diff_all.go
+++ b/diff_all.go
@@ -69,6 +69,11 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, fmt.Errorf("failed to fetch domains: %w", err)
 	}
 
+	currentSequences, err := cat.Sequences(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch sequences: %w", err)
+	}
+
 	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SQL file: %w", err)
@@ -80,11 +85,16 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	filteredViews := options.filterViews(currentViews)
 	filteredEnums := options.filterEnums(currentEnums)
 	filteredDomains := options.filterDomains(currentDomains)
+	filteredSequences := options.filterSequences(currentSequences)
 
 	desiredEnums := options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums))
 	desiredDomains := options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains))
 	desiredTables := options.filterTables(client.reverseRemapTableSchemas(desired.Tables))
 	desiredViews := options.filterViews(client.reverseRemapViewSchemas(desired.Views))
+	// Only standalone sequences are managed; sequences a desired CREATE
+	// SEQUENCE ties to a column via OWNED BY are excluded, matching the
+	// catalog side (which already drops serial/identity-owned sequences).
+	desiredSequences := options.filterSequences(standaloneSequences(client.reverseRemapSequenceSchemas(desired.Sequences)))
 
 	// Objects marked -- pista:ignore are unmanaged: drop them from both the
 	// desired and current sides so no create, alter, or drop is generated.
@@ -94,6 +104,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	ignored = append(ignored, removeIgnored(desiredViews, filteredViews, func(v *model.View) bool { return v.Ignore })...)
 	ignored = append(ignored, removeIgnored(desiredEnums, filteredEnums, func(e *model.Enum) bool { return e.Ignore })...)
 	ignored = append(ignored, removeIgnored(desiredDomains, filteredDomains, func(d *model.Domain) bool { return d.Ignore })...)
+	ignored = append(ignored, removeIgnored(desiredSequences, filteredSequences, func(s *model.Sequence) bool { return s.Ignore })...)
 	sort.Strings(ignored)
 	ignoredComments := make([]string, len(ignored))
 	for i, fqn := range ignored {
@@ -101,11 +112,12 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	}
 
 	count := ObjectCount{
-		Schemas: client.Schemas,
-		Tables:  filteredTables.Len(),
-		Views:   filteredViews.Len(),
-		Enums:   filteredEnums.Len(),
-		Domains: filteredDomains.Len(),
+		Schemas:   client.Schemas,
+		Tables:    filteredTables.Len(),
+		Views:     filteredViews.Len(),
+		Enums:     filteredEnums.Len(),
+		Domains:   filteredDomains.Len(),
+		Sequences: filteredSequences.Len(),
 	}
 
 	switch {
@@ -118,6 +130,11 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	enumDiff, err := diff.DiffEnums(filteredEnums, desiredEnums, &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff enums: %w", err)
+	}
+
+	sequenceDiff, err := diff.DiffSequences(filteredSequences, desiredSequences, &options.DropPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff sequences: %w", err)
 	}
 
 	domainDiff, err := diff.DiffDomains(filteredDomains, desiredDomains, &options.DropPolicy)
@@ -150,9 +167,9 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	}
 
 	stmts := orderStatements(
-		filteredEnums, filteredDomains, filteredTables, filteredViews,
-		desiredEnums, desiredDomains, desiredTables, desiredViews,
-		enumDiff, domainDiff, tableDiff, viewDiff,
+		filteredEnums, filteredDomains, filteredTables, filteredViews, filteredSequences,
+		desiredEnums, desiredDomains, desiredTables, desiredViews, desiredSequences,
+		enumDiff, domainDiff, tableDiff, viewDiff, sequenceDiff,
 	)
 
 	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
@@ -170,6 +187,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	disallowed = append(disallowed, tableDiff.DisallowedDropStmts...)
 	disallowed = append(disallowed, domainDiff.DisallowedDropStmts...)
 	disallowed = append(disallowed, enumDiff.DisallowedDropStmts...)
+	disallowed = append(disallowed, sequenceDiff.DisallowedDropStmts...)
 
 	return &diffAllResult{
 		Stmts:                stmts,
@@ -181,6 +199,20 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		ExecuteStmts:         desired.ExecuteStmts,
 		HasConcurrentlyIndex: tableDiff.HasConcurrently || viewDiff.HasConcurrently,
 	}, nil
+}
+
+// standaloneSequences returns only the sequences not owned by a table column.
+// A desired CREATE SEQUENCE with OWNED BY ties the sequence to a column, so it
+// is treated as unmanaged, keeping the desired side symmetric with the catalog
+// side (which already excludes serial/identity-owned sequences).
+func standaloneSequences(sequences *orderedmap.Map[string, *model.Sequence]) *orderedmap.Map[string, *model.Sequence] {
+	out := orderedmap.New[string, *model.Sequence]()
+	for k, s := range sequences.All() {
+		if !s.Owned() {
+			out.Set(k, s)
+		}
+	}
+	return out
 }
 
 // removeIgnored deletes every entry the ignored predicate matches from the
@@ -261,21 +293,24 @@ func orderStatements(
 	currentDomains *orderedmap.Map[string, *model.Domain],
 	currentTables *orderedmap.Map[string, *model.Table],
 	currentViews *orderedmap.Map[string, *model.View],
+	currentSequences *orderedmap.Map[string, *model.Sequence],
 	desiredEnums *orderedmap.Map[string, *model.Enum],
 	desiredDomains *orderedmap.Map[string, *model.Domain],
 	desiredTables *orderedmap.Map[string, *model.Table],
 	desiredViews *orderedmap.Map[string, *model.View],
+	desiredSequences *orderedmap.Map[string, *model.Sequence],
 	enumDiff *diff.EnumDiffResult,
 	domainDiff *diff.DomainDiffResult,
 	tableDiff *diff.TableDiffResult,
 	viewDiff *diff.ViewDiffResult,
+	sequenceDiff *diff.SequenceDiffResult,
 ) []string {
 	// Build topological order from desired schema for creates
-	createOrder, err := toposort.OrderFromSchema(
-		desiredEnums, desiredDomains, desiredTables, desiredViews,
+	createOrder, err := toposort.OrderFromSchemaWithSequences(
+		desiredEnums, desiredDomains, desiredTables, desiredViews, desiredSequences,
 	)
 	if err != nil {
-		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff)
+		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff, sequenceDiff)
 	}
 
 	createPosMap := make(map[string]int, len(createOrder))
@@ -286,11 +321,11 @@ func orderStatements(
 	// Build topological order from current schema for drops.
 	// Dropped objects are not in the desired schema, so we need the current
 	// schema's dependency graph to determine correct drop order.
-	dropOrder, err := toposort.OrderFromSchema(
-		currentEnums, currentDomains, currentTables, currentViews,
+	dropOrder, err := toposort.OrderFromSchemaWithSequences(
+		currentEnums, currentDomains, currentTables, currentViews, currentSequences,
 	)
 	if err != nil {
-		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff)
+		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff, sequenceDiff)
 	}
 
 	dropPosMap := make(map[string]int, len(dropOrder))
@@ -304,6 +339,7 @@ func orderStatements(
 	var createStmts []taggedStmt
 	createStmts = append(createStmts, tagStatements(enumDiff.Stmts, createPosMap)...)
 	createStmts = append(createStmts, tagStatements(domainDiff.Stmts, createPosMap)...)
+	createStmts = append(createStmts, tagStatements(sequenceDiff.Stmts, createPosMap)...)
 	createStmts = append(createStmts, tagStatements(tableDiff.Stmts, createPosMap)...)
 	sort.SliceStable(createStmts, func(i, j int) bool {
 		return compareTaggedPos(createStmts[i].pos, createStmts[j].pos, false)
@@ -324,6 +360,7 @@ func orderStatements(
 	// drops (tables must stop referencing them first).
 	var postDropStmts []taggedStmt
 	postDropStmts = append(postDropStmts, tagStatements(tableDiff.DropStmts, dropPosMap)...)
+	postDropStmts = append(postDropStmts, tagStatements(sequenceDiff.DropStmts, dropPosMap)...)
 	postDropStmts = append(postDropStmts, tagStatements(domainDiff.DropStmts, dropPosMap)...)
 	postDropStmts = append(postDropStmts, tagStatements(enumDiff.DropStmts, dropPosMap)...)
 	sort.SliceStable(postDropStmts, func(i, j int) bool {
@@ -368,14 +405,17 @@ func fallbackOrder(
 	domainDiff *diff.DomainDiffResult,
 	tableDiff *diff.TableDiffResult,
 	viewDiff *diff.ViewDiffResult,
+	sequenceDiff *diff.SequenceDiffResult,
 ) []string {
 	var stmts []string
 	stmts = append(stmts, enumDiff.Stmts...)
 	stmts = append(stmts, domainDiff.Stmts...)
+	stmts = append(stmts, sequenceDiff.Stmts...)
 	stmts = append(stmts, viewDiff.DropStmts...)
 	stmts = append(stmts, tableDiff.FKDropStmts...)
 	stmts = append(stmts, tableDiff.Stmts...)
 	stmts = append(stmts, tableDiff.DropStmts...)
+	stmts = append(stmts, sequenceDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
 	stmts = append(stmts, enumDiff.DropStmts...)
 	stmts = append(stmts, tableDiff.FKAddStmts...)
@@ -460,6 +500,10 @@ func extractObjectName(sql string) string {
 		{"ALTER TABLE "},
 		{"ALTER TYPE "},
 		{"ALTER DOMAIN "},
+		{"ALTER SEQUENCE "},
+		{"CREATE SEQUENCE "},
+		{"DROP SEQUENCE "},
+		{"COMMENT ON SEQUENCE "},
 		{"ALTER MATERIALIZED VIEW "},
 		{"ALTER VIEW "},
 		{"DROP TABLE "},

--- a/diff_all.go
+++ b/diff_all.go
@@ -306,7 +306,7 @@ func orderStatements(
 	sequenceDiff *diff.SequenceDiffResult,
 ) []string {
 	// Build topological order from desired schema for creates
-	createOrder, err := toposort.OrderFromSchemaWithSequences(
+	createOrder, err := toposort.OrderFromSchema(
 		desiredEnums, desiredDomains, desiredTables, desiredViews, desiredSequences,
 	)
 	if err != nil {
@@ -321,7 +321,7 @@ func orderStatements(
 	// Build topological order from current schema for drops.
 	// Dropped objects are not in the desired schema, so we need the current
 	// schema's dependency graph to determine correct drop order.
-	dropOrder, err := toposort.OrderFromSchemaWithSequences(
+	dropOrder, err := toposort.OrderFromSchema(
 		currentEnums, currentDomains, currentTables, currentViews, currentSequences,
 	)
 	if err != nil {

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -117,9 +117,9 @@ func TestOrderStatements_Fallback(t *testing.T) {
 	currentViews := orderedmap.New[string, *model.View]()
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews,
-		desiredEnums, desiredDomains, desiredTables, desiredViews,
-		enumDiff, domainDiff, tableDiff, viewDiff,
+		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	// Should still produce output (via fallback)
@@ -169,9 +169,9 @@ func TestOrderStatements_DropUsesCurrentSchema(t *testing.T) {
 	}
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews,
-		desiredEnums, desiredDomains, desiredTables, desiredViews,
-		enumDiff, domainDiff, tableDiff, viewDiff,
+		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	require.Len(t, result, 2)
@@ -217,9 +217,9 @@ func TestOrderStatements_DropFallbackOnCurrentCycle(t *testing.T) {
 	viewDiff := &diff.ViewDiffResult{}
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews,
-		desiredEnums, desiredDomains, desiredTables, desiredViews,
-		enumDiff, domainDiff, tableDiff, viewDiff,
+		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	// Should still produce output via fallback (not panic or error)
@@ -266,9 +266,9 @@ func TestOrderStatements_UnknownPosBeforeKnown(t *testing.T) {
 	viewDiff := &diff.ViewDiffResult{}
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews,
-		desiredEnums, desiredDomains, desiredTables, desiredViews,
-		enumDiff, domainDiff, tableDiff, viewDiff,
+		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	require.Len(t, result, 2)
@@ -310,9 +310,9 @@ func TestOrderStatements_CreateUniqueIndexAfterTable(t *testing.T) {
 	viewDiff := &diff.ViewDiffResult{}
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews,
-		desiredEnums, desiredDomains, desiredTables, desiredViews,
-		enumDiff, domainDiff, tableDiff, viewDiff,
+		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	require.Len(t, result, 2)

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -7,7 +7,7 @@ import "slices"
 // If AllowDrop contains "all", all drops are allowed.
 // Otherwise, only the listed object types are allowed to be dropped.
 type DropPolicy struct {
-	AllowDrop []string `enum:"all,table,view,enum,domain,column,constraint,foreign_key,index,policy" env:"PISTA_ALLOW_DROP" help:"Allow dropping these object types (repeatable; 'all' allows everything)."`
+	AllowDrop []string `enum:"all,table,view,enum,domain,sequence,column,constraint,foreign_key,index,policy" env:"PISTA_ALLOW_DROP" help:"Allow dropping these object types (repeatable; 'all' allows everything)."`
 }
 
 func (p *DropPolicy) IsDropAllowed(objectType string) bool {

--- a/dump.go
+++ b/dump.go
@@ -12,7 +12,7 @@ import (
 
 type DumpOptions struct {
 	FilterOptions
-	Split      string `help:"Output each table/view/enum/domain as a separate file in the specified directory."`
+	Split      string `help:"Output each table/view/enum/domain/sequence as a separate file in the specified directory."`
 	OmitSchema bool   `help:"Omit schema name from the dump output."`
 	NoReadOnly bool   `env:"PISTA_NO_READ_ONLY" help:"Open the database connection read-write. By default dump uses a read-only connection."`
 }
@@ -22,6 +22,7 @@ type DumpResult struct {
 	Views      *orderedmap.Map[string, *model.View]
 	Enums      *orderedmap.Map[string, *model.Enum]
 	Domains    *orderedmap.Map[string, *model.Domain]
+	Sequences  *orderedmap.Map[string, *model.Sequence]
 	OmitSchema bool
 	Count      ObjectCount
 }
@@ -138,16 +139,35 @@ func (r *DumpResult) domains() *orderedmap.Map[string, *model.Domain] {
 	return domains
 }
 
-func (r *DumpResult) String() string {
-	return formatSchemaSQL(r.enums(), r.domains(), r.tables(), r.views())
+func (r *DumpResult) sequences() *orderedmap.Map[string, *model.Sequence] {
+	if r.Sequences == nil {
+		return orderedmap.New[string, *model.Sequence]()
+	}
+	if !r.OmitSchema {
+		return r.Sequences
+	}
+	sequences := orderedmap.New[string, *model.Sequence]()
+	for _, s := range r.Sequences.CollectValues() {
+		copied := *s
+		copied.Schema = ""
+		sequences.Set(model.Ident(s.Name), &copied)
+	}
+	return sequences
 }
 
-// formatSchemaSQL formats enums, domains, tables, and views into canonical SQL
-// output for dump.
-// Order: enums -> domains -> tables -> views (enums first since domains may depend on them).
+func (r *DumpResult) String() string {
+	return formatSchemaSQL(r.enums(), r.domains(), r.sequences(), r.tables(), r.views())
+}
+
+// formatSchemaSQL formats enums, domains, sequences, tables, and views into
+// canonical SQL output for dump.
+// Order: enums -> domains -> sequences -> tables -> views (enums/domains first
+// since domains may depend on enums; sequences before tables since column
+// defaults may reference them).
 func formatSchemaSQL(
 	enums *orderedmap.Map[string, *model.Enum],
 	domains *orderedmap.Map[string, *model.Domain],
+	sequences *orderedmap.Map[string, *model.Sequence],
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
 ) string {
@@ -157,6 +177,9 @@ func formatSchemaSQL(
 	}
 	if domains != nil && domains.Len() > 0 {
 		parts = append(parts, model.DomainsToSQL(domains))
+	}
+	if sequences != nil && sequences.Len() > 0 {
+		parts = append(parts, model.SequencesToSQL(sequences))
 	}
 	if tables != nil && tables.Len() > 0 {
 		parts = append(parts, model.TablesToSQL(tables))
@@ -178,6 +201,11 @@ func (r *DumpResult) Files() map[string]string {
 	for _, d := range r.domains().CollectValues() {
 		name := uniqueFileName(seen, toFileName(d.Schema, d.Name))
 		files[name] = model.DomainToSQL(d) + "\n"
+		seen[strings.ToLower(name)] = true
+	}
+	for _, s := range r.sequences().CollectValues() {
+		name := uniqueFileName(seen, toFileName(s.Schema, s.Name))
+		files[name] = model.SequenceToSQL(s) + "\n"
 		seen[strings.ToLower(name)] = true
 	}
 	for _, t := range r.tables().CollectValues() {
@@ -259,23 +287,31 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 		return nil, fmt.Errorf("failed to fetch domains: %w", err)
 	}
 
+	sequences, err := catalog.Sequences(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch sequences: %w", err)
+	}
+
 	filteredTables := options.filterTables(client.remapTableSchemas(tables))
 	filteredViews := options.filterViews(client.remapViewSchemas(views))
 	filteredEnums := options.filterEnums(client.remapEnumSchemas(enums))
 	filteredDomains := options.filterDomains(client.remapDomainSchemas(domains))
+	filteredSequences := options.filterSequences(client.remapSequenceSchemas(sequences))
 
 	return &DumpResult{
 		Tables:     filteredTables,
 		Views:      filteredViews,
 		Enums:      filteredEnums,
 		Domains:    filteredDomains,
+		Sequences:  filteredSequences,
 		OmitSchema: options.OmitSchema,
 		Count: ObjectCount{
-			Schemas: client.Schemas,
-			Tables:  filteredTables.Len(),
-			Views:   filteredViews.Len(),
-			Enums:   filteredEnums.Len(),
-			Domains: filteredDomains.Len(),
+			Schemas:   client.Schemas,
+			Tables:    filteredTables.Len(),
+			Views:     filteredViews.Len(),
+			Enums:     filteredEnums.Len(),
+			Domains:   filteredDomains.Len(),
+			Sequences: filteredSequences.Len(),
 		},
 	}, nil
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -130,8 +130,9 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
 	assert.Equal(t, 1, got.Count.Views)
 	assert.Equal(t, 1, got.Count.Enums)
 	assert.Equal(t, 1, got.Count.Domains)
+	assert.Equal(t, 0, got.Count.Sequences)
 	assert.Equal(t, "schema public", got.Count.SchemaLabel())
-	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain", got.Count.Summary())
+	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain, 0 sequences", got.Count.Summary())
 }
 
 func TestDump_NoReadOnly(t *testing.T) {
@@ -174,7 +175,7 @@ func TestDump_Count_Empty(t *testing.T) {
 	assert.Equal(t, 0, got.Count.Views)
 	assert.Equal(t, 0, got.Count.Enums)
 	assert.Equal(t, 0, got.Count.Domains)
-	assert.Equal(t, "0 tables, 0 views, 0 enums, 0 domains", got.Count.Summary())
+	assert.Equal(t, "0 tables, 0 views, 0 enums, 0 domains, 0 sequences", got.Count.Summary())
 }
 
 func TestDump_Count_Filtered(t *testing.T) {
@@ -202,7 +203,7 @@ CREATE TABLE public.posts (
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, got.Count.Tables)
-	assert.Equal(t, "1 table, 0 views, 0 enums, 0 domains", got.Count.Summary())
+	assert.Equal(t, "1 table, 0 views, 0 enums, 0 domains, 0 sequences", got.Count.Summary())
 }
 
 func TestDumpResult_Files_Tables(t *testing.T) {

--- a/filter.go
+++ b/filter.go
@@ -56,6 +56,23 @@ func (f *FilterOptions) filterEnums(enums *orderedmap.Map[string, *model.Enum]) 
 	return filtered
 }
 
+func (f *FilterOptions) filterSequences(sequences *orderedmap.Map[string, *model.Sequence]) *orderedmap.Map[string, *model.Sequence] {
+	if !f.IsTypeEnabled("sequence") {
+		return orderedmap.New[string, *model.Sequence]()
+	}
+	if len(f.Include) == 0 && len(f.Exclude) == 0 {
+		return sequences
+	}
+
+	filtered := orderedmap.New[string, *model.Sequence]()
+	for k, s := range sequences.All() {
+		if f.MatchName(s.Name) {
+			filtered.Set(k, s)
+		}
+	}
+	return filtered
+}
+
 func (f *FilterOptions) filterDomains(domains *orderedmap.Map[string, *model.Domain]) *orderedmap.Map[string, *model.Domain] {
 	if !f.IsTypeEnabled("domain") {
 		return orderedmap.New[string, *model.Domain]()

--- a/model/sequence.go
+++ b/model/sequence.go
@@ -1,30 +1,92 @@
 package model
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
 
-// Sequence holds metadata for a PostgreSQL sequence. It is currently
-// populated only by catalog.Catalog.Sequences and not yet consumed by the
-// diff/apply pipeline; it is intentionally kept for future sequence-aware
-// schema management and should not be deleted as dead code.
+	"github.com/winebarrel/orderedmap"
+)
+
+// Sequence holds metadata for a standalone PostgreSQL sequence (one created by
+// CREATE SEQUENCE, not the sequence auto-generated behind a serial or identity
+// column). Sequences owned by a table column are handled as column attributes
+// and are excluded from the sequence diff pipeline.
 type Sequence struct {
-	OID         uint32
-	Schema      string
-	Name        string
-	DataType    string
-	Start       int64
-	Min         int64
-	Max         int64
-	Increment   int64
-	Cache       int64
-	Cycle       bool
+	OID       uint32
+	Schema    string
+	Name      string
+	DataType  string
+	Start     int64
+	Min       int64
+	Max       int64
+	Increment int64
+	Cache     int64
+	Cycle     bool
+	// OwnerTable and OwnerColumn are set from the OWNED BY relationship
+	// (pg_depend deptype 'a' for serial, 'i' for identity). They are nil for
+	// standalone sequences, which are the only ones the pipeline manages.
 	OwnerTable  *string
 	OwnerColumn *string
+	RenameFrom  *string
+	Comment     *string
+	// Ignore marks the sequence as unmanaged (set by -- pista:ignore). Ignored
+	// objects are not created, altered, or dropped; always false on the catalog
+	// side.
+	Ignore bool
 }
 
-// String returns a debug-friendly representation. Kept alongside Sequence as
-// part of the future sequence-aware schema management foundation.
-//
-//deadcode:keep
-func (seq *Sequence) String() string {
-	return fmt.Sprintf("%#v", *seq)
+func (seq Sequence) FQN() string {
+	return Ident(seq.Schema, seq.Name)
+}
+
+// Owned reports whether the sequence is owned by a table column (serial or
+// identity). Owned sequences are not managed as standalone objects.
+func (seq Sequence) Owned() bool {
+	return seq.OwnerTable != nil
+}
+
+func (seq Sequence) SQL() string {
+	lines := []string{
+		"CREATE SEQUENCE " + seq.FQN(),
+		"    AS " + seq.DataType,
+		"    START WITH " + strconv.FormatInt(seq.Start, 10),
+		"    INCREMENT BY " + strconv.FormatInt(seq.Increment, 10),
+		"    MINVALUE " + strconv.FormatInt(seq.Min, 10),
+		"    MAXVALUE " + strconv.FormatInt(seq.Max, 10),
+		"    CACHE " + strconv.FormatInt(seq.Cache, 10),
+	}
+	if seq.Cycle {
+		lines = append(lines, "    CYCLE")
+	}
+	return strings.Join(lines, "\n") + ";"
+}
+
+func (seq Sequence) CommentSQL() string {
+	if seq.Comment != nil {
+		return "COMMENT ON SEQUENCE " + seq.FQN() + " IS " + QuoteLiteral(*seq.Comment) + ";"
+	}
+	return ""
+}
+
+// String returns a debug-friendly representation.
+func (seq Sequence) String() string {
+	return fmt.Sprintf("%#v", seq)
+}
+
+func SequenceToSQL(seq *Sequence) string {
+	parts := []string{"-- " + seq.FQN(), seq.SQL()}
+	if s := seq.CommentSQL(); s != "" {
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func SequencesToSQL(sequences *orderedmap.Map[string, *Sequence]) string {
+	return strings.Join(
+		orderedmap.TransformSlice(sequences, func(_ string, seq *Sequence) string {
+			return SequenceToSQL(seq)
+		}),
+		"\n\n",
+	)
 }

--- a/model/sequence_test.go
+++ b/model/sequence_test.go
@@ -4,11 +4,79 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
 )
 
+func sampleSequence() *model.Sequence {
+	return &model.Sequence{
+		Schema:    "public",
+		Name:      "order_seq",
+		DataType:  "bigint",
+		Start:     1,
+		Min:       1,
+		Max:       9223372036854775807,
+		Increment: 1,
+		Cache:     1,
+	}
+}
+
+func TestSequence_FQN(t *testing.T) {
+	assert.Equal(t, "public.order_seq", sampleSequence().FQN())
+}
+
+func TestSequence_Owned(t *testing.T) {
+	seq := sampleSequence()
+	assert.False(t, seq.Owned())
+	owner := "public.users"
+	seq.OwnerTable = &owner
+	assert.True(t, seq.Owned())
+}
+
+func TestSequence_SQL(t *testing.T) {
+	assert.Equal(t, `CREATE SEQUENCE public.order_seq
+    AS bigint
+    START WITH 1
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    CACHE 1;`, sampleSequence().SQL())
+}
+
+func TestSequence_SQL_Cycle(t *testing.T) {
+	seq := sampleSequence()
+	seq.Cycle = true
+	assert.Contains(t, seq.SQL(), "\n    CYCLE;")
+}
+
+func TestSequence_CommentSQL(t *testing.T) {
+	seq := sampleSequence()
+	assert.Empty(t, seq.CommentSQL())
+	comment := "id generator"
+	seq.Comment = &comment
+	assert.Equal(t, "COMMENT ON SEQUENCE public.order_seq IS 'id generator';", seq.CommentSQL())
+}
+
+func TestSequenceToSQL_WithComment(t *testing.T) {
+	seq := sampleSequence()
+	comment := "id generator"
+	seq.Comment = &comment
+	sql := model.SequenceToSQL(seq)
+	assert.Contains(t, sql, "-- public.order_seq")
+	assert.Contains(t, sql, "CREATE SEQUENCE public.order_seq")
+	assert.Contains(t, sql, "COMMENT ON SEQUENCE public.order_seq IS 'id generator';")
+}
+
+func TestSequencesToSQL(t *testing.T) {
+	m := orderedmap.New[string, *model.Sequence]()
+	m.Set("public.a_seq", &model.Sequence{Schema: "public", Name: "a_seq", DataType: "bigint", Max: 1, Cache: 1, Increment: 1})
+	m.Set("public.b_seq", &model.Sequence{Schema: "public", Name: "b_seq", DataType: "bigint", Max: 1, Cache: 1, Increment: 1})
+	sql := model.SequencesToSQL(m)
+	assert.Contains(t, sql, "public.a_seq")
+	assert.Contains(t, sql, "public.b_seq")
+}
+
 func TestSequence_String(t *testing.T) {
 	seq := &model.Sequence{Schema: "public", Name: "users_id_seq", DataType: "bigint"}
-	s := seq.String()
-	assert.Contains(t, s, "users_id_seq")
+	assert.Contains(t, seq.String(), "users_id_seq")
 }

--- a/options.go
+++ b/options.go
@@ -15,10 +15,10 @@ type Options struct {
 }
 
 type FilterOptions struct {
-	Include []string `short:"I" env:"PISTA_INCLUDE" help:"Include only tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
-	Exclude []string `short:"E" env:"PISTA_EXCLUDE" help:"Exclude tables/views/enums/domains matching the pattern (wildcard: *, ?)."`
-	Enable  []string `enum:"table,view,enum,domain" env:"PISTA_ENABLE" help:"Enable only specified object types (can be repeated)."`
-	Disable []string `enum:"table,view,enum,domain" env:"PISTA_DISABLE" help:"Disable specified object types (can be repeated)."`
+	Include []string `short:"I" env:"PISTA_INCLUDE" help:"Include only tables/views/enums/domains/sequences matching the pattern (wildcard: *, ?)."`
+	Exclude []string `short:"E" env:"PISTA_EXCLUDE" help:"Exclude tables/views/enums/domains/sequences matching the pattern (wildcard: *, ?)."`
+	Enable  []string `enum:"table,view,enum,domain,sequence" env:"PISTA_ENABLE" help:"Enable only specified object types (can be repeated)."`
+	Disable []string `enum:"table,view,enum,domain,sequence" env:"PISTA_DISABLE" help:"Disable specified object types (can be repeated)."`
 }
 
 // IsTypeEnabled returns true if the given object type should be included.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
@@ -16,6 +17,7 @@ type ParseResult struct {
 	Views        *orderedmap.Map[string, *model.View]
 	Enums        *orderedmap.Map[string, *model.Enum]
 	Domains      *orderedmap.Map[string, *model.Domain]
+	Sequences    *orderedmap.Map[string, *model.Sequence]
 	ExecuteStmts []*ExecuteStmt
 }
 
@@ -74,6 +76,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	views := orderedmap.New[string, *model.View]()
 	enums := orderedmap.New[string, *model.Enum]()
 	domains := orderedmap.New[string, *model.Domain]()
+	sequences := orderedmap.New[string, *model.Sequence]()
 
 	stmtDirectives := extractStmtDirectives(sql, result.Stmts)
 	concurrentlyDirectives := extractConcurrentlyDirectives(sql, result.Stmts)
@@ -288,9 +291,23 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				policy.RenameFrom = &unquoted
 			}
 
+		case node.GetCreateSeqStmt() != nil:
+			seq, err := parseCreateSeqStmt(node.GetCreateSeqStmt(), defaultSchema)
+			if err != nil {
+				return nil, err
+			}
+			if renameFrom != "" {
+				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
+				seq.RenameFrom = &qualified
+			}
+			seq.Ignore = ignore
+			if err := setUnique(sequences, seq.FQN(), "sequence", seq); err != nil {
+				return nil, err
+			}
+
 		case node.GetCommentStmt() != nil:
 			cs := node.GetCommentStmt()
-			parseCommentStmt(cs, defaultSchema, tables, views, enums, domains)
+			parseCommentStmt(cs, defaultSchema, tables, views, enums, domains, sequences)
 		}
 	}
 
@@ -298,7 +315,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		return nil, err
 	}
 
-	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains, ExecuteStmts: executeStmts}, nil
+	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains, Sequences: sequences, ExecuteStmts: executeStmts}, nil
 }
 
 func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Table, error) {
@@ -917,7 +934,193 @@ func parseCreateEnumStmt(es *pg_query.CreateEnumStmt, defaultSchema string) (*mo
 	}, nil
 }
 
-func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View], enums *orderedmap.Map[string, *model.Enum], domains *orderedmap.Map[string, *model.Domain]) {
+// parseCreateSeqStmt parses a CREATE SEQUENCE statement, filling in the same
+// implicit defaults PostgreSQL applies (so a bare "CREATE SEQUENCE s" matches
+// the catalog values 1/1/2^63-1/1/1/false). NO MINVALUE and NO MAXVALUE (arg
+// nil) are treated as "use the default", matching PostgreSQL.
+func parseCreateSeqStmt(cs *pg_query.CreateSeqStmt, defaultSchema string) (*model.Sequence, error) {
+	schema := cs.Sequence.Schemaname
+	if schema == "" {
+		schema = defaultSchema
+	}
+
+	dataType := "bigint"
+	var (
+		increment                int64 = 1
+		hasMin, hasMax, hasStart bool
+		minVal, maxVal, startVal int64
+		cacheVal                 int64 = 1
+		cycle                    bool
+		ownerTable, ownerColumn  *string
+	)
+
+	for _, o := range cs.Options {
+		de := o.GetDefElem()
+		if de == nil {
+			continue
+		}
+		switch de.Defname {
+		case "as":
+			if tn := de.Arg.GetTypeName(); tn != nil {
+				dt, err := deparseTypeName(tn)
+				if err != nil {
+					return nil, fmt.Errorf("failed to deparse sequence data type: %w", err)
+				}
+				dataType = dt
+			}
+		case "increment":
+			v, ok, err := defElemInt64(de)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				increment = v
+			}
+		case "minvalue":
+			v, ok, err := defElemInt64(de)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				minVal = v
+				hasMin = true
+			}
+		case "maxvalue":
+			v, ok, err := defElemInt64(de)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				maxVal = v
+				hasMax = true
+			}
+		case "start":
+			v, ok, err := defElemInt64(de)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				startVal = v
+				hasStart = true
+			}
+		case "cache":
+			v, ok, err := defElemInt64(de)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				cacheVal = v
+			}
+		case "cycle":
+			if b := de.Arg.GetBoolean(); b != nil {
+				cycle = b.Boolval
+			}
+		case "owned_by":
+			ownerTable, ownerColumn = parseSeqOwnedBy(de.Arg)
+		}
+	}
+
+	// Apply PostgreSQL's defaults for any options left unspecified.
+	typeMin, typeMax := seqTypeBounds(dataType)
+	ascending := increment > 0
+	if !hasMin {
+		if ascending {
+			minVal = 1
+		} else {
+			minVal = typeMin
+		}
+	}
+	if !hasMax {
+		if ascending {
+			maxVal = typeMax
+		} else {
+			maxVal = -1
+		}
+	}
+	if !hasStart {
+		if ascending {
+			startVal = minVal
+		} else {
+			startVal = maxVal
+		}
+	}
+
+	return &model.Sequence{
+		Schema:      schema,
+		Name:        cs.Sequence.Relname,
+		DataType:    dataType,
+		Start:       startVal,
+		Min:         minVal,
+		Max:         maxVal,
+		Increment:   increment,
+		Cache:       cacheVal,
+		Cycle:       cycle,
+		OwnerTable:  ownerTable,
+		OwnerColumn: ownerColumn,
+	}, nil
+}
+
+// seqTypeBounds returns the min and max values of a sequence data type.
+// Unknown types fall back to bigint bounds.
+func seqTypeBounds(dataType string) (int64, int64) {
+	switch dataType {
+	case "smallint":
+		return -32768, 32767
+	case "integer":
+		return -2147483648, 2147483647
+	default: // bigint
+		return -9223372036854775808, 9223372036854775807
+	}
+}
+
+// defElemInt64 reads an integer sequence option. pg_query encodes values that
+// fit in int32 as Integer nodes and larger values (e.g. bigint bounds) as
+// Float nodes carrying the decimal string. Returns ok=false when the arg is
+// nil (NO MINVALUE / NO MAXVALUE).
+func defElemInt64(de *pg_query.DefElem) (int64, bool, error) {
+	if de.Arg == nil {
+		return 0, false, nil
+	}
+	if i := de.Arg.GetInteger(); i != nil {
+		return int64(i.Ival), true, nil
+	}
+	if f := de.Arg.GetFloat(); f != nil {
+		v, err := strconv.ParseInt(f.Fval, 10, 64)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid value %q for sequence option %s: %w", f.Fval, de.Defname, err)
+		}
+		return v, true, nil
+	}
+	return 0, false, fmt.Errorf("unexpected value for sequence option %s", de.Defname)
+}
+
+// parseSeqOwnedBy extracts the owner table and column from an OWNED BY clause.
+// OWNED BY NONE (list ["none"]) yields nil owner. The pipeline only manages
+// standalone sequences, so an owned sequence is filtered out downstream; the
+// values here just mark it as owned.
+func parseSeqOwnedBy(arg *pg_query.Node) (*string, *string) {
+	list := arg.GetList()
+	if list == nil {
+		return nil, nil
+	}
+	var names []string
+	for _, item := range list.Items {
+		if s := item.GetString_(); s != nil {
+			names = append(names, s.Sval)
+		}
+	}
+	if len(names) == 1 && strings.EqualFold(names[0], "none") {
+		return nil, nil
+	}
+	if len(names) < 2 {
+		return nil, nil
+	}
+	table := names[len(names)-2]
+	column := names[len(names)-1]
+	return &table, &column
+}
+
+func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View], enums *orderedmap.Map[string, *model.Enum], domains *orderedmap.Map[string, *model.Domain], sequences *orderedmap.Map[string, *model.Sequence]) {
 	// COMMENT ON TYPE/DOMAIN uses TypeName, not a list
 	if cs.Objtype == pg_query.ObjectType_OBJECT_TYPE {
 		parseCommentOnType(cs, defaultSchema, enums)
@@ -994,6 +1197,22 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 				} else {
 					col.Comment = nil
 				}
+			}
+		}
+	case pg_query.ObjectType_OBJECT_SEQUENCE:
+		schema := defaultSchema
+		seqName := names[0]
+		if len(names) >= 2 {
+			schema = names[0]
+			seqName = names[1]
+		}
+		fqn := model.Ident(schema, seqName)
+		if seq, ok := sequences.GetOk(fqn); ok {
+			if cs.Comment != "" {
+				c := cs.Comment
+				seq.Comment = &c
+			} else {
+				seq.Comment = nil
 			}
 		}
 	}

--- a/parser/sequences_test.go
+++ b/parser/sequences_test.go
@@ -1,0 +1,87 @@
+package parser_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/model"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+func parseOneSequence(t *testing.T, sql string) *model.Sequence {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "seq.sql")
+	require.NoError(t, os.WriteFile(f, []byte(sql), 0o644))
+	result, err := parser.ParseSQLFilesWithSchema([]string{f}, "public")
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Sequences.Len())
+	return result.Sequences.CollectValues()[0]
+}
+
+func TestParseCreateSeqStmt_Defaults(t *testing.T) {
+	seq := parseOneSequence(t, "CREATE SEQUENCE public.s;")
+	assert.Equal(t, "public", seq.Schema)
+	assert.Equal(t, "s", seq.Name)
+	assert.Equal(t, "bigint", seq.DataType)
+	assert.Equal(t, int64(1), seq.Start)
+	assert.Equal(t, int64(1), seq.Min)
+	assert.Equal(t, int64(9223372036854775807), seq.Max)
+	assert.Equal(t, int64(1), seq.Increment)
+	assert.Equal(t, int64(1), seq.Cache)
+	assert.False(t, seq.Cycle)
+	assert.Nil(t, seq.OwnerTable)
+}
+
+func TestParseCreateSeqStmt_Descending(t *testing.T) {
+	seq := parseOneSequence(t, "CREATE SEQUENCE public.s INCREMENT BY -1;")
+	assert.Equal(t, int64(-1), seq.Increment)
+	assert.Equal(t, int64(-9223372036854775808), seq.Min)
+	assert.Equal(t, int64(-1), seq.Max)
+	assert.Equal(t, int64(-1), seq.Start)
+}
+
+func TestParseCreateSeqStmt_TypeBounds(t *testing.T) {
+	small := parseOneSequence(t, "CREATE SEQUENCE public.s AS smallint;")
+	assert.Equal(t, "smallint", small.DataType)
+	assert.Equal(t, int64(32767), small.Max)
+
+	integer := parseOneSequence(t, "CREATE SEQUENCE public.s AS integer;")
+	assert.Equal(t, "integer", integer.DataType)
+	assert.Equal(t, int64(2147483647), integer.Max)
+}
+
+func TestParseCreateSeqStmt_NoMinvalueUsesDefault(t *testing.T) {
+	seq := parseOneSequence(t, "CREATE SEQUENCE public.s NO MINVALUE NO MAXVALUE;")
+	assert.Equal(t, int64(1), seq.Min)
+	assert.Equal(t, int64(9223372036854775807), seq.Max)
+}
+
+func TestParseCreateSeqStmt_AllOptions(t *testing.T) {
+	seq := parseOneSequence(t, `CREATE SEQUENCE public.s
+		AS integer INCREMENT BY 5 MINVALUE 10 MAXVALUE 10000 START WITH 20 CACHE 3 CYCLE;`)
+	assert.Equal(t, "integer", seq.DataType)
+	assert.Equal(t, int64(5), seq.Increment)
+	assert.Equal(t, int64(10), seq.Min)
+	assert.Equal(t, int64(10000), seq.Max)
+	assert.Equal(t, int64(20), seq.Start)
+	assert.Equal(t, int64(3), seq.Cache)
+	assert.True(t, seq.Cycle)
+}
+
+func TestParseCreateSeqStmt_OwnedBy(t *testing.T) {
+	seq := parseOneSequence(t, "CREATE SEQUENCE public.s OWNED BY public.t.id;")
+	require.NotNil(t, seq.OwnerTable)
+	assert.Equal(t, "t", *seq.OwnerTable)
+	require.NotNil(t, seq.OwnerColumn)
+	assert.Equal(t, "id", *seq.OwnerColumn)
+	assert.True(t, seq.Owned())
+}
+
+func TestParseCreateSeqStmt_OwnedByNone(t *testing.T) {
+	seq := parseOneSequence(t, "CREATE SEQUENCE public.s OWNED BY NONE;")
+	assert.Nil(t, seq.OwnerTable)
+	assert.False(t, seq.Owned())
+}

--- a/parser/sequences_test.go
+++ b/parser/sequences_test.go
@@ -59,6 +59,14 @@ func TestParseCreateSeqStmt_NoMinvalueUsesDefault(t *testing.T) {
 	assert.Equal(t, int64(9223372036854775807), seq.Max)
 }
 
+func TestParseCreateSeqStmt_ExplicitBigValues(t *testing.T) {
+	// Values beyond int32 arrive from pg_query as Float nodes carrying the
+	// decimal string, exercising defElemInt64's Float branch.
+	seq := parseOneSequence(t, "CREATE SEQUENCE public.s MINVALUE -9223372036854775808 MAXVALUE 9223372036854775807;")
+	assert.Equal(t, int64(-9223372036854775808), seq.Min)
+	assert.Equal(t, int64(9223372036854775807), seq.Max)
+}
+
 func TestParseCreateSeqStmt_AllOptions(t *testing.T) {
 	seq := parseOneSequence(t, `CREATE SEQUENCE public.s
 		AS integer INCREMENT BY 5 MINVALUE 10 MAXVALUE 10000 START WITH 20 CACHE 3 CYCLE;`)

--- a/plan.go
+++ b/plan.go
@@ -24,11 +24,12 @@ type PlanOptions struct {
 
 // ObjectCount holds the number of objects inspected by type.
 type ObjectCount struct {
-	Schemas []string
-	Tables  int
-	Views   int
-	Enums   int
-	Domains int
+	Schemas   []string
+	Tables    int
+	Views     int
+	Enums     int
+	Domains   int
+	Sequences int
 }
 
 func (c ObjectCount) SchemaLabel() string {
@@ -39,11 +40,12 @@ func (c ObjectCount) SchemaLabel() string {
 }
 
 func (c ObjectCount) Summary() string {
-	return fmt.Sprintf("%s, %s, %s, %s",
+	return fmt.Sprintf("%s, %s, %s, %s, %s",
 		pluralize(c.Tables, "table"),
 		pluralize(c.Views, "view"),
 		pluralize(c.Enums, "enum"),
 		pluralize(c.Domains, "domain"),
+		pluralize(c.Sequences, "sequence"),
 	)
 }
 

--- a/plan_test.go
+++ b/plan_test.go
@@ -48,10 +48,11 @@ type planDropPolicy struct {
 // is checked only when set, so a fixture can pin individual counts without
 // having to specify every field.
 type expectedCount struct {
-	Tables  *int `yaml:"tables,omitempty"`
-	Views   *int `yaml:"views,omitempty"`
-	Enums   *int `yaml:"enums,omitempty"`
-	Domains *int `yaml:"domains,omitempty"`
+	Tables    *int `yaml:"tables,omitempty"`
+	Views     *int `yaml:"views,omitempty"`
+	Enums     *int `yaml:"enums,omitempty"`
+	Domains   *int `yaml:"domains,omitempty"`
+	Sequences *int `yaml:"sequences,omitempty"`
 }
 
 func assertExpectedCount(t *testing.T, want *expectedCount, got pistachio.ObjectCount) {
@@ -70,6 +71,9 @@ func assertExpectedCount(t *testing.T, want *expectedCount, got pistachio.Object
 	}
 	if want.Domains != nil {
 		assert.Equal(t, *want.Domains, got.Domains, "Count.Domains")
+	}
+	if want.Sequences != nil {
+		assert.Equal(t, *want.Sequences, got.Sequences, "Count.Sequences")
 	}
 }
 

--- a/remap.go
+++ b/remap.go
@@ -186,6 +186,36 @@ func (client *Client) reverseRemapEnumSchemas(enums *orderedmap.Map[string, *mod
 	return remapped
 }
 
+func (client *Client) remapSequenceSchemas(sequences *orderedmap.Map[string, *model.Sequence]) *orderedmap.Map[string, *model.Sequence] {
+	if len(client.SchemaMap) == 0 {
+		return sequences
+	}
+
+	remapped := orderedmap.New[string, *model.Sequence]()
+
+	for _, s := range sequences.CollectValues() {
+		s.Schema = client.RemapSchema(s.Schema)
+		remapped.Set(s.FQN(), s)
+	}
+
+	return remapped
+}
+
+func (client *Client) reverseRemapSequenceSchemas(sequences *orderedmap.Map[string, *model.Sequence]) *orderedmap.Map[string, *model.Sequence] {
+	if len(client.SchemaMap) == 0 {
+		return sequences
+	}
+
+	remapped := orderedmap.New[string, *model.Sequence]()
+
+	for _, s := range sequences.CollectValues() {
+		s.Schema = client.ReverseRemapSchema(s.Schema)
+		remapped.Set(s.FQN(), s)
+	}
+
+	return remapped
+}
+
 func (client *Client) remapDomainSchemas(domains *orderedmap.Map[string, *model.Domain]) *orderedmap.Map[string, *model.Domain] {
 	if len(client.SchemaMap) == 0 {
 		return domains

--- a/remap_test.go
+++ b/remap_test.go
@@ -198,6 +198,52 @@ CREATE VIEW myschema.active_users AS SELECT id, name FROM myschema.users;
 	assert.Contains(t, output, "FROM public.users")
 }
 
+func TestDump_WithSchemaMap_Sequence(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE SEQUENCE myschema.order_seq;
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	// The sequence schema is remapped to "public" (exercises remapSequenceSchemas).
+	assert.Contains(t, got.String(), "CREATE SEQUENCE public.order_seq")
+	assert.NotContains(t, got.String(), "myschema.order_seq")
+}
+
+func TestPlan_WithSchemaMap_Sequence(t *testing.T) {
+	ctx := context.Background()
+
+	// DB sequence increments by 1; desired (written against public) increments by 2.
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE SEQUENCE myschema.order_seq INCREMENT BY 1;
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE SEQUENCE public.order_seq INCREMENT BY 2;"), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	// The desired public.order_seq is reverse-remapped to myschema.order_seq
+	// (exercises reverseRemapSequenceSchemas) and diffed against the real DB.
+	assert.Contains(t, got.SQL, "ALTER SEQUENCE myschema.order_seq INCREMENT BY 2;")
+}
+
 func TestDump_WithSchemaMap_Files(t *testing.T) {
 	ctx := context.Background()
 

--- a/schema_filter_test.go
+++ b/schema_filter_test.go
@@ -16,11 +16,11 @@ func TestObjectCount_SchemaLabel(t *testing.T) {
 }
 
 func TestObjectCount_Summary(t *testing.T) {
-	c := pistachio.ObjectCount{Tables: 3, Views: 1, Enums: 2, Domains: 0}
-	assert.Equal(t, "3 tables, 1 view, 2 enums, 0 domains", c.Summary())
+	c := pistachio.ObjectCount{Tables: 3, Views: 1, Enums: 2, Domains: 0, Sequences: 4}
+	assert.Equal(t, "3 tables, 1 view, 2 enums, 0 domains, 4 sequences", c.Summary())
 }
 
 func TestObjectCount_Summary_Singular(t *testing.T) {
-	c := pistachio.ObjectCount{Tables: 1, Views: 1, Enums: 1, Domains: 1}
-	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain", c.Summary())
+	c := pistachio.ObjectCount{Tables: 1, Views: 1, Enums: 1, Domains: 1, Sequences: 1}
+	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain, 1 sequence", c.Summary())
 }

--- a/test/scenario/sequence.test.sh
+++ b/test/scenario/sequence.test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Scenario test: standalone sequence management mixed with serial/identity.
+# The initial schema has a standalone sequence (code_seq, referenced by a
+# column default) alongside a serial column and an identity column. Those two
+# own auto-created sequences that must stay unmanaged: every step verifies the
+# schema is drift-free after apply, which fails if the owned sequences leak
+# into the diff.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/sequence"
+
+# --- Setup: load the mixed initial schema ---
+setup_db "$DATA/init.sql"
+
+# --- Step 0: mixed schema round-trips with no diff (owned sequences ignored) ---
+run_step_no_diff "00 init: no diff (serial/identity not managed)" "$DATA/init.sql" || true
+
+# --- Step 1: add a standalone sequence ---
+run_step "01 add sequence (order_seq)" \
+  "CREATE SEQUENCE public.order_seq" \
+  "$DATA/steps/01_add_sequence.sql" || true
+
+# --- Step 2: alter sequence options ---
+run_step "02 alter sequence (increment/maxvalue/cycle)" \
+  "ALTER SEQUENCE public.order_seq" \
+  "$DATA/steps/02_alter_sequence.sql" || true
+
+# --- Step 3: add a comment ---
+run_step "03 add comment" \
+  "COMMENT ON SEQUENCE public.order_seq IS 'Order id generator'" \
+  "$DATA/steps/03_add_comment.sql" || true
+
+# --- Step 4: rename the sequence ---
+run_step "04 rename sequence (order_seq -> seq_orders)" \
+  "ALTER SEQUENCE public.order_seq RENAME TO seq_orders" \
+  "$DATA/steps/04_rename_sequence.sql" || true
+
+# --- Step 5: drop the sequence ---
+run_step "05 drop sequence (seq_orders)" \
+  "DROP SEQUENCE public.seq_orders" \
+  "$DATA/steps/05_drop_sequence.sql" || true
+
+summary

--- a/test/scenario/testdata/sequence/init.sql
+++ b/test/scenario/testdata/sequence/init.sql
@@ -1,0 +1,11 @@
+-- Mixed schema: a standalone sequence (managed) alongside a serial column and
+-- an identity column (each owns an auto-created sequence that must stay
+-- unmanaged). The standalone code_seq is referenced by a column default.
+CREATE SEQUENCE public.code_seq;
+
+CREATE TABLE public.items (
+    id serial NOT NULL,
+    ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/sequence/steps/01_add_sequence.sql
+++ b/test/scenario/testdata/sequence/steps/01_add_sequence.sql
@@ -1,0 +1,13 @@
+CREATE SEQUENCE public.code_seq;
+
+CREATE SEQUENCE public.order_seq
+    INCREMENT BY 1
+    START WITH 1000
+    CACHE 5;
+
+CREATE TABLE public.items (
+    id serial NOT NULL,
+    ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/sequence/steps/02_alter_sequence.sql
+++ b/test/scenario/testdata/sequence/steps/02_alter_sequence.sql
@@ -1,0 +1,15 @@
+CREATE SEQUENCE public.code_seq;
+
+CREATE SEQUENCE public.order_seq
+    INCREMENT BY 2
+    START WITH 1000
+    MAXVALUE 999999
+    CACHE 5
+    CYCLE;
+
+CREATE TABLE public.items (
+    id serial NOT NULL,
+    ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/sequence/steps/03_add_comment.sql
+++ b/test/scenario/testdata/sequence/steps/03_add_comment.sql
@@ -1,0 +1,17 @@
+CREATE SEQUENCE public.code_seq;
+
+CREATE SEQUENCE public.order_seq
+    INCREMENT BY 2
+    START WITH 1000
+    MAXVALUE 999999
+    CACHE 5
+    CYCLE;
+
+COMMENT ON SEQUENCE public.order_seq IS 'Order id generator';
+
+CREATE TABLE public.items (
+    id serial NOT NULL,
+    ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/sequence/steps/04_rename_sequence.sql
+++ b/test/scenario/testdata/sequence/steps/04_rename_sequence.sql
@@ -1,0 +1,18 @@
+CREATE SEQUENCE public.code_seq;
+
+-- pista:renamed-from public.order_seq
+CREATE SEQUENCE public.seq_orders
+    INCREMENT BY 2
+    START WITH 1000
+    MAXVALUE 999999
+    CACHE 5
+    CYCLE;
+
+COMMENT ON SEQUENCE public.seq_orders IS 'Order id generator';
+
+CREATE TABLE public.items (
+    id serial NOT NULL,
+    ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/sequence/steps/05_drop_sequence.sql
+++ b/test/scenario/testdata/sequence/steps/05_drop_sequence.sql
@@ -1,0 +1,8 @@
+CREATE SEQUENCE public.code_seq;
+
+CREATE TABLE public.items (
+    id serial NOT NULL,
+    ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);

--- a/testdata/apply/alter_sequence.yml
+++ b/testdata/apply/alter_sequence.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE SEQUENCE public.order_seq INCREMENT BY 1 MAXVALUE 1000;
+desired: |
+  CREATE SEQUENCE public.order_seq
+      INCREMENT BY 2
+      MAXVALUE 5000
+      CYCLE;
+applied_sql: |
+  ALTER SEQUENCE public.order_seq INCREMENT BY 2 MAXVALUE 5000 CYCLE;
+applied: |
+  -- public.order_seq
+  CREATE SEQUENCE public.order_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 2
+      MINVALUE 1
+      MAXVALUE 5000
+      CACHE 1
+      CYCLE;
+verify_no_drift: true

--- a/testdata/apply/create_sequence.yml
+++ b/testdata/apply/create_sequence.yml
@@ -1,0 +1,23 @@
+init: ""
+desired: |
+  CREATE SEQUENCE public.order_seq
+      INCREMENT BY 5
+      START WITH 100;
+applied_sql: |
+  CREATE SEQUENCE public.order_seq
+      AS bigint
+      START WITH 100
+      INCREMENT BY 5
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+applied: |
+  -- public.order_seq
+  CREATE SEQUENCE public.order_seq
+      AS bigint
+      START WITH 100
+      INCREMENT BY 5
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+verify_no_drift: true

--- a/testdata/apply/create_sequence_descending.yml
+++ b/testdata/apply/create_sequence_descending.yml
@@ -1,0 +1,16 @@
+# Descending sequence: MINVALUE defaults to the type minimum, MAXVALUE to -1,
+# and START to MAXVALUE. verify_no_drift proves the parsed defaults match the
+# catalog (also exercises the bigint-min value carried as a pg_query Float).
+init: ""
+desired: |
+  CREATE SEQUENCE public.desc_seq INCREMENT BY -1;
+applied: |
+  -- public.desc_seq
+  CREATE SEQUENCE public.desc_seq
+      AS bigint
+      START WITH -1
+      INCREMENT BY -1
+      MINVALUE -9223372036854775808
+      MAXVALUE -1
+      CACHE 1;
+verify_no_drift: true

--- a/testdata/apply/create_sequence_smallint.yml
+++ b/testdata/apply/create_sequence_smallint.yml
@@ -1,0 +1,14 @@
+# AS smallint: MAXVALUE defaults to the smallint maximum (32767).
+init: ""
+desired: |
+  CREATE SEQUENCE public.small_seq AS smallint;
+applied: |
+  -- public.small_seq
+  CREATE SEQUENCE public.small_seq
+      AS smallint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 32767
+      CACHE 1;
+verify_no_drift: true

--- a/testdata/apply/drop_sequence.yml
+++ b/testdata/apply/drop_sequence.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE SEQUENCE public.order_seq;
+desired: ""
+applied_sql: |
+  DROP SEQUENCE public.order_seq;
+applied: ""
+verify_no_drift: true

--- a/testdata/apply/sequence_comment.yml
+++ b/testdata/apply/sequence_comment.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE SEQUENCE public.order_seq;
+desired: |
+  CREATE SEQUENCE public.order_seq;
+  COMMENT ON SEQUENCE public.order_seq IS 'Order id generator';
+applied_sql: |
+  COMMENT ON SEQUENCE public.order_seq IS 'Order id generator';
+applied: |
+  -- public.order_seq
+  CREATE SEQUENCE public.order_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+  COMMENT ON SEQUENCE public.order_seq IS 'Order id generator';
+verify_no_drift: true

--- a/testdata/apply/sequence_mixed_with_serial_identity.yml
+++ b/testdata/apply/sequence_mixed_with_serial_identity.yml
@@ -1,0 +1,42 @@
+# A mixed schema (standalone sequence + serial + identity) is stable: exactly
+# one sequence is counted as managed (not three), applying the same schema
+# makes no changes, and the dump shows only the standalone sequence. The
+# serial/identity-owned sequences never leak into the diff.
+init: |
+  CREATE SEQUENCE public.code_seq;
+  CREATE TABLE public.items (
+      id serial NOT NULL,
+      ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+      code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE SEQUENCE public.code_seq;
+  CREATE TABLE public.items (
+      id serial NOT NULL,
+      ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+      code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+applied_sql: ""
+applied: |
+  -- public.code_seq
+  CREATE SEQUENCE public.code_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+
+  -- public.items
+  CREATE TABLE public.items (
+      id serial NOT NULL,
+      ver integer GENERATED ALWAYS AS IDENTITY,
+      code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+count:
+  sequences: 1
+  tables: 1
+verify_no_drift: true

--- a/testdata/dump/sequence.yml
+++ b/testdata/dump/sequence.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE SEQUENCE public.order_seq
+      INCREMENT BY 5
+      START WITH 100
+      MAXVALUE 10000
+      CACHE 3;
+dump: |
+  -- public.order_seq
+  CREATE SEQUENCE public.order_seq
+      AS bigint
+      START WITH 100
+      INCREMENT BY 5
+      MINVALUE 1
+      MAXVALUE 10000
+      CACHE 3;

--- a/testdata/dump/sequence_disabled.yml
+++ b/testdata/dump/sequence_disabled.yml
@@ -1,0 +1,15 @@
+# --disable sequence turns off sequence dumping entirely (exercises the
+# IsTypeEnabled("sequence") false branch in filterSequences).
+disable: [sequence]
+init: |
+  CREATE SEQUENCE public.order_seq;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/dump/sequence_exclude.yml
+++ b/testdata/dump/sequence_exclude.yml
@@ -1,0 +1,14 @@
+# --exclude filters sequences by name (exercises filterSequences' match loop).
+exclude: [skip_*]
+init: |
+  CREATE SEQUENCE public.keep_seq;
+  CREATE SEQUENCE public.skip_seq;
+dump: |
+  -- public.keep_seq
+  CREATE SEQUENCE public.keep_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;

--- a/testdata/dump/sequence_excludes_serial.yml
+++ b/testdata/dump/sequence_excludes_serial.yml
@@ -1,0 +1,13 @@
+# The sequence behind a serial column is owned by that column, so dump must
+# not emit it as a standalone CREATE SEQUENCE; only the table appears.
+init: |
+  CREATE TABLE public.users (
+      id serial NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id serial NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/dump/sequence_omit_schema.yml
+++ b/testdata/dump/sequence_omit_schema.yml
@@ -1,0 +1,12 @@
+omit_schema: true
+init: |
+  CREATE SEQUENCE public.order_seq;
+dump: |
+  -- order_seq
+  CREATE SEQUENCE order_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;

--- a/testdata/dump/sequence_with_comment.yml
+++ b/testdata/dump/sequence_with_comment.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE SEQUENCE public.order_seq;
+  COMMENT ON SEQUENCE public.order_seq IS 'Order id generator';
+dump: |
+  -- public.order_seq
+  CREATE SEQUENCE public.order_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+  COMMENT ON SEQUENCE public.order_seq IS 'Order id generator';

--- a/testdata/plan/add_sequence_comment.yml
+++ b/testdata/plan/add_sequence_comment.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE SEQUENCE public.order_seq;
+desired: |
+  CREATE SEQUENCE public.order_seq;
+  COMMENT ON SEQUENCE public.order_seq IS 'Order id generator';
+plan: |
+  COMMENT ON SEQUENCE public.order_seq IS 'Order id generator';

--- a/testdata/plan/alter_sequence.yml
+++ b/testdata/plan/alter_sequence.yml
@@ -1,0 +1,10 @@
+init: |
+  CREATE SEQUENCE public.order_seq INCREMENT BY 1 MAXVALUE 1000 CACHE 1;
+desired: |
+  CREATE SEQUENCE public.order_seq
+      INCREMENT BY 2
+      MAXVALUE 5000
+      CACHE 10
+      CYCLE;
+plan: |
+  ALTER SEQUENCE public.order_seq INCREMENT BY 2 MAXVALUE 5000 CACHE 10 CYCLE;

--- a/testdata/plan/alter_sequence_no_cycle.yml
+++ b/testdata/plan/alter_sequence_no_cycle.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE SEQUENCE public.order_seq CYCLE;
+desired: |
+  CREATE SEQUENCE public.order_seq;
+plan: |
+  ALTER SEQUENCE public.order_seq NO CYCLE;

--- a/testdata/plan/alter_sequence_type.yml
+++ b/testdata/plan/alter_sequence_type.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE SEQUENCE public.s AS smallint MAXVALUE 100;
+desired: |
+  CREATE SEQUENCE public.s AS integer MAXVALUE 100;
+plan: |
+  ALTER SEQUENCE public.s AS integer;

--- a/testdata/plan/create_sequence.yml
+++ b/testdata/plan/create_sequence.yml
@@ -1,0 +1,13 @@
+init: ""
+desired: |
+  CREATE SEQUENCE public.order_seq;
+plan: |
+  CREATE SEQUENCE public.order_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+count:
+  sequences: 0

--- a/testdata/plan/create_sequence_before_table.yml
+++ b/testdata/plan/create_sequence_before_table.yml
@@ -1,0 +1,20 @@
+# The sequence must be created before the table whose column default
+# references it via nextval, even though "zzz_seq" sorts after "aaa"
+# alphabetically. The dependency edge, not the name, decides the order.
+init: ""
+desired: |
+  CREATE SEQUENCE public.zzz_seq;
+  CREATE TABLE public.aaa (
+      id bigint DEFAULT nextval('zzz_seq'::regclass) NOT NULL
+  );
+plan: |
+  CREATE SEQUENCE public.zzz_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+  CREATE TABLE public.aaa (
+      id bigint DEFAULT nextval('zzz_seq'::regclass) NOT NULL
+  );

--- a/testdata/plan/create_sequence_before_table_quoted_name.yml
+++ b/testdata/plan/create_sequence_before_table_quoted_name.yml
@@ -1,0 +1,21 @@
+# A quote-requiring sequence name ("Zzz_seq") referenced by a quoted table
+# name ("Aaa") that sorts before it alphabetically. Only the nextval
+# dependency edge can order the sequence first; the edge must resolve the
+# already-quoted literal without re-quoting it.
+init: ""
+desired: |
+  CREATE SEQUENCE public."Zzz_seq";
+  CREATE TABLE public."Aaa" (
+      id bigint DEFAULT nextval('"Zzz_seq"'::regclass) NOT NULL
+  );
+plan: |
+  CREATE SEQUENCE public."Zzz_seq"
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+  CREATE TABLE public."Aaa" (
+      id bigint DEFAULT nextval('"Zzz_seq"'::regclass) NOT NULL
+  );

--- a/testdata/plan/create_sequence_with_options.yml
+++ b/testdata/plan/create_sequence_with_options.yml
@@ -1,0 +1,19 @@
+init: ""
+desired: |
+  CREATE SEQUENCE public.custom_seq
+      AS integer
+      INCREMENT BY 5
+      START WITH 100
+      MINVALUE 10
+      MAXVALUE 10000
+      CACHE 3
+      CYCLE;
+plan: |
+  CREATE SEQUENCE public.custom_seq
+      AS integer
+      START WITH 100
+      INCREMENT BY 5
+      MINVALUE 10
+      MAXVALUE 10000
+      CACHE 3
+      CYCLE;

--- a/testdata/plan/drop_sequence.yml
+++ b/testdata/plan/drop_sequence.yml
@@ -1,0 +1,5 @@
+init: |
+  CREATE SEQUENCE public.order_seq;
+desired: ""
+plan: |
+  DROP SEQUENCE public.order_seq;

--- a/testdata/plan/drop_sequence_disallowed.yml
+++ b/testdata/plan/drop_sequence_disallowed.yml
@@ -1,0 +1,8 @@
+init: |
+  CREATE SEQUENCE public.order_seq;
+desired: ""
+drop_policy:
+  allow_drop: [table]
+plan: ""
+disallowed_drops: |
+  -- skipped: DROP SEQUENCE public.order_seq;

--- a/testdata/plan/drop_sequence_referenced_by_default.yml
+++ b/testdata/plan/drop_sequence_referenced_by_default.yml
@@ -1,0 +1,21 @@
+# Dropping a standalone sequence referenced by a column default: the default
+# reference is removed first (ALTER COLUMN DROP DEFAULT), then the sequence is
+# dropped. The serial/identity columns stay untouched.
+init: |
+  CREATE SEQUENCE public.code_seq;
+  CREATE TABLE public.items (
+      id serial NOT NULL,
+      ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+      code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.items (
+      id serial NOT NULL,
+      ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+      code integer NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.items ALTER COLUMN code DROP DEFAULT;
+  DROP SEQUENCE public.code_seq;

--- a/testdata/plan/error_sequence_rename_dest_exists.yml
+++ b/testdata/plan/error_sequence_rename_dest_exists.yml
@@ -1,0 +1,8 @@
+init: |
+  CREATE SEQUENCE public.old_seq;
+  CREATE SEQUENCE public.new_seq;
+desired: |
+  CREATE SEQUENCE public.old_seq;
+  -- pista:renamed-from public.old_seq
+  CREATE SEQUENCE public.new_seq;
+error: "destination already exists"

--- a/testdata/plan/error_sequence_rename_source_not_found.yml
+++ b/testdata/plan/error_sequence_rename_source_not_found.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE SEQUENCE public.order_seq;
+desired: |
+  -- pista:renamed-from public.nonexistent
+  CREATE SEQUENCE public.new_seq;
+error: "rename source"

--- a/testdata/plan/ignore_sequence.yml
+++ b/testdata/plan/ignore_sequence.yml
@@ -1,0 +1,18 @@
+# A sequence marked -- pista:ignore is unmanaged: no create, alter, or drop,
+# and its FQN is surfaced as -- ignored:.
+init: |
+  CREATE SEQUENCE public.ext_seq;
+desired: |
+  -- pista:ignore
+  CREATE SEQUENCE public.ext_seq;
+  CREATE SEQUENCE public.managed_seq;
+plan: |
+  CREATE SEQUENCE public.managed_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+ignored: |
+  -- ignored: public.ext_seq

--- a/testdata/plan/remove_sequence_comment.yml
+++ b/testdata/plan/remove_sequence_comment.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE SEQUENCE public.order_seq;
+  COMMENT ON SEQUENCE public.order_seq IS 'old comment';
+desired: |
+  CREATE SEQUENCE public.order_seq;
+plan: |
+  COMMENT ON SEQUENCE public.order_seq IS NULL;

--- a/testdata/plan/rename_sequence.yml
+++ b/testdata/plan/rename_sequence.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE SEQUENCE public.old_seq;
+desired: |
+  -- pista:renamed-from public.old_seq
+  CREATE SEQUENCE public.new_seq;
+plan: |
+  ALTER SEQUENCE public.old_seq RENAME TO new_seq;

--- a/testdata/plan/rename_sequence_with_option_change.yml
+++ b/testdata/plan/rename_sequence_with_option_change.yml
@@ -1,0 +1,11 @@
+# A rename combined with option changes in the same plan: the rename is
+# emitted first (on the old name), then the ALTER applies the new options
+# against the renamed sequence.
+init: |
+  CREATE SEQUENCE public.old_seq INCREMENT BY 1 MAXVALUE 1000;
+desired: |
+  -- pista:renamed-from public.old_seq
+  CREATE SEQUENCE public.new_seq INCREMENT BY 2 MAXVALUE 5000;
+plan: |
+  ALTER SEQUENCE public.old_seq RENAME TO new_seq;
+  ALTER SEQUENCE public.new_seq INCREMENT BY 2 MAXVALUE 5000;

--- a/testdata/plan/sequence_mixed_with_serial_identity.yml
+++ b/testdata/plan/sequence_mixed_with_serial_identity.yml
@@ -1,0 +1,31 @@
+# A standalone sequence (code_seq, referenced by a column default) alongside a
+# serial column and an identity column. Only the standalone sequence is
+# managed; the serial/identity-owned sequences are handled as column
+# attributes. The standalone sequence is created before the table that
+# references it via nextval.
+init: ""
+desired: |
+  CREATE SEQUENCE public.code_seq;
+  CREATE TABLE public.items (
+      id serial NOT NULL,
+      ver integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+      code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+plan: |
+  CREATE SEQUENCE public.code_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+  CREATE TABLE public.items (
+      id serial NOT NULL,
+      ver integer GENERATED ALWAYS AS IDENTITY,
+      code integer DEFAULT nextval('code_seq'::regclass) NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+count:
+  sequences: 0
+  tables: 0

--- a/testdata/plan/sequence_no_minvalue_no_drift.yml
+++ b/testdata/plan/sequence_no_minvalue_no_drift.yml
@@ -1,0 +1,7 @@
+# NO MINVALUE / NO MAXVALUE mean "use the default", so they must parse to the
+# same values the catalog reports for a bare sequence: no drift.
+init: |
+  CREATE SEQUENCE public.order_seq;
+desired: |
+  CREATE SEQUENCE public.order_seq NO MINVALUE NO MAXVALUE;
+plan: ""

--- a/testdata/plan/sequence_owned_by_not_managed.yml
+++ b/testdata/plan/sequence_owned_by_not_managed.yml
@@ -1,0 +1,14 @@
+# A desired CREATE SEQUENCE ... OWNED BY ties the sequence to a column, so it
+# is treated as unmanaged (like serial/identity): only the table is created.
+init: ""
+desired: |
+  CREATE TABLE public.t (
+      id integer NOT NULL
+  );
+  CREATE SEQUENCE public.s OWNED BY public.t.id;
+plan: |
+  CREATE TABLE public.t (
+      id integer NOT NULL
+  );
+count:
+  sequences: 0

--- a/testdata/plan/serial_and_identity_not_managed.yml
+++ b/testdata/plan/serial_and_identity_not_managed.yml
@@ -1,0 +1,19 @@
+# serial and identity columns own their sequences; those are managed as
+# column attributes, not as standalone sequences. The plan must be empty
+# and the sequence count zero.
+init: |
+  CREATE TABLE public.users (
+      id serial NOT NULL,
+      code integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id serial NOT NULL,
+      code integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: ""
+count:
+  sequences: 0
+  tables: 1

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -156,10 +156,15 @@ func extractSeqDeps(defaultExpr, defaultSchema string, defined map[string]bool) 
 		}
 		rest = remainder
 
+		// lit is the identifier as pg_get_expr / pg_query deparse emit it:
+		// already quoted when the name requires it, matching the form of both
+		// the `defined` keys and resolveUnqualified's name argument. Do not
+		// re-quote it with model.Ident, which would double-quote a name like
+		// "MySeq" and miss the lookup.
 		if defined[lit] {
 			deps = append(deps, lit)
 		} else if !strings.Contains(lit, ".") {
-			if q := resolveUnqualified(model.Ident(lit), defaultSchema, defined); q != "" {
+			if q := resolveUnqualified(lit, defaultSchema, defined); q != "" {
 				deps = append(deps, q)
 			}
 		}

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -12,19 +12,9 @@ import (
 
 // OrderFromSchema builds a dependency graph from parsed model objects and
 // returns the object names in topological order (dependencies first).
+// Sequences are leaf nodes; a table depends on a sequence when a column
+// default references it via nextval, so the sequence is created first.
 func OrderFromSchema(
-	enums *orderedmap.Map[string, *model.Enum],
-	domains *orderedmap.Map[string, *model.Domain],
-	tables *orderedmap.Map[string, *model.Table],
-	views *orderedmap.Map[string, *model.View],
-) ([]string, error) {
-	return OrderFromSchemaWithSequences(enums, domains, tables, views, orderedmap.New[string, *model.Sequence]())
-}
-
-// OrderFromSchemaWithSequences is OrderFromSchema extended with standalone
-// sequences. Sequences are leaf nodes; a table depends on a sequence when a
-// column default references it via nextval, so the sequence is created first.
-func OrderFromSchemaWithSequences(
 	enums *orderedmap.Map[string, *model.Enum],
 	domains *orderedmap.Map[string, *model.Domain],
 	tables *orderedmap.Map[string, *model.Table],

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -18,11 +18,29 @@ func OrderFromSchema(
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
 ) ([]string, error) {
+	return OrderFromSchemaWithSequences(enums, domains, tables, views, orderedmap.New[string, *model.Sequence]())
+}
+
+// OrderFromSchemaWithSequences is OrderFromSchema extended with standalone
+// sequences. Sequences are leaf nodes; a table depends on a sequence when a
+// column default references it via nextval, so the sequence is created first.
+func OrderFromSchemaWithSequences(
+	enums *orderedmap.Map[string, *model.Enum],
+	domains *orderedmap.Map[string, *model.Domain],
+	tables *orderedmap.Map[string, *model.Table],
+	views *orderedmap.Map[string, *model.View],
+	sequences *orderedmap.Map[string, *model.Sequence],
+) ([]string, error) {
 	g := newGraph()
-	defined := collectDefined(enums, domains, tables, views)
+	defined := collectDefined(enums, domains, tables, views, sequences)
 
 	// Enums: no dependencies (leaf nodes)
 	for k := range enums.Keys() {
+		g.AddNode(k)
+	}
+
+	// Sequences: no dependencies (leaf nodes)
+	for k := range sequences.Keys() {
 		g.AddNode(k)
 	}
 
@@ -34,7 +52,8 @@ func OrderFromSchema(
 		}
 	}
 
-	// Tables: may depend on enums/domains (column types) and other tables (FKs)
+	// Tables: may depend on enums/domains (column types), sequences (column
+	// defaults via nextval), and other tables (FKs)
 	for k, t := range tables.All() {
 		g.AddNode(k)
 
@@ -43,6 +62,11 @@ func OrderFromSchema(
 			for _, col := range t.Columns.CollectValues() {
 				if dep := resolveTypeDep(col.TypeName, t.Schema, defined); dep != "" {
 					g.AddEdge(k, dep)
+				}
+				if col.Default != nil {
+					for _, dep := range extractSeqDeps(*col.Default, t.Schema, defined) {
+						g.AddEdge(k, dep)
+					}
 				}
 			}
 		}
@@ -99,6 +123,7 @@ func collectDefined(
 	domains *orderedmap.Map[string, *model.Domain],
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
+	sequences *orderedmap.Map[string, *model.Sequence],
 ) map[string]bool {
 	defined := make(map[string]bool)
 	for k := range enums.Keys() {
@@ -113,7 +138,43 @@ func collectDefined(
 	for k := range views.Keys() {
 		defined[k] = true
 	}
+	for k := range sequences.Keys() {
+		defined[k] = true
+	}
 	return defined
+}
+
+// extractSeqDeps finds the sequences referenced by nextval(...) in a column
+// default expression and returns their resolved (schema-qualified) names.
+// Only sequences present in defined are returned; references to unmanaged
+// (e.g. serial/identity-owned) sequences are ignored.
+func extractSeqDeps(defaultExpr, defaultSchema string, defined map[string]bool) []string {
+	var deps []string
+	rest := defaultExpr
+	for {
+		_, afterCall, found := strings.Cut(rest, "nextval(")
+		if !found {
+			break
+		}
+		_, afterOpen, found := strings.Cut(afterCall, "'")
+		if !found {
+			break
+		}
+		lit, remainder, found := strings.Cut(afterOpen, "'")
+		if !found {
+			break
+		}
+		rest = remainder
+
+		if defined[lit] {
+			deps = append(deps, lit)
+		} else if !strings.Contains(lit, ".") {
+			if q := resolveUnqualified(model.Ident(lit), defaultSchema, defined); q != "" {
+				deps = append(deps, q)
+			}
+		}
+	}
+	return deps
 }
 
 // resolveTypeDep checks if a type name refers to a defined object.

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -47,6 +47,36 @@ func TestOrderFromSchema_Basic(t *testing.T) {
 	assert.Less(t, idx["public.users"], idx["public.active_users"], "table before view")
 }
 
+func TestOrderFromSchemaWithSequences_NextvalDependency(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	// Sequence name sorts AFTER the table name, so only the nextval
+	// dependency edge (not alphabetical order) can place it first.
+	sequences := orderedmap.New[string, *model.Sequence]()
+	sequences.Set("public.zzz_seq", &model.Sequence{Schema: "public", Name: "zzz_seq"})
+
+	def := "nextval('zzz_seq'::regclass)"
+	tables := orderedmap.New[string, *model.Table]()
+	aaa := &model.Table{Schema: "public", Name: "aaa"}
+	aaa.Columns = orderedmap.New[string, *model.Column]()
+	aaa.Columns.Set("id", &model.Column{Name: "id", TypeName: "bigint", Default: &def})
+	aaa.Indexes = orderedmap.New[string, *model.Index]()
+	aaa.Constraints = orderedmap.New[string, *model.Constraint]()
+	aaa.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.aaa", aaa)
+
+	order, err := toposort.OrderFromSchemaWithSequences(enums, domains, tables, views, sequences)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+	assert.Less(t, idx["public.zzz_seq"], idx["public.aaa"], "sequence before dependent table")
+}
+
 func TestOrderFromSchema_ForeignKey(t *testing.T) {
 	enums := orderedmap.New[string, *model.Enum]()
 	domains := orderedmap.New[string, *model.Domain]()

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -88,6 +88,39 @@ func TestOrderFromSchemaWithSequences_NextvalDependency(t *testing.T) {
 	assert.Less(t, idx["public.zzz_seq"], idx["public.aaa"], "sequence before dependent table")
 }
 
+func TestOrderFromSchemaWithSequences_NextvalQuotedName(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+	views := orderedmap.New[string, *model.View]()
+
+	// A quote-requiring sequence name. The default expression carries the name
+	// already quoted (as pg_get_expr / deparse emit it); the edge must resolve
+	// it without re-quoting.
+	sequences := orderedmap.New[string, *model.Sequence]()
+	sequences.Set(`public."Zzz_seq"`, &model.Sequence{Schema: "public", Name: "Zzz_seq"})
+
+	def := `nextval('"Zzz_seq"'::regclass)`
+	tables := orderedmap.New[string, *model.Table]()
+	// Quoted table name that sorts before the sequence, so only the edge (not
+	// alphabetical order) can place the sequence first.
+	aaa := &model.Table{Schema: "public", Name: "Aaa"}
+	aaa.Columns = orderedmap.New[string, *model.Column]()
+	aaa.Columns.Set("id", &model.Column{Name: "id", TypeName: "bigint", Default: &def})
+	aaa.Indexes = orderedmap.New[string, *model.Index]()
+	aaa.Constraints = orderedmap.New[string, *model.Constraint]()
+	aaa.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set(`public."Aaa"`, aaa)
+
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views, sequences)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+	assert.Less(t, idx[`public."Zzz_seq"`], idx[`public."Aaa"`], "quoted sequence before dependent table")
+}
+
 func TestOrderFromSchema_ForeignKey(t *testing.T) {
 	enums := orderedmap.New[string, *model.Enum]()
 	domains := orderedmap.New[string, *model.Domain]()

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/winebarrel/pistachio/toposort"
 )
 
+// orderFromSchema calls OrderFromSchema with no sequences, for the many tests
+// that predate sequence support.
+func orderFromSchema(
+	enums *orderedmap.Map[string, *model.Enum],
+	domains *orderedmap.Map[string, *model.Domain],
+	tables *orderedmap.Map[string, *model.Table],
+	views *orderedmap.Map[string, *model.View],
+) ([]string, error) {
+	return toposort.OrderFromSchema(enums, domains, tables, views, orderedmap.New[string, *model.Sequence]())
+}
+
 func TestOrderFromSchema_Basic(t *testing.T) {
 	enums := orderedmap.New[string, *model.Enum]()
 	enums.Set("public.status", &model.Enum{Schema: "public", Name: "status", Values: []string{"active", "inactive"}})
@@ -34,7 +45,7 @@ func TestOrderFromSchema_Basic(t *testing.T) {
 		Definition: "SELECT id, status FROM public.users WHERE status = 'active'",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -67,7 +78,7 @@ func TestOrderFromSchemaWithSequences_NextvalDependency(t *testing.T) {
 	aaa.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tables.Set("public.aaa", aaa)
 
-	order, err := toposort.OrderFromSchemaWithSequences(enums, domains, tables, views, sequences)
+	order, err := toposort.OrderFromSchema(enums, domains, tables, views, sequences)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -106,7 +117,7 @@ func TestOrderFromSchema_ForeignKey(t *testing.T) {
 	users.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tables.Set("public.users", users)
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -141,7 +152,7 @@ func TestOrderFromSchema_ViewToView(t *testing.T) {
 		Definition: "SELECT count(*) FROM public.active_users",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -159,7 +170,7 @@ func TestOrderFromSchema_Empty(t *testing.T) {
 	tables := orderedmap.New[string, *model.Table]()
 	views := orderedmap.New[string, *model.View]()
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 	assert.Empty(t, order)
 }
@@ -179,7 +190,7 @@ func TestOrderFromSchema_Independent(t *testing.T) {
 		tables.Set("public."+name, tbl)
 	}
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 	// Independent objects should be sorted alphabetically
 	assert.Equal(t, []string{"public.a_table", "public.b_table", "public.c_table"}, order)
@@ -201,7 +212,7 @@ func TestOrderFromSchema_ArrayColumnType(t *testing.T) {
 	tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tables.Set("public.users", tbl)
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -247,7 +258,7 @@ func TestOrderFromSchema_CyclicFK(t *testing.T) {
 	})
 	tables.Set("public.b", tblB)
 
-	_, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	_, err := orderFromSchema(enums, domains, tables, views)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cycle detected")
 }
@@ -263,7 +274,7 @@ func TestOrderFromSchema_UnqualifiedDomainBaseType(t *testing.T) {
 	tables := orderedmap.New[string, *model.Table]()
 	views := orderedmap.New[string, *model.View]()
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -296,7 +307,7 @@ func TestOrderFromSchema_UnqualifiedTypeInPublicFromOtherSchema(t *testing.T) {
 	tables.Set("humanresources.department", newTable("humanresources", "department",
 		&model.Column{Name: "name", TypeName: `"Name"`}))
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, orderedmap.New[string, *model.View]())
+	order, err := orderFromSchema(enums, domains, tables, orderedmap.New[string, *model.View]())
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -318,7 +329,7 @@ func TestOrderFromSchema_UnqualifiedEnumInPublicFromOtherSchema(t *testing.T) {
 	tables.Set("app.users", newTable("app", "users",
 		&model.Column{Name: "s", TypeName: "status"}))
 
-	order, err := toposort.OrderFromSchema(enums, orderedmap.New[string, *model.Domain](),
+	order, err := orderFromSchema(enums, orderedmap.New[string, *model.Domain](),
 		tables, orderedmap.New[string, *model.View]())
 	require.NoError(t, err)
 
@@ -335,7 +346,7 @@ func TestOrderFromSchema_UnqualifiedDomainBaseTypeFromPublic(t *testing.T) {
 	domains.Set("public.name_t", &model.Domain{Schema: "public", Name: "name_t", BaseType: "varchar(50)"})
 	domains.Set("app.short_name", &model.Domain{Schema: "app", Name: "short_name", BaseType: "name_t"})
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](), domains,
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](), domains,
 		orderedmap.New[string, *model.Table](), orderedmap.New[string, *model.View]())
 	require.NoError(t, err)
 
@@ -354,7 +365,7 @@ func TestOrderFromSchema_UnqualifiedArrayTypeInPublicFromOtherSchema(t *testing.
 	tables.Set("app.posts", newTable("app", "posts",
 		&model.Column{Name: "tags", TypeName: "tag[]"}))
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](), domains,
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](), domains,
 		tables, orderedmap.New[string, *model.View]())
 	require.NoError(t, err)
 
@@ -376,7 +387,7 @@ func TestOrderFromSchema_UnqualifiedTypeShadowedByDefaultSchema(t *testing.T) {
 	tables.Set("app.t", newTable("app", "t",
 		&model.Column{Name: "n", TypeName: "name_t"}))
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](), domains,
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](), domains,
 		tables, orderedmap.New[string, *model.View]())
 	require.NoError(t, err)
 
@@ -397,7 +408,7 @@ func TestOrderFromSchema_UnqualifiedFKInPublicFromOtherSchema(t *testing.T) {
 	posts.ForeignKeys.Set("fk_user", &model.ForeignKey{Constraint: model.Constraint{Name: "fk_user"}, RefTable: &refTable})
 	tables.Set("app.posts", posts)
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](),
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](),
 		orderedmap.New[string, *model.Domain](), tables, orderedmap.New[string, *model.View]())
 	require.NoError(t, err)
 
@@ -419,7 +430,7 @@ func TestOrderFromSchema_ViewInOtherSchemaReferencesUnqualifiedPublicTable(t *te
 		Definition: "SELECT id FROM users",
 	})
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](),
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](),
 		orderedmap.New[string, *model.Domain](), tables, views)
 	require.NoError(t, err)
 
@@ -443,7 +454,7 @@ func TestOrderFromSchema_FKWithNilRefTable(t *testing.T) {
 	tables.Set("public.events", tbl)
 
 	require.NotPanics(t, func() {
-		_, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](),
+		_, err := orderFromSchema(orderedmap.New[string, *model.Enum](),
 			orderedmap.New[string, *model.Domain](), tables, orderedmap.New[string, *model.View]())
 		require.NoError(t, err)
 	})
@@ -460,7 +471,7 @@ func TestOrderFromSchema_ViewBodyExplicitRefToUndefinedTable(t *testing.T) {
 		Definition: "SELECT relname FROM pg_catalog.pg_class",
 	})
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](),
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](),
 		orderedmap.New[string, *model.Domain](),
 		orderedmap.New[string, *model.Table](), views)
 	require.NoError(t, err)
@@ -481,7 +492,7 @@ func TestOrderFromSchema_UnqualifiedTypeInQuoteRequiringSchema(t *testing.T) {
 	tables := orderedmap.New[string, *model.Table]()
 	tables.Set(tbl.FQTN(), tbl)
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](), domains, tables, orderedmap.New[string, *model.View]())
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](), domains, tables, orderedmap.New[string, *model.View]())
 	require.NoError(t, err)
 	idx := make(map[string]int)
 	for i, name := range order {
@@ -500,7 +511,7 @@ func TestOrderFromSchema_UnqualifiedFKInQuoteRequiringSchema(t *testing.T) {
 	tables.Set(users.FQTN(), users)
 	tables.Set(posts.FQTN(), posts)
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](),
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](),
 		orderedmap.New[string, *model.Domain](), tables, orderedmap.New[string, *model.View]())
 	require.NoError(t, err)
 	idx := make(map[string]int)
@@ -523,7 +534,7 @@ func TestOrderFromSchema_ViewBodyTableRefInQuoteRequiringSchema(t *testing.T) {
 	views := orderedmap.New[string, *model.View]()
 	views.Set(model.Ident(v.Schema, v.Name), v)
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](),
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](),
 		orderedmap.New[string, *model.Domain](), tables, views)
 	require.NoError(t, err)
 	idx := make(map[string]int)
@@ -548,7 +559,7 @@ func TestOrderFromSchema_ViewBodyFallbackInQuoteRequiringSchema(t *testing.T) {
 	views := orderedmap.New[string, *model.View]()
 	views.Set(model.Ident(v.Schema, v.Name), v)
 
-	order, err := toposort.OrderFromSchema(orderedmap.New[string, *model.Enum](),
+	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](),
 		orderedmap.New[string, *model.Domain](), tables, views)
 	require.NoError(t, err)
 	idx := make(map[string]int)
@@ -581,7 +592,7 @@ func TestOrderFromSchema_PartitionChild(t *testing.T) {
 	child.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tables.Set("public.events_2024", child)
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -626,7 +637,7 @@ func TestOrderFromSchema_FKWithQuotedRefTable(t *testing.T) {
 	})
 	tables.Set(model.Ident("public", "Comments"), comments)
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -668,7 +679,7 @@ func TestOrderFromSchema_FKWithReservedWordRefTable(t *testing.T) {
 	})
 	tables.Set(model.Ident("public", "Items"), items)
 
-	sorted, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	sorted, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -710,7 +721,7 @@ func TestOrderFromSchema_FKWithQuotedRefSchema(t *testing.T) {
 	})
 	tables.Set(model.Ident("AppPublic", "posts"), posts)
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -749,7 +760,7 @@ func TestOrderFromSchema_FKWithDefaultSchema(t *testing.T) {
 	})
 	tables.Set("public.posts", posts)
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -771,7 +782,7 @@ func TestOrderFromSchema_NonPublicSchema(t *testing.T) {
 	tables := orderedmap.New[string, *model.Table]()
 	views := orderedmap.New[string, *model.View]()
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -802,7 +813,7 @@ func TestOrderFromSchema_ViewWithSchemalessTableRef(t *testing.T) {
 		Definition: "SELECT users.id FROM users",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -832,7 +843,7 @@ func TestOrderFromSchema_ViewWithCTE(t *testing.T) {
 		Definition: "WITH active AS (SELECT id FROM users WHERE id > 0) SELECT id FROM active",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -864,7 +875,7 @@ func TestOrderFromSchema_ViewWithHavingSubquery(t *testing.T) {
 		Definition: "SELECT user_id, count(*) FROM orders GROUP BY user_id HAVING count(*) > (SELECT min(val) FROM thresholds)",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -897,7 +908,7 @@ func TestOrderFromSchema_ViewWithScalarSubquery(t *testing.T) {
 		Definition: "SELECT id, (SELECT val FROM settings LIMIT 1) AS setting FROM users",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -930,7 +941,7 @@ func TestOrderFromSchema_ViewWithExistsSubquery(t *testing.T) {
 		Definition: "SELECT id FROM users WHERE EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id)",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -963,7 +974,7 @@ func TestOrderFromSchema_ViewWithJoinOnSubquery(t *testing.T) {
 		Definition: "SELECT u.id FROM users u JOIN posts p ON u.id = p.user_id AND p.id > (SELECT val FROM config LIMIT 1)",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -997,7 +1008,7 @@ func TestOrderFromSchema_ViewWithCoalesce(t *testing.T) {
 		Definition: "SELECT id, COALESCE(name, (SELECT val FROM defaults LIMIT 1)) FROM users",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -1030,7 +1041,7 @@ func TestOrderFromSchema_ViewWithCaseSubquery(t *testing.T) {
 		Definition: "SELECT id, CASE WHEN active THEN (SELECT val FROM config LIMIT 1) ELSE 'none' END FROM users",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -1063,7 +1074,7 @@ func TestOrderFromSchema_ViewWithFuncCallSubquery(t *testing.T) {
 		Definition: "SELECT id, array_agg((SELECT name FROM roles WHERE roles.user_id = users.id)) FROM users",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -1096,7 +1107,7 @@ func TestOrderFromSchema_ViewWithUnparseableDefinition(t *testing.T) {
 		Definition: "NOT VALID SQL BUT MENTIONS public.users",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -1128,7 +1139,7 @@ func TestOrderFromSchema_ViewWithUnparseableDefinition_SchemalessRef(t *testing.
 		Definition: "NOT VALID SQL BUT MENTIONS users TABLE",
 	})
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views)
+	order, err := orderFromSchema(enums, domains, tables, views)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)


### PR DESCRIPTION
## Summary

Adds declarative management of standalone sequences (`CREATE SEQUENCE`) through the plan/apply/dump pipeline: create, alter, drop, comment, and rename.

**Core rule:** only standalone sequences are managed. A sequence owned by a `serial` or identity column is handled as part of that column and excluded from the sequence diff, so it is never double-managed. The distinction comes from `pg_depend.deptype` — `'a'` for serial, `'i'` for identity; a sequence with neither is standalone.

## What it does

- **CREATE** — emits `CREATE SEQUENCE` filling in PostgreSQL's implicit defaults (type/increment sign decide min/max/start), so a bare `CREATE SEQUENCE s;` round-trips with no drift.
- **ALTER** — a single `ALTER SEQUENCE` combining only the changed options (`AS`, `INCREMENT BY`, `MINVALUE`, `MAXVALUE`, `START WITH`, `CACHE`, `CYCLE` / `NO CYCLE`).
- **DROP** — gated by `--allow-drop sequence`; skipped drops are surfaced as `-- skipped:`.
- **COMMENT** — `COMMENT ON SEQUENCE` add/remove, round-tripped by dump.
- **RENAME** — via the `-- pista:renamed-from` directive.
- **dump** — standalone sequences are emitted (respects `--omit-schema` / `--split`).

## Design notes

- **catalog** — `ListSequences` (all, incl. owned) is split from `Sequences` (standalone map). The owner-detection join now covers `deptype IN ('a','i')`, so identity-owned sequences are correctly excluded (previously only serial was). The sequence comment is now read too.
- **ordering** — the toposort learns a table→sequence dependency when a column default references the sequence via `nextval`, so the sequence is created before the table (and dropped after) regardless of name order.
- **defaults** — the parser reproduces PostgreSQL's defaults exactly; bigint bounds arrive from pg_query as `Float` nodes and are parsed to `int64`.

## Behavioral notes

- Changing `START WITH` does not reset the sequence's current value (`RESTART` is not part of declarative diffing).
- Shrinking `MAXVALUE` below the current value can make `ALTER SEQUENCE` error at apply time; the error propagates as-is.

## Tests

- 25 YAML fixtures across plan/apply/dump (create/alter/drop/rename/comment/ordering, serial+identity exclusion, `OWNED BY` exclusion, descending/smallint/`NO MINVALUE` defaults, disallowed drop, rename errors).
- Unit tests for `model`, `parser` (default table), `diff` (incl. cross-schema rename error), `toposort` (nextval edge), and `catalog` (owner + comment).
- `go vet`, `golangci-lint` (0 issues), full `make test`, and `make test-scenario` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)