### PR TITLE
Fix demo-gif render: install VHS via Homebrew

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - demo.tape
+      - .github/workflows/demo-gif.yml
 
 permissions:
   contents: write
@@ -44,16 +45,23 @@ jobs:
         run: |
           go build -o pista ./cmd/pista
           sudo mv pista /usr/local/bin/pista
-      - name: Install bat
+      - name: Install bat and font
         run: |
           sudo apt-get update
           sudo apt-get install -y bat
           sudo ln -sf /usr/bin/batcat /usr/local/bin/bat
+          # JetBrains Mono is the tape's default font; best-effort for fidelity.
+          sudo apt-get install -y fonts-jetbrains-mono || true
+      - name: Install VHS
+        # vhs-action's ffmpeg installer is broken (it fetches a BtbN asset that
+        # no longer exists), so install VHS via Homebrew. The vhs formula pulls
+        # in ttyd and ffmpeg as dependencies.
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: brew install vhs
       - name: Render demo.gif
-        uses: charmbracelet/vhs-action@59641cdc7fadf3978db65eb8c6937ea2752f4ec3 # v2.1.0
-        with:
-          path: demo.tape
-          install-fonts: "true"
+        run: vhs demo.tape
       - name: Create pull request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:


### PR DESCRIPTION
## Problem

The `demo-gif` workflow failed on the `Render demo.gif` step with `Failed to install ffmpeg` ([run](https://github.com/winebarrel/pistachio/actions/runs/29835314441/job/88650034513)).

Root cause is in `charmbracelet/vhs-action`: its `installLatestFfmpeg()` looks for an `ffmpeg-n5.1 ... linux64-gpl-5.1 .tar.xz` asset in the latest `BtbN/FFmpeg-Builds` release, which no longer exists. The dependency install runs unconditionally with no skip option, and upstream `main` still hardcodes `n5.1`, so the action is broken for all Linux users.

## Fix

- Drop `vhs-action`. Install VHS via Homebrew (`brew install vhs`), which pulls in `ttyd` and `ffmpeg` as formula dependencies, then run `vhs demo.tape` directly.
- Install `fonts-jetbrains-mono` (best-effort) so the tape's default font is available.
- Add `.github/workflows/demo-gif.yml` to the push `paths`, so edits to the workflow itself trigger a render.

## Verification

Confirmed locally that `brew deps vhs` includes `ffmpeg` and `ttyd`, and that `vhs demo.tape` renders a valid GIF with the same pipeline (postgres on 5432, `pista` on PATH, `bat` pager). `actionlint` passes.

Merging this PR touches `demo-gif.yml`, which now triggers the workflow on `main` and exercises the new install path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUDsTXhxbc5vdyg9FrXCME