### PR TITLE
Document Aurora DSQL support investigation in TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -217,3 +217,193 @@ LOGGED/UNLOGGED` for transitions. `TEMPORARY` sequences stay out of scope
 (session-local, never dumped).
 
 Origin: [#296](https://github.com/winebarrel/pistachio/pull/296).
+
+## Amazon Aurora DSQL support: findings from live testing
+
+Verified against a live DSQL cluster (PostgreSQL 16 wire protocol,
+ap-northeast-1). The premise "DSQL works if we only add ASYNC to
+CREATE INDEX" does not hold. Within DSQL's own supported feature set,
+pistachio does not reach a stable no-drift state today. Findings below
+are observed behavior, not inference.
+
+Scope note: features DSQL does not support (foreign keys, triggers,
+PL/pgSQL, etc.) are out of scope. A DSQL-targeted desired schema never
+contains them, so pistachio never needs to emit them. The issues below
+are all cases where the target state IS within DSQL's supported set but
+pistachio's transition DDL or drift comparison is wrong for DSQL.
+
+Support policy (if DSQL support is added):
+- Scope is DSQL's supported feature set only. pistachio's job is to work
+  correctly within that range, not to reproduce every PostgreSQL feature
+  on DSQL.
+- Unsupported diffs stay out of spec. When a diff needs an operation DSQL
+  has no path for (`DROP COLUMN`, `SET NOT NULL`, column `TYPE` change,
+  adding a NOT NULL column, adding a PK/CHECK constraint to an existing
+  table), pistachio emits standard PostgreSQL DDL and DSQL rejects it at
+  apply time. That is acceptable and requires no workaround; it is the
+  same as any unsupported feature. Do not build recreation/back-fill
+  machinery to force these through.
+- The real work is only where the target state IS supported by DSQL but
+  pistachio's generated DDL or drift comparison is wrong for it. Confirmed
+  set (details in the sections below):
+  1. Indexes: emit `CREATE INDEX ASYNC`, drop the `USING <method>` clause,
+     wait on the `job_id`; normalize `btree` vs `btree_index` in the diff.
+  2. Sequences: emit an explicit `CACHE`.
+  3. Primary-key drift: normalize DSQL's auto-`INCLUDE` on PK indexes so a
+     table that already matches does not re-plan (and so the inapplicable
+     `DROP/ADD CONSTRAINT` is never generated).
+- Optional niceties, not required (without them the diff just errors out
+  of spec, which is allowed): rewrite a column DEFAULT add into
+  `ADD COLUMN` + `SET DEFAULT`, and an existing-table UNIQUE add into
+  `CREATE UNIQUE INDEX ASYNC` + job-wait + `ADD CONSTRAINT ... UNIQUE
+  USING INDEX`.
+- Connection: a DSQL mode must not send `default_transaction_read_only`.
+- Gating: these behaviors should sit behind an explicit DSQL mode/dialect
+  (there is no dialect layer today), not change default PostgreSQL output.
+
+Connection:
+- DSQL rejects the `default_transaction_read_only` startup parameter
+  (`FATAL: setting configuration parameter "default_transaction_read_only"
+  not supported`, SQLSTATE 0A000). `plan` / `dump` must be run with
+  `--no-read-only`. A DSQL mode would need to stop sending this parameter.
+
+Catalog read layer (no incompatibility found):
+- Every catalog dependency exists on DSQL. All 7 catalog functions
+  (`pg_get_constraintdef`, `pg_get_indexdef`, `pg_get_viewdef`,
+  `pg_get_expr`, `pg_get_serial_sequence`, `pg_get_partkeydef`,
+  `format_type`) and all 16 system catalogs pistachio queries
+  (`pg_class`, `pg_namespace`, `pg_attribute`, `pg_attrdef`, `pg_type`,
+  `pg_collation`, `pg_constraint`, `pg_index`, `pg_inherits`, `pg_depend`,
+  `pg_description`, `pg_tablespace`, `pg_policy`, `pg_roles`, `pg_enum`,
+  `pg_sequence`) resolve.
+- `dump` read paths verified end to end on live objects: tables, columns,
+  PK/CHECK constraints, indexes, views, domains, and sequences all read
+  back correctly. The catalog surface is compatible; the incompatibilities
+  are in the returned values (see drift items below), not the queries.
+- The partition and extension read paths (`pg_inherits`,
+  `pg_get_partkeydef`, and the `pg_depend` extension-ownership subquery)
+  also run without error; they simply return nothing because DSQL cannot
+  create those objects (see below). `dump` exits 0 with them present.
+
+Objects DSQL cannot create (out of scope, never in a DSQL desired schema):
+- Enums: `CREATE TYPE ... AS ENUM` -> `unsupported statement: CreateEnum`.
+- Row-level security: `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` ->
+  `unsupported ALTER TABLE ENABLE ROW SECURITY statement`; `CREATE POLICY`
+  -> `unsupported statement: CreatePolicy`.
+- Partitioned tables: `PARTITION BY` -> `PARTITION BY clause not supported
+  for CREATE TABLE`; `PARTITION OF` -> `PARTITION OF clause not supported
+  for CREATE TABLE`.
+- Extensions: `CREATE EXTENSION` -> `unsupported statement:
+  CreateExtension`. `pg_available_extensions` is empty; `pg_extension`
+  holds only the built-in `plpgsql`.
+  The `pg_enum` / `pg_policy` / `pg_inherits` / `pg_depend` catalog reads
+  still run and return empty for these.
+
+Sequences:
+- `CREATE SEQUENCE` requires an explicit cache size: DSQL rejects a plain
+  `CREATE SEQUENCE` with `CREATE SEQUENCE is not supported without an
+  explicit cache size. please define CACHE greater than or equal to 65536
+  or equal to 1`. pistachio emits `CREATE SEQUENCE` without CACHE, so
+  sequence apply fails; the read path (with a CACHE-qualified sequence)
+  works.
+
+Tables and constraints:
+- CREATE TABLE with an inline PRIMARY KEY applies successfully.
+- Primary-key drift (false positive): DSQL auto-adds all non-key columns
+  as `INCLUDE` columns on the PK index, and stores the access method as
+  `btree_index`. So a table created from `PRIMARY KEY (id)` dumps back as
+  `PRIMARY KEY (id) INCLUDE (name, email)`. pistachio treats this as a
+  diff and re-plans forever with
+  `ALTER TABLE ... DROP CONSTRAINT ...; ALTER TABLE ... ADD CONSTRAINT ...`.
+- That generated fix is itself inapplicable: DSQL rejects
+  `ALTER TABLE ... DROP CONSTRAINT` on a primary key
+  (`unsupported ALTER TABLE DROP CONSTRAINT statement`, SQLSTATE 0A000),
+  and DSQL has no general `ALTER TABLE ... ADD CONSTRAINT` (see below for
+  the one `USING INDEX` exception).
+
+Column / constraint operations: reachable vs. no path. For each ALTER
+that pistachio emits, the question is not just "does the exact statement
+error" but "can the target state be reached by another supported DSQL
+syntax." Both categories were confirmed on the live cluster and checked
+against the `ALTER TABLE` grammar (the grammar is exhaustive; an action
+absent from it has no alternative form).
+
+Reachable via alternative DSQL syntax (pistachio would need to emit
+differently, not give up):
+- Add a column with a DEFAULT. `ADD COLUMN col type DEFAULT expr` fails
+  (`ALTER TABLE ADD COLUMN with constraint not supported`), but the plain
+  `ADD COLUMN col type` followed by `ALTER COLUMN col SET DEFAULT expr`
+  succeeds and yields the defaulted column. Two statements instead of one.
+- Add a UNIQUE constraint to an existing table. `ADD CONSTRAINT ... UNIQUE
+  (col)` is unavailable, but `CREATE UNIQUE INDEX ASYNC`, wait for the
+  build to reach VALID (`CALL sys.wait_for_job('<job_id>')`), then
+  `ALTER TABLE ... ADD CONSTRAINT name UNIQUE USING INDEX index_name`
+  succeeds and produces `UNIQUE (col)`. Confirmed. Note this requires the
+  job-wait step between the two statements, which pistachio's flat
+  synchronous apply loop does not do today.
+
+No alternative path (DSQL genuinely cannot do it to an existing table;
+these actions are simply absent from the `ALTER TABLE` grammar):
+- `DROP COLUMN` -> `unsupported ALTER TABLE DROP COLUMN statement`.
+- `ALTER COLUMN ... SET NOT NULL` -> `unsupported ... SET NOT NULL
+  statement`. `DROP NOT NULL` works, but there is no way to add NOT NULL
+  to an existing column (no `SET NOT NULL`, and no `ADD CONSTRAINT CHECK`
+  fallback since ADD CONSTRAINT is limited to `UNIQUE USING INDEX`).
+- `ALTER COLUMN ... TYPE` -> `unsupported ... SET DATA TYPE statement`.
+- Add a NOT NULL column to an existing table (only possible at CREATE
+  TABLE time; `ADD COLUMN` cannot carry NOT NULL and there is no post-hoc
+  SET NOT NULL).
+- Add a PRIMARY KEY or CHECK constraint to an existing table (the
+  `USING INDEX` exception is UNIQUE-only; PK/CHECK are CREATE TABLE-only).
+
+Supported directly (no change needed): `ALTER COLUMN SET DEFAULT`,
+`DROP DEFAULT`, `DROP NOT NULL`; inline PRIMARY KEY / UNIQUE / CHECK at
+CREATE TABLE. A UNIQUE constraint round-trips cleanly (its
+`pg_get_constraintdef` is `UNIQUE (col)` with no INCLUDE), unlike a
+primary key.
+
+Indexes (the original ASYNC question):
+- pistachio emits `CREATE INDEX ... USING btree (col)`. DSQL rejects the
+  access-method clause outright: `ERROR: USING not supported for CREATE
+  INDEX`. So this fails before ASYNC even matters; the `USING <method>`
+  clause must be stripped.
+- `CREATE INDEX ASYNC name ON t (col)` (no USING) succeeds and returns a
+  `job_id`; `sys.jobs` shows `INDEX_BUILD`. The build is asynchronous, so
+  completion must be awaited via `sys.jobs` / `sys.wait_for_job` before
+  dependent steps run.
+- DSQL stores and reports the index access method as `btree_index`, not
+  `btree`. pistachio's desired canonical form uses `btree`, so
+  `equalIndexDef` reports perpetual drift even for an already-correct
+  index (same root cause as the PK INCLUDE/method drift above).
+
+Minimum a DSQL mode would require, per the above:
+- Do not send `default_transaction_read_only`.
+- Index generation: `CREATE INDEX` -> `CREATE INDEX ASYNC`, drop the
+  `USING <method>` clause, and poll `job_id` to completion.
+- Drift normalization: ignore DSQL's auto-`INCLUDE` on PK indexes and
+  treat `btree` and `btree_index` as equivalent when comparing current
+  vs desired.
+- Sequence generation: emit an explicit `CACHE` (>= 65536 or = 1); DSQL
+  rejects a plain `CREATE SEQUENCE`.
+- Rewrite two reachable transitions into DSQL's alternative multi-step
+  form instead of failing:
+  - Column DEFAULT add -> plain `ADD COLUMN` then `SET DEFAULT`.
+  - Existing-table UNIQUE add -> `CREATE UNIQUE INDEX ASYNC` + job-wait +
+    `ADD CONSTRAINT ... UNIQUE USING INDEX`. This needs the same async
+    job-wait plumbing as index creation.
+- Detect-and-error (with a clear message) the transitions that have no
+  DSQL path, rather than emitting DDL that fails at apply: `DROP COLUMN`,
+  `SET NOT NULL`, column `TYPE` change, adding a NOT NULL column, and
+  adding a PK/CHECK constraint to an existing table.
+
+The catalog read layer itself needs no DSQL-specific work; the remaining
+gaps are all on the DDL-generation / drift-comparison side. The async
+job-wait requirement (for both plain index creation and the UNIQUE
+USING INDEX path) is the single biggest change to the apply loop, which
+is currently a flat synchronous send of each statement.
+
+None of this is abstracted in the codebase today (no dialect layer), so
+it is new work. This section records the verified gaps, not a commitment
+to implement DSQL support.
+
+Origin: live DSQL investigation, 2026-07-23.


### PR DESCRIPTION
## Summary

Records the results of testing pistachio against a live Aurora DSQL cluster (PostgreSQL 16 wire protocol, ap-northeast-1) and the support policy if DSQL support is added. Documentation only; no code changes.

The starting premise "DSQL works if we only add ASYNC to CREATE INDEX" does not hold. The findings separate three things that are easy to conflate:

- **Out of scope** - features DSQL cannot create (foreign keys, triggers, PL/pgSQL, enums, RLS/policies, partitioned tables, extensions). A DSQL-targeted desired schema never contains them.
- **Out of spec** - operations DSQL has no path for (`DROP COLUMN`, `SET NOT NULL`, column `TYPE` change, NOT NULL column add, PK/CHECK add to an existing table). pistachio emits standard PostgreSQL DDL and DSQL rejects it at apply; acceptable, no workaround needed.
- **Real work within DSQL's supported range** - a small set: index generation (`CREATE INDEX ASYNC`, drop `USING`, job-wait, `btree` vs `btree_index` normalization), sequence `CACHE`, and primary-key `INCLUDE` drift normalization.

## Verified against the live cluster

- Catalog read layer is compatible: all 7 catalog functions and 16 system catalogs pistachio queries exist; `dump` reads tables/columns/constraints/indexes/views/domains/sequences correctly. Partition and extension read paths run and return empty.
- Connection: DSQL rejects `default_transaction_read_only`, so `--no-read-only` is required.
- Alternative multi-step paths confirmed: column DEFAULT add via `ADD COLUMN` + `SET DEFAULT`; existing-table UNIQUE via `CREATE UNIQUE INDEX ASYNC` + job-wait + `ADD CONSTRAINT ... UNIQUE USING INDEX`.

## Policy

Any DSQL support should sit behind an explicit DSQL mode/dialect (there is no dialect layer today) and not change default PostgreSQL output. This PR does not commit to implementing DSQL support; it records the verified gaps and the intended approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxfj1qzDnUga3wq2UhiLuf