### PR TITLE
Add tests for reachable-but-uncovered paths

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -320,6 +320,46 @@ CREATE DOMAIN public.pos_int AS integer CONSTRAINT pos_check CHECK (VALUE > 0);`
 	assert.Contains(t, files["public.pos_int.sql"], "CREATE DOMAIN public.pos_int")
 }
 
+func TestDumpResult_Files_CompositeTypes(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE TYPE public.addr AS (street text, city text);`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Contains(t, files, "public.addr.sql")
+	assert.Contains(t, files["public.addr.sql"], "CREATE TYPE public.addr AS (")
+}
+
+func TestDumpResult_Files_Sequences(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+CREATE SEQUENCE public.order_seq;`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+	files := got.Files()
+	assert.Contains(t, files, "public.order_seq.sql")
+	assert.Contains(t, files["public.order_seq.sql"], "CREATE SEQUENCE public.order_seq")
+}
+
 func TestDumpResult_Files_SpecialCharacters(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/testdata/plan/add_constraint_unnamed.yml
+++ b/testdata/plan/add_constraint_unnamed.yml
@@ -1,0 +1,18 @@
+# ALTER TABLE ... ADD without a CONSTRAINT clause leaves the name empty in the
+# parsed statement, so the definition has to be recovered from the deparsed SQL
+# and the name filled in with PostgreSQL's auto-naming convention.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text
+  );
+  ALTER TABLE public.users ADD PRIMARY KEY (id);
+  ALTER TABLE public.users ADD UNIQUE (email);
+plan: |
+  ALTER TABLE public.users ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+  ALTER TABLE public.users ADD CONSTRAINT users_email_key UNIQUE (email);

--- a/testdata/plan/add_inline_foreign_key_unqualified_reference.yml
+++ b/testdata/plan/add_inline_foreign_key_unqualified_reference.yml
@@ -1,0 +1,26 @@
+# An inline FOREIGN KEY inside CREATE TABLE may reference an unqualified table;
+# the reference resolves against the default schema, so it matches the catalog
+# entry and produces no drift after the constraint is added.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id),
+      CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id)
+  );
+plan: |
+  ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id);

--- a/testdata/plan/add_partition_child_default.yml
+++ b/testdata/plan/add_partition_child_default.yml
@@ -1,0 +1,18 @@
+# A DEFAULT partition has no column list, so the inline-directive scan (which
+# looks for the opening parenthesis of the column/constraint list) has nothing
+# to scan and must return empty rather than misreading the statement.
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_default PARTITION OF public.events DEFAULT;
+plan: |
+  CREATE TABLE public.events_default PARTITION OF public.events DEFAULT;

--- a/testdata/plan/alter_sequence_minvalue_start.yml
+++ b/testdata/plan/alter_sequence_minvalue_start.yml
@@ -1,0 +1,8 @@
+# MINVALUE and START WITH are diffed independently of the other sequence
+# options, so a change to only those two must still produce an ALTER.
+init: |
+  CREATE SEQUENCE public.order_seq MINVALUE 1 START WITH 1;
+desired: |
+  CREATE SEQUENCE public.order_seq MINVALUE 5 START WITH 10;
+plan: |
+  ALTER SEQUENCE public.order_seq MINVALUE 5 START WITH 10;

--- a/testdata/plan/create_sequence_before_table_qualified_nextval.yml
+++ b/testdata/plan/create_sequence_before_table_qualified_nextval.yml
@@ -1,0 +1,20 @@
+# Same ordering rule as create_sequence_before_table.yml, but the nextval
+# argument is already schema-qualified, so the dependency resolves by direct
+# lookup instead of going through the search_path fallback.
+init: ""
+desired: |
+  CREATE SEQUENCE public.zzz_seq;
+  CREATE TABLE public.aaa (
+      id bigint DEFAULT nextval('public.zzz_seq'::regclass) NOT NULL
+  );
+plan: |
+  CREATE SEQUENCE public.zzz_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+  CREATE TABLE public.aaa (
+      id bigint DEFAULT nextval('public.zzz_seq'::regclass) NOT NULL
+  );

--- a/testdata/plan/create_sequence_unqualified.yml
+++ b/testdata/plan/create_sequence_unqualified.yml
@@ -1,0 +1,8 @@
+# A CREATE SEQUENCE without a schema prefix belongs to the default schema, so
+# it must diff against the same catalog sequence a qualified name would.
+init: |
+  CREATE SEQUENCE public.order_seq INCREMENT BY 1;
+desired: |
+  CREATE SEQUENCE order_seq INCREMENT BY 2;
+plan: |
+  ALTER SEQUENCE public.order_seq INCREMENT BY 2;

--- a/testdata/plan/create_sequence_with_comment.yml
+++ b/testdata/plan/create_sequence_with_comment.yml
@@ -1,0 +1,15 @@
+# A sequence created and commented in the same plan emits the COMMENT right
+# after its CREATE, rather than relying on a later comment-diff pass.
+init: ""
+desired: |
+  CREATE SEQUENCE public.order_seq;
+  COMMENT ON SEQUENCE public.order_seq IS 'order ids';
+plan: |
+  CREATE SEQUENCE public.order_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+  COMMENT ON SEQUENCE public.order_seq IS 'order ids';

--- a/testdata/plan/create_view_with_case_expr_after_table.yml
+++ b/testdata/plan/create_view_with_case_expr_after_table.yml
@@ -1,0 +1,19 @@
+# The dependency walk has to descend into a simple-form CASE (CASE <expr> WHEN
+# ...) in the select list, so the view is still created after the table it
+# reads from even though it is written first.
+init: ""
+desired: |
+  CREATE VIEW public.order_labels AS
+      SELECT CASE status WHEN 1 THEN 'new'::text ELSE 'done'::text END AS label
+        FROM public.orders;
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      status integer NOT NULL
+  );
+plan: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      status integer NOT NULL
+  );
+  CREATE OR REPLACE VIEW public.order_labels AS
+  SELECT CASE status WHEN 1 THEN 'new'::text ELSE 'done'::text END AS label FROM public.orders;

--- a/testdata/plan/no_diff_view_target_cast.yml
+++ b/testdata/plan/no_diff_view_target_cast.yml
@@ -1,0 +1,16 @@
+# A cast written on a select target survives into pg_get_viewdef, so both sides
+# carry it. Cast alignment must match them up instead of treating the
+# catalog-side cast as an extra to strip: no drift.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.user_labels AS SELECT (id)::text AS label FROM public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.user_labels AS SELECT (id)::text AS label FROM public.users;
+plan: ""

--- a/testdata/plan/rename_inline_foreign_key.yml
+++ b/testdata/plan/rename_inline_foreign_key.yml
@@ -1,0 +1,28 @@
+# An inline `-- pista:renamed-from` directive above a FOREIGN KEY constraint
+# inside CREATE TABLE has to resolve against the table's foreign keys, not only
+# its check/unique/primary-key constraints.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id),
+      CONSTRAINT posts_user_fk FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT posts_pkey PRIMARY KEY (id),
+      -- pista:renamed-from posts_user_fk
+      CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+plan: |
+  ALTER TABLE public.posts RENAME CONSTRAINT posts_user_fk TO posts_user_id_fkey;


### PR DESCRIPTION
Fills coverage gaps that correspond to real, naturally reachable behavior,
without changing any production code:

- Sequence diff: MINVALUE / START WITH clauses, and the COMMENT emitted
  alongside a newly created sequence.
- Parser: unnamed ALTER TABLE ... ADD constraints (definition recovered via
  the " ADD " fallback), an inline renamed-from directive on a FOREIGN KEY,
  an unqualified CREATE SEQUENCE, and an inline FK with an unqualified
  REFERENCES target.
- Directives: a DEFAULT partition child, which has no column list for the
  inline-directive scan to look at.
- Toposort: a schema-qualified nextval() dependency and a simple-form CASE
  in a view's select list.
- View diff: a select-target cast present on both the catalog and desired
  sides, which cast alignment has to match up rather than strip.
- DumpResult.Files(): composite types and sequences.

The remaining uncovered blocks are defensive nil/error guards, deliberately
documented dead code, or the Windows-only pager branch.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AVCVLN3NVri7Vy3qhiZn4o