### PR TITLE
Embed source revision in the demo image

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -53,6 +53,7 @@ jobs:
           outputs: type=image,name=ghcr.io/${{ github.repository }}-demo,push-by-digest=true,name-canonical=true,push=true
           build-args: |
             PISTA_VERSION=${{ github.ref_name }}
+            PISTA_REVISION=${{ github.sha }}
       - name: Export digest
         run: |
           mkdir -p "${{ runner.temp }}/digests"

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -46,5 +46,10 @@ RUN initdb -D /var/lib/postgresql/data >/dev/null && \
     psql -d demo -v ON_ERROR_STOP=1 -f /demo/current.sql && \
     pg_ctl -D /var/lib/postgresql/data -m fast stop
 
+# Source revision this image was built from (set in CI). Placed last so it
+# does not invalidate the cache of the expensive initdb layer above.
+ARG PISTA_REVISION
+ENV PISTA_REVISION=${PISTA_REVISION}
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
## Summary

Expose the source revision a demo image was built from as an environment variable.

- `demo/Dockerfile`: add `ARG PISTA_REVISION` + `ENV PISTA_REVISION=${PISTA_REVISION}`, placed after the `initdb` layer so it does not invalidate that expensive layer's cache.
- `.github/workflows/demo.yml`: pass `PISTA_REVISION=${{ github.sha }}` as a build-arg.

In a running container, `echo $PISTA_REVISION` prints the commit SHA the image was built from. Via CI (demo/** push or release) it is `github.sha`; a local `docker build` without the build-arg leaves it empty.

## Verification

Built the demo image locally with `--build-arg PISTA_REVISION=testrev123abc` and confirmed both the running container env and the image config carry `PISTA_REVISION=testrev123abc`. `actionlint` passes on `demo.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUDsTXhxbc5vdyg9FrXCME