### PR TITLE
Cache Homebrew downloads in demo-gif

### DIFF
--- a/.github/workflows/demo-gif.yml
+++ b/.github/workflows/demo-gif.yml
@@ -52,6 +52,13 @@ jobs:
           sudo ln -sf /usr/bin/batcat /usr/local/bin/bat
           # JetBrains Mono is the tape's default font; best-effort for fidelity.
           sudo apt-get install -y fonts-jetbrains-mono || true
+      - name: Cache Homebrew downloads
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/Homebrew/downloads
+          key: brew-downloads-${{ runner.os }}-${{ hashFiles('.github/workflows/demo-gif.yml') }}
+          restore-keys: |
+            brew-downloads-${{ runner.os }}-
       - name: Install VHS
         # vhs-action's ffmpeg installer is broken (it fetches a BtbN asset that
         # no longer exists), so install VHS via Homebrew. The vhs formula pulls


### PR DESCRIPTION
## Summary

Add `actions/cache` to the `demo-gif` workflow to cache Homebrew bottle downloads, so `brew install vhs` reuses cached `ttyd` / `ffmpeg` / `vhs` bottles instead of re-downloading them each run.

- Cache path: `~/.cache/Homebrew/downloads`
- Key: `brew-downloads-${{ runner.os }}-${{ hashFiles('.github/workflows/demo-gif.yml') }}`
- Prefix `restore-keys` so a bottle version bump still reuses the earlier cache partially.

The step is placed before `Install VHS`. `actions/setup-go` already caches Go build/modules by default, so only the Homebrew side is added here.

## Verification

`actionlint` passes. The first run after merge populates the cache (miss); subsequent runs restore it and skip the bottle downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUDsTXhxbc5vdyg9FrXCME