### PR TITLE
Load Homebrew shellenv before installing VHS

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -55,11 +55,16 @@ jobs:
       - name: Install VHS
         # vhs-action's ffmpeg installer is broken (it fetches a BtbN asset that
         # no longer exists), so install VHS via Homebrew. The vhs formula pulls
-        # in ttyd and ffmpeg as dependencies.
+        # in ttyd and ffmpeg as dependencies. Homebrew ships with the runner but
+        # is not on PATH by default, so load its shellenv and expose its bin to
+        # later steps.
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
           HOMEBREW_NO_INSTALL_CLEANUP: "1"
-        run: brew install vhs
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "$HOMEBREW_PREFIX/bin" >> "$GITHUB_PATH"
+          brew install vhs
       - name: Render demo.gif
         run: vhs demo.tape
       - name: Create pull request


### PR DESCRIPTION
## Problem

The `demo-gif` render failed at the `Install VHS` step with `brew: command not found` ([run](https://github.com/winebarrel/pistachio/actions/runs/29836489149/job/88654053546)).

The GitHub-hosted runner ships Homebrew under `/home/linuxbrew/.linuxbrew`, but `brew` is not on `PATH` by default in a plain `run` step.

## Fix

Eval `brew shellenv` using the full path, then append `$HOMEBREW_PREFIX/bin` to `GITHUB_PATH` so the later `Render demo.gif` step finds `vhs` (and the `ttyd` / `ffmpeg` it depends on).

## Verification

`actionlint` passes. Merging this touches `demo-gif.yml`, which triggers the workflow on `main` and exercises the install path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUDsTXhxbc5vdyg9FrXCME