### PR TITLE
Track validation state of domain CHECK constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.20.0] - 2026-07-29
+
+* Track the validation state of domain CHECK constraints. A constraint that is `NOT VALID` in the database no longer produces a spurious `DROP` + `ADD` on every plan. When its definition matches the desired schema, it is validated with `ALTER DOMAIN ... VALIDATE CONSTRAINT` instead. `--assume-validated` also covers domain constraints.
+
 ## [1.19.0] - 2026-07-29
 
 * Add `--assume-validated` (env `$PISTA_ASSUME_VALIDATED`) to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Constraint additions and definition changes still apply, without `NOT VALID`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
-## [1.20.0] - 2026-07-29
-
-* Track the validation state of domain CHECK constraints. A constraint that is `NOT VALID` in the database no longer produces a spurious `DROP` + `ADD` on every plan. When its definition matches the desired schema, it is validated with `ALTER DOMAIN ... VALIDATE CONSTRAINT` instead. `--assume-validated` also covers domain constraints.
-
 ## [1.19.0] - 2026-07-29
 
 * Add `--assume-validated` (env `$PISTA_ASSUME_VALIDATED`) to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Constraint additions and definition changes still apply, without `NOT VALID`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state.
+
+* Track the validation state of domain CHECK constraints. A constraint that is `NOT VALID` in the database no longer produces a spurious `DROP` + `ADD` on every plan. When its definition matches the desired schema, it is validated with `ALTER DOMAIN ... VALIDATE CONSTRAINT` instead. `--assume-validated` also covers domain constraints.
 
 ## [1.18.0] - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ CREATE TABLE public.users (
 );
 ```
 
-Use `--assume-validated` to treat every table constraint and foreign key as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state. Also available as `$PISTA_ASSUME_VALIDATED`.
+Use `--assume-validated` to treat every table constraint, domain constraint, and foreign key as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state. Also available as `$PISTA_ASSUME_VALIDATED`.
 
 ```bash
 pista plan --assume-validated schema.sql
@@ -544,7 +544,7 @@ pista dump --split ./schema/
 
 ## Supported Objects
 
-- Domain types (`CREATE DOMAIN`, `ALTER DOMAIN SET/DROP DEFAULT`, `SET/DROP NOT NULL`, `ADD/DROP CONSTRAINT`)
+- Domain types (`CREATE DOMAIN`, `ALTER DOMAIN SET/DROP DEFAULT`, `SET/DROP NOT NULL`, `ADD/DROP/VALIDATE CONSTRAINT`)
 - Enum types (`CREATE TYPE ... AS ENUM`, `ALTER TYPE ... ADD VALUE`)
 - Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables)

--- a/apply.go
+++ b/apply.go
@@ -23,7 +23,7 @@ type ApplyOptions struct {
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently,tx-mode" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops. Cannot be combined with --with-tx."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
-	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every table constraint and foreign key as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
+	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every table constraint, domain constraint, and foreign key as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
 }
 
 // ApplyResult holds the result of an Apply operation.

--- a/catalog/domains.go
+++ b/catalog/domains.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/winebarrel/orderedmap"
@@ -108,7 +109,8 @@ func (c *Catalog) listDomainConstraints(ctx context.Context, domainOID uint32) (
 	q := `
 		SELECT
 			con.conname,
-			pg_catalog.pg_get_constraintdef(con.oid) AS definition
+			pg_catalog.pg_get_constraintdef(con.oid) AS definition,
+			con.convalidated
 		FROM
 			pg_catalog.pg_constraint con
 		WHERE
@@ -131,10 +133,14 @@ func (c *Catalog) listDomainConstraints(ctx context.Context, domainOID uint32) (
 	var constraints []*model.DomainConstraint
 	for rows.Next() {
 		var dc model.DomainConstraint
-		err := rows.Scan(&dc.Name, &dc.Definition)
+		err := rows.Scan(&dc.Name, &dc.Definition, &dc.Validated)
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan domain constraint: %w", err)
 		}
+		// pg_get_constraintdef appends "NOT VALID" for unvalidated
+		// constraints. Strip it so Definition only holds the constraint body;
+		// validation state is tracked via Validated.
+		dc.Definition = strings.TrimSuffix(dc.Definition, " NOT VALID")
 		constraints = append(constraints, &dc)
 	}
 

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -113,30 +113,40 @@ func diffDomain(fqdn string, current, desired *model.Domain) ([]string, error) {
 func diffDomainConstraints(fqdn string, current, desired []*model.DomainConstraint) []string {
 	var stmts []string
 
-	currentByName := make(map[string]string)
+	currentByName := make(map[string]*model.DomainConstraint)
 	for _, c := range current {
-		currentByName[c.Name] = c.Definition
+		currentByName[c.Name] = c
 	}
 
-	desiredByName := make(map[string]string)
+	desiredByName := make(map[string]*model.DomainConstraint)
 	for _, c := range desired {
-		desiredByName[c.Name] = c.Definition
+		desiredByName[c.Name] = c
 	}
 
-	// Drop removed or changed constraints
+	// Drop removed or changed constraints. A constraint with the same
+	// definition is kept: a NOT VALID -> validated transition is handled by
+	// VALIDATE CONSTRAINT below, not by recreation.
 	for _, c := range current {
-		desiredDef, ok := desiredByName[c.Name]
-		if !ok || !equalConstraintDef(c.Definition, desiredDef) {
+		d, ok := desiredByName[c.Name]
+		if !ok || !equalConstraintDef(c.Definition, d.Definition) {
 			stmts = append(stmts, "ALTER DOMAIN "+fqdn+" DROP CONSTRAINT "+model.Ident(c.Name)+";")
 		}
 	}
 
-	// Add new or changed constraints
+	// Add new or changed constraints, or validate an existing NOT VALID one.
+	// A desired domain constraint is always validated: inline CREATE DOMAIN
+	// cannot express NOT VALID, and ALTER DOMAIN is not parsed as desired
+	// input. So the only same-definition action is to validate a current
+	// NOT VALID constraint; a changed or new one is a plain ADD.
 	for _, c := range desired {
-		currentDef, ok := currentByName[c.Name]
-		if !ok || !equalConstraintDef(currentDef, c.Definition) {
-			stmts = append(stmts, "ALTER DOMAIN "+fqdn+" ADD CONSTRAINT "+model.Ident(c.Name)+" "+c.Definition+";")
+		cur, ok := currentByName[c.Name]
+		if ok && equalConstraintDef(cur.Definition, c.Definition) {
+			if !cur.Validated {
+				stmts = append(stmts, "ALTER DOMAIN "+fqdn+" VALIDATE CONSTRAINT "+model.Ident(c.Name)+";")
+			}
+			continue
 		}
+		stmts = append(stmts, "ALTER DOMAIN "+fqdn+" ADD CONSTRAINT "+model.Ident(c.Name)+" "+c.Definition+";")
 	}
 
 	return stmts

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -107,13 +107,34 @@ func TestDiffDomains_AddConstraint(t *testing.T) {
 		Name:     "pos_int",
 		BaseType: "integer",
 		Constraints: []*model.DomainConstraint{
-			{Name: "pos_check", Definition: "CHECK (VALUE > 0)"},
+			{Name: "pos_check", Definition: "CHECK (VALUE > 0)", Validated: true},
 		},
 	})
 	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
-	assert.Len(t, result.Stmts, 1)
-	assert.Contains(t, result.Stmts[0], "ADD CONSTRAINT pos_check")
+	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int ADD CONSTRAINT pos_check CHECK (VALUE > 0);"}, result.Stmts)
+}
+
+func TestDiffDomains_ValidateConstraint(t *testing.T) {
+	current := newDomainMap(&model.Domain{
+		Schema:   "public",
+		Name:     "pos_int",
+		BaseType: "integer",
+		Constraints: []*model.DomainConstraint{
+			{Name: "pos_check", Definition: "CHECK (VALUE > 0)", Validated: false},
+		},
+	})
+	desired := newDomainMap(&model.Domain{
+		Schema:   "public",
+		Name:     "pos_int",
+		BaseType: "integer",
+		Constraints: []*model.DomainConstraint{
+			{Name: "pos_check", Definition: "CHECK (VALUE > 0)", Validated: true},
+		},
+	})
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER DOMAIN public.pos_int VALIDATE CONSTRAINT pos_check;"}, result.Stmts)
 }
 
 func TestDiffDomains_DropConstraint(t *testing.T) {

--- a/diff_all.go
+++ b/diff_all.go
@@ -129,7 +129,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	}
 
 	if options.AssumeValidated {
-		assumeValidatedConstraints(filteredTables, desiredTables)
+		assumeValidatedConstraints(filteredTables, desiredTables, filteredDomains, desiredDomains)
 	}
 
 	enumDiff, err := diff.DiffEnums(filteredEnums, desiredEnums, &options.DropPolicy)
@@ -257,14 +257,16 @@ func clearConcurrentlyDirectives(
 	}
 }
 
-// assumeValidatedConstraints marks every check constraint and foreign key as
-// validated on both the current and desired sides, used to implement
-// --assume-validated. Forcing the validation state to true means NOT VALID is
-// never emitted and validation-state differences produce no VALIDATE
+// assumeValidatedConstraints marks every table constraint, domain constraint,
+// and foreign key as validated on both the current and desired sides, used to
+// implement --assume-validated. Forcing the validation state to true means NOT
+// VALID is never emitted and validation-state differences produce no VALIDATE
 // CONSTRAINT, keeping the validated flag out of the diff entirely.
 func assumeValidatedConstraints(
 	currentTables *orderedmap.Map[string, *model.Table],
 	desiredTables *orderedmap.Map[string, *model.Table],
+	currentDomains *orderedmap.Map[string, *model.Domain],
+	desiredDomains *orderedmap.Map[string, *model.Domain],
 ) {
 	for _, tables := range []*orderedmap.Map[string, *model.Table]{currentTables, desiredTables} {
 		for _, t := range tables.CollectValues() {
@@ -273,6 +275,13 @@ func assumeValidatedConstraints(
 			}
 			for _, fk := range t.ForeignKeys.CollectValues() {
 				fk.Validated = true
+			}
+		}
+	}
+	for _, domains := range []*orderedmap.Map[string, *model.Domain]{currentDomains, desiredDomains} {
+		for _, d := range domains.CollectValues() {
+			for _, c := range d.Constraints {
+				c.Validated = true
 			}
 		}
 	}

--- a/model/domain.go
+++ b/model/domain.go
@@ -9,6 +9,7 @@ import (
 type DomainConstraint struct {
 	Name       string
 	Definition string
+	Validated  bool
 }
 
 type Domain struct {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -842,6 +842,7 @@ func parseCreateDomainStmt(ds *pg_query.CreateDomainStmt, rawStmt *pg_query.RawS
 			domain.Constraints = append(domain.Constraints, &model.DomainConstraint{
 				Name:       con.Conname,
 				Definition: def,
+				Validated:  !con.SkipValidation,
 			})
 		}
 	}

--- a/plan.go
+++ b/plan.go
@@ -19,7 +19,7 @@ type PlanOptions struct {
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
-	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every table constraint and foreign key as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
+	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every table constraint, domain constraint, and foreign key as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
 	NoReadOnly               bool     `env:"PISTA_NO_READ_ONLY" help:"Open the database connection read-write. By default plan uses a read-only connection."`
 }
 

--- a/testdata/apply/validate_domain_constraint.yml
+++ b/testdata/apply/validate_domain_constraint.yml
@@ -1,0 +1,11 @@
+verify_no_drift: true
+init: |
+  CREATE DOMAIN public.pos_int AS integer;
+  ALTER DOMAIN public.pos_int ADD CONSTRAINT pos_check CHECK (VALUE > 0) NOT VALID;
+desired: |
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (VALUE > 0);
+applied: |
+  -- public.pos_int
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK ((VALUE > 0));

--- a/testdata/dump/domain_not_valid_constraint.yml
+++ b/testdata/dump/domain_not_valid_constraint.yml
@@ -1,0 +1,7 @@
+init: |
+  CREATE DOMAIN public.pos_int AS integer;
+  ALTER DOMAIN public.pos_int ADD CONSTRAINT pos_check CHECK (VALUE > 0) NOT VALID;
+dump: |
+  -- public.pos_int
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK ((VALUE > 0));

--- a/testdata/plan/assume_validated_domain.yml
+++ b/testdata/plan/assume_validated_domain.yml
@@ -1,0 +1,8 @@
+assume_validated: true
+init: |
+  CREATE DOMAIN public.pos_int AS integer;
+  ALTER DOMAIN public.pos_int ADD CONSTRAINT pos_check CHECK (VALUE > 0) NOT VALID;
+desired: |
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (VALUE > 0);
+plan: ""

--- a/testdata/plan/change_domain_constraint_not_valid.yml
+++ b/testdata/plan/change_domain_constraint_not_valid.yml
@@ -1,0 +1,9 @@
+init: |
+  CREATE DOMAIN public.pos_int AS integer;
+  ALTER DOMAIN public.pos_int ADD CONSTRAINT pos_check CHECK (VALUE > 0) NOT VALID;
+desired: |
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (VALUE >= 0);
+plan: |
+  ALTER DOMAIN public.pos_int DROP CONSTRAINT pos_check;
+  ALTER DOMAIN public.pos_int ADD CONSTRAINT pos_check CHECK (value >= 0);

--- a/testdata/plan/validate_domain_constraint.yml
+++ b/testdata/plan/validate_domain_constraint.yml
@@ -1,0 +1,8 @@
+init: |
+  CREATE DOMAIN public.pos_int AS integer;
+  ALTER DOMAIN public.pos_int ADD CONSTRAINT pos_check CHECK (VALUE > 0) NOT VALID;
+desired: |
+  CREATE DOMAIN public.pos_int AS integer
+      CONSTRAINT pos_check CHECK (VALUE > 0);
+plan: |
+  ALTER DOMAIN public.pos_int VALIDATE CONSTRAINT pos_check;


### PR DESCRIPTION
## Summary

Track the validation state (validated vs `NOT VALID`) of PostgreSQL domain CHECK constraints, mirroring what already exists for table constraints and foreign keys.

## Motivation

When a domain constraint is `NOT VALID` in the database, `pg_get_constraintdef` appends `NOT VALID` to the definition. The desired schema uses inline `CREATE DOMAIN`, which cannot express `NOT VALID`, so the two definitions never matched and `plan` emitted a spurious `DROP CONSTRAINT` + `ADD CONSTRAINT` on every run.

## Changes

* `catalog/domains.go`: select `convalidated` and strip `NOT VALID` from the definition, tracking the state in a new `DomainConstraint.Validated` field.
* `parser/parser.go`: set `Validated` from the parsed constraint.
* `diff/domains.go`: when a current `NOT VALID` constraint has the same definition as desired, emit `ALTER DOMAIN ... VALIDATE CONSTRAINT` instead of drop and re-add. A definition change is still a `DROP` + `ADD`.
* `diff_all.go`: `--assume-validated` now also covers domain constraints.

## Scope

Inline `CREATE DOMAIN` cannot express `NOT VALID`, so a desired domain constraint is always validated. This is the current-to-validated direction only, matching how the desired schema is written.

## Tests

* Unit: `TestDiffDomains_ValidateConstraint`, plus `AddConstraint` tightened to assert the exact statement.
* Fixtures: plan (validate, definition-change boundary, assume-validated suppression) and apply (validate with `verify_no_drift`).
* Full test suite passes, lint clean. `diffDomainConstraints`, `assumeValidatedConstraints`, and `listDomainConstraints` are all at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yGoKA43ktjL7LtZCodYtp