### PR TITLE
Add --try-tx to wrap apply in a transaction when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.21.0] - 2026-07-31
+
+* Add `--try-tx` (env `$PISTA_TRY_TX`) to `apply`. It wraps the apply in a transaction like `--with-tx`, but a diff containing `CREATE/DROP INDEX CONCURRENTLY` runs without a transaction instead of failing, and the output records `-- Transaction skipped: plan contains CONCURRENTLY index DDL`. The decision follows the generated diff, so a `-- pista:concurrently` index that is not being changed still gets a transaction. `--with-tx` is unchanged and still errors on such a diff; the two flags are mutually exclusive. Unlike `--with-tx`, `--try-tx` can be combined with `--force-index-concurrently`.
+
 ## [1.20.0] - 2026-07-30
 
 * Manage composite types. `plan`, `apply`, and `dump` handle `CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME TO`, `RENAME ATTRIBUTE`, and comments on the type and its attributes. A composite type is created after the enums, domains, and composite types its attributes reference, and before tables that use it. `--enable`, `--disable`, `--include`, `--exclude`, and `--allow-drop` accept `composite_type`; `--allow-drop=composite_type` also gates `DROP ATTRIBUTE`. Attribute reordering is not diffed (PostgreSQL cannot reorder attributes), and `ALTER ATTRIBUTE ... TYPE` fails at apply while a table column uses the type. ([#331](https://github.com/winebarrel/pistachio/pull/331))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.21.0] - 2026-07-31
 
-* Add `--try-tx` (env `$PISTA_TRY_TX`) to `apply`. It wraps the apply in a transaction like `--with-tx`, but a diff containing `CREATE/DROP INDEX CONCURRENTLY` runs without a transaction instead of failing, and the output records `-- Transaction skipped: plan contains CONCURRENTLY index DDL`. The decision follows the generated diff, so a `-- pista:concurrently` index that is not being changed still gets a transaction. `--with-tx` is unchanged and still errors on such a diff; the two flags are mutually exclusive. Unlike `--with-tx`, `--try-tx` can be combined with `--force-index-concurrently`.
+* Add `--try-tx` (env `$PISTA_TRY_TX`) to `apply`. It works like `--with-tx`, except that a diff containing `CREATE/DROP INDEX CONCURRENTLY` runs without a transaction instead of failing, and the output records `-- Transaction skipped: plan contains CONCURRENTLY index DDL`. The decision follows the generated diff, so a `-- pista:concurrently` index that is not being changed still gets a transaction. `--with-tx` is unchanged and the two flags are mutually exclusive. `--try-tx` can be combined with `--force-index-concurrently`.
 
 ## [1.20.0] - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -172,21 +172,6 @@ pista apply tables.sql views.sql
 
 Use `--pre-sql` or `--pre-sql-file` to run SQL before applying changes (mutually exclusive). Also available as `$PISTA_PRE_SQL` / `$PISTA_PRE_SQL_FILE`. Use `--with-tx` to wrap the apply in a transaction (also available as `$PISTA_WITH_TX`).
 
-Use `--try-tx` to wrap the apply in a transaction only when one is possible. It behaves exactly like `--with-tx`, except that a diff containing `CREATE/DROP INDEX CONCURRENTLY` runs without a transaction instead of failing. The two flags are mutually exclusive. Also available as `$PISTA_TRY_TX`.
-
-```bash
-pista apply --try-tx schema.sql
-```
-
-When the transaction is skipped, the output records why:
-
-```sql
--- Transaction skipped: plan contains CONCURRENTLY index DDL
-CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);
-```
-
-Note that an apply which skips the transaction is not all-or-nothing: a failure part-way through leaves the statements that already ran in place. Re-running `pista apply` reconciles the rest, but a failed `CREATE INDEX CONCURRENTLY` leaves an invalid index that must be dropped by hand (this is PostgreSQL behavior, not specific to pistachio).
-
 ```bash
 # Inline SQL
 pista apply schema.sql --pre-sql "SET statement_timeout = '5s';" --with-tx
@@ -194,6 +179,21 @@ pista apply schema.sql --pre-sql "SET statement_timeout = '5s';" --with-tx
 # From file
 pista apply schema.sql --pre-sql-file pre.sql --with-tx
 ```
+
+Use `--try-tx` to wrap the apply in a transaction only when possible. It works like `--with-tx`, except that a diff containing `CREATE/DROP INDEX CONCURRENTLY` runs without a transaction instead of failing. The two flags are mutually exclusive. Also available as `$PISTA_TRY_TX`.
+
+```bash
+pista apply --try-tx schema.sql
+```
+
+The skipped transaction is recorded in the output:
+
+```sql
+-- Transaction skipped: plan contains CONCURRENTLY index DDL
+CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);
+```
+
+An apply that skips the transaction is not all-or-nothing. A failure leaves the statements that already ran in place, and re-running `pista apply` applies the rest. A failed `CREATE INDEX CONCURRENTLY` also leaves an invalid index that must be dropped by hand.
 
 To apply `CONCURRENTLY` to individual indexes, either write `CREATE INDEX CONCURRENTLY` directly or use the `-- pista:concurrently` directive before the `CREATE INDEX` statement. Both are treated equivalently:
 
@@ -229,7 +229,7 @@ pista apply --force-index-concurrently schema.sql
 ```
 
 > [!NOTE]
-> When the generated diff includes `CREATE INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY`, `--with-tx` cannot be used because `CONCURRENTLY` operations cannot run inside a transaction. If there are no index changes, `--with-tx` is allowed even when an index is opted into `CONCURRENTLY`. To run `apply` inside a transaction in spite of the opt-in, combine `--with-tx` with `--disable-index-concurrently`. To keep the opt-in and fall back to no transaction on those runs, use `--try-tx` instead.
+> When the generated diff includes `CREATE INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY`, `--with-tx` cannot be used because `CONCURRENTLY` operations cannot run inside a transaction. If there are no index changes, `--with-tx` is allowed even when an index is opted into `CONCURRENTLY`. To run `apply` inside a transaction in spite of the opt-in, combine `--with-tx` with `--disable-index-concurrently`. To keep the opt-in and run without a transaction instead, use `--try-tx`.
 
 Use `--bulk-alter` to combine consecutive `ALTER TABLE` actions on the same table into a single statement with comma-separated actions. This reduces metadata-lock churn and lets PostgreSQL plan the changes together. Foreign keys, `RENAME`, `VALIDATE CONSTRAINT`, RLS toggles, and skipped DROPs are kept as separate statements. Also available as `$PISTA_BULK_ALTER`.
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ pista apply tables.sql views.sql
 
 Use `--pre-sql` or `--pre-sql-file` to run SQL before applying changes (mutually exclusive). Also available as `$PISTA_PRE_SQL` / `$PISTA_PRE_SQL_FILE`. Use `--with-tx` to wrap the apply in a transaction (also available as `$PISTA_WITH_TX`).
 
+Use `--try-tx` to wrap the apply in a transaction only when one is possible. It behaves exactly like `--with-tx`, except that a diff containing `CREATE/DROP INDEX CONCURRENTLY` runs without a transaction instead of failing. The two flags are mutually exclusive. Also available as `$PISTA_TRY_TX`.
+
+```bash
+pista apply --try-tx schema.sql
+```
+
+When the transaction is skipped, the output records why:
+
+```sql
+-- Transaction skipped: plan contains CONCURRENTLY index DDL
+CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);
+```
+
+Note that an apply which skips the transaction is not all-or-nothing: a failure part-way through leaves the statements that already ran in place. Re-running `pista apply` reconciles the rest, but a failed `CREATE INDEX CONCURRENTLY` leaves an invalid index that must be dropped by hand (this is PostgreSQL behavior, not specific to pistachio).
+
 ```bash
 # Inline SQL
 pista apply schema.sql --pre-sql "SET statement_timeout = '5s';" --with-tx
@@ -214,7 +229,7 @@ pista apply --force-index-concurrently schema.sql
 ```
 
 > [!NOTE]
-> When the generated diff includes `CREATE INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY`, `--with-tx` cannot be used because `CONCURRENTLY` operations cannot run inside a transaction. If there are no index changes, `--with-tx` is allowed even when an index is opted into `CONCURRENTLY`. To run `apply` inside a transaction in spite of the opt-in, combine `--with-tx` with `--disable-index-concurrently`.
+> When the generated diff includes `CREATE INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY`, `--with-tx` cannot be used because `CONCURRENTLY` operations cannot run inside a transaction. If there are no index changes, `--with-tx` is allowed even when an index is opted into `CONCURRENTLY`. To run `apply` inside a transaction in spite of the opt-in, combine `--with-tx` with `--disable-index-concurrently`. To keep the opt-in and fall back to no transaction on those runs, use `--try-tx` instead.
 
 Use `--bulk-alter` to combine consecutive `ALTER TABLE` actions on the same table into a single statement with comma-separated actions. This reduces metadata-lock churn and lets PostgreSQL plan the changes together. Foreign keys, `RENAME`, `VALIDATE CONSTRAINT`, RLS toggles, and skipped DROPs are kept as separate statements. Also available as `$PISTA_BULK_ALTER`.
 

--- a/apply.go
+++ b/apply.go
@@ -20,7 +20,7 @@ type ApplyOptions struct {
 	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index DDL (e.g. SET lock_timeout). Runs outside any transaction, only when the diff contains CONCURRENTLY index DDL."`
 	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to execute before CONCURRENTLY index DDL."`
 	WithTx                   bool     `xor:"tx-mode,tx-choice" env:"PISTA_WITH_TX" help:"Execute pre-SQL and schema changes in a transaction."`
-	TryTx                    bool     `xor:"tx-choice" env:"PISTA_TRY_TX" help:"Execute pre-SQL and schema changes in a transaction when possible. Runs without one, instead of failing, when the diff contains CONCURRENTLY index DDL."`
+	TryTx                    bool     `xor:"tx-choice" env:"PISTA_TRY_TX" help:"Execute pre-SQL and schema changes in a transaction when possible. A diff containing CONCURRENTLY index DDL runs without a transaction instead of failing."`
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently,tx-mode" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops. Cannot be combined with --with-tx."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
@@ -76,7 +76,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	// --with-tx is an explicit all-or-nothing request, so CONCURRENTLY index
 	// DDL (which PostgreSQL cannot run inside a transaction) stays an error.
 	// --try-tx asks for a transaction only when one is possible, so the same
-	// diff downgrades to running without one.
+	// diff runs without one.
 	if options.WithTx && result.HasConcurrentlyIndex {
 		return nil, fmt.Errorf("--with-tx cannot be used with CONCURRENTLY index operations")
 	}
@@ -123,8 +123,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 			return nil
 		}
 	} else if options.TryTx {
-		// Record why the transaction the caller asked for was not opened, in
-		// the same sentence form as the comments above.
+		// Record why the requested transaction was not opened, in the same
+		// sentence form as the comments above.
 		fmt.Fprintln(w, "-- Transaction skipped: plan contains CONCURRENTLY index DDL") //nolint:errcheck
 	}
 

--- a/apply.go
+++ b/apply.go
@@ -19,7 +19,8 @@ type ApplyOptions struct {
 	PreSQLFile               string   `type:"path" xor:"pre-sql" env:"PISTA_PRE_SQL_FILE" help:"Path to a SQL file to execute before applying changes."`
 	ConcurrentlyPreSQL       string   `xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL" help:"SQL to execute before CONCURRENTLY index DDL (e.g. SET lock_timeout). Runs outside any transaction, only when the diff contains CONCURRENTLY index DDL."`
 	ConcurrentlyPreSQLFile   string   `type:"path" xor:"concurrently-pre-sql" env:"PISTA_CONCURRENTLY_PRE_SQL_FILE" help:"Path to a SQL file to execute before CONCURRENTLY index DDL."`
-	WithTx                   bool     `xor:"tx-mode" env:"PISTA_WITH_TX" help:"Execute pre-SQL and schema changes in a transaction."`
+	WithTx                   bool     `xor:"tx-mode,tx-choice" env:"PISTA_WITH_TX" help:"Execute pre-SQL and schema changes in a transaction."`
+	TryTx                    bool     `xor:"tx-choice" env:"PISTA_TRY_TX" help:"Execute pre-SQL and schema changes in a transaction when possible. Runs without one, instead of failing, when the diff contains CONCURRENTLY index DDL."`
 	DisableIndexConcurrently bool     `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
 	ForceIndexConcurrently   bool     `xor:"index-concurrently,tx-mode" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops. Cannot be combined with --with-tx."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
@@ -72,9 +73,14 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return nil, err
 	}
 
+	// --with-tx is an explicit all-or-nothing request, so CONCURRENTLY index
+	// DDL (which PostgreSQL cannot run inside a transaction) stays an error.
+	// --try-tx asks for a transaction only when one is possible, so the same
+	// diff downgrades to running without one.
 	if options.WithTx && result.HasConcurrentlyIndex {
 		return nil, fmt.Errorf("--with-tx cannot be used with CONCURRENTLY index operations")
 	}
+	withTx := options.WithTx || (options.TryTx && !result.HasConcurrentlyIndex)
 
 	applyResult := &ApplyResult{
 		Count:           result.Count,
@@ -93,7 +99,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	queryRow := conn.QueryRow
 	commit := func(context.Context) error { return nil }
 
-	if options.WithTx {
+	if withTx {
 		tx, err := conn.Begin(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to begin transaction: %w", err)
@@ -116,6 +122,10 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 			fmt.Fprintln(w, "-- Transaction committed") //nolint:errcheck
 			return nil
 		}
+	} else if options.TryTx {
+		// Record why the transaction the caller asked for was not opened, in
+		// the same sentence form as the comments above.
+		fmt.Fprintln(w, "-- Transaction skipped: plan contains CONCURRENTLY index DDL") //nolint:errcheck
 	}
 
 	// Pre-SQL and concurrently-pre-SQL are setup steps (e.g. SET lock_timeout),
@@ -131,7 +141,8 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 
 	// concurrently-pre-SQL is gated on HasConcurrentlyIndex so it only runs
 	// when there is CONCURRENTLY index DDL to apply. WithTx + HasConcurrentlyIndex
-	// is rejected above, so this always runs outside a transaction.
+	// is rejected above and TryTx opens no transaction in that case, so this
+	// always runs outside a transaction.
 	if result.ConcurrentlyPreSQL != "" && result.HasConcurrentlyIndex {
 		fmt.Fprintln(w, result.ConcurrentlyPreSQL) //nolint:errcheck
 		if _, err := exec(ctx, result.ConcurrentlyPreSQL); err != nil {

--- a/apply_test.go
+++ b/apply_test.go
@@ -1127,6 +1127,93 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
 	assert.NotContains(t, out, "-- Transaction skipped")
 }
 
+func TestApply_TryTx_DirectiveIndexUnchanged_UsesTransaction(t *testing.T) {
+	// The decision follows the generated diff, not the presence of the
+	// directive: an opted-in index that is not being changed leaves the diff
+	// free of CONCURRENTLY DDL, so the other changes run in a transaction.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    age integer,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pista:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files: []string{desiredFile},
+		TryTx: true,
+	}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ADD COLUMN age")
+	assert.Contains(t, out, "-- Transaction started")
+	assert.Contains(t, out, "-- Transaction committed")
+	assert.NotContains(t, out, "-- Transaction skipped")
+}
+
+func TestApply_TryTx_ConcurrentlyPreSQL_RunsOutsideTransaction(t *testing.T) {
+	// concurrently-pre-SQL keeps running outside a transaction under --try-tx.
+	// The apply succeeding is the proof: CONCURRENTLY index DDL would fail if
+	// a transaction had been opened.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pista:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:              []string{desiredFile},
+		ConcurrentlyPreSQL: "SET lock_timeout = '5s';",
+		TryTx:              true,
+	}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "SET lock_timeout = '5s';")
+	assert.Contains(t, out, "CREATE INDEX CONCURRENTLY")
+	assert.Contains(t, out, "-- Transaction skipped")
+	assert.NotContains(t, out, "-- Transaction started")
+}
+
 func TestApply_TryTx_ForceIndexConcurrently_SkipsTransaction(t *testing.T) {
 	// --force-index-concurrently is allowed with --try-tx: the forced
 	// CONCURRENTLY index DDL simply means no transaction is opened.

--- a/apply_test.go
+++ b/apply_test.go
@@ -962,6 +962,274 @@ CREATE INDEX idx_users_id ON public.users USING btree (id);`), 0o644))
 	assert.NotContains(t, got, "CONCURRENTLY")
 }
 
+func TestApply_TryTx_Concurrently_SkipsTransaction(t *testing.T) {
+	// --try-tx runs without a transaction instead of failing when the plan
+	// contains CONCURRENTLY index DDL.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pista:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files: []string{desiredFile},
+		TryTx: true,
+	}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "CREATE INDEX CONCURRENTLY")
+	assert.Contains(t, out, "-- Transaction skipped")
+	assert.NotContains(t, out, "-- Transaction started")
+	assert.NotContains(t, out, "-- Transaction committed")
+
+	got, dumpErr := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, dumpErr)
+	assert.Contains(t, got.String(), "CREATE INDEX idx_users_name")
+}
+
+func TestApply_TryTx_NoConcurrently_UsesTransaction(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files: []string{desiredFile},
+		TryTx: true,
+	}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "-- Transaction started")
+	assert.Contains(t, out, "-- Transaction committed")
+	assert.NotContains(t, out, "-- Transaction skipped")
+
+	got, dumpErr := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, dumpErr)
+	assert.Contains(t, got.String(), "CREATE TABLE public.users")
+}
+
+func TestApply_TryTx_NoConcurrently_RollsBackOnError(t *testing.T) {
+	// The transaction --try-tx opens is a real one: a failure rolls the
+	// schema changes back.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	tmpDir := t.TempDir()
+	desiredFile := filepath.Join(tmpDir, "desired.sql")
+	preSQLFile := filepath.Join(tmpDir, "pre.sql")
+
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`), 0o644))
+	require.NoError(t, os.WriteFile(preSQLFile, []byte(`CREATE TABLE public.pre_hook (
+    id integer NOT NULL
+);
+SELECT * FROM public.missing_table;`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:      []string{desiredFile},
+		PreSQLFile: preSQLFile,
+		TryTx:      true,
+	}, &buf)
+	require.Error(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "-- Transaction started")
+	assert.Contains(t, out, "-- Transaction rolled back")
+
+	got, dumpErr := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, dumpErr)
+	assert.NotContains(t, got.String(), "CREATE TABLE public.pre_hook")
+	assert.NotContains(t, got.String(), "CREATE TABLE public.users")
+}
+
+func TestApply_TryTx_NoChanges_OmitsTransactionComments(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	initSQL := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`
+	testutil.SetupDB(t, ctx, conn, initSQL)
+
+	// The directive is present but the index already matches, so no index DDL
+	// is generated and no transaction is opened either way.
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pista:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{Files: []string{desiredFile}, TryTx: true}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotContains(t, out, "-- Transaction started")
+	assert.NotContains(t, out, "-- Transaction committed")
+	assert.NotContains(t, out, "-- Transaction rolled back")
+	assert.NotContains(t, out, "-- Transaction skipped")
+}
+
+func TestApply_TryTx_ForceIndexConcurrently_SkipsTransaction(t *testing.T) {
+	// --force-index-concurrently is allowed with --try-tx: the forced
+	// CONCURRENTLY index DDL simply means no transaction is opened.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:                  []string{desiredFile},
+		ForceIndexConcurrently: true,
+		TryTx:                  true,
+	}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "CREATE INDEX CONCURRENTLY")
+	assert.Contains(t, out, "-- Transaction skipped")
+	assert.NotContains(t, out, "-- Transaction started")
+}
+
+func TestApply_TryTx_DisableIndexConcurrently_UsesTransaction(t *testing.T) {
+	// CONCURRENTLY is suppressed, so --try-tx opens a transaction even though
+	// the directive is present.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+-- pista:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:                    []string{desiredFile},
+		DisableIndexConcurrently: true,
+		TryTx:                    true,
+	}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "-- Transaction started")
+	assert.Contains(t, out, "-- Transaction committed")
+	assert.NotContains(t, out, "-- Transaction skipped")
+	assert.NotContains(t, out, "CONCURRENTLY")
+}
+
+func TestApplyOptions_TryTx_XorEnforcement(t *testing.T) {
+	t.Run("try_tx_and_with_tx", func(t *testing.T) {
+		var opts pistachio.ApplyOptions
+		parser, err := kong.New(&opts)
+		require.NoError(t, err)
+		_, err = parser.Parse([]string{"--with-tx", "--try-tx", "schema.sql"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--try-tx")
+	})
+
+	t.Run("try_tx_and_force_index_concurrently", func(t *testing.T) {
+		var opts pistachio.ApplyOptions
+		parser, err := kong.New(&opts)
+		require.NoError(t, err)
+		_, err = parser.Parse([]string{"--force-index-concurrently", "--try-tx", "schema.sql"})
+		require.NoError(t, err)
+		assert.True(t, opts.TryTx)
+		assert.True(t, opts.ForceIndexConcurrently)
+	})
+}
+
 func TestApply_ConcurrentlyDirective_MatviewIndex_WithTx_Error(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/apply_test.go
+++ b/apply_test.go
@@ -1214,6 +1214,38 @@ CREATE INDEX idx_users_name ON public.users USING btree (name);`), 0o644))
 	assert.NotContains(t, out, "-- Transaction started")
 }
 
+func TestApply_TryTx_MatviewIndex_SkipsTransaction(t *testing.T) {
+	// A materialized view index carries CONCURRENTLY through the view diff, so
+	// --try-tx skips the transaction for it too.
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(`CREATE MATERIALIZED VIEW public.mv AS SELECT 1 AS n;
+-- pista:concurrently
+CREATE INDEX idx_mv_n ON public.mv USING btree (n);`), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files: []string{desiredFile},
+		TryTx: true,
+	}, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "CREATE INDEX CONCURRENTLY")
+	assert.Contains(t, out, "-- Transaction skipped")
+	assert.NotContains(t, out, "-- Transaction started")
+}
+
 func TestApply_TryTx_ForceIndexConcurrently_SkipsTransaction(t *testing.T) {
 	// --force-index-concurrently is allowed with --try-tx: the forced
 	// CONCURRENTLY index DDL simply means no transaction is opened.

--- a/directives.md
+++ b/directives.md
@@ -77,7 +77,7 @@ Opts an index into `CONCURRENTLY` for `CREATE INDEX` and `DROP INDEX`. Writing `
 CREATE INDEX idx_users_name ON public.users USING btree (name);
 ```
 
-`--disable-index-concurrently` ignores all opt-ins; `--force-index-concurrently` applies `CONCURRENTLY` to every index change. `CONCURRENTLY` operations cannot run inside a transaction, so a plan containing them conflicts with `apply --with-tx`.
+`--disable-index-concurrently` ignores all opt-ins; `--force-index-concurrently` applies `CONCURRENTLY` to every index change. `CONCURRENTLY` operations cannot run inside a transaction, so a plan containing them conflicts with `apply --with-tx`. Use `apply --try-tx` to run without a transaction on those plans instead of failing.
 
 ## -- pista:bulk-alter
 

--- a/directives.md
+++ b/directives.md
@@ -77,7 +77,7 @@ Opts an index into `CONCURRENTLY` for `CREATE INDEX` and `DROP INDEX`. Writing `
 CREATE INDEX idx_users_name ON public.users USING btree (name);
 ```
 
-`--disable-index-concurrently` ignores all opt-ins; `--force-index-concurrently` applies `CONCURRENTLY` to every index change. `CONCURRENTLY` operations cannot run inside a transaction, so a plan containing them conflicts with `apply --with-tx`. Use `apply --try-tx` to run without a transaction on those plans instead of failing.
+`--disable-index-concurrently` ignores all opt-ins; `--force-index-concurrently` applies `CONCURRENTLY` to every index change. `CONCURRENTLY` operations cannot run inside a transaction, so a plan containing them conflicts with `apply --with-tx`. `apply --try-tx` runs such a plan without a transaction instead of failing.
 
 ## -- pista:bulk-alter
 

--- a/test/scenario/index_concurrently.test.sh
+++ b/test/scenario/index_concurrently.test.sh
@@ -107,4 +107,50 @@ else
   fi
 fi
 
+# --- Step 6: --try-tx skips the transaction when CONCURRENTLY index DDL is generated ---
+setup_db "$DATA/init.sql"
+
+step "06 try-tx skips transaction (concurrently)"
+apply_output=$("$PISTA" apply --allow-drop all --try-tx "$DATA/steps/06_try_tx.sql" 2>&1) || { fail "apply failed: $apply_output"; true; }
+if ! echo "$apply_output" | grep -qF 'CREATE INDEX CONCURRENTLY idx_users_name'; then
+  fail "expected CREATE INDEX CONCURRENTLY idx_users_name in apply output"
+  echo "    $apply_output" >&2
+elif ! echo "$apply_output" | grep -qF -- '-- Transaction skipped'; then
+  fail "expected -- Transaction skipped in apply output"
+  echo "    $apply_output" >&2
+elif echo "$apply_output" | grep -qF -- '-- Transaction started'; then
+  fail "transaction should not be started with CONCURRENTLY index DDL"
+  echo "    $apply_output" >&2
+else
+  drift=$(pista_plan "$DATA/steps/06_try_tx.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 7: --try-tx uses a transaction when the diff has no index changes ---
+step "07 try-tx uses transaction (no index change)"
+apply_output=$("$PISTA" apply --allow-drop all --try-tx "$DATA/steps/07_try_tx_no_index_change.sql" 2>&1) || { fail "apply failed: $apply_output"; true; }
+if ! echo "$apply_output" | grep -qF -- '-- Transaction started'; then
+  fail "expected -- Transaction started in apply output"
+  echo "    $apply_output" >&2
+elif ! echo "$apply_output" | grep -qF -- '-- Transaction committed'; then
+  fail "expected -- Transaction committed in apply output"
+  echo "    $apply_output" >&2
+elif echo "$apply_output" | grep -qF -- '-- Transaction skipped'; then
+  fail "transaction should not be skipped without index changes"
+  echo "    $apply_output" >&2
+else
+  drift=$(pista_plan "$DATA/steps/07_try_tx_no_index_change.sql") || { fail "drift check failed: $drift"; true; }
+  if echo "$drift" | grep -q 'No changes'; then
+    pass
+  else
+    fail "drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
 summary

--- a/test/scenario/testdata/index_concurrently/steps/06_try_tx.sql
+++ b/test/scenario/testdata/index_concurrently/steps/06_try_tx.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+-- pista:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);

--- a/test/scenario/testdata/index_concurrently/steps/07_try_tx_no_index_change.sql
+++ b/test/scenario/testdata/index_concurrently/steps/07_try_tx_no_index_change.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    age integer,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+-- pista:concurrently
+CREATE INDEX idx_users_name ON public.users USING btree (name);


### PR DESCRIPTION
--with-tx fails when the diff contains CREATE/DROP INDEX CONCURRENTLY,
because PostgreSQL cannot run those inside a transaction. That leaves no
way to keep a per-index CONCURRENTLY opt-in and still get a transaction
on the runs that do not touch indexes.

--try-tx (env $PISTA_TRY_TX) behaves like --with-tx, except that such a
diff runs without a transaction instead of failing, and the output
records "-- Transaction skipped: plan contains CONCURRENTLY index DDL".
The decision follows the generated diff, so an index carrying
-- pista:concurrently that is not being changed still gets a
transaction.

--with-tx is unchanged and still errors, so an explicit all-or-nothing
request is never silently weakened. The two flags are mutually
exclusive; unlike --with-tx, --try-tx can be combined with
--force-index-concurrently.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V5GQnLhxyfKP28s5hiZE94