### PR TITLE
Add sequences count to plan/apply/dump summary examples in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ pista apply --allow-drop column,table schema.sql
 Suppressed drops are emitted as commented-out DDL prefixed with `-- skipped:`. The plan still reports `-- No changes` when the only diff would be a suppressed drop, since no executable DDL is generated:
 
 ```sql
--- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
+-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)
 -- skipped: DROP TABLE public.legacy_users;
 -- No changes
 ```
@@ -381,7 +381,7 @@ pista dump --omit-schema
 # => CREATE TABLE users (...) instead of CREATE TABLE public.users (...)
 
 pista dump --omit-schema --split ./schema/
-# -- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains)
+# -- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains, 0 sequences)
 # -- Wrote 2 file(s) to ./schema/
 # (writes ./schema/users.sql, ./schema/orders.sql, ...)
 ```
@@ -489,7 +489,7 @@ Use `--split` to output each table/view/enum/domain as a separate file in the sp
 
 ```bash
 pista dump --split ./schema/
-# -- Dump of schema public (3 tables, 0 views, 1 enum, 0 domains)
+# -- Dump of schema public (3 tables, 0 views, 1 enum, 0 domains, 0 sequences)
 # -- Wrote 4 file(s) to ./schema/
 # (writes ./schema/public.status.sql, ./schema/public.users.sql, ./schema/public.orders.sql, ...)
 ```

--- a/getting-started.md
+++ b/getting-started.md
@@ -71,7 +71,7 @@ pista plan schema.sql
 Output:
 
 ```sql
--- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
+-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)
 ALTER TABLE public.users ADD COLUMN email text;
 ```
 
@@ -86,7 +86,7 @@ pista apply schema.sql
 Output:
 
 ```sql
--- Apply to schema public (1 table, 0 views, 0 enums, 0 domains)
+-- Apply to schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)
 ALTER TABLE public.users ADD COLUMN email text;
 -- Apply finished in 12ms
 ```
@@ -99,7 +99,7 @@ Verify by running plan again:
 
 ```bash
 pista plan schema.sql
-# => -- Plan for schema public (1 table, 0 views, 0 enums, 0 domains)
+# => -- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)
 # => -- No changes
 ```
 


### PR DESCRIPTION
## Summary

The summary line produced by `Summary()` in `plan.go` ends with the sequences count (`pluralize(c.Sequences, "sequence")`), but the documentation examples still ended at `0 domains)`. This updates the examples to match the actual output.

## Changes

- `README.md`: `plan` and `dump` example output (3 lines)
- `getting-started.md`: `plan` and `apply` example output (3 lines)

Each `... 0 domains)` becomes `... 0 domains, 0 sequences)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)