### PR TITLE
Add a sequence to the demo schema

### DIFF
--- a/demo/current.sql
+++ b/demo/current.sql
@@ -10,6 +10,9 @@ CREATE TYPE post_status AS ENUM ('draft', 'published', 'archived');
 CREATE DOMAIN email_address AS text
     CHECK (VALUE ~ '^[^@]+@[^@]+\.[^@]+$');
 
+-- Sequence: public-facing post reference numbers
+CREATE SEQUENCE post_ref_seq START 1000;
+
 -- ---------- users ----------
 CREATE TABLE users (
     id           bigserial PRIMARY KEY,

--- a/demo/desired.sql
+++ b/demo/desired.sql
@@ -9,6 +9,9 @@ CREATE TYPE post_status AS ENUM ('draft', 'published', 'archived', 'pinned');
 CREATE DOMAIN email_address AS text
     CHECK (VALUE ~ '^[^@]+@[^@]+\.[^@]+$');
 
+-- Sequence: post_ref_seq, increment bumped to 10
+CREATE SEQUENCE post_ref_seq START 1000 INCREMENT BY 10;
+
 -- ---------- users ----------
 --  +avatar_url
 CREATE TABLE users (


### PR DESCRIPTION
## Summary

Add a standalone `post_ref_seq` sequence (for public-facing post reference numbers) to the demo schema so the demo also covers sequences.

- `demo/current.sql`: `CREATE SEQUENCE post_ref_seq START 1000;`
- `demo/desired.sql`: `CREATE SEQUENCE post_ref_seq START 1000 INCREMENT BY 10;`

This makes `pista plan desired.sql` show an `ALTER SEQUENCE`, so the demo now exercises sequences alongside the existing table/index/policy/view/enum/domain objects.

## Verification

Ran against `postgres:18-alpine`:

- `pista plan` header now reports `1 sequence` and outputs `ALTER SEQUENCE public.post_ref_seq INCREMENT BY 10;`
- After `pista apply`, a re-plan prints `-- No changes` (drift-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUDsTXhxbc5vdyg9FrXCME