### PR TITLE
Add --assume-validated to ignore NOT VALID constraint state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.19.0] - 2026-07-29
+
+* Add `--assume-validated` (env `$PISTA_ASSUME_VALIDATED`) to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Constraint additions and definition changes still apply, without `NOT VALID`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state.
+
 ## [1.18.0] - 2026-07-27
 
 * Add `--config` (`-C`, env `$PISTA_CONFIG`) to load options from a YAML file. Keys are flag names (e.g. `conn-string`); an unknown key is an error. One file works for every command, and keys the running command does not use are ignored. Precedence is command-line flag > environment variable > config file > default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.19.0] - 2026-07-29
+## [1.19.0] - 2026-07-28
 
 * Add `--assume-validated` (env `$PISTA_ASSUME_VALIDATED`) to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Constraint additions and definition changes still apply, without `NOT VALID`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.19.0] - 2026-07-28
+## [1.19.0] - 2026-07-29
 
 * Add `--assume-validated` (env `$PISTA_ASSUME_VALIDATED`) to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Constraint additions and definition changes still apply, without `NOT VALID`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state.
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ CREATE TABLE public.users (
 );
 ```
 
-Use `--assume-validated` to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state. Also available as `$PISTA_ASSUME_VALIDATED`.
+Use `--assume-validated` to treat every table constraint and foreign key as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state. Also available as `$PISTA_ASSUME_VALIDATED`.
 
 ```bash
 pista plan --assume-validated schema.sql

--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ CREATE TABLE public.users (
 );
 ```
 
+Use `--assume-validated` to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state. Also available as `$PISTA_ASSUME_VALIDATED`.
+
+```bash
+pista plan --assume-validated schema.sql
+pista apply --assume-validated schema.sql
+```
+
 By default, `plan` and `apply` do not drop tables, views, enums, domains, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `foreign_key`, `index`). Also available as `$PISTA_ALLOW_DROP`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately.
 
 ```bash

--- a/apply.go
+++ b/apply.go
@@ -23,6 +23,7 @@ type ApplyOptions struct {
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently,tx-mode" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops. Cannot be combined with --with-tx."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
+	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every constraint as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
 }
 
 // ApplyResult holds the result of an Apply operation.
@@ -65,6 +66,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		DisableIndexConcurrently: options.DisableIndexConcurrently,
 		ForceIndexConcurrently:   options.ForceIndexConcurrently,
 		BulkAlter:                options.BulkAlter,
+		AssumeValidated:          options.AssumeValidated,
 	})
 	if err != nil {
 		return nil, err

--- a/apply.go
+++ b/apply.go
@@ -23,7 +23,7 @@ type ApplyOptions struct {
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently,tx-mode" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops. Cannot be combined with --with-tx."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
-	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every constraint as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
+	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every table constraint and foreign key as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
 }
 
 // ApplyResult holds the result of an Apply operation.

--- a/apply_test.go
+++ b/apply_test.go
@@ -30,6 +30,7 @@ type applyTestCase struct {
 	DisableIndexConcurrently bool             `yaml:"disable_index_concurrently,omitempty"`
 	ForceIndexConcurrently   bool             `yaml:"force_index_concurrently,omitempty"`
 	BulkAlter                bool             `yaml:"bulk_alter,omitempty"`
+	AssumeValidated          bool             `yaml:"assume_validated,omitempty"`
 	Include                  []string         `yaml:"include,omitempty"`
 	Exclude                  []string         `yaml:"exclude,omitempty"`
 	Enable                   []string         `yaml:"enable,omitempty"`
@@ -121,6 +122,7 @@ func TestApply(t *testing.T) {
 				DisableIndexConcurrently: tc.DisableIndexConcurrently,
 				ForceIndexConcurrently:   tc.ForceIndexConcurrently,
 				BulkAlter:                tc.BulkAlter,
+				AssumeValidated:          tc.AssumeValidated,
 				PreSQL:                   tc.PreSQL,
 				PreSQLFile:               preSQLFile,
 				ConcurrentlyPreSQL:       tc.ConcurrentlyPreSQL,
@@ -150,6 +152,7 @@ func TestApply(t *testing.T) {
 					Files:                    []string{desiredFile},
 					DisableIndexConcurrently: tc.DisableIndexConcurrently,
 					ForceIndexConcurrently:   tc.ForceIndexConcurrently,
+					AssumeValidated:          tc.AssumeValidated,
 					PreSQL:                   tc.PreSQL,
 					PreSQLFile:               preSQLFile,
 					ConcurrentlyPreSQL:       tc.ConcurrentlyPreSQL,

--- a/diff_all.go
+++ b/diff_all.go
@@ -27,6 +27,7 @@ type diffAllOptions struct {
 	DisableIndexConcurrently bool
 	ForceIndexConcurrently   bool
 	BulkAlter                bool
+	AssumeValidated          bool
 }
 
 // diffAllResult holds the result of diffAll.
@@ -125,6 +126,10 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		clearConcurrentlyDirectives(desiredTables, desiredViews)
 	case options.ForceIndexConcurrently:
 		forceConcurrentlyDirectives(filteredTables, filteredViews, desiredTables, desiredViews)
+	}
+
+	if options.AssumeValidated {
+		assumeValidatedConstraints(filteredTables, desiredTables)
 	}
 
 	enumDiff, err := diff.DiffEnums(filteredEnums, desiredEnums, &options.DropPolicy)
@@ -248,6 +253,27 @@ func clearConcurrentlyDirectives(
 	for _, v := range views.CollectValues() {
 		for _, idx := range v.Indexes.CollectValues() {
 			idx.Concurrently = false
+		}
+	}
+}
+
+// assumeValidatedConstraints marks every check constraint and foreign key as
+// validated on both the current and desired sides, used to implement
+// --assume-validated. Forcing the validation state to true means NOT VALID is
+// never emitted and validation-state differences produce no VALIDATE
+// CONSTRAINT, keeping the validated flag out of the diff entirely.
+func assumeValidatedConstraints(
+	currentTables *orderedmap.Map[string, *model.Table],
+	desiredTables *orderedmap.Map[string, *model.Table],
+) {
+	for _, tables := range []*orderedmap.Map[string, *model.Table]{currentTables, desiredTables} {
+		for _, t := range tables.CollectValues() {
+			for _, con := range t.Constraints.CollectValues() {
+				con.Validated = true
+			}
+			for _, fk := range t.ForeignKeys.CollectValues() {
+				fk.Validated = true
+			}
 		}
 	}
 }

--- a/plan.go
+++ b/plan.go
@@ -19,7 +19,7 @@ type PlanOptions struct {
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
-	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every constraint as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
+	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every table constraint and foreign key as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
 	NoReadOnly               bool     `env:"PISTA_NO_READ_ONLY" help:"Open the database connection read-write. By default plan uses a read-only connection."`
 }
 

--- a/plan.go
+++ b/plan.go
@@ -19,6 +19,7 @@ type PlanOptions struct {
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
+	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every constraint as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
 	NoReadOnly               bool     `env:"PISTA_NO_READ_ONLY" help:"Open the database connection read-write. By default plan uses a read-only connection."`
 }
 
@@ -88,6 +89,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 		DisableIndexConcurrently: options.DisableIndexConcurrently,
 		ForceIndexConcurrently:   options.ForceIndexConcurrently,
 		BulkAlter:                options.BulkAlter,
+		AssumeValidated:          options.AssumeValidated,
 	})
 	if err != nil {
 		return nil, err

--- a/plan_test.go
+++ b/plan_test.go
@@ -26,6 +26,7 @@ type planTestCase struct {
 	DisableIndexConcurrently bool            `yaml:"disable_index_concurrently,omitempty"`
 	ForceIndexConcurrently   bool            `yaml:"force_index_concurrently,omitempty"`
 	BulkAlter                bool            `yaml:"bulk_alter,omitempty"`
+	AssumeValidated          bool            `yaml:"assume_validated,omitempty"`
 	Include                  []string        `yaml:"include,omitempty"`
 	Exclude                  []string        `yaml:"exclude,omitempty"`
 	Enable                   []string        `yaml:"enable,omitempty"`
@@ -325,6 +326,7 @@ func TestPlan(t *testing.T) {
 				DisableIndexConcurrently: tc.DisableIndexConcurrently,
 				ForceIndexConcurrently:   tc.ForceIndexConcurrently,
 				BulkAlter:                tc.BulkAlter,
+				AssumeValidated:          tc.AssumeValidated,
 				PreSQL:                   tc.PreSQL,
 				PreSQLFile:               preSQLFile,
 				ConcurrentlyPreSQL:       tc.ConcurrentlyPreSQL,

--- a/testdata/apply/assume_validated_new_table_check.yml
+++ b/testdata/apply/assume_validated_new_table_check.yml
@@ -1,0 +1,18 @@
+assume_validated: true
+verify_no_drift: true
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0) NOT VALID
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0)
+  );

--- a/testdata/apply/assume_validated_new_table_fk.yml
+++ b/testdata/apply/assume_validated_new_table_fk.yml
@@ -1,0 +1,33 @@
+assume_validated: true
+verify_no_drift: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID
+  );
+applied: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id);
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/assume_validated_add_check.yml
+++ b/testdata/plan/assume_validated_add_check.yml
@@ -1,0 +1,16 @@
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0) NOT VALID
+  );
+plan: |
+  ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0);

--- a/testdata/plan/assume_validated_add_fk.yml
+++ b/testdata/plan/assume_validated_add_fk.yml
@@ -1,0 +1,24 @@
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID
+  );
+plan: |
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users (id);

--- a/testdata/plan/assume_validated_change_check.yml
+++ b/testdata/plan/assume_validated_change_check.yml
@@ -1,0 +1,18 @@
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age >= 0) NOT VALID
+  );
+plan: |
+  ALTER TABLE public.users DROP CONSTRAINT chk_age;
+  ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age >= 0);

--- a/testdata/plan/assume_validated_change_fk.yml
+++ b/testdata/plan/assume_validated_change_fk.yml
@@ -1,0 +1,26 @@
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE NOT VALID
+  );
+plan: |
+  ALTER TABLE public.orders DROP CONSTRAINT fk_user;
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE;

--- a/testdata/plan/assume_validated_check_current_not_valid.yml
+++ b/testdata/plan/assume_validated_check_current_not_valid.yml
@@ -1,0 +1,16 @@
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0)
+  );
+plan: ""

--- a/testdata/plan/assume_validated_check_desired_not_valid.yml
+++ b/testdata/plan/assume_validated_check_desired_not_valid.yml
@@ -1,0 +1,16 @@
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;
+plan: ""

--- a/testdata/plan/assume_validated_fk_current_not_valid.yml
+++ b/testdata/plan/assume_validated_fk_current_not_valid.yml
@@ -1,0 +1,24 @@
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+plan: ""

--- a/testdata/plan/assume_validated_fk_desired_not_valid.yml
+++ b/testdata/plan/assume_validated_fk_desired_not_valid.yml
@@ -1,0 +1,24 @@
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+plan: ""


### PR DESCRIPTION
## Summary

Add `--assume-validated` (env `$PISTA_ASSUME_VALIDATED`) to `plan` and `apply`. It treats every constraint as validated: pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. The validation state is kept out of the diff.

## Motivation

A table created with an inline `NOT VALID` constraint is created as validated, because `CREATE TABLE` inline syntax cannot carry `NOT VALID`. The next plan then shows a spurious `DROP CONSTRAINT` + `ADD ... NOT VALID`. This flag removes that drift and, more generally, lets you keep `NOT VALID` as a one-off migration step without it becoming part of the desired state.

## Behavior

* `NOT VALID` in the desired schema is ignored, so there is no drift when the current constraint is already validated.
* An existing `NOT VALID` constraint is left as is, with no `VALIDATE CONSTRAINT`.
* Constraint additions and definition changes still apply, emitted without `NOT VALID`.
* CHECK constraints and foreign keys are handled the same way.

## Tests

10 fixtures covering CHECK and FK symmetrically: desired-not-valid, current-not-valid, add, and change (plan), plus new-table (apply, with no-drift verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yGoKA43ktjL7LtZCodYtp