### PR TITLE
Create the demo.gif PR with gh instead of an action

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -68,13 +68,24 @@ jobs:
       - name: Render demo.gif
         run: vhs demo.tape
       - name: Create pull request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          add-paths: demo.gif
-          base: main
-          branch: update-demo-gif
-          delete-branch: true
-          commit-message: Update demo.gif
-          title: Update demo.gif
-          body: |
-            Regenerated demo.gif from demo.tape.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- demo.gif; then
+            echo "demo.gif unchanged; nothing to do."
+            exit 0
+          fi
+          branch=update-demo-gif
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add demo.gif
+          git commit -m "Update demo.gif"
+          git push -f origin "$branch"
+          if [ "$(gh pr list --head "$branch" --state open --json number --jq 'length')" -eq 0 ]; then
+            gh pr create --base main --head "$branch" \
+              --title "Update demo.gif" \
+              --body "Regenerated demo.gif from demo.tape."
+          else
+            echo "PR already open; branch updated."
+          fi


### PR DESCRIPTION
## Summary

Self-implement the PR creation in `demo-gif`, dropping `peter-evans/create-pull-request`.

The `Create pull request` step now uses `gh`:
- Skip when `demo.gif` is unchanged.
- Otherwise force-push the `update-demo-gif` branch with the regenerated GIF.
- Open a PR only when no open PR exists for that branch (an already-open PR is just updated by the push).

This removes the third-party action. It relies on the repo setting that now allows GitHub Actions to create PRs (`can_approve_pull_request_reviews: true`).

## Verification

`actionlint` passes; the step's shell logic passes `bash -n`. Merging this touches `demo-gif.yml`, which triggers the workflow on `main` and exercises the new PR-creation path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUDsTXhxbc5vdyg9FrXCME