### PR TITLE
Build the pista Docker image with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,100 +15,42 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - &checkout
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+      # goreleaser-cross ships the docker CLI and buildx, so GoReleaser
+      # builds and pushes the image itself (dockers_v2 in .goreleaser.yml).
+      # It needs a multi-platform capable builder and registry credentials,
+      # both set up here on the runner and passed into the container: the
+      # docker socket, $HOME/.docker (login credentials and the buildx
+      # instance), and the builder name via BUILDX_BUILDER.
+      - id: buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         run: |
           docker run -q \
             --rm \
             -e CGO_ENABLED=1 \
             -e GITHUB_TOKEN \
+            -e BUILDX_BUILDER \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$HOME/.docker:/root/.docker" \
             -v "$GITHUB_WORKSPACE:/src" \
             -w /src \
             "ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION}" \
             release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-
-  docker-build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-      - *checkout
-      - &setup-buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ghcr.io/${{ github.repository }}
-      - &login-ghcr
-        uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
-          build-args: |
-            PISTA_VERSION=${{ github.ref_name }}
-      - name: Export digest
-        run: |
-          mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-      - name: Upload digest
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  docker:
-    runs-on: ubuntu-latest
-    needs:
-      - docker-build
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
-          merge-multiple: true
-      - *setup-buildx
-      - id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ghcr.io/${{ github.repository }}
-      - *login-ghcr
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          # shellcheck disable=SC2046  # intentional word splitting to pass each -t flag and digest as separate args
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+          BUILDX_BUILDER: ${{ steps.buildx.outputs.name }}
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
   demo:
     uses: ./.github/workflows/demo.yml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,26 @@ archives:
         formats: [zip]
 checksum:
   name_template: "checksums.txt"
+dockers_v2:
+  - ids: [linux-amd64, linux-arm64]
+    images:
+      - ghcr.io/winebarrel/pistachio
+    tags:
+      - "v{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels: &image_labels
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: pistachio is a declarative schema management tool for PostgreSQL.
+      org.opencontainers.image.url: https://github.com/winebarrel/pistachio
+      org.opencontainers.image.source: https://github.com/winebarrel/pistachio
+      org.opencontainers.image.licenses: MIT
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.created: "{{ .Date }}"
+    annotations: *image_labels
 homebrew_casks:
   - repository:
       owner: winebarrel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
-FROM golang:1.26-alpine AS build
+# Image for the pista CLI, built and pushed by GoReleaser (see .goreleaser.yml).
+#
+# GoReleaser passes a build context that holds the already cross-built
+# binaries, one directory per platform (e.g. linux/amd64/pista), so this
+# Dockerfile only copies the right one in. The binary links against glibc
+# because of cgo (libpg_query), so the runtime image cannot be musl-based.
+FROM gcr.io/distroless/base-debian13
 
-RUN apk add --no-cache gcc musl-dev
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/pista /usr/local/bin/pista
 
-WORKDIR /src
-COPY go.* /src/
-RUN go mod download
-
-COPY . /src/
-ARG PISTA_VERSION
-RUN CGO_ENABLED=1 go build -o pista -ldflags "-X main.version=${PISTA_VERSION#v}" ./cmd/pista
-
-FROM alpine:3
-
-RUN apk add --no-cache ca-certificates
-
-COPY --from=build /src/pista /usr/local/bin/
-
-ENTRYPOINT ["pista"]
+ENTRYPOINT ["/usr/local/bin/pista"]


### PR DESCRIPTION
Replace the separate docker-build/docker jobs with GoReleaser's dockers_v2
pipe. GoReleaser already cross-builds the linux binaries, so the image no
longer rebuilds them from source; the Dockerfile just copies the binary for
$TARGETPLATFORM out of the context GoReleaser prepares, and GoReleaser
builds the multi-platform manifest and pushes it.

goreleaser-cross ships the docker CLI and buildx, so the release job mounts
the docker socket and $HOME/.docker into the container and passes the
builder created by setup-buildx-action via BUILDX_BUILDER.

The runtime base image changes from alpine to gcr.io/distroless/base-debian13:
cgo (libpg_query) links pista against glibc, so a musl base cannot run the
binaries GoReleaser produces. Keeping the Dockerfile to FROM/COPY also means
the linux/arm64 image builds on an amd64 runner without qemu.

Tags (v<version> and latest) and the OCI labels are now declared in
.goreleaser.yml instead of docker/metadata-action.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SnopmYBYH8s2rU6Fpg6Xxn