### PR TITLE
Add --config to load options from a YAML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.18.0] - 2026-07-27
+
+* Add `--config` (`-C`) to load options from a YAML file. Keys are flag names (e.g. `conn-string`); an unknown key is an error. One file works for every command, and keys the running command does not use are ignored. Precedence is command-line flag > environment variable > config file > default.
+
 ## [1.17.0] - 2026-07-21
 
 * Manage standalone sequences. `plan`, `apply`, and `dump` handle `CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`, `COMMENT ON SEQUENCE`, and rename via `-- pista:renamed-from`. Only standalone sequences are managed. A sequence owned by a `serial` or identity column stays with that column and is excluded from the diff, classified by `pg_depend.deptype`. A sequence referenced by a column default via `nextval` is created before that table and dropped after. `--enable`, `--disable`, `--include`, `--exclude`, and `--allow-drop` accept `sequence`. The `UNLOGGED` attribute is not tracked. ([#296](https://github.com/winebarrel/pistachio/pull/296))

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Flags:
   -n, --schemas=public,...    Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
-  -C, --config=CONFIG-FLAG    Load options from a YAML file. Keys must match
+  -C, --config=FILE           Load options from a YAML file. Keys must match
                               flag names (e.g. conn-string). Precedence:
                               command-line flag > environment variable > config
                               file.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Flags:
   -n, --schemas=public,...    Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
+  -C, --config=CONFIG-FLAG    Load options from a YAML file. Keys must match
+                              flag names (e.g. conn-string). Precedence:
+                              command-line flag > environment variable > config
+                              file.
       --version
       --[no-]pager            Force paging via $PISTA_PAGER even when stdout is
                               not a TTY. PISTA_PAGER must be set.
@@ -310,6 +314,33 @@ pista --no-pager plan schema.sql
 # Force the pager even when stdout is not a TTY
 PISTA_PAGER='source-highlight -s sql -f esc' pista --pager dump
 ```
+
+### Configuration file
+
+Use `-C` / `--config` to load options from a YAML file.
+
+Keys are flag names (for example `conn-string`, not `conn_string`). An unknown key is an error.
+
+```yaml
+# pista.yml
+conn-string: postgres://user@db.example.com/app
+schemas:
+  - public
+  - billing
+schema-map:
+  staging: public
+exclude:
+  - tmp_*
+```
+
+```bash
+pista --config pista.yml dump
+pista --config pista.yml plan schema.sql
+```
+
+One file works for every command. Keys that the running command does not use are ignored.
+
+Precedence: command-line flag > environment variable > config file > default.
 
 ### Schema name mapping
 

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -15,6 +15,7 @@ var version string
 
 var cli struct {
 	pistachio.Options
+	Config  kong.ConfigFlag `short:"C" name:"config" help:"Load options from a YAML file. Keys must match flag names (e.g. conn-string). Precedence: command-line flag > environment variable > config file."`
 	Version kong.VersionFlag
 	Pager   *bool `name:"pager" negatable:"" help:"Force paging via $PISTA_PAGER even when stdout is not a TTY. PISTA_PAGER must be set."`
 
@@ -27,6 +28,7 @@ func main() {
 	ctx := context.Background()
 	kctx := kong.Parse(&cli,
 		kong.Vars{"version": version},
+		kong.Configuration(pistachio.YAMLConfig),
 		kong.BindTo(ctx, (*context.Context)(nil)),
 		kong.BindTo(os.Stdout, (*io.Writer)(nil)),
 	)

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -15,7 +15,7 @@ var version string
 
 var cli struct {
 	pistachio.Options
-	Config  kong.ConfigFlag `short:"C" name:"config" help:"Load options from a YAML file. Keys must match flag names (e.g. conn-string). Precedence: command-line flag > environment variable > config file."`
+	Config  kong.ConfigFlag `short:"C" name:"config" placeholder:"FILE" help:"Load options from a YAML file. Keys must match flag names (e.g. conn-string). Precedence: command-line flag > environment variable > config file."`
 	Version kong.VersionFlag
 	Pager   *bool `name:"pager" negatable:"" help:"Force paging via $PISTA_PAGER even when stdout is not a TTY. PISTA_PAGER must be set."`
 

--- a/config.go
+++ b/config.go
@@ -1,0 +1,72 @@
+package pistachio
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"gopkg.in/yaml.v3"
+)
+
+// YAMLConfig is a kong.ConfigurationLoader that reads options from a YAML file.
+// Keys must exactly match CLI flag names (e.g. "conn-string"); snake_case or
+// camelCase variants are not accepted. Keys that do not match any flag are
+// rejected. Values only apply to flags not set on the command line; a config
+// file passed with --config takes precedence over environment variables.
+func YAMLConfig(r io.Reader) (kong.Resolver, error) {
+	values := map[string]any{}
+	if err := yaml.NewDecoder(r).Decode(&values); err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return &yamlResolver{values: values}, nil
+}
+
+type yamlResolver struct {
+	values map[string]any
+}
+
+func (y *yamlResolver) Resolve(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
+	v, ok := y.values[flag.Name]
+	if !ok {
+		return nil, nil
+	}
+	// Environment variables take precedence over the config file. Kong applies
+	// an env value before resolvers run, so defer to it by returning nil when
+	// one is set for this flag. Precedence: flag > env > config > default.
+	for _, env := range flag.Tag.Envs {
+		if _, set := os.LookupEnv(env); set {
+			return nil, nil
+		}
+	}
+	return v, nil
+}
+
+func (y *yamlResolver) Validate(app *kong.Application) error {
+	known := map[string]bool{}
+	collectFlagNames(app.Node, known)
+
+	var unknown []string
+	for key := range y.values {
+		if !known[key] {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("unknown config key(s): %s", strings.Join(unknown, ", "))
+	}
+	return nil
+}
+
+func collectFlagNames(node *kong.Node, out map[string]bool) {
+	for _, flag := range node.Flags {
+		out[flag.Name] = true
+	}
+	for _, child := range node.Children {
+		collectFlagNames(child, out)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -5,12 +5,21 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 
 	"github.com/alecthomas/kong"
 	"gopkg.in/yaml.v3"
 )
+
+// Built-in kong meta flags are not loadable from the config file. --help is
+// matched by pointer via Application.HelpFlag; the rest by their kong type.
+var metaFlagTypes = map[reflect.Type]bool{
+	reflect.TypeFor[kong.ConfigFlag]():    true,
+	reflect.TypeFor[kong.VersionFlag]():   true,
+	reflect.TypeFor[kong.ChangeDirFlag](): true,
+}
 
 // YAMLConfig is a kong.ConfigurationLoader that reads options from a YAML file.
 // Keys must exactly match CLI flag names (e.g. "conn-string"); snake_case or
@@ -30,6 +39,9 @@ type yamlResolver struct {
 }
 
 func (y *yamlResolver) Resolve(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
+	if isMetaFlag(flag) {
+		return nil, nil
+	}
 	v, ok := y.values[flag.Name]
 	if !ok {
 		return nil, nil
@@ -47,7 +59,7 @@ func (y *yamlResolver) Resolve(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (
 
 func (y *yamlResolver) Validate(app *kong.Application) error {
 	known := map[string]bool{}
-	collectFlagNames(app.Node, known)
+	collectFlagNames(app.Node, app.HelpFlag, known)
 
 	var unknown []string
 	for key := range y.values {
@@ -62,11 +74,18 @@ func (y *yamlResolver) Validate(app *kong.Application) error {
 	return nil
 }
 
-func collectFlagNames(node *kong.Node, out map[string]bool) {
+func collectFlagNames(node *kong.Node, help *kong.Flag, out map[string]bool) {
 	for _, flag := range node.Flags {
+		if flag == help || isMetaFlag(flag) {
+			continue
+		}
 		out[flag.Name] = true
 	}
 	for _, child := range node.Children {
-		collectFlagNames(child, out)
+		collectFlagNames(child, help, out)
 	}
+}
+
+func isMetaFlag(flag *kong.Flag) bool {
+	return metaFlagTypes[flag.Target.Type()]
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,193 @@
+package pistachio_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio"
+)
+
+// testCLI mirrors the global options plus the --config flag so the YAML
+// configuration loader can be exercised without a running database.
+type testCLI struct {
+	pistachio.Options
+	Config kong.ConfigFlag `name:"config" short:"C"`
+}
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pista.yml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func parseWithConfig(t *testing.T, args ...string) (*testCLI, error) {
+	t.Helper()
+	var cli testCLI
+	parser, err := kong.New(&cli,
+		kong.Name("pista"),
+		kong.Configuration(pistachio.YAMLConfig),
+		kong.Exit(func(int) {}),
+	)
+	require.NoError(t, err)
+	_, err = parser.Parse(args)
+	return &cli, err
+}
+
+func TestYAMLConfig_LoadsOptions(t *testing.T) {
+	path := writeConfig(t, `
+conn-string: postgres://user@db/app
+dbname: app
+schemas:
+  - public
+  - billing
+schema-map:
+  old: new
+`)
+
+	cli, err := parseWithConfig(t, "--config", path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgres://user@db/app", cli.ConnString)
+	assert.Equal(t, "app", cli.DBName)
+	assert.Equal(t, []string{"public", "billing"}, cli.Schemas)
+	assert.Equal(t, map[string]string{"old": "new"}, cli.SchemaMap)
+}
+
+func TestYAMLConfig_CLIFlagWins(t *testing.T) {
+	path := writeConfig(t, "conn-string: postgres://config@db/app\n")
+
+	cli, err := parseWithConfig(t, "--config", path, "--conn-string", "postgres://cli@db/app")
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgres://cli@db/app", cli.ConnString)
+}
+
+// Pin the precedence: command-line flag > environment variable > config file.
+// An environment variable overrides the config file.
+func TestYAMLConfig_EnvOverridesConfig(t *testing.T) {
+	t.Setenv("PISTA_CONN_STR", "postgres://env@db/app")
+	path := writeConfig(t, "conn-string: postgres://config@db/app\n")
+
+	cli, err := parseWithConfig(t, "--config", path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgres://env@db/app", cli.ConnString)
+}
+
+// A command-line flag still wins over both the env var and the config file.
+func TestYAMLConfig_FlagOverridesEnvAndConfig(t *testing.T) {
+	t.Setenv("PISTA_CONN_STR", "postgres://env@db/app")
+	path := writeConfig(t, "conn-string: postgres://config@db/app\n")
+
+	cli, err := parseWithConfig(t, "--config", path, "--conn-string", "postgres://cli@db/app")
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgres://cli@db/app", cli.ConnString)
+}
+
+// The config file is used when no env var or flag is set.
+func TestYAMLConfig_ConfigUsedWithoutEnv(t *testing.T) {
+	path := writeConfig(t, "conn-string: postgres://config@db/app\n")
+
+	cli, err := parseWithConfig(t, "--config", path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgres://config@db/app", cli.ConnString)
+}
+
+// Without a config file the env var still applies.
+func TestYAMLConfig_EnvUsedWithoutConfig(t *testing.T) {
+	t.Setenv("PISTA_CONN_STR", "postgres://env@db/app")
+
+	cli, err := parseWithConfig(t)
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgres://env@db/app", cli.ConnString)
+}
+
+func TestYAMLConfig_UnknownKeyIsRejected(t *testing.T) {
+	path := writeConfig(t, "bogus: 1\n")
+
+	_, err := parseWithConfig(t, "--config", path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bogus")
+}
+
+// Keys must match flag names exactly; the snake_case variant is not accepted
+// and is reported as an unknown key.
+func TestYAMLConfig_ExactKeyNameOnly(t *testing.T) {
+	path := writeConfig(t, "conn_string: postgres://config@db/app\n")
+
+	_, err := parseWithConfig(t, "--config", path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conn_string")
+}
+
+func TestYAMLConfig_EmptyFile(t *testing.T) {
+	path := writeConfig(t, "")
+
+	cli, err := parseWithConfig(t, "--config", path)
+	require.NoError(t, err)
+
+	// Falls back to the flag default.
+	assert.Equal(t, "postgres://postgres@localhost/postgres", cli.ConnString)
+}
+
+func TestYAMLConfig_MissingFileIsError(t *testing.T) {
+	_, err := parseWithConfig(t, "--config", filepath.Join(t.TempDir(), "nope.yml"))
+	require.Error(t, err)
+}
+
+func TestYAMLConfig_InvalidYAMLIsError(t *testing.T) {
+	// A top-level sequence cannot decode into a mapping.
+	path := writeConfig(t, "- one\n- two\n")
+
+	_, err := parseWithConfig(t, "--config", path)
+	require.Error(t, err)
+}
+
+// commandCLI mirrors the real CLI closely enough to exercise command-specific
+// flags loaded from a shared config file.
+type commandCLI struct {
+	pistachio.Options
+	Config kong.ConfigFlag `name:"config" short:"C"`
+	Plan   struct {
+		pistachio.PlanOptions
+	} `cmd:""`
+	Dump struct {
+		pistachio.DumpOptions
+	} `cmd:""`
+}
+
+func parseCommandCLI(t *testing.T, args ...string) (*commandCLI, error) {
+	t.Helper()
+	var cli commandCLI
+	parser, err := kong.New(&cli,
+		kong.Name("pista"),
+		kong.Configuration(pistachio.YAMLConfig),
+		kong.Exit(func(int) {}),
+	)
+	require.NoError(t, err)
+	_, err = parser.Parse(args)
+	return &cli, err
+}
+
+// A command-specific flag is loaded, and a key that belongs to another command
+// is accepted (a single file can be shared across commands).
+func TestYAMLConfig_CommandSpecificFlag(t *testing.T) {
+	path := writeConfig(t, `
+omit-schema: true
+bulk-alter: true
+`)
+
+	cli, err := parseCommandCLI(t, "--config", path, "dump")
+	require.NoError(t, err)
+
+	assert.True(t, cli.Dump.OmitSchema)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/winebarrel/pistachio"
 )
 
-// testCLI mirrors the global options plus the --config flag so the YAML
-// configuration loader can be exercised without a running database.
+// testCLI mirrors the global options plus the meta flags (--config, --version,
+// --pager) so the YAML configuration loader can be exercised without a running
+// database. --help is added by kong automatically.
 type testCLI struct {
 	pistachio.Options
-	Config kong.ConfigFlag `name:"config" short:"C"`
+	Config  kong.ConfigFlag `name:"config" short:"C"`
+	Version kong.VersionFlag
+	Pager   *bool `name:"pager" negatable:""`
 }
 
 func writeConfig(t *testing.T, content string) string {
@@ -31,6 +34,7 @@ func parseWithConfig(t *testing.T, args ...string) (*testCLI, error) {
 	var cli testCLI
 	parser, err := kong.New(&cli,
 		kong.Name("pista"),
+		kong.Vars{"version": "test"},
 		kong.Configuration(pistachio.YAMLConfig),
 		kong.Exit(func(int) {}),
 	)
@@ -179,15 +183,45 @@ func parseCommandCLI(t *testing.T, args ...string) (*commandCLI, error) {
 }
 
 // A command-specific flag is loaded, and a key that belongs to another command
-// is accepted (a single file can be shared across commands).
+// is accepted and ignored (a single file can be shared across commands).
 func TestYAMLConfig_CommandSpecificFlag(t *testing.T) {
-	path := writeConfig(t, `
+	// omit-schema belongs to dump; bulk-alter belongs to plan.
+	content := `
 omit-schema: true
 bulk-alter: true
-`)
+`
 
-	cli, err := parseCommandCLI(t, "--config", path, "dump")
-	require.NoError(t, err)
+	t.Run("dump uses omit-schema, ignores bulk-alter", func(t *testing.T) {
+		path := writeConfig(t, content)
+		cli, err := parseCommandCLI(t, "--config", path, "dump")
+		require.NoError(t, err)
+		assert.True(t, cli.Dump.OmitSchema)
+	})
 
-	assert.True(t, cli.Dump.OmitSchema)
+	t.Run("plan uses bulk-alter, ignores omit-schema", func(t *testing.T) {
+		path := writeConfig(t, content)
+		cli, err := parseCommandCLI(t, "--config", path, "plan", "schema.sql")
+		require.NoError(t, err)
+		assert.True(t, cli.Plan.BulkAlter)
+	})
+}
+
+// Built-in meta flags (help, version, and config itself) are not configurable;
+// naming one is an unknown key. The values below are valid for each flag's
+// type, so the only possible error is the unknown-key rejection.
+func TestYAMLConfig_MetaFlagsAreNotConfigurable(t *testing.T) {
+	cases := map[string]string{
+		"version": "version: true\n",
+		"help":    "help: true\n",
+		"config":  "config: other.yml\n",
+	}
+	for key, content := range cases {
+		t.Run(key, func(t *testing.T) {
+			path := writeConfig(t, content)
+			_, err := parseWithConfig(t, "--config", path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown config key")
+			assert.Contains(t, err.Error(), key)
+		})
+	}
 }

--- a/getting-started.md
+++ b/getting-started.md
@@ -31,6 +31,12 @@ export PISTA_PASSWORD='s3cret'
 pista dump
 ```
 
+You can also put options in a YAML file and load it with `--config`. See [README#configuration-file](README.md#configuration-file).
+
+```bash
+pista --config pista.yml dump
+```
+
 ## Step 2: Dump the current schema
 
 Export your existing database schema to a SQL file:

--- a/test/scenario/config.test.sh
+++ b/test/scenario/config.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Scenario test: --config loads options from a YAML file.
+# Exercises the real CLI wiring (kong.Configuration + the --config flag) and
+# the flag > env > config precedence end to end.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/config"
+
+setup_db "$DATA/init.sql"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# --- Step 1: options in the config file are applied ---
+step "01 --config applies exclude"
+printf 'exclude:\n  - tmp_*\n' > "$tmp_dir/pista.yml"
+out=$("$PISTA" --config "$tmp_dir/pista.yml" dump 2>&1) || out="DUMP FAILED: $out"
+if echo "$out" | grep -q 'CREATE TABLE public.users' && ! echo "$out" | grep -q 'tmp_cache'; then
+  pass
+else
+  fail "exclude from config not applied"
+  echo "    $out" >&2
+fi
+
+# --- Step 2: an unknown key is rejected ---
+step "02 unknown config key is rejected"
+printf 'bogus: 1\n' > "$tmp_dir/bad.yml"
+if err=$("$PISTA" --config "$tmp_dir/bad.yml" dump 2>&1); then
+  fail "expected an error for an unknown key"
+  echo "    $err" >&2
+elif echo "$err" | grep -q 'unknown config key'; then
+  pass
+else
+  fail "unexpected error: $err"
+fi
+
+# --- Step 3: an environment variable overrides the config file ---
+step "03 env overrides config"
+printf 'exclude:\n  - users\n' > "$tmp_dir/pista.yml"
+out=$(PISTA_EXCLUDE='tmp_*' "$PISTA" --config "$tmp_dir/pista.yml" dump 2>&1) || out="DUMP FAILED: $out"
+if echo "$out" | grep -q 'CREATE TABLE public.users' && ! echo "$out" | grep -q 'tmp_cache'; then
+  pass
+else
+  fail "env did not override config exclude"
+  echo "    $out" >&2
+fi
+
+# --- Step 4: a command-line flag overrides both env and config ---
+step "04 flag overrides env and config"
+out=$(PISTA_EXCLUDE='tmp_*' "$PISTA" --config "$tmp_dir/pista.yml" dump --exclude 'nomatch_*' 2>&1) || out="DUMP FAILED: $out"
+if echo "$out" | grep -q 'CREATE TABLE public.users' && echo "$out" | grep -q 'CREATE TABLE public.tmp_cache'; then
+  pass
+else
+  fail "flag did not override env and config exclude"
+  echo "    $out" >&2
+fi
+
+summary

--- a/test/scenario/testdata/config/init.sql
+++ b/test/scenario/testdata/config/init.sql
@@ -1,0 +1,2 @@
+CREATE TABLE users (id integer PRIMARY KEY);
+CREATE TABLE tmp_cache (id integer PRIMARY KEY);


### PR DESCRIPTION
## Summary

Add `--config` / `-C` to load options from a YAML file.

- Keys are flag names (e.g. `conn-string`, not `conn_string`). An unknown key is an error.
- One file works for every command; keys the running command does not use are ignored.
- Precedence: command-line flag > environment variable > config file > default.

```yaml
# pista.yml
conn-string: postgres://user@db.example.com/app
schemas:
  - public
  - billing
exclude:
  - tmp_*
```

```bash
pista --config pista.yml dump
```

## Implementation

- `config.go`: a `kong.ConfigurationLoader` (`YAMLConfig`) with a resolver that reads YAML keyed by exact flag name, rejects unknown keys in `Validate`, and defers to a set environment variable so env wins over the file.
- `cmd/pista/main.go`: wire `kong.ConfigFlag` (`--config`/`-C`) and `kong.Configuration(pistachio.YAMLConfig)`.
- Docs: README (Usage + Configuration file section), getting-started, CHANGELOG.

## Tests

`config_test.go` covers loading (string / list / map), the full arg > env > config > default precedence, exact-key matching, unknown-key rejection, command-specific flags, empty file, invalid YAML, and missing file. `config.go` is 100% covered.

## Verification

`go build`, `go vet`, `make lint` (0 issues), and `go test -p 1 ./...` all pass. Verified end-to-end with the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWStjmqAaSnaCgho6UrFur