### PR TITLE
Raise view/toposort coverage and mark dead branches

### DIFF
--- a/diff/views.go
+++ b/diff/views.go
@@ -539,6 +539,9 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 		if !dok || !cok {
 			continue
 		}
+		// TODO: dead code. detectViewRenames already rejects a rename that
+		// switches between VIEW and MATERIALIZED VIEW, so this condition is
+		// never true here. Consider removing.
 		if currentView.Materialized != desiredView.Materialized {
 			needsRecreateRenamed[newKey] = true
 			continue
@@ -684,6 +687,9 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 
 		// If the type changed (VIEW <-> MATERIALIZED VIEW) but drop was denied,
 		// the object type hasn't changed yet; skip comment diff.
+		// TODO: dead code. A denied type change always sets recreateDenied[k],
+		// so the check above already continues before reaching this. Consider
+		// removing.
 		if ok && currentView.Materialized != desiredView.Materialized && !dc.IsDropAllowed("view") {
 			continue
 		}

--- a/testdata/plan/matview_to_view_disallowed.yml
+++ b/testdata/plan/matview_to_view_disallowed.yml
@@ -1,0 +1,17 @@
+drop_policy:
+  allow_drop: []
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.report AS SELECT id FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.report AS SELECT id FROM public.users;
+plan: ""
+disallowed_drops: |
+  -- skipped: DROP MATERIALIZED VIEW public.report;

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -1183,3 +1183,72 @@ func TestOrderFromSchema_ViewWithUnparseableDefinition_SchemalessRef(t *testing.
 	// Fallback should match "users" part of "public.users" using defaultSchema
 	assert.Less(t, idx["public.users"], idx["public.bad_view"])
 }
+
+func TestOrderFromSchema_ViewWithSetOperation(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	for _, name := range []string{"users", "admins", "guests"} {
+		tbl := &model.Table{Schema: "public", Name: name}
+		tbl.Columns = orderedmap.New[string, *model.Column]()
+		tbl.Indexes = orderedmap.New[string, *model.Index]()
+		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
+		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+		tables.Set("public."+name, tbl)
+	}
+
+	views := orderedmap.New[string, *model.View]()
+	// A set operation puts each SELECT in Larg/Rarg, and the top-level
+	// FromClause is empty. Both arms of the UNION must be walked, and Larg
+	// is itself a UNION so the walk must recurse.
+	views.Set("public.everyone", &model.View{
+		Schema:     "public",
+		Name:       "everyone",
+		Definition: "SELECT id FROM users UNION SELECT id FROM admins UNION SELECT id FROM guests",
+	})
+
+	order, err := orderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.users"], idx["public.everyone"])
+	assert.Less(t, idx["public.admins"], idx["public.everyone"])
+	assert.Less(t, idx["public.guests"], idx["public.everyone"])
+}
+
+func TestOrderFromSchema_ViewWithFromSubquery(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	domains := orderedmap.New[string, *model.Domain]()
+
+	tables := orderedmap.New[string, *model.Table]()
+	orders := &model.Table{Schema: "public", Name: "orders"}
+	orders.Columns = orderedmap.New[string, *model.Column]()
+	orders.Indexes = orderedmap.New[string, *model.Index]()
+	orders.Constraints = orderedmap.New[string, *model.Constraint]()
+	orders.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
+	tables.Set("public.orders", orders)
+
+	views := orderedmap.New[string, *model.View]()
+	// A subquery in FROM is a RangeSubselect; the dependency on "orders"
+	// only shows up if the subquery body is walked.
+	views.Set("public.order_totals", &model.View{
+		Schema:     "public",
+		Name:       "order_totals",
+		Definition: "SELECT sub.total FROM (SELECT sum(amount) AS total FROM orders) sub",
+	})
+
+	order, err := orderFromSchema(enums, domains, tables, views)
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.orders"], idx["public.order_totals"], "orders referenced in FROM subquery")
+}


### PR DESCRIPTION
## Summary

Fills naturally-testable gaps in view dependency ordering and adds TODO markers on two unreachable branches found while checking coverage.

### Tests added
- `toposort`: `TestOrderFromSchema_ViewWithSetOperation` covers `UNION`/set-operation views, where each `SELECT` lives in `Larg`/`Rarg` and the top-level `FromClause` is empty. A 3-table `UNION` also exercises the recursive walk into a nested set operation.
- `toposort`: `TestOrderFromSchema_ViewWithFromSubquery` covers a `FROM (SELECT ...)` subquery (`RangeSubselect`), whose table dependency only surfaces if the subquery body is walked.
- `testdata/plan/matview_to_view_disallowed.yml`: a `MATERIALIZED VIEW` to `VIEW` type change with drops denied, covering the `-- skipped: DROP MATERIALIZED VIEW` branch in `DiffViews`.

### Dead code marked (not removed)
While chasing the last view branches I found two that are unreachable and left a `TODO` on each instead of a test:
- The rename type-switch check in `DiffViews` (`currentView.Materialized != desiredView.Materialized` in the `renamedFrom` loop). `detectViewRenames` already rejects a rename that switches between `VIEW` and `MATERIALIZED VIEW`, so the condition is never true there.
- The denied type-change comment skip. A denied type change always sets `recreateDenied[k]`, so the earlier `recreateDenied` check continues before this line is reached (confirmed by coverage: count 0).

Whether to delete these is left for a follow-up.

### Verification
- All tests pass, `go vet` and `golangci-lint` clean.
- Overall coverage 82.6% -> 82.7%; the four target lines are now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)