### PR TITLE
Add composite type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Manage composite types. `plan`, `apply`, and `dump` handle `CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME TO`, `RENAME ATTRIBUTE`, and comments on the type and its attributes. A composite type is created after the enums, domains, and composite types its attributes reference, and before tables that use it. `--enable`, `--disable`, `--include`, `--exclude`, and `--allow-drop` accept `composite_type`; `--allow-drop=composite_type` also gates `DROP ATTRIBUTE`. Attribute reordering is not diffed (PostgreSQL cannot reorder attributes), and `ALTER ATTRIBUTE ... TYPE` fails at apply while a table column uses the type. ([#331](https://github.com/winebarrel/pistachio/pull/331))
 
-* Fix a schema-qualified user-defined type (enum, domain, or composite) used as a column or attribute type producing a no-op `SET DATA TYPE` on every plan. The column type is now compared with the type's own schema stripped. Also set `search_path` to the target schemas before applying managed DDL, so an unqualified user-type reference resolves for a non-public target schema instead of failing at apply. ([#331](https://github.com/winebarrel/pistachio/pull/331))
+* Fix a schema-qualified user-defined type (enum, domain, or composite) used as a column or attribute type producing a no-op `SET DATA TYPE` on every plan. The column type is now compared with the type's own schema stripped. Also set `search_path` to the target schemas plus `public` before applying managed DDL, so an unqualified reference to a user type or to a `public` object (such as an extension type) resolves for a non-public target schema instead of failing at apply. ([#331](https://github.com/winebarrel/pistachio/pull/331))
 
 ## [1.19.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.20.0] - 2026-07-30
+
+* Manage composite types. `plan`, `apply`, and `dump` handle `CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME TO`, `RENAME ATTRIBUTE`, and comments on the type and its attributes. A composite type is created after the enums, domains, and composite types its attributes reference, and before tables that use it. `--enable`, `--disable`, `--include`, `--exclude`, and `--allow-drop` accept `composite_type`; `--allow-drop=composite_type` also gates `DROP ATTRIBUTE`. Attribute reordering is not diffed (PostgreSQL cannot reorder attributes), and `ALTER ATTRIBUTE ... TYPE` fails at apply while a table column uses the type. ([#331](https://github.com/winebarrel/pistachio/pull/331))
+
 ## [1.19.0] - 2026-07-29
 
 * Add `--assume-validated` (env `$PISTA_ASSUME_VALIDATED`) to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Constraint additions and definition changes still apply, without `NOT VALID`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Manage composite types. `plan`, `apply`, and `dump` handle `CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME TO`, `RENAME ATTRIBUTE`, and comments on the type and its attributes. A composite type is created after the enums, domains, and composite types its attributes reference, and before tables that use it. `--enable`, `--disable`, `--include`, `--exclude`, and `--allow-drop` accept `composite_type`; `--allow-drop=composite_type` also gates `DROP ATTRIBUTE`. Attribute reordering is not diffed (PostgreSQL cannot reorder attributes), and `ALTER ATTRIBUTE ... TYPE` fails at apply while a table column uses the type. ([#331](https://github.com/winebarrel/pistachio/pull/331))
 
+* Fix a schema-qualified user-defined type (enum, domain, or composite) used as a column or attribute type producing a no-op `SET DATA TYPE` on every plan. The column type is now compared with the type's own schema stripped. Also set `search_path` to the target schemas before applying managed DDL, so an unqualified user-type reference resolves for a non-public target schema instead of failing at apply. ([#331](https://github.com/winebarrel/pistachio/pull/331))
+
 ## [1.19.0] - 2026-07-29
 
 * Add `--assume-validated` (env `$PISTA_ASSUME_VALIDATED`) to treat every constraint as validated. Pistachio ignores `NOT VALID` in the desired schema and never emits `NOT VALID` or `VALIDATE CONSTRAINT`. Constraint additions and definition changes still apply, without `NOT VALID`. Use it when `NOT VALID` is a one-off migration step you do not want in the desired state.

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ CREATE TYPE public.status AS ENUM (
 );
 ```
 
-**Composite types** (statement level) **and their attributes** (inside `CREATE TYPE ... AS (...)`, before the attribute). A type rename emits `ALTER TYPE ... RENAME TO`; an attribute rename emits `ALTER TYPE ... RENAME ATTRIBUTE`, which keeps stored data:
+**Composite types and their attributes**. The statement-level directive renames the type (`ALTER TYPE ... RENAME TO`). A directive inside `CREATE TYPE ... AS (...)`, before an attribute, renames that attribute (`ALTER TYPE ... RENAME ATTRIBUTE`) and keeps stored data:
 
 ```sql
 -- pista:renamed-from public.address

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pista apply schema.sql                 # apply it
 Or split the schema across multiple files:
 
 ```bash
-pista dump --split ./schema/       # dump per table/view/enum/domain
+pista dump --split ./schema/       # dump per table/view/enum/domain/composite type
 pista plan ./schema/*.sql          # review the diff
 pista apply ./schema/*.sql         # apply it
 ```
@@ -245,7 +245,7 @@ pista plan --assume-validated schema.sql
 pista apply --assume-validated schema.sql
 ```
 
-By default, `plan` and `apply` do not drop tables, views, enums, domains, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `column`, `constraint`, `foreign_key`, `index`). Also available as `$PISTA_ALLOW_DROP`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately.
+By default, `plan` and `apply` do not drop tables, views, enums, domains, composite types, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `composite_type`, `column`, `constraint`, `foreign_key`, `index`, `policy`). Also available as `$PISTA_ALLOW_DROP`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately. `composite_type` also gates `DROP ATTRIBUTE` on a composite type.
 
 ```bash
 # Allow all drops
@@ -372,7 +372,7 @@ pista -n staging -m staging=public apply schema.sql
 
 Use `-I` / `--include` to include only matching objects by name, or `-E` / `--exclude` to exclude them. Patterns support `*` and `?` wildcards. Patterns match against object names only (not schema-qualified names). Also available as `$PISTA_INCLUDE` / `$PISTA_EXCLUDE` environment variables.
 
-Use `--enable` to restrict operations to specific object types, or `--disable` to exclude specific types. Valid types: `table`, `view`, `enum`, `domain`, `sequence`. Can be repeated. Also available as `$PISTA_ENABLE` / `$PISTA_DISABLE` environment variables.
+Use `--enable` to restrict operations to specific object types, or `--disable` to exclude specific types. Valid types: `table`, `view`, `enum`, `domain`, `composite_type`, `sequence`. Can be repeated. Also available as `$PISTA_ENABLE` / `$PISTA_DISABLE` environment variables.
 
 These flags are available on the `dump`, `plan`, and `apply` subcommands.
 
@@ -462,6 +462,17 @@ CREATE TYPE public.status AS ENUM (
 );
 ```
 
+**Composite types** (statement level) **and their attributes** (inside `CREATE TYPE ... AS (...)`, before the attribute). A type rename emits `ALTER TYPE ... RENAME TO`; an attribute rename emits `ALTER TYPE ... RENAME ATTRIBUTE`, which keeps stored data:
+
+```sql
+-- pista:renamed-from public.address
+CREATE TYPE public.postal_address AS (
+    -- pista:renamed-from street
+    road text,
+    city text
+);
+```
+
 **Columns, constraints, indexes** (inside `CREATE TABLE` or before `CREATE INDEX` / `ALTER TABLE ADD CONSTRAINT`):
 
 ```sql
@@ -510,7 +521,7 @@ The following references are not auto-rewritten and may produce a redundant `DRO
 
 ### Ignoring objects
 
-Use the `-- pista:ignore` directive to leave an object unmanaged. pistachio does not create, alter, or drop a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` marked with it. This is the in-file equivalent of `--exclude` for a single object, useful for a table managed by another tool or one whose definition intentionally drifts.
+Use the `-- pista:ignore` directive to leave an object unmanaged. pistachio does not create, alter, or drop a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE TYPE ... AS (...)` / `CREATE DOMAIN` / `CREATE VIEW` marked with it. This is the in-file equivalent of `--exclude` for a single object, useful for a table managed by another tool or one whose definition intentionally drifts.
 
 ```sql
 -- pista:ignore
@@ -524,7 +535,7 @@ Each ignored object is reported as an `-- ignored: <name>` comment in `plan` and
 
 ### Split dump
 
-Use `--split` to output each table/view/enum/domain as a separate file in the specified directory.
+Use `--split` to output each table/view/enum/domain/composite type as a separate file in the specified directory.
 
 ```bash
 pista dump --split ./schema/
@@ -546,6 +557,7 @@ pista dump --split ./schema/
 
 - Domain types (`CREATE DOMAIN`, `ALTER DOMAIN SET/DROP DEFAULT`, `SET/DROP NOT NULL`, `ADD/DROP/VALIDATE CONSTRAINT`)
 - Enum types (`CREATE TYPE ... AS ENUM`, `ALTER TYPE ... ADD VALUE`)
+- Composite types (`CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME ATTRIBUTE`)
 - Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables)
 - Views
@@ -553,9 +565,9 @@ pista dump --split ./schema/
 - Columns (serial/bigserial/smallserial, identity, generated)
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
-- Comments (on tables, columns, views, types, domains, sequences)
+- Comments (on tables, columns, views, types, domains, composite types, composite attributes, sequences)
 - Row-level security (`ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY`, policies via `CREATE POLICY` / `ALTER POLICY` / `DROP POLICY`)
-- Renaming (tables, views, enums, enum values, domains, sequences, columns, constraints, foreign keys, indexes, policies via `-- pista:renamed-from` directive)
+- Renaming (tables, views, enums, enum values, domains, composite types, composite attributes, sequences, columns, constraints, foreign keys, indexes, policies via `-- pista:renamed-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ pista apply --allow-drop column,table schema.sql
 Suppressed drops are emitted as commented-out DDL prefixed with `-- skipped:`. The plan still reports `-- No changes` when the only diff would be a suppressed drop, since no executable DDL is generated:
 
 ```sql
--- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)
+-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)
 -- skipped: DROP TABLE public.legacy_users;
 -- No changes
 ```
@@ -420,7 +420,7 @@ pista dump --omit-schema
 # => CREATE TABLE users (...) instead of CREATE TABLE public.users (...)
 
 pista dump --omit-schema --split ./schema/
-# -- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains, 0 sequences)
+# -- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)
 # -- Wrote 2 file(s) to ./schema/
 # (writes ./schema/users.sql, ./schema/orders.sql, ...)
 ```
@@ -539,7 +539,7 @@ Use `--split` to output each table/view/enum/domain/composite type as a separate
 
 ```bash
 pista dump --split ./schema/
-# -- Dump of schema public (3 tables, 0 views, 1 enum, 0 domains, 0 sequences)
+# -- Dump of schema public (3 tables, 0 views, 1 enum, 0 domains, 0 composite types, 0 sequences)
 # -- Wrote 4 file(s) to ./schema/
 # (writes ./schema/public.status.sql, ./schema/public.users.sql, ./schema/public.orders.sql, ...)
 ```
@@ -557,7 +557,7 @@ pista dump --split ./schema/
 
 - Domain types (`CREATE DOMAIN`, `ALTER DOMAIN SET/DROP DEFAULT`, `SET/DROP NOT NULL`, `ADD/DROP/VALIDATE CONSTRAINT`)
 - Enum types (`CREATE TYPE ... AS ENUM`, `ALTER TYPE ... ADD VALUE`)
-- Composite types (`CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME ATTRIBUTE`)
+- Composite types (`CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME ATTRIBUTE`). Attributes are matched by name, so reordering them produces no diff (PostgreSQL cannot reorder attributes). `ALTER ATTRIBUTE ... TYPE` fails at apply while a table column uses the type; PostgreSQL does not allow it and `CASCADE` does not help.
 - Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables)
 - Views

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ echo $?  # 0: no changes, 2: changes, 1: error
 
 `plan` and `dump` open a read-only connection, so they cannot write to the database. Pass `--no-read-only` (env `$PISTA_NO_READ_ONLY`) to use a read-write connection.
 
+> [!NOTE]
+> `apply` sets `search_path` to the target schemas plus `public` so unqualified type and object references resolve. `plan` output does not include that `SET search_path`, so piping `pista plan -n <schema>` into `psql` for a non-public schema may fail on an unqualified reference. Qualify the reference or run `pista apply`.
+
 ### apply
 
 Apply the diff to the database.

--- a/TODO.md
+++ b/TODO.md
@@ -392,3 +392,25 @@ The codebase has no dialect layer today, so this is new work. This section
 records the verified gaps, not a commitment to implement DSQL support.
 
 Origin: live DSQL investigation, 2026-07-23.
+
+## Silent drift on schema-qualified user-type columns
+
+A table column whose type is a user-defined type (enum, domain, or composite
+type) written schema-qualified in desired SQL (e.g. `home public.addr`) drifts
+on every plan. The catalog reads the column type via `format_type`, which
+returns the type unqualified (`addr`) when the type is in the search_path,
+while the desired parser keeps the qualified form (`public.addr`). The
+mismatch emits a redundant `ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE`
+that never converges.
+
+The behavior is pre-existing and shared by enum, domain, and composite type
+columns, but composite types surface it more often because a composite type
+is only useful once a column references it. Workaround: write the column type
+unqualified (`home addr`) when the type is in the search_path.
+
+A fix would normalize the two sides: strip the schema prefix from a desired
+column type when its schema is in the target schemas (matching `format_type`),
+or qualify the catalog side. Both touch the shared column-type comparison, so
+it is out of scope for the composite type PR.
+
+Origin: [#331](https://github.com/winebarrel/pistachio/pull/331).

--- a/TODO.md
+++ b/TODO.md
@@ -3,20 +3,6 @@
 Items intentionally deferred from prior PRs. Each entry notes the originating
 PR for context.
 
-## apply does not set search_path before managed DDL
-
-`apply` sets `search_path` only just before `-- pista:execute` statements
-(`apply.go`). The managed DDL it generates references user-defined types by
-whatever the desired SQL wrote, so an unqualified user-type reference
-(`home addr`) fails at apply for any target schema other than `public`
-(`type "addr" does not exist`, SQLSTATE 42704). Qualifying the type
-(`home app.addr`) works. The behavior is pre-existing and reproduces with an
-enum type; a composite or domain type behaves the same. A fix would set
-`search_path` to the target schemas before running the managed DDL, or qualify
-generated references.
-
-Origin: surfaced during the [#331](https://github.com/winebarrel/pistachio/pull/331) review; pre-existing.
-
 ## Auto-rewrite of column references in views and cross-table FKs
 
 When a column is renamed via `-- pista:renamed-from`, the rewriter only

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,20 @@
 Items intentionally deferred from prior PRs. Each entry notes the originating
 PR for context.
 
+## apply does not set search_path before managed DDL
+
+`apply` sets `search_path` only just before `-- pista:execute` statements
+(`apply.go`). The managed DDL it generates references user-defined types by
+whatever the desired SQL wrote, so an unqualified user-type reference
+(`home addr`) fails at apply for any target schema other than `public`
+(`type "addr" does not exist`, SQLSTATE 42704). Qualifying the type
+(`home app.addr`) works. The behavior is pre-existing and reproduces with an
+enum type; a composite or domain type behaves the same. A fix would set
+`search_path` to the target schemas before running the managed DDL, or qualify
+generated references.
+
+Origin: surfaced during the [#331](https://github.com/winebarrel/pistachio/pull/331) review; pre-existing.
+
 ## Auto-rewrite of column references in views and cross-table FKs
 
 When a column is renamed via `-- pista:renamed-from`, the rewriter only

--- a/TODO.md
+++ b/TODO.md
@@ -393,24 +393,46 @@ records the verified gaps, not a commitment to implement DSQL support.
 
 Origin: live DSQL investigation, 2026-07-23.
 
-## Silent drift on schema-qualified user-type columns
+## Composite type: ALTER ATTRIBUTE ... TYPE while a table column uses the type
+
+`ALTER TYPE ... ALTER ATTRIBUTE ... TYPE` fails at apply when a table column
+references the composite type (`cannot alter type "x" because column "..."
+uses it`, SQLSTATE 0A000). `CASCADE` does not lift the restriction, and
+`ADD` / `DROP` / `RENAME ATTRIBUTE` are not affected. The plan looks valid
+but apply rolls back, so nothing is destroyed. Domain base-type changes
+already error at plan time; composite attribute type changes could do the
+same, but that needs the diff to know which composite types are referenced by
+a table column (cross-object awareness the composite diff does not have
+today). For now the limitation is documented in the README.
+
+Origin: [#331](https://github.com/winebarrel/pistachio/pull/331).
+
+## Composite type: attribute reordering is not diffed
+
+Attributes are matched by name, so a desired schema that only reorders
+attributes produces no diff. This matches PostgreSQL, which has no operation
+to reorder composite type attributes (`ADD ATTRIBUTE` always appends). A
+mid-list `ADD` therefore appends the new attribute; the result is
+order-independent and stable across plans. Recorded as a deliberate choice,
+not a bug.
+
+Origin: [#331](https://github.com/winebarrel/pistachio/pull/331).
+
+## Silent drift on cross-schema user-type columns
 
 A table column whose type is a user-defined type (enum, domain, or composite
-type) written schema-qualified in desired SQL (e.g. `home public.addr`) drifts
-on every plan. The catalog reads the column type via `format_type`, which
-returns the type unqualified (`addr`) when the type is in the search_path,
-while the desired parser keeps the qualified form (`public.addr`). The
-mismatch emits a redundant `ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE`
-that never converges.
+type) written schema-qualified in desired SQL drifts on every plan when the
+type's schema differs from the table's own schema. The catalog reads the
+column type via `format_type`, which returns the type unqualified when it is
+in the search_path, while the desired parser keeps the qualified form. The
+column diff (`equalTypeName`) strips the table's own schema from both sides,
+so `home public.addr` on a table in `public` no longer drifts, but a type in
+a different search-path schema than its table (e.g. a `shared` schema on the
+search_path) is still compared qualified-vs-unqualified and emits a redundant
+`SET DATA TYPE`.
 
-The behavior is pre-existing and shared by enum, domain, and composite type
-columns, but composite types surface it more often because a composite type
-is only useful once a column references it. Workaround: write the column type
-unqualified (`home addr`) when the type is in the search_path.
-
-A fix would normalize the two sides: strip the schema prefix from a desired
-column type when its schema is in the target schemas (matching `format_type`),
-or qualify the catalog side. Both touch the shared column-type comparison, so
-it is out of scope for the composite type PR.
+Closing it fully needs the target-schema list in the column diff (to strip any
+search-path schema, not just the table's own), which the diff does not thread
+today. Workaround: write such a column type unqualified.
 
 Origin: [#331](https://github.com/winebarrel/pistachio/pull/331).

--- a/TODO.md
+++ b/TODO.md
@@ -418,21 +418,21 @@ not a bug.
 
 Origin: [#331](https://github.com/winebarrel/pistachio/pull/331).
 
-## Silent drift on cross-schema user-type columns
+## Silent drift on cross-schema user-type references
 
-A table column whose type is a user-defined type (enum, domain, or composite
-type) written schema-qualified in desired SQL drifts on every plan when the
-type's schema differs from the table's own schema. The catalog reads the
-column type via `format_type`, which returns the type unqualified when it is
-in the search_path, while the desired parser keeps the qualified form. The
-column diff (`equalTypeName`) strips the table's own schema from both sides,
-so `home public.addr` on a table in `public` no longer drifts, but a type in
-a different search-path schema than its table (e.g. a `shared` schema on the
-search_path) is still compared qualified-vs-unqualified and emits a redundant
-`SET DATA TYPE`.
+A table column, or a composite type attribute, whose type is a user-defined
+type (enum, domain, or composite) written schema-qualified in desired SQL
+drifts on every plan when the type's schema differs from the container's own
+schema. The catalog reads the type via `format_type`, which returns it
+unqualified when it is in the search_path, while the desired parser keeps the
+qualified form. The diff (`equalTypeName`) strips the container's own schema
+from both sides, so `home public.addr` on a table in `public` no longer
+drifts, but a type in a different search-path schema than its table or
+composite type (e.g. a `shared` schema on the search_path) is still compared
+qualified-vs-unqualified and emits a redundant `SET DATA TYPE`.
 
-Closing it fully needs the target-schema list in the column diff (to strip any
-search-path schema, not just the table's own), which the diff does not thread
-today. Workaround: write such a column type unqualified.
+Closing it fully needs the target-schema list in the diff (to strip any
+search-path schema, not just the container's own), which the diff does not
+thread today. Workaround: write such a reference unqualified.
 
 Origin: [#331](https://github.com/winebarrel/pistachio/pull/331).

--- a/apply.go
+++ b/apply.go
@@ -139,6 +139,21 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		}
 	}
 
+	// Set search_path to the target schemas before running the managed DDL and
+	// the -- pista:execute statements, so an unqualified user-type reference in
+	// a column or attribute definition (e.g. "home addr") resolves. The
+	// generated DDL always schema-qualifies object names, so this only affects
+	// name resolution inside definitions, not where objects are created. It is
+	// not written to the output writer, matching the emitted-SQL contract.
+	quoted := make([]string, len(client.Schemas))
+	for i, s := range client.Schemas {
+		quoted[i] = model.Ident(s)
+	}
+	searchPath := "SET search_path TO " + strings.Join(quoted, ", ")
+	if _, err := exec(ctx, searchPath); err != nil {
+		return nil, fmt.Errorf("failed to set search_path: %w", err)
+	}
+
 	for _, stmt := range result.Stmts {
 		fmt.Fprintln(w, stmt) //nolint:errcheck
 		if _, err := exec(ctx, stmt); err != nil {
@@ -147,19 +162,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		applied = true
 	}
 
-	// Execute -- pista:execute statements after schema changes.
-	// Set search_path so unqualified names resolve to the configured schemas.
-	if len(result.ExecuteStmts) > 0 && len(client.Schemas) > 0 {
-		quoted := make([]string, len(client.Schemas))
-		for i, s := range client.Schemas {
-			quoted[i] = model.Ident(s)
-		}
-		searchPath := "SET search_path TO " + strings.Join(quoted, ", ")
-		if _, err := exec(ctx, searchPath); err != nil {
-			return nil, fmt.Errorf("failed to set search_path: %w", err)
-		}
-	}
-
+	// Execute -- pista:execute statements after schema changes. search_path is
+	// already set above.
 	for _, es := range result.ExecuteStmts {
 		shouldExecute := true
 

--- a/apply.go
+++ b/apply.go
@@ -139,15 +139,26 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		}
 	}
 
-	// Set search_path to the target schemas before running the managed DDL and
-	// the -- pista:execute statements, so an unqualified user-type reference in
-	// a column or attribute definition (e.g. "home addr") resolves. The
-	// generated DDL always schema-qualifies object names, so this only affects
-	// name resolution inside definitions, not where objects are created. It is
-	// not written to the output writer, matching the emitted-SQL contract.
-	quoted := make([]string, len(client.Schemas))
-	for i, s := range client.Schemas {
-		quoted[i] = model.Ident(s)
+	// Set search_path to the target schemas, plus public, before running the
+	// managed DDL and the -- pista:execute statements, so an unqualified
+	// user-type reference in a column or attribute definition (e.g. "home addr")
+	// resolves. public is appended so a reference to an object commonly kept
+	// there (extension types such as citext, functions) still resolves from a
+	// non-public target schema; this extends the default search_path rather than
+	// replacing it. The generated DDL always schema-qualifies object names, so
+	// this only affects name resolution inside definitions, not where objects
+	// are created. It is not written to the output writer, matching the
+	// emitted-SQL contract.
+	quoted := make([]string, 0, len(client.Schemas)+1)
+	hasPublic := false
+	for _, s := range client.Schemas {
+		quoted = append(quoted, model.Ident(s))
+		if s == "public" {
+			hasPublic = true
+		}
+	}
+	if !hasPublic {
+		quoted = append(quoted, "public")
 	}
 	searchPath := "SET search_path TO " + strings.Join(quoted, ", ")
 	if _, err := exec(ctx, searchPath); err != nil {

--- a/catalog/composite_types.go
+++ b/catalog/composite_types.go
@@ -1,0 +1,147 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func (c *Catalog) CompositeTypes(ctx context.Context) (*orderedmap.Map[string, *model.CompositeType], error) {
+	compositeTypes, err := c.ListCompositeTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	byKey := orderedmap.New[string, *model.CompositeType]()
+	for _, ct := range compositeTypes {
+		byKey.Set(ct.FQCN(), ct)
+	}
+
+	return byKey, nil
+}
+
+func (c *Catalog) ListCompositeTypes(ctx context.Context) ([]*model.CompositeType, error) {
+	q := `
+		WITH
+			dependency_extension AS (
+				SELECT DISTINCT
+					d.objid
+				FROM
+					pg_catalog.pg_depend d
+				WHERE
+					d.deptype = 'e'
+			)
+		SELECT
+			t.oid,
+			n.nspname,
+			t.typname,
+			t.typrelid,
+			d.description
+		FROM
+			pg_catalog.pg_type t
+			JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+			JOIN pg_catalog.pg_class cl ON cl.oid = t.typrelid AND cl.relkind = 'c'
+			LEFT JOIN pg_catalog.pg_description d ON d.objoid = t.oid
+			AND d.classoid = 'pg_type'::regclass
+			AND d.objsubid = 0
+			LEFT JOIN dependency_extension de ON de.objid = t.oid
+		WHERE
+			t.typtype = 'c'
+			AND n.nspname = ANY(@schemas)
+			AND de.objid IS NULL
+		ORDER BY
+			n.nspname,
+			t.typname
+	`
+
+	args := pgx.NamedArgs{
+		"schemas": c.schemas,
+	}
+
+	rows, err := c.conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get composite type info: %w", err)
+	}
+	defer rows.Close()
+
+	type ctRow struct {
+		ct       *model.CompositeType
+		typrelid uint32
+	}
+	var ctRows []ctRow
+	for rows.Next() {
+		var ct model.CompositeType
+		var typrelid uint32
+		err := rows.Scan(&ct.OID, &ct.Schema, &ct.Name, &typrelid, &ct.Comment)
+		if err != nil {
+			return nil, fmt.Errorf("catalog: failed to scan composite type info: %w", err)
+		}
+		ctRows = append(ctRows, ctRow{ct: &ct, typrelid: typrelid})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: failed to scan composite type info rows: %w", err)
+	}
+
+	compositeTypes := make([]*model.CompositeType, 0, len(ctRows))
+	for _, r := range ctRows {
+		attrs, err := c.listCompositeAttributes(ctx, r.typrelid)
+		if err != nil {
+			return nil, err
+		}
+		r.ct.Attributes = attrs
+		compositeTypes = append(compositeTypes, r.ct)
+	}
+
+	return compositeTypes, nil
+}
+
+func (c *Catalog) listCompositeAttributes(ctx context.Context, relid uint32) ([]*model.CompositeAttribute, error) {
+	q := `
+		SELECT
+			a.attname,
+			pg_catalog.format_type(a.atttypid, a.atttypmod) AS type,
+			(SELECT cn.nspname || '.' || coll.collname FROM pg_catalog.pg_collation coll JOIN pg_catalog.pg_namespace cn ON cn.oid = coll.collnamespace WHERE coll.oid = a.attcollation AND a.attcollation <> 0 AND coll.collname <> 'default') AS collation,
+			d.description
+		FROM
+			pg_catalog.pg_attribute a
+			LEFT JOIN pg_catalog.pg_description d ON d.objoid = a.attrelid
+			AND d.classoid = 'pg_class'::regclass
+			AND d.objsubid = a.attnum
+		WHERE
+			a.attrelid = @relid
+			AND a.attnum > 0
+			AND NOT a.attisdropped
+		ORDER BY
+			a.attnum
+	`
+
+	args := pgx.NamedArgs{
+		"relid": relid,
+	}
+
+	rows, err := c.conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get composite attributes: %w", err)
+	}
+	defer rows.Close()
+
+	var attrs []*model.CompositeAttribute
+	for rows.Next() {
+		var a model.CompositeAttribute
+		err := rows.Scan(&a.Name, &a.TypeName, &a.Collation, &a.Comment)
+		if err != nil {
+			return nil, fmt.Errorf("catalog: failed to scan composite attribute: %w", err)
+		}
+		attrs = append(attrs, &a)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: failed to scan composite attribute rows: %w", err)
+	}
+
+	return attrs, nil
+}

--- a/catalog/composite_types_test.go
+++ b/catalog/composite_types_test.go
@@ -1,0 +1,78 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/catalog"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+func TestCompositeTypes(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	t.Run("empty", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, "")
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		cts, err := cat.CompositeTypes(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, cts.Len())
+	})
+
+	t.Run("single composite type", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TYPE public.address AS (street text, city text, zip text);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		cts, err := cat.CompositeTypes(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, cts.Len())
+
+		ct, ok := cts.GetOk("public.address")
+		require.True(t, ok)
+		assert.Equal(t, "address", ct.Name)
+		assert.Equal(t, "public", ct.Schema)
+		require.Len(t, ct.Attributes, 3)
+		assert.Equal(t, "street", ct.Attributes[0].Name)
+		assert.Equal(t, "text", ct.Attributes[0].TypeName)
+		assert.Equal(t, "zip", ct.Attributes[2].Name)
+		assert.Nil(t, ct.Comment)
+	})
+
+	t.Run("composite type with comments", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TYPE public.address AS (street text, city text);
+			COMMENT ON TYPE public.address IS 'postal address';
+			COMMENT ON COLUMN public.address.city IS 'city name';
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		cts, err := cat.CompositeTypes(ctx)
+		require.NoError(t, err)
+
+		ct := cts.Get("public.address")
+		require.NotNil(t, ct)
+		require.NotNil(t, ct.Comment)
+		assert.Equal(t, "postal address", *ct.Comment)
+		require.Len(t, ct.Attributes, 2)
+		require.NotNil(t, ct.Attributes[1].Comment)
+		assert.Equal(t, "city name", *ct.Attributes[1].Comment)
+	})
+
+	t.Run("table rowtype is not a composite type", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.users (id int, name text);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		cts, err := cat.CompositeTypes(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, cts.Len())
+	})
+}

--- a/cmd/command/dump_test.go
+++ b/cmd/command/dump_test.go
@@ -34,7 +34,7 @@ func TestDump_Run(t *testing.T) {
 	cmd := &command.Dump{}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- Dump of schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)")
+	assert.Contains(t, buf.String(), "-- Dump of schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)")
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
 	assertConnectedCommentFirst(t, buf.String(), conn.Config())
 }
@@ -74,7 +74,7 @@ CREATE TABLE public.posts (
 	assert.Contains(t, string(postsData), "CREATE TABLE public.posts")
 
 	out := buf.String()
-	assert.Contains(t, out, "-- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains, 0 sequences)")
+	assert.Contains(t, out, "-- Dump of schema public (2 tables, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)")
 	assert.Contains(t, out, fmt.Sprintf("-- Wrote 2 file(s) to %s", splitDir))
 	assert.NotContains(t, out, "public.users.sql")
 	assert.NotContains(t, out, "public.posts.sql")
@@ -96,7 +96,7 @@ func TestDump_Run_Empty(t *testing.T) {
 	cmd := &command.Dump{}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains, 0 sequences)")
+	assert.Contains(t, buf.String(), "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)")
 }
 
 func TestDump_Run_Split_WithView(t *testing.T) {
@@ -153,7 +153,7 @@ func TestDump_Run_Split_Empty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, entries)
 	out := buf.String()
-	assert.Contains(t, out, "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains, 0 sequences)")
+	assert.Contains(t, out, "-- Dump of schema public (0 tables, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)")
 	assert.Contains(t, out, fmt.Sprintf("-- Wrote 0 file(s) to %s", splitDir))
 }
 

--- a/diff/composite_types.go
+++ b/diff/composite_types.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
@@ -77,6 +78,25 @@ func cloneCompositeAttributes(attrs []*model.CompositeAttribute) []*model.Compos
 	return out
 }
 
+// equalCollation compares two attribute collations by their trailing name
+// component. The catalog reports a collation schema-qualified (e.g.
+// "pg_catalog.C"), while the parser keeps what the user wrote ("C"). Comparing
+// only the collation name avoids a spurious ALTER ATTRIBUTE on every plan when
+// the two forms differ but name the same collation.
+func equalCollation(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return collationName(*a) == collationName(*b)
+}
+
+func collationName(s string) string {
+	if i := strings.LastIndex(s, "."); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
 func indexCompositeAttribute(attrs []*model.CompositeAttribute, name string) int {
 	for i, a := range attrs {
 		if a.Name == name {
@@ -149,7 +169,7 @@ func diffCompositeType(fqcn string, current, desired *model.CompositeType, dc Dr
 			stmts = append(stmts, "ALTER TYPE "+fqcn+" ADD ATTRIBUTE "+model.Ident(da.Name)+" "+da.TypeSQL()+";")
 			continue
 		}
-		if wa.TypeName != da.TypeName || !equalPtr(wa.Collation, da.Collation) {
+		if wa.TypeName != da.TypeName || !equalCollation(wa.Collation, da.Collation) {
 			stmts = append(stmts, "ALTER TYPE "+fqcn+" ALTER ATTRIBUTE "+model.Ident(da.Name)+" TYPE "+da.TypeSQL()+";")
 		}
 	}

--- a/diff/composite_types.go
+++ b/diff/composite_types.go
@@ -169,7 +169,7 @@ func diffCompositeType(fqcn string, current, desired *model.CompositeType, dc Dr
 			stmts = append(stmts, "ALTER TYPE "+fqcn+" ADD ATTRIBUTE "+model.Ident(da.Name)+" "+da.TypeSQL()+";")
 			continue
 		}
-		if wa.TypeName != da.TypeName || !equalCollation(wa.Collation, da.Collation) {
+		if !equalTypeName(wa.TypeName, da.TypeName, schemaOf(fqcn)) || !equalCollation(wa.Collation, da.Collation) {
 			stmts = append(stmts, "ALTER TYPE "+fqcn+" ALTER ATTRIBUTE "+model.Ident(da.Name)+" TYPE "+da.TypeSQL()+";")
 		}
 	}

--- a/diff/composite_types.go
+++ b/diff/composite_types.go
@@ -1,0 +1,230 @@
+package diff
+
+import (
+	"fmt"
+
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+type CompositeTypeDiffResult struct {
+	Stmts               []string
+	DropStmts           []string
+	DisallowedDropStmts []string
+}
+
+func DiffCompositeTypes(current, desired *orderedmap.Map[string, *model.CompositeType], dc DropChecker) (*CompositeTypeDiffResult, error) {
+	dc = normalizeDropChecker(dc)
+	result := &CompositeTypeDiffResult{}
+
+	// Detect renames
+	renameStmts, current, err := detectCompositeTypeRenames(current, desired)
+	if err != nil {
+		return nil, err
+	}
+	result.Stmts = append(result.Stmts, renameStmts...)
+
+	// New composite types
+	for k, desiredCT := range desired.All() {
+		if _, ok := current.GetOk(k); !ok {
+			result.Stmts = append(result.Stmts, desiredCT.SQL())
+			if commentSQL := desiredCT.CommentSQL(); commentSQL != "" {
+				result.Stmts = append(result.Stmts, commentSQL)
+			}
+			result.Stmts = append(result.Stmts, desiredCT.AttributeCommentSQLs()...)
+		}
+	}
+
+	// Modified composite types
+	for k, desiredCT := range desired.All() {
+		currentCT, ok := current.GetOk(k)
+		if !ok {
+			continue
+		}
+
+		stmts, disallowed, err := diffCompositeType(k, currentCT, desiredCT, dc)
+		if err != nil {
+			return nil, err
+		}
+		result.Stmts = append(result.Stmts, stmts...)
+		result.DisallowedDropStmts = append(result.DisallowedDropStmts, disallowed...)
+	}
+
+	// Dropped composite types. When the composite-type-drop policy disallows it,
+	// emit a commented DROP.
+	ctAllowed := dc.IsDropAllowed("composite_type")
+	for k := range current.Keys() {
+		if _, ok := desired.GetOk(k); !ok {
+			if ctAllowed {
+				result.DropStmts = append(result.DropStmts, "DROP TYPE "+k+";")
+			} else {
+				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP TYPE "+k+";")
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// cloneCompositeAttributes returns value copies of the attributes so renames
+// applied to the working slice do not mutate the current model.
+func cloneCompositeAttributes(attrs []*model.CompositeAttribute) []*model.CompositeAttribute {
+	out := make([]*model.CompositeAttribute, len(attrs))
+	for i, a := range attrs {
+		copied := *a
+		out[i] = &copied
+	}
+	return out
+}
+
+func indexCompositeAttribute(attrs []*model.CompositeAttribute, name string) int {
+	for i, a := range attrs {
+		if a.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// diffCompositeType returns the ALTER statements to converge a composite type,
+// plus any disallowed DROP ATTRIBUTE statements (gated by the composite_type
+// drop policy). Attributes are matched by name after applying renames;
+// attribute order is not enforced because PostgreSQL cannot reorder them and
+// ADD ATTRIBUTE always appends.
+func diffCompositeType(fqcn string, current, desired *model.CompositeType, dc DropChecker) ([]string, []string, error) {
+	var stmts []string
+	var disallowed []string
+
+	// Apply attribute renames first so renamed attributes are not seen as a
+	// drop plus add.
+	working := cloneCompositeAttributes(current.Attributes)
+	for _, da := range desired.Attributes {
+		if da.RenameFrom == nil || *da.RenameFrom == da.Name {
+			continue
+		}
+		old := *da.RenameFrom
+
+		oldIdx := indexCompositeAttribute(working, old)
+		if oldIdx < 0 {
+			if indexCompositeAttribute(working, da.Name) >= 0 {
+				// Already applied
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source attribute %s not found in composite type %s", model.Ident(old), fqcn)
+		}
+		if indexCompositeAttribute(working, da.Name) >= 0 {
+			return nil, nil, fmt.Errorf("cannot rename attribute %s to %s in composite type %s: destination already exists", model.Ident(old), model.Ident(da.Name), fqcn)
+		}
+
+		stmts = append(stmts, "ALTER TYPE "+fqcn+" RENAME ATTRIBUTE "+model.Ident(old)+" TO "+model.Ident(da.Name)+";")
+		working[oldIdx].Name = da.Name
+	}
+
+	workingByName := make(map[string]*model.CompositeAttribute, len(working))
+	for _, a := range working {
+		workingByName[a.Name] = a
+	}
+	desiredByName := make(map[string]*model.CompositeAttribute, len(desired.Attributes))
+	for _, a := range desired.Attributes {
+		desiredByName[a.Name] = a
+	}
+
+	// Drop attributes present in current but not desired.
+	ctAllowed := dc.IsDropAllowed("composite_type")
+	for _, wa := range working {
+		if _, ok := desiredByName[wa.Name]; !ok {
+			drop := "ALTER TYPE " + fqcn + " DROP ATTRIBUTE " + model.Ident(wa.Name) + ";"
+			if ctAllowed {
+				stmts = append(stmts, drop)
+			} else {
+				disallowed = append(disallowed, "-- skipped: "+drop)
+			}
+		}
+	}
+
+	// Add new attributes and alter changed types.
+	for _, da := range desired.Attributes {
+		wa, ok := workingByName[da.Name]
+		if !ok {
+			stmts = append(stmts, "ALTER TYPE "+fqcn+" ADD ATTRIBUTE "+model.Ident(da.Name)+" "+da.TypeSQL()+";")
+			continue
+		}
+		if wa.TypeName != da.TypeName || !equalPtr(wa.Collation, da.Collation) {
+			stmts = append(stmts, "ALTER TYPE "+fqcn+" ALTER ATTRIBUTE "+model.Ident(da.Name)+" TYPE "+da.TypeSQL()+";")
+		}
+	}
+
+	// Type comment change.
+	if !equalPtr(current.Comment, desired.Comment) {
+		if desired.Comment != nil {
+			stmts = append(stmts, "COMMENT ON TYPE "+fqcn+" IS "+model.QuoteLiteral(*desired.Comment)+";")
+		} else {
+			stmts = append(stmts, "COMMENT ON TYPE "+fqcn+" IS NULL;")
+		}
+	}
+
+	// Attribute comment changes. The current comment is read from the working
+	// attribute (matched by the desired name after rename); a newly added
+	// attribute has no current comment.
+	for _, da := range desired.Attributes {
+		var currentComment *string
+		if wa, ok := workingByName[da.Name]; ok {
+			currentComment = wa.Comment
+		}
+		if equalPtr(currentComment, da.Comment) {
+			continue
+		}
+		col := model.Ident(desired.Schema, desired.Name, da.Name)
+		if da.Comment != nil {
+			stmts = append(stmts, "COMMENT ON COLUMN "+col+" IS "+model.QuoteLiteral(*da.Comment)+";")
+		} else {
+			stmts = append(stmts, "COMMENT ON COLUMN "+col+" IS NULL;")
+		}
+	}
+
+	return stmts, disallowed, nil
+}
+
+// detectCompositeTypeRenames finds desired composite types with RenameFrom that
+// match a current composite type.
+func detectCompositeTypeRenames(current, desired *orderedmap.Map[string, *model.CompositeType]) ([]string, *orderedmap.Map[string, *model.CompositeType], error) {
+	var stmts []string
+	adjusted := cloneMap(current)
+
+	for newKey, desiredCT := range desired.All() {
+		if desiredCT.RenameFrom == nil {
+			continue
+		}
+		oldKey := *desiredCT.RenameFrom
+
+		if oldKey == newKey {
+			continue
+		}
+
+		oldCT, ok := adjusted.GetOk(oldKey)
+		if !ok {
+			if _, exists := adjusted.GetOk(newKey); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source %s not found for %s", oldKey, newKey)
+		}
+
+		if _, exists := adjusted.GetOk(newKey); exists {
+			return nil, nil, fmt.Errorf("cannot rename %s to %s: destination already exists", oldKey, newKey)
+		}
+
+		if oldCT.Schema != desiredCT.Schema {
+			return nil, nil, fmt.Errorf("cannot rename %s to %s: cross-schema rename is not supported", oldKey, newKey)
+		}
+
+		stmts = append(stmts, "ALTER TYPE "+oldKey+" RENAME TO "+model.Ident(desiredCT.Name)+";")
+
+		adjusted.Delete(oldKey)
+		renamed := *oldCT
+		renamed.Name = desiredCT.Name
+		renamed.Attributes = cloneCompositeAttributes(oldCT.Attributes)
+		adjusted.Set(newKey, &renamed)
+	}
+
+	return stmts, adjusted, nil
+}

--- a/diff/composite_types_test.go
+++ b/diff/composite_types_test.go
@@ -245,6 +245,40 @@ func TestDiffCompositeTypes_AttributeCommentRemoved(t *testing.T) {
 	assert.Equal(t, []string{"COMMENT ON COLUMN public.address.street IS NULL;"}, result.Stmts)
 }
 
+func TestDiffCompositeTypes_CollationEquivalentForms(t *testing.T) {
+	// Catalog reports "pg_catalog.C"; the parser keeps the user's "C". They name
+	// the same collation, so no ALTER ATTRIBUTE should be emitted.
+	catalogColl := "pg_catalog.C"
+	current := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public", Name: "ct",
+		Attributes: []*model.CompositeAttribute{{Name: "name", TypeName: "text", Collation: &catalogColl}},
+	})
+	desiredColl := "C"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public", Name: "ct",
+		Attributes: []*model.CompositeAttribute{{Name: "name", TypeName: "text", Collation: &desiredColl}},
+	})
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+}
+
+func TestDiffCompositeTypes_CollationChange(t *testing.T) {
+	cColl := "pg_catalog.C"
+	current := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public", Name: "ct",
+		Attributes: []*model.CompositeAttribute{{Name: "name", TypeName: "text", Collation: &cColl}},
+	})
+	newColl := "en_US"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public", Name: "ct",
+		Attributes: []*model.CompositeAttribute{{Name: "name", TypeName: "text", Collation: &newColl}},
+	})
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{`ALTER TYPE public.ct ALTER ATTRIBUTE name TYPE text COLLATE "en_US";`}, result.Stmts)
+}
+
 func TestDiffCompositeTypes_CommentChange(t *testing.T) {
 	comment := "an address"
 	current := newCompositeTypeMap(ct("address", attr("street", "text")))

--- a/diff/composite_types_test.go
+++ b/diff/composite_types_test.go
@@ -263,6 +263,17 @@ func TestDiffCompositeTypes_CollationEquivalentForms(t *testing.T) {
 	assert.Empty(t, result.Stmts)
 }
 
+func TestDiffCompositeTypes_QualifiedAttributeTypeNoDiff(t *testing.T) {
+	// The catalog reports the attribute type unqualified ("inner_t"); desired
+	// keeps the qualified form ("public.inner_t"). They name the same type in
+	// the composite type's own schema, so no ALTER ATTRIBUTE is emitted.
+	current := newCompositeTypeMap(ct("outer_t", attr("i", "inner_t")))
+	desired := newCompositeTypeMap(ct("outer_t", attr("i", "public.inner_t")))
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+}
+
 func TestDiffCompositeTypes_CollationChange(t *testing.T) {
 	cColl := "pg_catalog.C"
 	current := newCompositeTypeMap(&model.CompositeType{

--- a/diff/composite_types_test.go
+++ b/diff/composite_types_test.go
@@ -1,0 +1,260 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/diff"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// allowCompositeTypeDrops permits only composite_type drops.
+type allowCompositeTypeDrops struct{}
+
+func (allowCompositeTypeDrops) IsDropAllowed(objectType string) bool {
+	return objectType == "composite_type"
+}
+
+func newCompositeTypeMap(cts ...*model.CompositeType) *orderedmap.Map[string, *model.CompositeType] {
+	m := orderedmap.New[string, *model.CompositeType]()
+	for _, ct := range cts {
+		m.Set(ct.FQCN(), ct)
+	}
+	return m
+}
+
+func ct(name string, attrs ...*model.CompositeAttribute) *model.CompositeType {
+	return &model.CompositeType{Schema: "public", Name: name, Attributes: attrs}
+}
+
+func attr(name, typeName string) *model.CompositeAttribute {
+	return &model.CompositeAttribute{Name: name, TypeName: typeName}
+}
+
+func TestDiffCompositeTypes_CreateNew(t *testing.T) {
+	current := newCompositeTypeMap()
+	desired := newCompositeTypeMap(ct("address", attr("street", "text"), attr("city", "text")))
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.Stmts, 1)
+	assert.Contains(t, result.Stmts[0], "CREATE TYPE public.address AS (")
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffCompositeTypes_DropExisting(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("street", "text")))
+	desired := newCompositeTypeMap()
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Equal(t, []string{"DROP TYPE public.address;"}, result.DropStmts)
+}
+
+func TestDiffCompositeTypes_DropDisallowed(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("street", "text")))
+	desired := newCompositeTypeMap()
+	result, err := diff.DiffCompositeTypes(current, desired, diff.DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.DropStmts)
+	assert.Equal(t, []string{"-- skipped: DROP TYPE public.address;"}, result.DisallowedDropStmts)
+}
+
+func TestDiffCompositeTypes_AddAttribute(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("street", "text")))
+	desired := newCompositeTypeMap(ct("address", attr("street", "text"), attr("city", "text")))
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TYPE public.address ADD ATTRIBUTE city text;"}, result.Stmts)
+}
+
+func TestDiffCompositeTypes_DropAttribute(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("street", "text"), attr("zip", "text")))
+	desired := newCompositeTypeMap(ct("address", attr("street", "text")))
+	result, err := diff.DiffCompositeTypes(current, desired, allowCompositeTypeDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TYPE public.address DROP ATTRIBUTE zip;"}, result.Stmts)
+}
+
+func TestDiffCompositeTypes_DropAttributeDisallowed(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("street", "text"), attr("zip", "text")))
+	desired := newCompositeTypeMap(ct("address", attr("street", "text")))
+	result, err := diff.DiffCompositeTypes(current, desired, diff.DenyAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+	assert.Equal(t, []string{"-- skipped: ALTER TYPE public.address DROP ATTRIBUTE zip;"}, result.DisallowedDropStmts)
+}
+
+func TestDiffCompositeTypes_AlterAttributeType(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("city", "text")))
+	desired := newCompositeTypeMap(ct("address", attr("city", "character varying(100)")))
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TYPE public.address ALTER ATTRIBUTE city TYPE character varying(100);"}, result.Stmts)
+}
+
+func TestDiffCompositeTypes_RenameType(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("street", "text")))
+	renameFrom := "public.address"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema:     "public",
+		Name:       "postal_address",
+		RenameFrom: &renameFrom,
+		Attributes: []*model.CompositeAttribute{attr("street", "text")},
+	})
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TYPE public.address RENAME TO postal_address;"}, result.Stmts)
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffCompositeTypes_RenameAttribute(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("street", "text"), attr("city", "text")))
+	renameFrom := "street"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public",
+		Name:   "address",
+		Attributes: []*model.CompositeAttribute{
+			{Name: "road", TypeName: "text", RenameFrom: &renameFrom},
+			attr("city", "text"),
+		},
+	})
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TYPE public.address RENAME ATTRIBUTE street TO road;"}, result.Stmts)
+}
+
+func TestDiffCompositeTypes_RenameAttributeDestinationExists(t *testing.T) {
+	current := newCompositeTypeMap(ct("address", attr("street", "text"), attr("road", "text")))
+	renameFrom := "street"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public",
+		Name:   "address",
+		Attributes: []*model.CompositeAttribute{
+			{Name: "road", TypeName: "text", RenameFrom: &renameFrom},
+		},
+	})
+	_, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
+func TestDiffCompositeTypes_RenameTypeSourceNotFound(t *testing.T) {
+	current := newCompositeTypeMap()
+	renameFrom := "public.nonexist"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema:     "public",
+		Name:       "postal_address",
+		RenameFrom: &renameFrom,
+		Attributes: []*model.CompositeAttribute{attr("street", "text")},
+	})
+	_, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source public.nonexist not found")
+}
+
+func TestDiffCompositeTypes_RenameTypeDestinationExists(t *testing.T) {
+	current := newCompositeTypeMap(
+		ct("address", attr("street", "text")),
+		ct("postal_address", attr("street", "text")),
+	)
+	renameFrom := "public.address"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema:     "public",
+		Name:       "postal_address",
+		RenameFrom: &renameFrom,
+		Attributes: []*model.CompositeAttribute{attr("street", "text")},
+	})
+	_, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
+func TestDiffCompositeTypes_RenameTypeCrossSchema(t *testing.T) {
+	current := newCompositeTypeMap(&model.CompositeType{
+		Schema: "old", Name: "address",
+		Attributes: []*model.CompositeAttribute{attr("street", "text")},
+	})
+	renameFrom := "old.address"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema:     "new",
+		Name:       "address",
+		RenameFrom: &renameFrom,
+		Attributes: []*model.CompositeAttribute{attr("street", "text")},
+	})
+	_, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-schema rename is not supported")
+}
+
+func TestDiffCompositeTypes_RenameTypeAlreadyApplied(t *testing.T) {
+	// RenameFrom points at the current key itself: nothing to rename.
+	current := newCompositeTypeMap(ct("address", attr("street", "text")))
+	renameFrom := "public.address"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema:     "public",
+		Name:       "address",
+		RenameFrom: &renameFrom,
+		Attributes: []*model.CompositeAttribute{attr("street", "text")},
+	})
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+}
+
+func TestDiffCompositeTypes_RenameAttributeAlreadyApplied(t *testing.T) {
+	// The new attribute name is already present; the old source is gone. The
+	// rename was applied on a previous run, so it is silently skipped.
+	current := newCompositeTypeMap(ct("address", attr("road", "text"), attr("city", "text")))
+	renameFrom := "street"
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public",
+		Name:   "address",
+		Attributes: []*model.CompositeAttribute{
+			{Name: "road", TypeName: "text", RenameFrom: &renameFrom},
+			attr("city", "text"),
+		},
+	})
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+}
+
+func TestDiffCompositeTypes_TypeCommentRemoved(t *testing.T) {
+	comment := "an address"
+	current := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public", Name: "address", Comment: &comment,
+		Attributes: []*model.CompositeAttribute{attr("street", "text")},
+	})
+	desired := newCompositeTypeMap(ct("address", attr("street", "text")))
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"COMMENT ON TYPE public.address IS NULL;"}, result.Stmts)
+}
+
+func TestDiffCompositeTypes_AttributeCommentRemoved(t *testing.T) {
+	c := "the street"
+	current := newCompositeTypeMap(&model.CompositeType{
+		Schema: "public", Name: "address",
+		Attributes: []*model.CompositeAttribute{{Name: "street", TypeName: "text", Comment: &c}},
+	})
+	desired := newCompositeTypeMap(ct("address", attr("street", "text")))
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"COMMENT ON COLUMN public.address.street IS NULL;"}, result.Stmts)
+}
+
+func TestDiffCompositeTypes_CommentChange(t *testing.T) {
+	comment := "an address"
+	current := newCompositeTypeMap(ct("address", attr("street", "text")))
+	desired := newCompositeTypeMap(&model.CompositeType{
+		Schema:     "public",
+		Name:       "address",
+		Comment:    &comment,
+		Attributes: []*model.CompositeAttribute{attr("street", "text")},
+	})
+	result, err := diff.DiffCompositeTypes(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"COMMENT ON TYPE public.address IS 'an address';"}, result.Stmts)
+}

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -348,7 +348,7 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 	// Type or collation change. Collation is altered via SET DATA TYPE
 	// because PostgreSQL has no separate "set collation" syntax; re-issuing
 	// SET DATA TYPE without COLLATE reverts to the type's default collation.
-	if !equalTypeName(current.TypeName, desired.TypeName) || !equalPtr(current.Collation, desired.Collation) {
+	if !equalTypeName(current.TypeName, desired.TypeName, schemaOf(fqtn)) || !equalPtr(current.Collation, desired.Collation) {
 		sql := "ALTER TABLE " + fqtn + " ALTER COLUMN " + colIdent + " SET DATA TYPE " + desired.TypeName
 		if desired.Collation != nil {
 			sql += " COLLATE " + model.Ident(*desired.Collation)
@@ -1333,7 +1333,9 @@ var serialBaseTypes = map[string]string{
 }
 
 // equalTypeName compares two type names, treating serial types as equal to their base types.
-func equalTypeName(a, b string) bool {
+func equalTypeName(a, b, schema string) bool {
+	a = stripTypeSchema(a, schema)
+	b = stripTypeSchema(b, schema)
 	if a == b {
 		return true
 	}
@@ -1344,6 +1346,40 @@ func equalTypeName(a, b string) bool {
 		return t
 	}
 	return normalize(a) == normalize(b)
+}
+
+// stripTypeSchema removes a redundant "<schema>." qualifier from a column type
+// name, preserving any trailing "[]". The catalog reports a type in the search
+// path unqualified (via format_type), while desired SQL may write it schema-
+// qualified. Stripping the table's own schema makes the two forms compare
+// equal instead of emitting a no-op SET DATA TYPE on every plan. A type in a
+// different search-path schema than its table is not covered.
+func stripTypeSchema(typeName, schema string) string {
+	if schema == "" {
+		return typeName
+	}
+	prefix := schema + "."
+	if strings.HasPrefix(typeName, prefix) {
+		return typeName[len(prefix):]
+	}
+	return typeName
+}
+
+// schemaOf returns the schema component of a canonical "schema.name"
+// identifier, preserving quoting. It returns "" when there is no top-level dot.
+func schemaOf(fqtn string) string {
+	inQuote := false
+	for i := 0; i < len(fqtn); i++ {
+		switch fqtn[i] {
+		case '"':
+			inQuote = !inQuote
+		case '.':
+			if !inQuote {
+				return fqtn[:i]
+			}
+		}
+	}
+	return ""
 }
 
 // equalDefault compares two default expressions (current, desired) by

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1213,12 +1213,21 @@ func TestEqualPtr(t *testing.T) {
 }
 
 func TestEqualTypeName(t *testing.T) {
-	assert.True(t, equalTypeName("integer", "integer"))
-	assert.True(t, equalTypeName("serial", "integer"))
-	assert.True(t, equalTypeName("integer", "serial"))
-	assert.True(t, equalTypeName("bigserial", "bigint"))
-	assert.True(t, equalTypeName("smallserial", "smallint"))
-	assert.False(t, equalTypeName("integer", "text"))
+	assert.True(t, equalTypeName("integer", "integer", "public"))
+	assert.True(t, equalTypeName("serial", "integer", "public"))
+	assert.True(t, equalTypeName("integer", "serial", "public"))
+	assert.True(t, equalTypeName("bigserial", "bigint", "public"))
+	assert.True(t, equalTypeName("smallserial", "smallint", "public"))
+	assert.False(t, equalTypeName("integer", "text", "public"))
+	// A schema-qualified user type matches the unqualified form the catalog
+	// reports for a type in the search path.
+	assert.True(t, equalTypeName("public.addr", "addr", "public"))
+	assert.True(t, equalTypeName("addr", "public.addr", "public"))
+	assert.True(t, equalTypeName("public.addr[]", "addr[]", "public"))
+	// A different-named type still differs.
+	assert.False(t, equalTypeName("public.addr", "public.other", "public"))
+	// A quoted schema qualifier is stripped too.
+	assert.True(t, equalTypeName(`"My Schema".addr`, "addr", `"My Schema"`))
 }
 
 func TestEqualDefault(t *testing.T) {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1230,6 +1230,24 @@ func TestEqualTypeName(t *testing.T) {
 	assert.True(t, equalTypeName(`"My Schema".addr`, "addr", `"My Schema"`))
 }
 
+func TestSchemaOf(t *testing.T) {
+	assert.Equal(t, "public", schemaOf("public.people"))
+	assert.Equal(t, `"My Schema"`, schemaOf(`"My Schema".people`))
+	// A quoted schema containing a dot: the dot inside quotes is not a separator.
+	assert.Equal(t, `"a.b"`, schemaOf(`"a.b".people`))
+	// No top-level dot yields "".
+	assert.Equal(t, "", schemaOf("people"))
+}
+
+func TestStripTypeSchema(t *testing.T) {
+	assert.Equal(t, "addr", stripTypeSchema("public.addr", "public"))
+	assert.Equal(t, "addr[]", stripTypeSchema("public.addr[]", "public"))
+	// A different schema prefix is left intact.
+	assert.Equal(t, "other.addr", stripTypeSchema("other.addr", "public"))
+	// An empty schema is a no-op.
+	assert.Equal(t, "addr", stripTypeSchema("addr", ""))
+}
+
 func TestEqualDefault(t *testing.T) {
 	assert.True(t, equalDefault(nil, nil))
 	assert.False(t, equalDefault(new("0"), nil))

--- a/diff_all.go
+++ b/diff_all.go
@@ -70,6 +70,11 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, fmt.Errorf("failed to fetch domains: %w", err)
 	}
 
+	currentCompositeTypes, err := cat.CompositeTypes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch composite types: %w", err)
+	}
+
 	currentSequences, err := cat.Sequences(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch sequences: %w", err)
@@ -86,10 +91,12 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	filteredViews := options.filterViews(currentViews)
 	filteredEnums := options.filterEnums(currentEnums)
 	filteredDomains := options.filterDomains(currentDomains)
+	filteredCompositeTypes := options.filterCompositeTypes(currentCompositeTypes)
 	filteredSequences := options.filterSequences(currentSequences)
 
 	desiredEnums := options.filterEnums(client.reverseRemapEnumSchemas(desired.Enums))
 	desiredDomains := options.filterDomains(client.reverseRemapDomainSchemas(desired.Domains))
+	desiredCompositeTypes := options.filterCompositeTypes(client.reverseRemapCompositeTypeSchemas(desired.CompositeTypes))
 	desiredTables := options.filterTables(client.reverseRemapTableSchemas(desired.Tables))
 	desiredViews := options.filterViews(client.reverseRemapViewSchemas(desired.Views))
 	// Only standalone sequences are managed; sequences a desired CREATE
@@ -105,6 +112,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	ignored = append(ignored, removeIgnored(desiredViews, filteredViews, func(v *model.View) bool { return v.Ignore })...)
 	ignored = append(ignored, removeIgnored(desiredEnums, filteredEnums, func(e *model.Enum) bool { return e.Ignore })...)
 	ignored = append(ignored, removeIgnored(desiredDomains, filteredDomains, func(d *model.Domain) bool { return d.Ignore })...)
+	ignored = append(ignored, removeIgnored(desiredCompositeTypes, filteredCompositeTypes, func(ct *model.CompositeType) bool { return ct.Ignore })...)
 	ignored = append(ignored, removeIgnored(desiredSequences, filteredSequences, func(s *model.Sequence) bool { return s.Ignore })...)
 	sort.Strings(ignored)
 	ignoredComments := make([]string, len(ignored))
@@ -113,12 +121,13 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	}
 
 	count := ObjectCount{
-		Schemas:   client.Schemas,
-		Tables:    filteredTables.Len(),
-		Views:     filteredViews.Len(),
-		Enums:     filteredEnums.Len(),
-		Domains:   filteredDomains.Len(),
-		Sequences: filteredSequences.Len(),
+		Schemas:        client.Schemas,
+		Tables:         filteredTables.Len(),
+		Views:          filteredViews.Len(),
+		Enums:          filteredEnums.Len(),
+		Domains:        filteredDomains.Len(),
+		CompositeTypes: filteredCompositeTypes.Len(),
+		Sequences:      filteredSequences.Len(),
 	}
 
 	switch {
@@ -147,6 +156,11 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, fmt.Errorf("failed to diff domains: %w", err)
 	}
 
+	compositeTypeDiff, err := diff.DiffCompositeTypes(filteredCompositeTypes, desiredCompositeTypes, &options.DropPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff composite types: %w", err)
+	}
+
 	tableDiff, err := diff.DiffTables(filteredTables, desiredTables, &options.DropPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to diff tables: %w", err)
@@ -172,9 +186,9 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	}
 
 	stmts := orderStatements(
-		filteredEnums, filteredDomains, filteredTables, filteredViews, filteredSequences,
-		desiredEnums, desiredDomains, desiredTables, desiredViews, desiredSequences,
-		enumDiff, domainDiff, tableDiff, viewDiff, sequenceDiff,
+		filteredEnums, filteredDomains, filteredCompositeTypes, filteredTables, filteredViews, filteredSequences,
+		desiredEnums, desiredDomains, desiredCompositeTypes, desiredTables, desiredViews, desiredSequences,
+		enumDiff, domainDiff, compositeTypeDiff, tableDiff, viewDiff, sequenceDiff,
 	)
 
 	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
@@ -191,6 +205,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 	disallowed = append(disallowed, viewDiff.DisallowedDropStmts...)
 	disallowed = append(disallowed, tableDiff.DisallowedDropStmts...)
 	disallowed = append(disallowed, domainDiff.DisallowedDropStmts...)
+	disallowed = append(disallowed, compositeTypeDiff.DisallowedDropStmts...)
 	disallowed = append(disallowed, enumDiff.DisallowedDropStmts...)
 	disallowed = append(disallowed, sequenceDiff.DisallowedDropStmts...)
 
@@ -326,26 +341,29 @@ func forceConcurrentlyDirectives(
 func orderStatements(
 	currentEnums *orderedmap.Map[string, *model.Enum],
 	currentDomains *orderedmap.Map[string, *model.Domain],
+	currentCompositeTypes *orderedmap.Map[string, *model.CompositeType],
 	currentTables *orderedmap.Map[string, *model.Table],
 	currentViews *orderedmap.Map[string, *model.View],
 	currentSequences *orderedmap.Map[string, *model.Sequence],
 	desiredEnums *orderedmap.Map[string, *model.Enum],
 	desiredDomains *orderedmap.Map[string, *model.Domain],
+	desiredCompositeTypes *orderedmap.Map[string, *model.CompositeType],
 	desiredTables *orderedmap.Map[string, *model.Table],
 	desiredViews *orderedmap.Map[string, *model.View],
 	desiredSequences *orderedmap.Map[string, *model.Sequence],
 	enumDiff *diff.EnumDiffResult,
 	domainDiff *diff.DomainDiffResult,
+	compositeTypeDiff *diff.CompositeTypeDiffResult,
 	tableDiff *diff.TableDiffResult,
 	viewDiff *diff.ViewDiffResult,
 	sequenceDiff *diff.SequenceDiffResult,
 ) []string {
 	// Build topological order from desired schema for creates
 	createOrder, err := toposort.OrderFromSchema(
-		desiredEnums, desiredDomains, desiredTables, desiredViews, desiredSequences,
+		desiredEnums, desiredDomains, desiredCompositeTypes, desiredTables, desiredViews, desiredSequences,
 	)
 	if err != nil {
-		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff, sequenceDiff)
+		return fallbackOrder(enumDiff, domainDiff, compositeTypeDiff, tableDiff, viewDiff, sequenceDiff)
 	}
 
 	createPosMap := make(map[string]int, len(createOrder))
@@ -357,10 +375,10 @@ func orderStatements(
 	// Dropped objects are not in the desired schema, so we need the current
 	// schema's dependency graph to determine correct drop order.
 	dropOrder, err := toposort.OrderFromSchema(
-		currentEnums, currentDomains, currentTables, currentViews, currentSequences,
+		currentEnums, currentDomains, currentCompositeTypes, currentTables, currentViews, currentSequences,
 	)
 	if err != nil {
-		return fallbackOrder(enumDiff, domainDiff, tableDiff, viewDiff, sequenceDiff)
+		return fallbackOrder(enumDiff, domainDiff, compositeTypeDiff, tableDiff, viewDiff, sequenceDiff)
 	}
 
 	dropPosMap := make(map[string]int, len(dropOrder))
@@ -374,6 +392,7 @@ func orderStatements(
 	var createStmts []taggedStmt
 	createStmts = append(createStmts, tagStatements(enumDiff.Stmts, createPosMap)...)
 	createStmts = append(createStmts, tagStatements(domainDiff.Stmts, createPosMap)...)
+	createStmts = append(createStmts, tagStatements(compositeTypeDiff.Stmts, createPosMap)...)
 	createStmts = append(createStmts, tagStatements(sequenceDiff.Stmts, createPosMap)...)
 	createStmts = append(createStmts, tagStatements(tableDiff.Stmts, createPosMap)...)
 	sort.SliceStable(createStmts, func(i, j int) bool {
@@ -396,6 +415,7 @@ func orderStatements(
 	var postDropStmts []taggedStmt
 	postDropStmts = append(postDropStmts, tagStatements(tableDiff.DropStmts, dropPosMap)...)
 	postDropStmts = append(postDropStmts, tagStatements(sequenceDiff.DropStmts, dropPosMap)...)
+	postDropStmts = append(postDropStmts, tagStatements(compositeTypeDiff.DropStmts, dropPosMap)...)
 	postDropStmts = append(postDropStmts, tagStatements(domainDiff.DropStmts, dropPosMap)...)
 	postDropStmts = append(postDropStmts, tagStatements(enumDiff.DropStmts, dropPosMap)...)
 	sort.SliceStable(postDropStmts, func(i, j int) bool {
@@ -438,6 +458,7 @@ func orderStatements(
 func fallbackOrder(
 	enumDiff *diff.EnumDiffResult,
 	domainDiff *diff.DomainDiffResult,
+	compositeTypeDiff *diff.CompositeTypeDiffResult,
 	tableDiff *diff.TableDiffResult,
 	viewDiff *diff.ViewDiffResult,
 	sequenceDiff *diff.SequenceDiffResult,
@@ -445,12 +466,14 @@ func fallbackOrder(
 	var stmts []string
 	stmts = append(stmts, enumDiff.Stmts...)
 	stmts = append(stmts, domainDiff.Stmts...)
+	stmts = append(stmts, compositeTypeDiff.Stmts...)
 	stmts = append(stmts, sequenceDiff.Stmts...)
 	stmts = append(stmts, viewDiff.DropStmts...)
 	stmts = append(stmts, tableDiff.FKDropStmts...)
 	stmts = append(stmts, tableDiff.Stmts...)
 	stmts = append(stmts, tableDiff.DropStmts...)
 	stmts = append(stmts, sequenceDiff.DropStmts...)
+	stmts = append(stmts, compositeTypeDiff.DropStmts...)
 	stmts = append(stmts, domainDiff.DropStmts...)
 	stmts = append(stmts, enumDiff.DropStmts...)
 	stmts = append(stmts, tableDiff.FKAddStmts...)

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -117,9 +117,9 @@ func TestOrderStatements_Fallback(t *testing.T) {
 	currentViews := orderedmap.New[string, *model.View]()
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
-		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
-		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
+		currentEnums, currentDomains, orderedmap.New[string, *model.CompositeType](), currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, orderedmap.New[string, *model.CompositeType](), desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, &diff.CompositeTypeDiffResult{}, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	// Should still produce output (via fallback)
@@ -169,9 +169,9 @@ func TestOrderStatements_DropUsesCurrentSchema(t *testing.T) {
 	}
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
-		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
-		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
+		currentEnums, currentDomains, orderedmap.New[string, *model.CompositeType](), currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, orderedmap.New[string, *model.CompositeType](), desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, &diff.CompositeTypeDiffResult{}, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	require.Len(t, result, 2)
@@ -217,9 +217,9 @@ func TestOrderStatements_DropFallbackOnCurrentCycle(t *testing.T) {
 	viewDiff := &diff.ViewDiffResult{}
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
-		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
-		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
+		currentEnums, currentDomains, orderedmap.New[string, *model.CompositeType](), currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, orderedmap.New[string, *model.CompositeType](), desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, &diff.CompositeTypeDiffResult{}, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	// Should still produce output via fallback (not panic or error)
@@ -266,9 +266,9 @@ func TestOrderStatements_UnknownPosBeforeKnown(t *testing.T) {
 	viewDiff := &diff.ViewDiffResult{}
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
-		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
-		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
+		currentEnums, currentDomains, orderedmap.New[string, *model.CompositeType](), currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, orderedmap.New[string, *model.CompositeType](), desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, &diff.CompositeTypeDiffResult{}, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	require.Len(t, result, 2)
@@ -310,9 +310,9 @@ func TestOrderStatements_CreateUniqueIndexAfterTable(t *testing.T) {
 	viewDiff := &diff.ViewDiffResult{}
 
 	result := pistachio.OrderStatements(
-		currentEnums, currentDomains, currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
-		desiredEnums, desiredDomains, desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
-		enumDiff, domainDiff, tableDiff, viewDiff, &diff.SequenceDiffResult{},
+		currentEnums, currentDomains, orderedmap.New[string, *model.CompositeType](), currentTables, currentViews, orderedmap.New[string, *model.Sequence](),
+		desiredEnums, desiredDomains, orderedmap.New[string, *model.CompositeType](), desiredTables, desiredViews, orderedmap.New[string, *model.Sequence](),
+		enumDiff, domainDiff, &diff.CompositeTypeDiffResult{}, tableDiff, viewDiff, &diff.SequenceDiffResult{},
 	)
 
 	require.Len(t, result, 2)

--- a/directives.md
+++ b/directives.md
@@ -4,15 +4,15 @@ pistachio reads directives from SQL comments in schema files. A directive is a l
 
 | Directive | Arguments | Applies to | Purpose |
 |---|---|---|---|
-| `renamed-from` | old name (required) | tables, views, enums, enum values, domains, columns, constraints, foreign keys, indexes, policies | Rename instead of drop and create |
+| `renamed-from` | old name (required) | tables, views, enums, enum values, domains, composite types, composite attributes, columns, constraints, foreign keys, indexes, policies | Rename instead of drop and create |
 | `execute` | check SQL (optional) | any statement | Run non-managed SQL during apply |
 | `concurrently` | none | `CREATE INDEX` | Create and drop the index with `CONCURRENTLY` |
 | `bulk-alter` | none | `CREATE TABLE` | Merge the table's `ALTER TABLE` actions into one statement |
-| `ignore` | none | tables, views, enums, domains | Leave the object unmanaged |
+| `ignore` | none | tables, views, enums, domains, composite types | Leave the object unmanaged |
 
 ## -- pista:renamed-from
 
-Renames an object instead of dropping and recreating it. The argument is the old name. For tables, views, enums, and domains, the old name may be schema-qualified; without a schema it defaults to the default schema. For columns, constraints, foreign keys, indexes, and policies, the old name is unqualified.
+Renames an object instead of dropping and recreating it. The argument is the old name. For tables, views, enums, domains, and composite types, the old name may be schema-qualified; without a schema it defaults to the default schema. For composite attributes, columns, constraints, foreign keys, indexes, and policies, the old name is unqualified.
 
 ```sql
 -- pista:renamed-from public.old_users
@@ -41,6 +41,17 @@ CREATE TYPE public.status AS ENUM (
     'active',
     -- pista:renamed-from 'inactive'
     'disabled'
+);
+```
+
+For composite types, the statement-level directive renames the type (`ALTER TYPE ... RENAME TO`). To rename an attribute, write the directive inside `CREATE TYPE ... AS (...)` on the line before the attribute; it emits `ALTER TYPE ... RENAME ATTRIBUTE`, which keeps stored data.
+
+```sql
+-- pista:renamed-from public.address
+CREATE TYPE public.postal_address AS (
+    -- pista:renamed-from street
+    road text,
+    city text
 );
 ```
 
@@ -90,7 +101,7 @@ Foreign keys, `RENAME`, `VALIDATE CONSTRAINT`, RLS toggles, and skipped DROPs st
 
 ## -- pista:ignore
 
-Marks a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE DOMAIN` / `CREATE VIEW` (including materialized views) as unmanaged. pistachio does not create, alter, or drop the object: it is dropped from both the desired and current state before diffing. This is the in-file equivalent of `--exclude` for a single object, useful for a table managed by another tool or one whose definition intentionally drifts.
+Marks a `CREATE TABLE` / `CREATE TYPE ... AS ENUM` / `CREATE TYPE ... AS (...)` / `CREATE DOMAIN` / `CREATE VIEW` (including materialized views) as unmanaged. pistachio does not create, alter, or drop the object: it is dropped from both the desired and current state before diffing. This is the in-file equivalent of `--exclude` for a single object, useful for a table managed by another tool or one whose definition intentionally drifts.
 
 ```sql
 -- pista:ignore

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -7,7 +7,7 @@ import "slices"
 // If AllowDrop contains "all", all drops are allowed.
 // Otherwise, only the listed object types are allowed to be dropped.
 type DropPolicy struct {
-	AllowDrop []string `enum:"all,table,view,enum,domain,sequence,column,constraint,foreign_key,index,policy" env:"PISTA_ALLOW_DROP" help:"Allow dropping these object types (repeatable; 'all' allows everything)."`
+	AllowDrop []string `enum:"all,table,view,enum,domain,composite_type,sequence,column,constraint,foreign_key,index,policy" env:"PISTA_ALLOW_DROP" help:"Allow dropping these object types (repeatable; 'all' allows everything)."`
 }
 
 func (p *DropPolicy) IsDropAllowed(objectType string) bool {

--- a/dump.go
+++ b/dump.go
@@ -12,19 +12,20 @@ import (
 
 type DumpOptions struct {
 	FilterOptions
-	Split      string `help:"Output each table/view/enum/domain/sequence as a separate file in the specified directory."`
+	Split      string `help:"Output each table/view/enum/domain/composite type/sequence as a separate file in the specified directory."`
 	OmitSchema bool   `help:"Omit schema name from the dump output."`
 	NoReadOnly bool   `env:"PISTA_NO_READ_ONLY" help:"Open the database connection read-write. By default dump uses a read-only connection."`
 }
 
 type DumpResult struct {
-	Tables     *orderedmap.Map[string, *model.Table]
-	Views      *orderedmap.Map[string, *model.View]
-	Enums      *orderedmap.Map[string, *model.Enum]
-	Domains    *orderedmap.Map[string, *model.Domain]
-	Sequences  *orderedmap.Map[string, *model.Sequence]
-	OmitSchema bool
-	Count      ObjectCount
+	Tables         *orderedmap.Map[string, *model.Table]
+	Views          *orderedmap.Map[string, *model.View]
+	Enums          *orderedmap.Map[string, *model.Enum]
+	Domains        *orderedmap.Map[string, *model.Domain]
+	CompositeTypes *orderedmap.Map[string, *model.CompositeType]
+	Sequences      *orderedmap.Map[string, *model.Sequence]
+	OmitSchema     bool
+	Count          ObjectCount
 }
 
 // stripIndexSchemaPrefix removes the schema qualification from the relation an
@@ -139,6 +140,22 @@ func (r *DumpResult) domains() *orderedmap.Map[string, *model.Domain] {
 	return domains
 }
 
+func (r *DumpResult) compositeTypes() *orderedmap.Map[string, *model.CompositeType] {
+	if r.CompositeTypes == nil {
+		return orderedmap.New[string, *model.CompositeType]()
+	}
+	if !r.OmitSchema {
+		return r.CompositeTypes
+	}
+	compositeTypes := orderedmap.New[string, *model.CompositeType]()
+	for _, ct := range r.CompositeTypes.CollectValues() {
+		copied := *ct
+		copied.Schema = ""
+		compositeTypes.Set(model.Ident(ct.Name), &copied)
+	}
+	return compositeTypes
+}
+
 func (r *DumpResult) sequences() *orderedmap.Map[string, *model.Sequence] {
 	if r.Sequences == nil {
 		return orderedmap.New[string, *model.Sequence]()
@@ -156,17 +173,18 @@ func (r *DumpResult) sequences() *orderedmap.Map[string, *model.Sequence] {
 }
 
 func (r *DumpResult) String() string {
-	return formatSchemaSQL(r.enums(), r.domains(), r.sequences(), r.tables(), r.views())
+	return formatSchemaSQL(r.enums(), r.domains(), r.compositeTypes(), r.sequences(), r.tables(), r.views())
 }
 
-// formatSchemaSQL formats enums, domains, sequences, tables, and views into
-// canonical SQL output for dump.
-// Order: enums -> domains -> sequences -> tables -> views (enums/domains first
-// since domains may depend on enums; sequences before tables since column
-// defaults may reference them).
+// formatSchemaSQL formats enums, domains, composite types, sequences, tables,
+// and views into canonical SQL output for dump.
+// Order: enums -> domains -> composite types -> sequences -> tables -> views
+// (enums/domains/composite types first since later objects may depend on them;
+// sequences before tables since column defaults may reference them).
 func formatSchemaSQL(
 	enums *orderedmap.Map[string, *model.Enum],
 	domains *orderedmap.Map[string, *model.Domain],
+	compositeTypes *orderedmap.Map[string, *model.CompositeType],
 	sequences *orderedmap.Map[string, *model.Sequence],
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
@@ -177,6 +195,9 @@ func formatSchemaSQL(
 	}
 	if domains != nil && domains.Len() > 0 {
 		parts = append(parts, model.DomainsToSQL(domains))
+	}
+	if compositeTypes != nil && compositeTypes.Len() > 0 {
+		parts = append(parts, model.CompositeTypesToSQL(compositeTypes))
 	}
 	if sequences != nil && sequences.Len() > 0 {
 		parts = append(parts, model.SequencesToSQL(sequences))
@@ -201,6 +222,11 @@ func (r *DumpResult) Files() map[string]string {
 	for _, d := range r.domains().CollectValues() {
 		name := uniqueFileName(seen, toFileName(d.Schema, d.Name))
 		files[name] = model.DomainToSQL(d) + "\n"
+		seen[strings.ToLower(name)] = true
+	}
+	for _, ct := range r.compositeTypes().CollectValues() {
+		name := uniqueFileName(seen, toFileName(ct.Schema, ct.Name))
+		files[name] = model.CompositeTypeToSQL(ct) + "\n"
 		seen[strings.ToLower(name)] = true
 	}
 	for _, s := range r.sequences().CollectValues() {
@@ -287,6 +313,11 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 		return nil, fmt.Errorf("failed to fetch domains: %w", err)
 	}
 
+	compositeTypes, err := catalog.CompositeTypes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch composite types: %w", err)
+	}
+
 	sequences, err := catalog.Sequences(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch sequences: %w", err)
@@ -296,22 +327,25 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 	filteredViews := options.filterViews(client.remapViewSchemas(views))
 	filteredEnums := options.filterEnums(client.remapEnumSchemas(enums))
 	filteredDomains := options.filterDomains(client.remapDomainSchemas(domains))
+	filteredCompositeTypes := options.filterCompositeTypes(client.remapCompositeTypeSchemas(compositeTypes))
 	filteredSequences := options.filterSequences(client.remapSequenceSchemas(sequences))
 
 	return &DumpResult{
-		Tables:     filteredTables,
-		Views:      filteredViews,
-		Enums:      filteredEnums,
-		Domains:    filteredDomains,
-		Sequences:  filteredSequences,
-		OmitSchema: options.OmitSchema,
+		Tables:         filteredTables,
+		Views:          filteredViews,
+		Enums:          filteredEnums,
+		Domains:        filteredDomains,
+		CompositeTypes: filteredCompositeTypes,
+		Sequences:      filteredSequences,
+		OmitSchema:     options.OmitSchema,
 		Count: ObjectCount{
-			Schemas:   client.Schemas,
-			Tables:    filteredTables.Len(),
-			Views:     filteredViews.Len(),
-			Enums:     filteredEnums.Len(),
-			Domains:   filteredDomains.Len(),
-			Sequences: filteredSequences.Len(),
+			Schemas:        client.Schemas,
+			Tables:         filteredTables.Len(),
+			Views:          filteredViews.Len(),
+			Enums:          filteredEnums.Len(),
+			Domains:        filteredDomains.Len(),
+			CompositeTypes: filteredCompositeTypes.Len(),
+			Sequences:      filteredSequences.Len(),
 		},
 	}, nil
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -132,7 +132,7 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
 	assert.Equal(t, 1, got.Count.Domains)
 	assert.Equal(t, 0, got.Count.Sequences)
 	assert.Equal(t, "schema public", got.Count.SchemaLabel())
-	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain, 0 sequences", got.Count.Summary())
+	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain, 0 composite types, 0 sequences", got.Count.Summary())
 }
 
 func TestDump_NoReadOnly(t *testing.T) {
@@ -175,7 +175,7 @@ func TestDump_Count_Empty(t *testing.T) {
 	assert.Equal(t, 0, got.Count.Views)
 	assert.Equal(t, 0, got.Count.Enums)
 	assert.Equal(t, 0, got.Count.Domains)
-	assert.Equal(t, "0 tables, 0 views, 0 enums, 0 domains, 0 sequences", got.Count.Summary())
+	assert.Equal(t, "0 tables, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences", got.Count.Summary())
 }
 
 func TestDump_Count_Filtered(t *testing.T) {
@@ -203,7 +203,7 @@ CREATE TABLE public.posts (
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, got.Count.Tables)
-	assert.Equal(t, "1 table, 0 views, 0 enums, 0 domains, 0 sequences", got.Count.Summary())
+	assert.Equal(t, "1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences", got.Count.Summary())
 }
 
 func TestDumpResult_Files_Tables(t *testing.T) {

--- a/filter.go
+++ b/filter.go
@@ -73,6 +73,23 @@ func (f *FilterOptions) filterSequences(sequences *orderedmap.Map[string, *model
 	return filtered
 }
 
+func (f *FilterOptions) filterCompositeTypes(compositeTypes *orderedmap.Map[string, *model.CompositeType]) *orderedmap.Map[string, *model.CompositeType] {
+	if !f.IsTypeEnabled("composite_type") {
+		return orderedmap.New[string, *model.CompositeType]()
+	}
+	if len(f.Include) == 0 && len(f.Exclude) == 0 {
+		return compositeTypes
+	}
+
+	filtered := orderedmap.New[string, *model.CompositeType]()
+	for k, ct := range compositeTypes.All() {
+		if f.MatchName(ct.Name) {
+			filtered.Set(k, ct)
+		}
+	}
+	return filtered
+}
+
 func (f *FilterOptions) filterDomains(domains *orderedmap.Map[string, *model.Domain]) *orderedmap.Map[string, *model.Domain] {
 	if !f.IsTypeEnabled("domain") {
 		return orderedmap.New[string, *model.Domain]()

--- a/getting-started.md
+++ b/getting-started.md
@@ -77,7 +77,7 @@ pista plan schema.sql
 Output:
 
 ```sql
--- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)
+-- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)
 ALTER TABLE public.users ADD COLUMN email text;
 ```
 
@@ -92,7 +92,7 @@ pista apply schema.sql
 Output:
 
 ```sql
--- Apply to schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)
+-- Apply to schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)
 ALTER TABLE public.users ADD COLUMN email text;
 -- Apply finished in 12ms
 ```
@@ -105,7 +105,7 @@ Verify by running plan again:
 
 ```bash
 pista plan schema.sql
-# => -- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 sequences)
+# => -- Plan for schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)
 # => -- No changes
 ```
 

--- a/model/composite_type.go
+++ b/model/composite_type.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"strings"
+
+	"github.com/winebarrel/orderedmap"
+)
+
+// CompositeAttribute is one field of a composite type (CREATE TYPE ... AS (...)).
+type CompositeAttribute struct {
+	Name     string
+	TypeName string
+	// Collation is the attribute collation, schema-qualified (e.g.
+	// "pg_catalog.C"). nil when the attribute uses the default collation.
+	Collation *string
+	// RenameFrom maps the attribute to the current attribute it renames. Set by
+	// the parser from an inline -- pista:renamed-from directive; always nil on
+	// the catalog side.
+	RenameFrom *string
+	Comment    *string
+}
+
+type CompositeType struct {
+	OID        uint32
+	Schema     string
+	Name       string
+	RenameFrom *string
+	Attributes []*CompositeAttribute
+	Comment    *string
+	// Ignore marks the composite type as unmanaged (set by -- pista:ignore).
+	// Ignored objects are not created, altered, or dropped; always false on the
+	// catalog side.
+	Ignore bool
+}
+
+func (ct CompositeType) FQCN() string {
+	return Ident(ct.Schema, ct.Name)
+}
+
+// TypeSQL renders the attribute's type with its COLLATE clause, e.g.
+// "text" or "text COLLATE \"C\"".
+func (a CompositeAttribute) TypeSQL() string {
+	return a.TypeName + collateClause(a.Collation)
+}
+
+// collateClause renders a COLLATE clause for a possibly schema-qualified
+// collation name, or "" when collation is nil.
+func collateClause(collation *string) string {
+	if collation == nil {
+		return ""
+	}
+	parts := strings.Split(*collation, ".")
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		quoted[i] = Ident(p)
+	}
+	return " COLLATE " + strings.Join(quoted, ".")
+}
+
+func (ct CompositeType) SQL() string {
+	lines := make([]string, len(ct.Attributes))
+	for i, a := range ct.Attributes {
+		lines[i] = "    " + Ident(a.Name) + " " + a.TypeName + collateClause(a.Collation)
+	}
+	return "CREATE TYPE " + Ident(ct.Schema, ct.Name) + " AS (\n" +
+		strings.Join(lines, ",\n") + "\n);"
+}
+
+func (ct CompositeType) CommentSQL() string {
+	if ct.Comment != nil {
+		return "COMMENT ON TYPE " + Ident(ct.Schema, ct.Name) + " IS " + QuoteLiteral(*ct.Comment) + ";"
+	}
+	return ""
+}
+
+// AttributeCommentSQLs returns a COMMENT ON COLUMN statement for each attribute
+// that carries a comment.
+func (ct CompositeType) AttributeCommentSQLs() []string {
+	var stmts []string
+	for _, a := range ct.Attributes {
+		if a.Comment != nil {
+			stmts = append(stmts, "COMMENT ON COLUMN "+Ident(ct.Schema, ct.Name, a.Name)+" IS "+QuoteLiteral(*a.Comment)+";")
+		}
+	}
+	return stmts
+}
+
+func CompositeTypeToSQL(ct *CompositeType) string {
+	parts := []string{"-- " + ct.FQCN(), ct.SQL()}
+	if s := ct.CommentSQL(); s != "" {
+		parts = append(parts, s)
+	}
+	parts = append(parts, ct.AttributeCommentSQLs()...)
+	return strings.Join(parts, "\n")
+}
+
+func CompositeTypesToSQL(compositeTypes *orderedmap.Map[string, *CompositeType]) string {
+	return strings.Join(
+		orderedmap.TransformSlice(compositeTypes, func(_ string, ct *CompositeType) string {
+			return CompositeTypeToSQL(ct)
+		}),
+		"\n\n",
+	)
+}

--- a/model/composite_type_test.go
+++ b/model/composite_type_test.go
@@ -1,0 +1,110 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestCompositeType_FQCN(t *testing.T) {
+	ct := &model.CompositeType{Schema: "public", Name: "address"}
+	assert.Equal(t, "public.address", ct.FQCN())
+}
+
+func TestCompositeType_FQCN_QuotedIdentifier(t *testing.T) {
+	ct := &model.CompositeType{Schema: "public", Name: "My Type"}
+	assert.Equal(t, `public."My Type"`, ct.FQCN())
+}
+
+func TestCompositeType_SQL(t *testing.T) {
+	ct := &model.CompositeType{
+		Schema: "public",
+		Name:   "address",
+		Attributes: []*model.CompositeAttribute{
+			{Name: "street", TypeName: "text"},
+			{Name: "city", TypeName: "text"},
+		},
+	}
+	expected := "CREATE TYPE public.address AS (\n" +
+		"    street text,\n" +
+		"    city text\n" +
+		");"
+	assert.Equal(t, expected, ct.SQL())
+}
+
+func TestCompositeType_SQL_Collation(t *testing.T) {
+	coll := "pg_catalog.C"
+	ct := &model.CompositeType{
+		Schema: "public",
+		Name:   "t",
+		Attributes: []*model.CompositeAttribute{
+			{Name: "name", TypeName: "text", Collation: &coll},
+		},
+	}
+	expected := "CREATE TYPE public.t AS (\n" +
+		`    name text COLLATE pg_catalog."C"` + "\n" +
+		");"
+	assert.Equal(t, expected, ct.SQL())
+}
+
+func TestCompositeAttribute_TypeSQL(t *testing.T) {
+	assert.Equal(t, "text", (model.CompositeAttribute{TypeName: "text"}).TypeSQL())
+	coll := "pg_catalog.C"
+	assert.Equal(t, `text COLLATE pg_catalog."C"`, (model.CompositeAttribute{TypeName: "text", Collation: &coll}).TypeSQL())
+}
+
+func TestCompositeType_CommentSQL(t *testing.T) {
+	comment := "an address"
+	ct := &model.CompositeType{Schema: "public", Name: "address", Comment: &comment}
+	assert.Equal(t, "COMMENT ON TYPE public.address IS 'an address';", ct.CommentSQL())
+
+	ct.Comment = nil
+	assert.Equal(t, "", ct.CommentSQL())
+}
+
+func TestCompositeType_AttributeCommentSQLs(t *testing.T) {
+	c := "the city"
+	ct := &model.CompositeType{
+		Schema: "public",
+		Name:   "address",
+		Attributes: []*model.CompositeAttribute{
+			{Name: "street", TypeName: "text"},
+			{Name: "city", TypeName: "text", Comment: &c},
+		},
+	}
+	assert.Equal(t, []string{"COMMENT ON COLUMN public.address.city IS 'the city';"}, ct.AttributeCommentSQLs())
+}
+
+func TestCompositeTypeToSQL(t *testing.T) {
+	comment := "an address"
+	attrComment := "the city"
+	ct := &model.CompositeType{
+		Schema:  "public",
+		Name:    "address",
+		Comment: &comment,
+		Attributes: []*model.CompositeAttribute{
+			{Name: "street", TypeName: "text"},
+			{Name: "city", TypeName: "text", Comment: &attrComment},
+		},
+	}
+	expected := "-- public.address\n" +
+		"CREATE TYPE public.address AS (\n" +
+		"    street text,\n" +
+		"    city text\n" +
+		");\n" +
+		"COMMENT ON TYPE public.address IS 'an address';\n" +
+		"COMMENT ON COLUMN public.address.city IS 'the city';"
+	assert.Equal(t, expected, model.CompositeTypeToSQL(ct))
+}
+
+func TestCompositeTypesToSQL(t *testing.T) {
+	m := orderedmap.New[string, *model.CompositeType]()
+	m.Set("public.a", &model.CompositeType{Schema: "public", Name: "a", Attributes: []*model.CompositeAttribute{{Name: "x", TypeName: "int"}}})
+	m.Set("public.b", &model.CompositeType{Schema: "public", Name: "b", Attributes: []*model.CompositeAttribute{{Name: "y", TypeName: "text"}}})
+	out := model.CompositeTypesToSQL(m)
+	assert.Contains(t, out, "CREATE TYPE public.a AS (")
+	assert.Contains(t, out, "CREATE TYPE public.b AS (")
+	assert.Contains(t, out, "\n\n")
+}

--- a/options.go
+++ b/options.go
@@ -15,10 +15,10 @@ type Options struct {
 }
 
 type FilterOptions struct {
-	Include []string `short:"I" env:"PISTA_INCLUDE" help:"Include only tables/views/enums/domains/sequences matching the pattern (wildcard: *, ?)."`
-	Exclude []string `short:"E" env:"PISTA_EXCLUDE" help:"Exclude tables/views/enums/domains/sequences matching the pattern (wildcard: *, ?)."`
-	Enable  []string `enum:"table,view,enum,domain,sequence" env:"PISTA_ENABLE" help:"Enable only specified object types (can be repeated)."`
-	Disable []string `enum:"table,view,enum,domain,sequence" env:"PISTA_DISABLE" help:"Disable specified object types (can be repeated)."`
+	Include []string `short:"I" env:"PISTA_INCLUDE" help:"Include only tables/views/enums/domains/composite types/sequences matching the pattern (wildcard: *, ?)."`
+	Exclude []string `short:"E" env:"PISTA_EXCLUDE" help:"Exclude tables/views/enums/domains/composite types/sequences matching the pattern (wildcard: *, ?)."`
+	Enable  []string `enum:"table,view,enum,domain,composite_type,sequence" env:"PISTA_ENABLE" help:"Enable only specified object types (can be repeated)."`
+	Disable []string `enum:"table,view,enum,domain,composite_type,sequence" env:"PISTA_DISABLE" help:"Disable specified object types (can be repeated)."`
 }
 
 // IsTypeEnabled returns true if the given object type should be included.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -13,12 +13,13 @@ import (
 )
 
 type ParseResult struct {
-	Tables       *orderedmap.Map[string, *model.Table]
-	Views        *orderedmap.Map[string, *model.View]
-	Enums        *orderedmap.Map[string, *model.Enum]
-	Domains      *orderedmap.Map[string, *model.Domain]
-	Sequences    *orderedmap.Map[string, *model.Sequence]
-	ExecuteStmts []*ExecuteStmt
+	Tables         *orderedmap.Map[string, *model.Table]
+	Views          *orderedmap.Map[string, *model.View]
+	Enums          *orderedmap.Map[string, *model.Enum]
+	Domains        *orderedmap.Map[string, *model.Domain]
+	CompositeTypes *orderedmap.Map[string, *model.CompositeType]
+	Sequences      *orderedmap.Map[string, *model.Sequence]
+	ExecuteStmts   []*ExecuteStmt
 }
 
 func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error {
@@ -76,6 +77,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 	views := orderedmap.New[string, *model.View]()
 	enums := orderedmap.New[string, *model.Enum]()
 	domains := orderedmap.New[string, *model.Domain]()
+	compositeTypes := orderedmap.New[string, *model.CompositeType]()
 	sequences := orderedmap.New[string, *model.Sequence]()
 
 	stmtDirectives := extractStmtDirectives(sql, result.Stmts)
@@ -143,6 +145,37 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			}
 			domain.Ignore = ignore
 			if err := setUnique(domains, domain.FQDN(), "domain", domain); err != nil {
+				return nil, err
+			}
+
+		case node.GetCompositeTypeStmt() != nil:
+			compositeType, err := parseCompositeTypeStmt(node.GetCompositeTypeStmt(), defaultSchema)
+			if err != nil {
+				return nil, err
+			}
+			if renameFrom != "" {
+				qualified := qualifyRenameFrom(renameFrom, defaultSchema)
+				compositeType.RenameFrom = &qualified
+			}
+
+			// Extract attribute-level rename directives from raw SQL. The
+			// composite type body is a column-like list, so the CREATE TABLE
+			// inline-directive scanner applies unchanged.
+			stmtEnd := rawStmt.StmtLocation + rawStmt.StmtLen
+			if stmtEnd > int32(len(sql)) {
+				stmtEnd = int32(len(sql))
+			}
+			rawStmtSQL := sql[rawStmt.StmtLocation:stmtEnd]
+			attrDirectives := extractInlineDirectives(rawStmtSQL)
+			for _, attr := range compositeType.Attributes {
+				if oldName, ok := attrDirectives.Columns[attr.Name]; ok {
+					old := oldName
+					attr.RenameFrom = &old
+				}
+			}
+
+			compositeType.Ignore = ignore
+			if err := setUnique(compositeTypes, compositeType.FQCN(), "composite type", compositeType); err != nil {
 				return nil, err
 			}
 
@@ -307,7 +340,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 
 		case node.GetCommentStmt() != nil:
 			cs := node.GetCommentStmt()
-			parseCommentStmt(cs, defaultSchema, tables, views, enums, domains, sequences)
+			parseCommentStmt(cs, defaultSchema, tables, views, enums, domains, compositeTypes, sequences)
 		}
 	}
 
@@ -315,7 +348,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		return nil, err
 	}
 
-	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains, Sequences: sequences, ExecuteStmts: executeStmts}, nil
+	return &ParseResult{Tables: tables, Views: views, Enums: enums, Domains: domains, CompositeTypes: compositeTypes, Sequences: sequences, ExecuteStmts: executeStmts}, nil
 }
 
 func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Table, error) {
@@ -876,6 +909,60 @@ func extractCheckDefFromDeparsed(deparsed, conName string) string {
 	return def
 }
 
+func parseCompositeTypeStmt(cts *pg_query.CompositeTypeStmt, defaultSchema string) (*model.CompositeType, error) {
+	schema := defaultSchema
+	name := ""
+	if cts.Typevar != nil {
+		name = cts.Typevar.Relname
+		if cts.Typevar.Schemaname != "" {
+			schema = cts.Typevar.Schemaname
+		}
+	}
+
+	compositeType := &model.CompositeType{
+		Schema: schema,
+		Name:   name,
+	}
+
+	for _, node := range cts.Coldeflist {
+		cd := node.GetColumnDef()
+		if cd == nil {
+			continue
+		}
+
+		typeName := ""
+		if cd.TypeName != nil {
+			tn, err := deparseTypeName(cd.TypeName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to deparse attribute type for composite type %s: %w", name, err)
+			}
+			typeName = tn
+		}
+
+		attr := &model.CompositeAttribute{
+			Name:     cd.Colname,
+			TypeName: typeName,
+		}
+
+		if cd.CollClause != nil && len(cd.CollClause.Collname) > 0 {
+			var parts []string
+			for _, n := range cd.CollClause.Collname {
+				if s := n.GetString_(); s != nil {
+					parts = append(parts, s.Sval)
+				}
+			}
+			if len(parts) > 0 && parts[len(parts)-1] != "default" {
+				collation := strings.Join(parts, ".")
+				attr.Collation = &collation
+			}
+		}
+
+		compositeType.Attributes = append(compositeType.Attributes, attr)
+	}
+
+	return compositeType, nil
+}
+
 func parseCommentOnDomain(cs *pg_query.CommentStmt, defaultSchema string, domains *orderedmap.Map[string, *model.Domain]) {
 	tn := cs.Object.GetTypeName()
 	if tn == nil {
@@ -1121,10 +1208,10 @@ func parseSeqOwnedBy(arg *pg_query.Node) (*string, *string) {
 	return &table, &column
 }
 
-func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View], enums *orderedmap.Map[string, *model.Enum], domains *orderedmap.Map[string, *model.Domain], sequences *orderedmap.Map[string, *model.Sequence]) {
+func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View], enums *orderedmap.Map[string, *model.Enum], domains *orderedmap.Map[string, *model.Domain], compositeTypes *orderedmap.Map[string, *model.CompositeType], sequences *orderedmap.Map[string, *model.Sequence]) {
 	// COMMENT ON TYPE/DOMAIN uses TypeName, not a list
 	if cs.Objtype == pg_query.ObjectType_OBJECT_TYPE {
-		parseCommentOnType(cs, defaultSchema, enums)
+		parseCommentOnType(cs, defaultSchema, enums, compositeTypes)
 		return
 	}
 	if cs.Objtype == pg_query.ObjectType_OBJECT_DOMAIN {
@@ -1190,13 +1277,24 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 			colName = names[2]
 		}
 		fqtn := model.Ident(schema, tableName)
+		var comment *string
+		if cs.Comment != "" {
+			c := cs.Comment
+			comment = &c
+		}
 		if t, ok := tables.GetOk(fqtn); ok {
 			if col, ok := t.Columns.GetOk(colName); ok {
-				if cs.Comment != "" {
-					c := cs.Comment
-					col.Comment = &c
-				} else {
-					col.Comment = nil
+				col.Comment = comment
+			}
+			return
+		}
+		// COMMENT ON COLUMN also targets composite type attributes
+		// (schema.type.attribute).
+		if ct, ok := compositeTypes.GetOk(fqtn); ok {
+			for _, attr := range ct.Attributes {
+				if attr.Name == colName {
+					attr.Comment = comment
+					break
 				}
 			}
 		}
@@ -1219,7 +1317,7 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 	}
 }
 
-func parseCommentOnType(cs *pg_query.CommentStmt, defaultSchema string, enums *orderedmap.Map[string, *model.Enum]) {
+func parseCommentOnType(cs *pg_query.CommentStmt, defaultSchema string, enums *orderedmap.Map[string, *model.Enum], compositeTypes *orderedmap.Map[string, *model.CompositeType]) {
 	tn := cs.Object.GetTypeName()
 	if tn == nil {
 		return
@@ -1239,14 +1337,19 @@ func parseCommentOnType(cs *pg_query.CommentStmt, defaultSchema string, enums *o
 		schema = names[0]
 		typeName = names[1]
 	}
-	fqen := model.Ident(schema, typeName)
-	if e, ok := enums.GetOk(fqen); ok {
-		if cs.Comment != "" {
-			c := cs.Comment
-			e.Comment = &c
-		} else {
-			e.Comment = nil
-		}
+	// COMMENT ON TYPE names both enums and composite types; set on whichever
+	// this file defines.
+	fqn := model.Ident(schema, typeName)
+	var comment *string
+	if cs.Comment != "" {
+		c := cs.Comment
+		comment = &c
+	}
+	if e, ok := enums.GetOk(fqn); ok {
+		e.Comment = comment
+	}
+	if ct, ok := compositeTypes.GetOk(fqn); ok {
+		ct.Comment = comment
 	}
 }
 

--- a/plan.go
+++ b/plan.go
@@ -25,12 +25,13 @@ type PlanOptions struct {
 
 // ObjectCount holds the number of objects inspected by type.
 type ObjectCount struct {
-	Schemas   []string
-	Tables    int
-	Views     int
-	Enums     int
-	Domains   int
-	Sequences int
+	Schemas        []string
+	Tables         int
+	Views          int
+	Enums          int
+	Domains        int
+	CompositeTypes int
+	Sequences      int
 }
 
 func (c ObjectCount) SchemaLabel() string {
@@ -41,11 +42,12 @@ func (c ObjectCount) SchemaLabel() string {
 }
 
 func (c ObjectCount) Summary() string {
-	return fmt.Sprintf("%s, %s, %s, %s, %s",
+	return fmt.Sprintf("%s, %s, %s, %s, %s, %s",
 		pluralize(c.Tables, "table"),
 		pluralize(c.Views, "view"),
 		pluralize(c.Enums, "enum"),
 		pluralize(c.Domains, "domain"),
+		pluralize(c.CompositeTypes, "composite type"),
 		pluralize(c.Sequences, "sequence"),
 	)
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -49,11 +49,12 @@ type planDropPolicy struct {
 // is checked only when set, so a fixture can pin individual counts without
 // having to specify every field.
 type expectedCount struct {
-	Tables    *int `yaml:"tables,omitempty"`
-	Views     *int `yaml:"views,omitempty"`
-	Enums     *int `yaml:"enums,omitempty"`
-	Domains   *int `yaml:"domains,omitempty"`
-	Sequences *int `yaml:"sequences,omitempty"`
+	Tables         *int `yaml:"tables,omitempty"`
+	Views          *int `yaml:"views,omitempty"`
+	Enums          *int `yaml:"enums,omitempty"`
+	Domains        *int `yaml:"domains,omitempty"`
+	CompositeTypes *int `yaml:"composite_types,omitempty"`
+	Sequences      *int `yaml:"sequences,omitempty"`
 }
 
 func assertExpectedCount(t *testing.T, want *expectedCount, got pistachio.ObjectCount) {
@@ -72,6 +73,9 @@ func assertExpectedCount(t *testing.T, want *expectedCount, got pistachio.Object
 	}
 	if want.Domains != nil {
 		assert.Equal(t, *want.Domains, got.Domains, "Count.Domains")
+	}
+	if want.CompositeTypes != nil {
+		assert.Equal(t, *want.CompositeTypes, got.CompositeTypes, "Count.CompositeTypes")
 	}
 	if want.Sequences != nil {
 		assert.Equal(t, *want.Sequences, got.Sequences, "Count.Sequences")

--- a/remap.go
+++ b/remap.go
@@ -249,3 +249,41 @@ func (client *Client) reverseRemapDomainSchemas(domains *orderedmap.Map[string, 
 
 	return remapped
 }
+
+func (client *Client) remapCompositeTypeSchemas(compositeTypes *orderedmap.Map[string, *model.CompositeType]) *orderedmap.Map[string, *model.CompositeType] {
+	if len(client.SchemaMap) == 0 {
+		return compositeTypes
+	}
+
+	replacer := buildDefReplacer(client.SchemaMap)
+	remapped := orderedmap.New[string, *model.CompositeType]()
+
+	for _, ct := range compositeTypes.CollectValues() {
+		ct.Schema = client.RemapSchema(ct.Schema)
+		for _, a := range ct.Attributes {
+			a.TypeName = replacer.Replace(a.TypeName)
+		}
+		remapped.Set(ct.FQCN(), ct)
+	}
+
+	return remapped
+}
+
+func (client *Client) reverseRemapCompositeTypeSchemas(compositeTypes *orderedmap.Map[string, *model.CompositeType]) *orderedmap.Map[string, *model.CompositeType] {
+	if len(client.SchemaMap) == 0 {
+		return compositeTypes
+	}
+
+	replacer := buildReverseDefReplacer(client.SchemaMap)
+	remapped := orderedmap.New[string, *model.CompositeType]()
+
+	for _, ct := range compositeTypes.CollectValues() {
+		ct.Schema = client.ReverseRemapSchema(ct.Schema)
+		for _, a := range ct.Attributes {
+			a.TypeName = replacer.Replace(a.TypeName)
+		}
+		remapped.Set(ct.FQCN(), ct)
+	}
+
+	return remapped
+}

--- a/remap_test.go
+++ b/remap_test.go
@@ -244,6 +244,56 @@ CREATE SEQUENCE myschema.order_seq INCREMENT BY 1;
 	assert.Contains(t, got.SQL, "ALTER SEQUENCE myschema.order_seq INCREMENT BY 2;")
 }
 
+func TestDump_WithSchemaMap_CompositeType(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TYPE myschema.point AS (x integer, y integer);
+CREATE TYPE myschema.shape AS (name text, origin myschema.point);
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	// The type schema and the schema-qualified attribute type are both remapped
+	// to "public" (exercises remapCompositeTypeSchemas).
+	assert.Contains(t, got.String(), "CREATE TYPE public.point")
+	assert.Contains(t, got.String(), "CREATE TYPE public.shape")
+	assert.Contains(t, got.String(), "origin public.point")
+	assert.NotContains(t, got.String(), "myschema.")
+}
+
+func TestPlan_WithSchemaMap_CompositeType(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TYPE myschema.address AS (street text, city text);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(
+		"CREATE TYPE public.address AS (street text, city text, country text);"), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	// The desired public.address is reverse-remapped to myschema.address
+	// (exercises reverseRemapCompositeTypeSchemas) and diffed against the DB.
+	assert.Contains(t, got.SQL, "ALTER TYPE myschema.address ADD ATTRIBUTE country text;")
+}
+
 func TestDump_WithSchemaMap_Files(t *testing.T) {
 	ctx := context.Background()
 

--- a/remap_test.go
+++ b/remap_test.go
@@ -275,6 +275,34 @@ func TestApply_UnqualifiedUserTypeInNonPublicSchema(t *testing.T) {
 	assert.Empty(t, plan.SQL, "expected no drift after apply")
 }
 
+// TestApply_PublicObjectFromNonPublicSchema guards that the apply search_path
+// keeps public searchable: a non-public target schema must still resolve an
+// unqualified reference to an object in public (extension types and functions
+// commonly live there), so the search_path extends the default rather than
+// replacing it.
+func TestApply_PublicObjectFromNonPublicSchema(t *testing.T) {
+	ctx := context.Background()
+	connString := setupSchemaDB(t, ctx, "app",
+		"DROP DOMAIN IF EXISTS public.pubdm CASCADE; CREATE DOMAIN public.pubdm AS text; "+
+			"CREATE OR REPLACE FUNCTION public.pubfn() RETURNS text AS $$ SELECT 'x'::text $$ LANGUAGE sql;")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(
+		"CREATE TABLE app.t1 (id integer, c pubdm);\n"+
+			"CREATE TABLE app.t2 (id integer, c text DEFAULT pubfn());\n"), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"app"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
+		Files:      []string{desiredFile},
+	}, io.Discard)
+	require.NoError(t, err)
+}
+
 func TestDump_WithSchemaMap_CompositeType(t *testing.T) {
 	ctx := context.Background()
 

--- a/remap_test.go
+++ b/remap_test.go
@@ -244,6 +244,37 @@ CREATE SEQUENCE myschema.order_seq INCREMENT BY 1;
 	assert.Contains(t, got.SQL, "ALTER SEQUENCE myschema.order_seq INCREMENT BY 2;")
 }
 
+// TestApply_UnqualifiedUserTypeInNonPublicSchema guards the apply-time
+// search_path setup: an unqualified user-type reference in a column definition
+// must resolve for a non-public target schema. The apply fixtures cannot cover
+// it because the harness always targets public.
+func TestApply_UnqualifiedUserTypeInNonPublicSchema(t *testing.T) {
+	ctx := context.Background()
+	connString := setupSchemaDB(t, ctx, "app", "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(
+		"CREATE TYPE app.addr AS (x text);\nCREATE TABLE app.people (id integer, home addr);\n"), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"app"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
+		Files:      []string{desiredFile},
+	}, io.Discard)
+	require.NoError(t, err)
+
+	plan, err := client.Plan(ctx, &pistachio.PlanOptions{
+		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
+		Files:      []string{desiredFile},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, plan.SQL, "expected no drift after apply")
+}
+
 func TestDump_WithSchemaMap_CompositeType(t *testing.T) {
 	ctx := context.Background()
 

--- a/schema_filter.go
+++ b/schema_filter.go
@@ -23,6 +23,7 @@ func filterDesiredBySchemas(result *parser.ParseResult, schemas []string, schema
 	result.Views = filterMapBySchema(result.Views, schemaSet, func(v *model.View) string { return v.Schema })
 	result.Enums = filterMapBySchema(result.Enums, schemaSet, func(e *model.Enum) string { return e.Schema })
 	result.Domains = filterMapBySchema(result.Domains, schemaSet, func(d *model.Domain) string { return d.Schema })
+	result.CompositeTypes = filterMapBySchema(result.CompositeTypes, schemaSet, func(ct *model.CompositeType) string { return ct.Schema })
 }
 
 func filterMapBySchema[V any](m *orderedmap.Map[string, V], schemas map[string]bool, getSchema func(V) string) *orderedmap.Map[string, V] {

--- a/schema_filter_test.go
+++ b/schema_filter_test.go
@@ -16,11 +16,11 @@ func TestObjectCount_SchemaLabel(t *testing.T) {
 }
 
 func TestObjectCount_Summary(t *testing.T) {
-	c := pistachio.ObjectCount{Tables: 3, Views: 1, Enums: 2, Domains: 0, Sequences: 4}
-	assert.Equal(t, "3 tables, 1 view, 2 enums, 0 domains, 4 sequences", c.Summary())
+	c := pistachio.ObjectCount{Tables: 3, Views: 1, Enums: 2, Domains: 0, CompositeTypes: 0, Sequences: 4}
+	assert.Equal(t, "3 tables, 1 view, 2 enums, 0 domains, 0 composite types, 4 sequences", c.Summary())
 }
 
 func TestObjectCount_Summary_Singular(t *testing.T) {
-	c := pistachio.ObjectCount{Tables: 1, Views: 1, Enums: 1, Domains: 1, Sequences: 1}
-	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain, 1 sequence", c.Summary())
+	c := pistachio.ObjectCount{Tables: 1, Views: 1, Enums: 1, Domains: 1, CompositeTypes: 1, Sequences: 1}
+	assert.Equal(t, "1 table, 1 view, 1 enum, 1 domain, 1 composite type, 1 sequence", c.Summary())
 }

--- a/test/scenario/composite_type.test.sh
+++ b/test/scenario/composite_type.test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Scenario test: composite type lifecycle (create, alter attributes, rename,
+# comment), verifying drift-free state at each step.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+STEPS="$SCRIPT_DIR/testdata/composite_type/steps"
+
+setup_db ""
+
+run_step "01 create composite type" \
+  "CREATE TYPE public.addr AS (" \
+  "$STEPS/01_create.sql"
+
+run_step "02 add / drop / alter attribute" \
+  "ALTER TYPE public.addr ADD ATTRIBUTE city text;" \
+  "$STEPS/02_alter_attrs.sql"
+
+run_step "03 rename type and attribute" \
+  "ALTER TYPE public.addr RENAME TO address;" \
+  "$STEPS/03_rename.sql"
+
+run_step "04 type and attribute comments" \
+  "COMMENT ON TYPE public.address IS 'an address';" \
+  "$STEPS/04_comment.sql"
+
+summary

--- a/test/scenario/testdata/composite_type/steps/01_create.sql
+++ b/test/scenario/testdata/composite_type/steps/01_create.sql
@@ -1,0 +1,4 @@
+CREATE TYPE public.addr AS (
+    street text,
+    zip    text
+);

--- a/test/scenario/testdata/composite_type/steps/02_alter_attrs.sql
+++ b/test/scenario/testdata/composite_type/steps/02_alter_attrs.sql
@@ -1,0 +1,4 @@
+CREATE TYPE public.addr AS (
+    street varchar(200),
+    city   text
+);

--- a/test/scenario/testdata/composite_type/steps/03_rename.sql
+++ b/test/scenario/testdata/composite_type/steps/03_rename.sql
@@ -1,0 +1,6 @@
+-- pista:renamed-from addr
+CREATE TYPE public.address AS (
+    -- pista:renamed-from street
+    road varchar(200),
+    city text
+);

--- a/test/scenario/testdata/composite_type/steps/04_comment.sql
+++ b/test/scenario/testdata/composite_type/steps/04_comment.sql
@@ -1,0 +1,8 @@
+-- pista:renamed-from addr
+CREATE TYPE public.address AS (
+    -- pista:renamed-from street
+    road varchar(200),
+    city text
+);
+COMMENT ON TYPE public.address IS 'an address';
+COMMENT ON COLUMN public.address.city IS 'city';

--- a/testdata/apply/alter_composite_type.yml
+++ b/testdata/apply/alter_composite_type.yml
@@ -1,0 +1,25 @@
+drop_policy:
+  allow_drop:
+    - composite_type
+init: |
+  CREATE TYPE public.address AS (street text, city text, zip text);
+desired: |
+  -- pista:renamed-from address
+  CREATE TYPE public.postal_address AS (
+      street  text,
+      city    varchar(100),
+      country text
+  );
+applied_sql: |
+  ALTER TYPE public.address RENAME TO postal_address;
+  ALTER TYPE public.postal_address DROP ATTRIBUTE zip;
+  ALTER TYPE public.postal_address ALTER ATTRIBUTE city TYPE character varying(100);
+  ALTER TYPE public.postal_address ADD ATTRIBUTE country text;
+applied: |
+  -- public.postal_address
+  CREATE TYPE public.postal_address AS (
+      street text,
+      city character varying(100),
+      country text
+  );
+verify_no_drift: true

--- a/testdata/apply/composite_type_collation.yml
+++ b/testdata/apply/composite_type_collation.yml
@@ -1,0 +1,18 @@
+init: ""
+desired: |
+  CREATE TYPE public.t AS (
+      name  text COLLATE pg_catalog."C",
+      other text
+  );
+applied_sql: |
+  CREATE TYPE public.t AS (
+      name text COLLATE pg_catalog."C",
+      other text
+  );
+applied: |
+  -- public.t
+  CREATE TYPE public.t AS (
+      name text COLLATE pg_catalog."C",
+      other text
+  );
+verify_no_drift: true

--- a/testdata/apply/composite_type_collation_unqualified.yml
+++ b/testdata/apply/composite_type_collation_unqualified.yml
@@ -1,0 +1,15 @@
+init: ""
+desired: |
+  CREATE TYPE public.ct AS (
+      name text COLLATE "C"
+  );
+applied_sql: |
+  CREATE TYPE public.ct AS (
+      name text COLLATE "C"
+  );
+applied: |
+  -- public.ct
+  CREATE TYPE public.ct AS (
+      name text COLLATE pg_catalog."C"
+  );
+verify_no_drift: true

--- a/testdata/apply/composite_type_qualified_attribute_no_drift.yml
+++ b/testdata/apply/composite_type_qualified_attribute_no_drift.yml
@@ -1,0 +1,26 @@
+init: ""
+desired: |
+  CREATE TYPE public.inner_t AS (
+      x text
+  );
+  CREATE TYPE public.outer_t AS (
+      i public.inner_t
+  );
+applied_sql: |
+  CREATE TYPE public.inner_t AS (
+      x text
+  );
+  CREATE TYPE public.outer_t AS (
+      i public.inner_t
+  );
+applied: |
+  -- public.inner_t
+  CREATE TYPE public.inner_t AS (
+      x text
+  );
+
+  -- public.outer_t
+  CREATE TYPE public.outer_t AS (
+      i inner_t
+  );
+verify_no_drift: true

--- a/testdata/apply/composite_type_qualified_column_no_drift.yml
+++ b/testdata/apply/composite_type_qualified_column_no_drift.yml
@@ -1,0 +1,29 @@
+init: ""
+desired: |
+  CREATE TYPE public.addr AS (
+      street text
+  );
+  CREATE TABLE public.people (
+      id   integer,
+      home public.addr
+  );
+applied_sql: |
+  CREATE TYPE public.addr AS (
+      street text
+  );
+  CREATE TABLE public.people (
+      id integer,
+      home public.addr
+  );
+applied: |
+  -- public.addr
+  CREATE TYPE public.addr AS (
+      street text
+  );
+
+  -- public.people
+  CREATE TABLE public.people (
+      id integer,
+      home addr
+  );
+verify_no_drift: true

--- a/testdata/apply/composite_type_unqualified.yml
+++ b/testdata/apply/composite_type_unqualified.yml
@@ -1,0 +1,24 @@
+init: ""
+desired: |
+  CREATE TYPE address AS (
+      street text,
+      city   text
+  );
+  COMMENT ON TYPE address IS 'addr';
+  COMMENT ON COLUMN address.city IS 'c';
+applied_sql: |
+  CREATE TYPE public.address AS (
+      street text,
+      city text
+  );
+  COMMENT ON TYPE public.address IS 'addr';
+  COMMENT ON COLUMN public.address.city IS 'c';
+applied: |
+  -- public.address
+  CREATE TYPE public.address AS (
+      street text,
+      city text
+  );
+  COMMENT ON TYPE public.address IS 'addr';
+  COMMENT ON COLUMN public.address.city IS 'c';
+verify_no_drift: true

--- a/testdata/apply/create_composite_type.yml
+++ b/testdata/apply/create_composite_type.yml
@@ -1,0 +1,26 @@
+init: ""
+desired: |
+  CREATE TYPE public.address AS (
+      street text,
+      city   text
+  );
+  COMMENT ON TYPE public.address IS 'an address';
+  COMMENT ON COLUMN public.address.city IS 'the city';
+applied_sql: |
+  CREATE TYPE public.address AS (
+      street text,
+      city text
+  );
+  COMMENT ON TYPE public.address IS 'an address';
+  COMMENT ON COLUMN public.address.city IS 'the city';
+applied: |
+  -- public.address
+  CREATE TYPE public.address AS (
+      street text,
+      city text
+  );
+  COMMENT ON TYPE public.address IS 'an address';
+  COMMENT ON COLUMN public.address.city IS 'the city';
+count:
+  composite_types: 0
+verify_no_drift: true

--- a/testdata/apply/disallowed_drop_composite_type.yml
+++ b/testdata/apply/disallowed_drop_composite_type.yml
@@ -1,0 +1,19 @@
+drop_policy:
+  allow_drop:
+    - table
+init: |
+  CREATE TYPE public.address AS (street text);
+desired: |
+  CREATE TABLE public.t (id int);
+disallowed_drops: |
+  -- skipped: DROP TYPE public.address;
+applied: |
+  -- public.address
+  CREATE TYPE public.address AS (
+      street text
+  );
+
+  -- public.t
+  CREATE TABLE public.t (
+      id integer
+  );

--- a/testdata/apply/drop_composite_type.yml
+++ b/testdata/apply/drop_composite_type.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TYPE public.address AS (street text);
+  CREATE TYPE public.keepme AS (a int);
+desired: |
+  CREATE TYPE public.keepme AS (
+      a int
+  );
+applied_sql: |
+  DROP TYPE public.address;
+applied: |
+  -- public.keepme
+  CREATE TYPE public.keepme AS (
+      a integer
+  );
+verify_no_drift: true

--- a/testdata/apply/enable_composite_type.yml
+++ b/testdata/apply/enable_composite_type.yml
@@ -1,0 +1,18 @@
+enable:
+  - composite_type
+init: ""
+desired: |
+  CREATE TYPE public.addr AS (
+      street text
+  );
+  CREATE TABLE public.t (id int);
+applied_sql: |
+  CREATE TYPE public.addr AS (
+      street text
+  );
+applied: |
+  -- public.addr
+  CREATE TYPE public.addr AS (
+      street text
+  );
+verify_no_drift: true

--- a/testdata/apply/ignore_composite_type.yml
+++ b/testdata/apply/ignore_composite_type.yml
@@ -1,0 +1,14 @@
+init: |
+  CREATE TYPE public.address AS (street text);
+desired: |
+  -- pista:ignore
+  CREATE TYPE public.address AS (
+      street text,
+      city   text
+  );
+applied: |
+  -- public.address
+  CREATE TYPE public.address AS (
+      street text
+  );
+verify_no_drift: true

--- a/testdata/apply/no_diff_composite_type.yml
+++ b/testdata/apply/no_diff_composite_type.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+  COMMENT ON TYPE public.address IS 'an address';
+desired: |
+  CREATE TYPE public.address AS (
+      street text,
+      city   text
+  );
+  COMMENT ON TYPE public.address IS 'an address';
+applied_sql: ""
+applied: |
+  -- public.address
+  CREATE TYPE public.address AS (
+      street text,
+      city text
+  );
+  COMMENT ON TYPE public.address IS 'an address';
+verify_no_drift: true

--- a/testdata/dump/composite_type.yml
+++ b/testdata/dump/composite_type.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TYPE public.address AS (
+      street text,
+      city   text,
+      zip    text
+  );
+  COMMENT ON TYPE public.address IS 'postal address';
+  COMMENT ON COLUMN public.address.city IS 'city name';
+dump: |
+  -- public.address
+  CREATE TYPE public.address AS (
+      street text,
+      city text,
+      zip text
+  );
+  COMMENT ON TYPE public.address IS 'postal address';
+  COMMENT ON COLUMN public.address.city IS 'city name';

--- a/testdata/dump/composite_type_include.yml
+++ b/testdata/dump/composite_type_include.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+  CREATE TABLE public.users (id integer);
+include:
+  - address
+dump: |
+  -- public.address
+  CREATE TYPE public.address AS (
+      street text,
+      city text
+  );

--- a/testdata/dump/composite_type_omit_schema.yml
+++ b/testdata/dump/composite_type_omit_schema.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+  COMMENT ON TYPE public.address IS 'an address';
+  COMMENT ON COLUMN public.address.city IS 'the city';
+omit_schema: true
+dump: |
+  -- address
+  CREATE TYPE address AS (
+      street text,
+      city text
+  );
+  COMMENT ON TYPE address IS 'an address';
+  COMMENT ON COLUMN address.city IS 'the city';

--- a/testdata/plan/add_composite_attribute.yml
+++ b/testdata/plan/add_composite_attribute.yml
@@ -1,0 +1,12 @@
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+desired: |
+  CREATE TYPE public.address AS (
+      street  text,
+      city    text,
+      country text
+  );
+plan: |
+  ALTER TYPE public.address ADD ATTRIBUTE country text;
+count:
+  composite_types: 1

--- a/testdata/plan/add_composite_type_comment.yml
+++ b/testdata/plan/add_composite_type_comment.yml
@@ -1,0 +1,12 @@
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+desired: |
+  CREATE TYPE public.address AS (
+      street text,
+      city   text
+  );
+  COMMENT ON TYPE public.address IS 'an address';
+  COMMENT ON COLUMN public.address.city IS 'the city';
+plan: |
+  COMMENT ON TYPE public.address IS 'an address';
+  COMMENT ON COLUMN public.address.city IS 'the city';

--- a/testdata/plan/alter_composite_attribute_type.yml
+++ b/testdata/plan/alter_composite_attribute_type.yml
@@ -1,0 +1,9 @@
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+desired: |
+  CREATE TYPE public.address AS (
+      street text,
+      city   varchar(100)
+  );
+plan: |
+  ALTER TYPE public.address ALTER ATTRIBUTE city TYPE character varying(100);

--- a/testdata/plan/create_composite_type.yml
+++ b/testdata/plan/create_composite_type.yml
@@ -1,0 +1,13 @@
+init: ""
+desired: |
+  CREATE TYPE public.address AS (
+      street text,
+      city   text
+  );
+plan: |
+  CREATE TYPE public.address AS (
+      street text,
+      city text
+  );
+count:
+  composite_types: 0

--- a/testdata/plan/create_composite_type_enum_chain.yml
+++ b/testdata/plan/create_composite_type_enum_chain.yml
@@ -1,0 +1,16 @@
+init: ""
+desired: |
+  CREATE TYPE public.addr AS (
+      street text,
+      kind   public.kind
+  );
+  CREATE TYPE public.kind AS ENUM ('home', 'work');
+plan: |
+  CREATE TYPE public.kind AS ENUM (
+      'home',
+      'work'
+  );
+  CREATE TYPE public.addr AS (
+      street text,
+      kind public.kind
+  );

--- a/testdata/plan/create_composite_type_table_chain.yml
+++ b/testdata/plan/create_composite_type_table_chain.yml
@@ -1,0 +1,19 @@
+init: ""
+desired: |
+  CREATE TABLE public.people (
+      id   int,
+      home public.addr
+  );
+  CREATE TYPE public.addr AS (
+      street text,
+      city   text
+  );
+plan: |
+  CREATE TYPE public.addr AS (
+      street text,
+      city text
+  );
+  CREATE TABLE public.people (
+      id integer,
+      home public.addr
+  );

--- a/testdata/plan/disable_composite_type.yml
+++ b/testdata/plan/disable_composite_type.yml
@@ -1,0 +1,11 @@
+disable: [composite_type]
+init: ""
+desired: |
+  CREATE TYPE public.address AS (
+      street text
+  );
+  CREATE TABLE public.t (id int);
+plan: |
+  CREATE TABLE public.t (
+      id integer
+  );

--- a/testdata/plan/disallowed_drop_composite_type.yml
+++ b/testdata/plan/disallowed_drop_composite_type.yml
@@ -1,0 +1,12 @@
+drop_policy:
+  allow_drop: []
+init: |
+  CREATE TYPE public.address AS (street text, city text, zip text);
+desired: |
+  CREATE TYPE public.address AS (
+      street text,
+      city   text
+  );
+plan: ""
+disallowed_drops: |
+  -- skipped: ALTER TYPE public.address DROP ATTRIBUTE zip;

--- a/testdata/plan/error_composite_attribute_rename_missing.yml
+++ b/testdata/plan/error_composite_attribute_rename_missing.yml
@@ -1,0 +1,8 @@
+init: |
+  CREATE TYPE public.address AS (street text);
+desired: |
+  CREATE TYPE public.address AS (
+      -- pista:renamed-from nonexist
+      road text
+  );
+error: "rename source attribute nonexist not found in composite type public.address"

--- a/testdata/plan/ignore_composite_type.yml
+++ b/testdata/plan/ignore_composite_type.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TYPE public.address AS (street text);
+desired: |
+  -- pista:ignore
+  CREATE TYPE public.address AS (
+      street text,
+      city   text
+  );
+plan: ""
+ignored: |
+  -- ignored: public.address

--- a/testdata/plan/include_composite_type.yml
+++ b/testdata/plan/include_composite_type.yml
@@ -1,0 +1,16 @@
+include: [address]
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+  CREATE TYPE public.other AS (a integer);
+desired: |
+  CREATE TYPE public.address AS (
+      street  text,
+      city    text,
+      country text
+  );
+  CREATE TYPE public.other AS (
+      a integer,
+      b integer
+  );
+plan: |
+  ALTER TYPE public.address ADD ATTRIBUTE country text;

--- a/testdata/plan/rename_composite_attribute.yml
+++ b/testdata/plan/rename_composite_attribute.yml
@@ -1,0 +1,10 @@
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+desired: |
+  CREATE TYPE public.address AS (
+      -- pista:renamed-from street
+      road text,
+      city text
+  );
+plan: |
+  ALTER TYPE public.address RENAME ATTRIBUTE street TO road;

--- a/testdata/plan/rename_composite_type.yml
+++ b/testdata/plan/rename_composite_type.yml
@@ -1,0 +1,10 @@
+init: |
+  CREATE TYPE public.address AS (street text, city text);
+desired: |
+  -- pista:renamed-from address
+  CREATE TYPE public.postal_address AS (
+      street text,
+      city   text
+  );
+plan: |
+  ALTER TYPE public.address RENAME TO postal_address;

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -17,12 +17,13 @@ import (
 func OrderFromSchema(
 	enums *orderedmap.Map[string, *model.Enum],
 	domains *orderedmap.Map[string, *model.Domain],
+	compositeTypes *orderedmap.Map[string, *model.CompositeType],
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
 	sequences *orderedmap.Map[string, *model.Sequence],
 ) ([]string, error) {
 	g := newGraph()
-	defined := collectDefined(enums, domains, tables, views, sequences)
+	defined := collectDefined(enums, domains, compositeTypes, tables, views, sequences)
 
 	// Enums: no dependencies (leaf nodes)
 	for k := range enums.Keys() {
@@ -39,6 +40,17 @@ func OrderFromSchema(
 		g.AddNode(k)
 		if dep := resolveTypeDep(d.BaseType, d.Schema, defined); dep != "" {
 			g.AddEdge(k, dep)
+		}
+	}
+
+	// Composite types: may depend on enums, domains, or other composite types
+	// via attribute types.
+	for k, ct := range compositeTypes.All() {
+		g.AddNode(k)
+		for _, a := range ct.Attributes {
+			if dep := resolveTypeDep(a.TypeName, ct.Schema, defined); dep != "" && dep != k {
+				g.AddEdge(k, dep)
+			}
 		}
 	}
 
@@ -111,6 +123,7 @@ func OrderFromSchema(
 func collectDefined(
 	enums *orderedmap.Map[string, *model.Enum],
 	domains *orderedmap.Map[string, *model.Domain],
+	compositeTypes *orderedmap.Map[string, *model.CompositeType],
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
 	sequences *orderedmap.Map[string, *model.Sequence],
@@ -120,6 +133,9 @@ func collectDefined(
 		defined[k] = true
 	}
 	for k := range domains.Keys() {
+		defined[k] = true
+	}
+	for k := range compositeTypes.Keys() {
 		defined[k] = true
 	}
 	for k := range tables.Keys() {

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -18,7 +18,7 @@ func orderFromSchema(
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
 ) ([]string, error) {
-	return toposort.OrderFromSchema(enums, domains, tables, views, orderedmap.New[string, *model.Sequence]())
+	return toposort.OrderFromSchema(enums, domains, orderedmap.New[string, *model.CompositeType](), tables, views, orderedmap.New[string, *model.Sequence]())
 }
 
 func TestOrderFromSchema_Basic(t *testing.T) {
@@ -78,7 +78,7 @@ func TestOrderFromSchemaWithSequences_NextvalDependency(t *testing.T) {
 	aaa.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tables.Set("public.aaa", aaa)
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views, sequences)
+	order, err := toposort.OrderFromSchema(enums, domains, orderedmap.New[string, *model.CompositeType](), tables, views, sequences)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)
@@ -111,7 +111,7 @@ func TestOrderFromSchemaWithSequences_NextvalQuotedName(t *testing.T) {
 	aaa.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tables.Set(`public."Aaa"`, aaa)
 
-	order, err := toposort.OrderFromSchema(enums, domains, tables, views, sequences)
+	order, err := toposort.OrderFromSchema(enums, domains, orderedmap.New[string, *model.CompositeType](), tables, views, sequences)
 	require.NoError(t, err)
 
 	idx := make(map[string]int)


### PR DESCRIPTION
## Summary

Adds declarative management of PostgreSQL **composite types** (`CREATE TYPE ... AS (...)`), alongside the existing enum and domain support. You define the desired composite types in your schema files and pistachio generates the DDL diff to converge the database.

## What's covered

- **Create / drop** composite types, gated by `--allow-drop=composite_type`
- **ALTER TYPE** `ADD ATTRIBUTE` / `DROP ATTRIBUTE` / `ALTER ATTRIBUTE ... TYPE`, matched by attribute name (order-independent, since PostgreSQL cannot reorder attributes)
- **Rename**: type (`ALTER TYPE ... RENAME TO`) and attribute (`ALTER TYPE ... RENAME ATTRIBUTE`) via `-- pista:renamed-from`
- **Comments** on the type and on each attribute (`COMMENT ON TYPE` / `COMMENT ON COLUMN`)
- **Collation** on attributes (`COLLATE`)
- **Dependency ordering**: a composite type is created after the enums / domains / composite types its attributes reference, and before tables that use it
- Wired through **dump** (including `--split` and `--omit-schema`), **plan**, **apply**, `--include` / `--exclude`, `--enable` / `--disable` (`composite_type`), **schema-map** remap, and the `-- pista:ignore` directive

`--allow-drop=composite_type` also gates `DROP ATTRIBUTE` (attribute removal loses data). Whole-object and attribute-level drops are suppressed by default and surfaced as `-- skipped:` comments, matching the existing drop-policy behavior.

## Scope notes

- Attribute reordering produces no diff (PostgreSQL has no reorder operation; `ADD ATTRIBUTE` always appends).
- `--omit-schema` remains dump-only (unchanged); plan/apply resolve unqualified type names to the default schema.
- Roles / grants / functions / triggers stay out of scope (use `-- pista:execute`); this PR only adds the composite type object.

## Tests

- Unit: `model` (9), `diff` (18, 100% coverage), `catalog` (4), schema-map remap (2)
- Fixtures: `plan` (15), `apply` (10), `dump` (3) covering create / alter / drop / rename / comment / collation / dependency ordering / ignore / enable / disable / include / omit-schema / disallowed-drop / unqualified names / idempotency
- New-code coverage: `model` and `diff` 100%; `catalog` and `parser` at parity with the existing enum/domain code (only DB-error and nil-guard branches remain)
- `make test` (`-p 1`) all pass, `make lint` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)