### PR TITLE
Add sequence to --enable/--disable valid types in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ pista -n staging -m staging=public apply schema.sql
 
 Use `-I` / `--include` to include only matching objects by name, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names). Also available as `$PISTA_INCLUDE` / `$PISTA_EXCLUDE` environment variables.
 
-Use `--enable` to restrict operations to specific object types, or `--disable` to exclude specific types. Valid types: `table`, `view`, `enum`, `domain`. Can be repeated. Also available as `$PISTA_ENABLE` / `$PISTA_DISABLE` environment variables.
+Use `--enable` to restrict operations to specific object types, or `--disable` to exclude specific types. Valid types: `table`, `view`, `enum`, `domain`, `sequence`. Can be repeated. Also available as `$PISTA_ENABLE` / `$PISTA_DISABLE` environment variables.
 
 These flags are available on the `dump`, `plan`, and `apply` subcommands.
 


### PR DESCRIPTION
## Summary

The `--enable` / `--disable` flags accept `sequence` as a valid object type (`options.go:20-21`), but the README listed only `table`, `view`, `enum`, `domain`. This adds the missing `sequence` type.

## Changes

- `README.md`: add `sequence` to the list of valid `--enable` / `--disable` types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UixmRWvR2EFJhFUtuw7xXZ