### PR TITLE
Reword the second verify/dump comments in demo.tape

### DIFF
--- a/demo.tape
+++ b/demo.tape
@@ -83,14 +83,14 @@ Sleep 4s
 
 # Verify no remaining diff
 Enter
-Type "# Verify that the schema is now in sync" Enter
+Type "# Verify no changes remain" Enter
 Sleep 2s
 Type "pista plan schema.sql" Enter
 Sleep 4s
 
 # Dump
 Enter
-Type "# Dump the current database schema" Enter
+Type "# Dump the updated schema" Enter
 Sleep 2s
 Type "pista dump" Enter
 Sleep 4s


### PR DESCRIPTION
## Summary

Reword the second-pass comments in `demo.tape` so they no longer duplicate the first pass.

- `# Verify that the schema is now in sync` -> `# Verify no changes remain`
- `# Dump the current database schema` -> `# Dump the updated schema`

The dump wording also matches that the second dump reflects the added `body` column. The first-pass comments are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUDsTXhxbc5vdyg9FrXCME