### PR TITLE
Always tag the demo image as latest

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}-demo
+          flavor: latest=true
       - &login-ghcr
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -81,6 +82,7 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}-demo
+          flavor: latest=true
       - *login-ghcr
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
## Summary

Update the demo image to always carry the `latest` tag.

- Set `flavor: latest=true` on both `docker/metadata-action` steps in `demo.yml`.

By default `metadata-action` uses `latest=auto`, which only adds `latest` for semver tags. So a `demo/**` push to `main` produced only `:main` and left `:latest` pointing at the last release. With `latest=true`, `latest` is updated on both `demo/**` pushes to `main` and releases. The default tags are preserved:

- `demo/**` push to `main`: `:main` + `:latest`
- release (`vX.Y.Z`): `:1.2.3` + `:latest`

## Verification

`actionlint` passes on `demo.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUDsTXhxbc5vdyg9FrXCME