### PR TITLE
Allow the --config path via $PISTA_CONFIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.18.0] - 2026-07-27
 
-* Add `--config` (`-C`) to load options from a YAML file. Keys are flag names (e.g. `conn-string`); an unknown key is an error. One file works for every command, and keys the running command does not use are ignored. Precedence is command-line flag > environment variable > config file > default.
+* Add `--config` (`-C`, env `$PISTA_CONFIG`) to load options from a YAML file. Keys are flag names (e.g. `conn-string`); an unknown key is an error. One file works for every command, and keys the running command does not use are ignored. Precedence is command-line flag > environment variable > config file > default.
 
 ## [1.17.0] - 2026-07-21
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,7 @@ Flags:
   -n, --schemas=public,...    Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
                               Schema name mapping (e.g. -m old=new).
-  -C, --config=FILE           Load options from a YAML file. Keys must match
-                              flag names (e.g. conn-string). Precedence:
-                              command-line flag > environment variable > config
-                              file ($PISTA_CONFIG).
+  -C, --config=FILE           Load options from a YAML file ($PISTA_CONFIG).
       --version
       --[no-]pager            Force paging via $PISTA_PAGER even when stdout is
                               not a TTY. PISTA_PAGER must be set.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Flags:
   -C, --config=FILE           Load options from a YAML file. Keys must match
                               flag names (e.g. conn-string). Precedence:
                               command-line flag > environment variable > config
-                              file.
+                              file ($PISTA_CONFIG).
       --version
       --[no-]pager            Force paging via $PISTA_PAGER even when stdout is
                               not a TTY. PISTA_PAGER must be set.
@@ -336,6 +336,10 @@ exclude:
 ```bash
 pista --config pista.yml dump
 pista --config pista.yml plan schema.sql
+
+# Or set the path with an environment variable
+export PISTA_CONFIG=pista.yml
+pista dump
 ```
 
 One file works for every command. Keys that the running command does not use are ignored.

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -15,7 +15,7 @@ var version string
 
 var cli struct {
 	pistachio.Options
-	Config  kong.ConfigFlag `short:"C" name:"config" placeholder:"FILE" env:"PISTA_CONFIG" help:"Load options from a YAML file. Keys must match flag names (e.g. conn-string). Precedence: command-line flag > environment variable > config file."`
+	Config  kong.ConfigFlag `short:"C" name:"config" placeholder:"FILE" env:"PISTA_CONFIG" help:"Load options from a YAML file."`
 	Version kong.VersionFlag
 	Pager   *bool `name:"pager" negatable:"" help:"Force paging via $PISTA_PAGER even when stdout is not a TTY. PISTA_PAGER must be set."`
 

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -15,7 +15,7 @@ var version string
 
 var cli struct {
 	pistachio.Options
-	Config  kong.ConfigFlag `short:"C" name:"config" placeholder:"FILE" help:"Load options from a YAML file. Keys must match flag names (e.g. conn-string). Precedence: command-line flag > environment variable > config file."`
+	Config  kong.ConfigFlag `short:"C" name:"config" placeholder:"FILE" env:"PISTA_CONFIG" help:"Load options from a YAML file. Keys must match flag names (e.g. conn-string). Precedence: command-line flag > environment variable > config file."`
 	Version kong.VersionFlag
 	Pager   *bool `name:"pager" negatable:"" help:"Force paging via $PISTA_PAGER even when stdout is not a TTY. PISTA_PAGER must be set."`
 

--- a/config_test.go
+++ b/config_test.go
@@ -16,7 +16,7 @@ import (
 // database. --help is added by kong automatically.
 type testCLI struct {
 	pistachio.Options
-	Config  kong.ConfigFlag `name:"config" short:"C"`
+	Config  kong.ConfigFlag `name:"config" short:"C" env:"PISTA_CONFIG"`
 	Version kong.VersionFlag
 	Pager   *bool `name:"pager" negatable:""`
 }
@@ -113,6 +113,29 @@ func TestYAMLConfig_EnvUsedWithoutConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "postgres://env@db/app", cli.ConnString)
+}
+
+// The config file path can be provided via $PISTA_CONFIG.
+func TestYAMLConfig_PathFromEnv(t *testing.T) {
+	path := writeConfig(t, "conn-string: postgres://config@db/app\n")
+	t.Setenv("PISTA_CONFIG", path)
+
+	cli, err := parseWithConfig(t)
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgres://config@db/app", cli.ConnString)
+}
+
+// --config on the command line overrides the $PISTA_CONFIG path.
+func TestYAMLConfig_FlagPathOverridesEnvPath(t *testing.T) {
+	envPath := writeConfig(t, "conn-string: postgres://env-file@db/app\n")
+	flagPath := writeConfig(t, "conn-string: postgres://flag-file@db/app\n")
+	t.Setenv("PISTA_CONFIG", envPath)
+
+	cli, err := parseWithConfig(t, "--config", flagPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgres://flag-file@db/app", cli.ConnString)
 }
 
 func TestYAMLConfig_UnknownKeyIsRejected(t *testing.T) {

--- a/test/scenario/config.test.sh
+++ b/test/scenario/config.test.sh
@@ -25,6 +25,16 @@ else
   echo "    $out" >&2
 fi
 
+# --- Step 1b: the config path can come from $PISTA_CONFIG ---
+step "01b PISTA_CONFIG selects the file"
+out=$(PISTA_CONFIG="$tmp_dir/pista.yml" "$PISTA" dump 2>&1) || out="DUMP FAILED: $out"
+if echo "$out" | grep -q 'CREATE TABLE public.users' && ! echo "$out" | grep -q 'tmp_cache'; then
+  pass
+else
+  fail "PISTA_CONFIG not applied"
+  echo "    $out" >&2
+fi
+
 # --- Step 2: an unknown key is rejected ---
 step "02 unknown config key is rejected"
 printf 'bogus: 1\n' > "$tmp_dir/bad.yml"


### PR DESCRIPTION
## Summary

Add an `env:"PISTA_CONFIG"` tag to the `--config` flag so the config file path can be set with an environment variable.

```bash
export PISTA_CONFIG=pista.yml
pista dump
```

A command-line `--config` still overrides the `PISTA_CONFIG` path. kong fires `ConfigFlag.BeforeResolve` for a flag whose value comes from an env var (`applyHookToDefaultFlags`), so the file loads without `--config` on the command line.

## Tests

- Go: `TestYAMLConfig_PathFromEnv` (env selects the file) and `TestYAMLConfig_FlagPathOverridesEnvPath` (`--config` wins over the env path).
- Scenario: a `PISTA_CONFIG selects the file` step in `test/scenario/config.test.sh`.

## Docs

README (flags block + Configuration file section) and the CHANGELOG note `$PISTA_CONFIG`.

## Verification

`go build`, `go vet`, `make lint` (0 issues), `go test -p 1 ./...`, and the scenario suite all pass. Verified end-to-end with the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWStjmqAaSnaCgho6UrFur