### PR TITLE
Split collation names on the quoting, not on every dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [1.21.1] - 2026-07-31
 
+* Fix broken DDL for a collation whose name contains a dot, such as the `C.utf8` and `en_US.utf8` family. The schema-qualified name was split on every dot, so a domain or composite attribute was emitted as `COLLATE pg_catalog."C".utf8`, which PostgreSQL rejects as a cross-database reference. Collation names are now split on the quoting instead.
+
+* Fix `dump` dropping the schema from a column collation. `COLLATE mycoll` resolved only when the collation's schema was on `search_path`; the dump now emits `COLLATE public.mycoll`, matching what domains and composite types already did. A column collation written schema-qualified in the desired schema also no longer produces a no-op `SET DATA TYPE` on every plan.
+
 * Fix a domain `CHECK` definition being truncated when the expression contains the text ` CONSTRAINT `, as in `CHECK (VALUE <> ' CONSTRAINT ')`. The definition was read out of the deparsed statement and cut at the next occurrence of that text, which also matches inside a string literal. It is now built from the parse tree, the same path a definition that did not match the marker already took.
 
 * Fix broken DDL for an identifier that is one of PostgreSQL's 23 `type_func_name` keywords (`left`, `right`, `full`, `inner`, `binary`, `natural`, and so on). They are valid as a type or function name but not as a table, column, index, constraint, sequence, type, or policy name. Only reserved keywords were quoted, so these were emitted bare: `dump` produced SQL that could not be parsed again, and `plan` / `apply` produced DDL that PostgreSQL rejected with a syntax error. Quoting now follows the grammar's `ColId` rule, which accepts a bare identifier, an unreserved keyword, or a `col_name` keyword.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Fix `dump` dropping the schema from a column collation. `COLLATE mycoll` resolved only when the collation's schema was on `search_path`; the dump now emits `COLLATE public.mycoll`, matching what domains and composite types already did. A column collation written schema-qualified in the desired schema also no longer produces a no-op `SET DATA TYPE` on every plan.
 
+* Fix `plan` failing with `cannot change collation of domain ...` when the desired schema writes a domain collation unqualified, such as `COLLATE "C"` against the catalog's `pg_catalog."C"`. The two forms are now recognized as the same collation, as they already were for composite attributes.
+
 * Fix a domain `CHECK` definition being truncated when the expression contains the text ` CONSTRAINT `, as in `CHECK (VALUE <> ' CONSTRAINT ')`. The definition was read out of the deparsed statement and cut at the next occurrence of that text, which also matches inside a string literal. It is now built from the parse tree, the same path a definition that did not match the marker already took.
 
 * Fix broken DDL for an identifier that is one of PostgreSQL's 23 `type_func_name` keywords (`left`, `right`, `full`, `inner`, `binary`, `natural`, and so on). They are valid as a type or function name but not as a table, column, index, constraint, sequence, type, or policy name. Only reserved keywords were quoted, so these were emitted bare: `dump` produced SQL that could not be parsed again, and `plan` / `apply` produced DDL that PostgreSQL rejected with a syntax error. Quoting now follows the grammar's `ColId` rule, which accepts a bare identifier, an unreserved keyword, or a `col_name` keyword.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Fix `plan` failing with `cannot change collation of domain ...` when the desired schema writes a domain collation unqualified, such as `COLLATE "C"` against the catalog's `pg_catalog."C"`. The two forms are now recognized as the same collation, as they already were for composite attributes.
 
+* Fix a no-op `SET DATA TYPE` on every plan for a column written with `COLLATE "default"`. The default collation is what a column gets implicitly and the catalog never reports it, so it is now ignored on columns as it already was on domains and composite attributes.
+
 * Fix a domain `CHECK` definition being truncated when the expression contains the text ` CONSTRAINT `, as in `CHECK (VALUE <> ' CONSTRAINT ')`. The definition was read out of the deparsed statement and cut at the next occurrence of that text, which also matches inside a string literal. It is now built from the parse tree, the same path a definition that did not match the marker already took.
 
 * Fix broken DDL for an identifier that is one of PostgreSQL's 23 `type_func_name` keywords (`left`, `right`, `full`, `inner`, `binary`, `natural`, and so on). They are valid as a type or function name but not as a table, column, index, constraint, sequence, type, or policy name. Only reserved keywords were quoted, so these were emitted bare: `dump` produced SQL that could not be parsed again, and `plan` / `apply` produced DDL that PostgreSQL rejected with a syntax error. Quoting now follows the grammar's `ColId` rule, which accepts a bare identifier, an unreserved keyword, or a `col_name` keyword.

--- a/catalog/columns.go
+++ b/catalog/columns.go
@@ -36,7 +36,7 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 			END AS default,
 			a.attidentity,
 			a.attgenerated,
-			co.collname,
+			quote_ident(con.nspname) || '.' || quote_ident(co.collname) AS collation,
 			d.description
 		FROM
 			pg_catalog.pg_attribute a
@@ -45,6 +45,7 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 			AND ad.adnum = a.attnum
 			LEFT JOIN pg_catalog.pg_collation co ON co.OID = a.attcollation
 			AND co.oid != t.typcollation
+			LEFT JOIN pg_catalog.pg_namespace con ON con.oid = co.collnamespace
 			-- https://www.postgresql.org/docs/current/catalog-pg-description.html
 			LEFT JOIN pg_catalog.pg_description d ON d.objoid = a.attrelid
 			AND d.objsubid = a.attnum

--- a/catalog/columns_test.go
+++ b/catalog/columns_test.go
@@ -202,7 +202,7 @@ func TestListColumnsByTable(t *testing.T) {
 		name, ok := tbl.Columns.GetOk("name")
 		require.True(t, ok)
 		require.NotNil(t, name.Collation)
-		assert.Equal(t, "C", *name.Collation)
+		assert.Equal(t, `pg_catalog."C"`, *name.Collation)
 	})
 
 	t.Run("generated column", func(t *testing.T) {

--- a/catalog/composite_types.go
+++ b/catalog/composite_types.go
@@ -104,7 +104,7 @@ func (c *Catalog) listCompositeAttributes(ctx context.Context, relid uint32) ([]
 		SELECT
 			a.attname,
 			pg_catalog.format_type(a.atttypid, a.atttypmod) AS type,
-			(SELECT cn.nspname || '.' || coll.collname FROM pg_catalog.pg_collation coll JOIN pg_catalog.pg_namespace cn ON cn.oid = coll.collnamespace WHERE coll.oid = a.attcollation AND a.attcollation <> 0 AND coll.collname <> 'default') AS collation,
+			(SELECT quote_ident(cn.nspname) || '.' || quote_ident(coll.collname) FROM pg_catalog.pg_collation coll JOIN pg_catalog.pg_namespace cn ON cn.oid = coll.collnamespace WHERE coll.oid = a.attcollation AND a.attcollation <> 0 AND coll.collname <> 'default') AS collation,
 			d.description
 		FROM
 			pg_catalog.pg_attribute a

--- a/catalog/domains.go
+++ b/catalog/domains.go
@@ -42,7 +42,7 @@ func (c *Catalog) ListDomains(ctx context.Context) ([]*model.Domain, error) {
 			pg_catalog.format_type(t.typbasetype, t.typtypmod) AS base_type,
 			t.typnotnull,
 			pg_catalog.pg_get_expr(t.typdefaultbin, 0) AS default_value,
-			(SELECT cn.nspname || '.' || c.collname FROM pg_catalog.pg_collation c JOIN pg_catalog.pg_namespace cn ON cn.oid = c.collnamespace WHERE c.oid = t.typcollation AND t.typcollation <> 0 AND c.collname <> 'default') AS collation,
+			(SELECT quote_ident(cn.nspname) || '.' || quote_ident(c.collname) FROM pg_catalog.pg_collation c JOIN pg_catalog.pg_namespace cn ON cn.oid = c.collnamespace WHERE c.oid = t.typcollation AND t.typcollation <> 0 AND c.collname <> 'default') AS collation,
 			d.description
 		FROM
 			pg_catalog.pg_type t

--- a/diff/collation.go
+++ b/diff/collation.go
@@ -3,10 +3,9 @@ package diff
 import "github.com/winebarrel/pistachio/model"
 
 // equalCollation reports whether two COLLATE clauses name the same collation.
-// The catalog always reports a collation schema-qualified, while the desired
-// schema may leave it unqualified, so the schema is compared only when both
-// sides carry one. Splitting respects quoting, because a collation name can
-// contain a dot ("C.utf8", "en_US.utf8").
+// The catalog always qualifies the name and the desired schema may not, so the
+// schema is compared only when both sides carry one. The split respects
+// quoting: a collation name can contain a dot ("C.utf8").
 func equalCollation(a, b *string) bool {
 	if a == nil || b == nil {
 		return a == b

--- a/diff/collation.go
+++ b/diff/collation.go
@@ -5,14 +5,15 @@ import "github.com/winebarrel/pistachio/model"
 // equalCollation reports whether two COLLATE clauses name the same collation.
 // The catalog always qualifies the name and the desired schema may not, so the
 // schema is compared only when both sides carry one. The split respects
-// quoting: a collation name can contain a dot ("C.utf8").
+// quoting: a collation name can contain a dot ("C.utf8"). Parts are compared
+// unquoted, so the two sides need not agree on which names to quote.
 func equalCollation(a, b *string) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
 
-	pa := model.SplitQualifiedName(*a)
-	pb := model.SplitQualifiedName(*b)
+	pa := splitCollation(*a)
+	pb := splitCollation(*b)
 	if len(pa) == 0 || len(pb) == 0 {
 		return *a == *b
 	}
@@ -24,4 +25,12 @@ func equalCollation(a, b *string) bool {
 		return pa[len(pa)-2] == pb[len(pb)-2]
 	}
 	return true
+}
+
+func splitCollation(s string) []string {
+	parts := model.SplitQualifiedName(s)
+	for i, p := range parts {
+		parts[i] = model.UnquoteIdent(p)
+	}
+	return parts
 }

--- a/diff/collation.go
+++ b/diff/collation.go
@@ -1,0 +1,28 @@
+package diff
+
+import "github.com/winebarrel/pistachio/model"
+
+// equalCollation reports whether two COLLATE clauses name the same collation.
+// The catalog always reports a collation schema-qualified, while the desired
+// schema may leave it unqualified, so the schema is compared only when both
+// sides carry one. Splitting respects quoting, because a collation name can
+// contain a dot ("C.utf8", "en_US.utf8").
+func equalCollation(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	pa := model.SplitQualifiedName(*a)
+	pb := model.SplitQualifiedName(*b)
+	if len(pa) == 0 || len(pb) == 0 {
+		return *a == *b
+	}
+
+	if pa[len(pa)-1] != pb[len(pb)-1] {
+		return false
+	}
+	if len(pa) > 1 && len(pb) > 1 {
+		return pa[len(pa)-2] == pb[len(pb)-2]
+	}
+	return true
+}

--- a/diff/collation_test.go
+++ b/diff/collation_test.go
@@ -1,0 +1,38 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqualCollation(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     *string
+		expected bool
+	}{
+		{"both nil", nil, nil, true},
+		{"one nil", ptr(`pg_catalog."C"`), nil, false},
+		{"identical", ptr(`pg_catalog."C"`), ptr(`pg_catalog."C"`), true},
+		{"qualified vs bare", ptr(`pg_catalog."C"`), ptr(`"C"`), true},
+		{"different name", ptr(`pg_catalog."C"`), ptr(`pg_catalog."POSIX"`), false},
+		{"different schema", ptr(`pg_catalog."C"`), ptr(`public."C"`), false},
+		// A dot inside the name is part of the name, not a separator.
+		{"dotted name", ptr(`public."my.coll"`), ptr(`public."my.coll"`), true},
+		{"dotted name vs bare", ptr(`public."my.coll"`), ptr(`"my.coll"`), true},
+		{"dotted name differs", ptr(`public."C.utf8"`), ptr(`public."C.iso"`), false},
+		// Without the quote-aware split these would compare as schema "C" and
+		// name "utf8".
+		{"dotted vs undotted", ptr(`pg_catalog."C.utf8"`), ptr(`"C"`), false},
+		{"empty", ptr(""), ptr(""), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, equalCollation(tt.a, tt.b))
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/diff/collation_test.go
+++ b/diff/collation_test.go
@@ -26,6 +26,12 @@ func TestEqualCollation(t *testing.T) {
 		// name "utf8".
 		{"dotted vs undotted", ptr(`pg_catalog."C.utf8"`), ptr(`"C"`), false},
 		{"empty", ptr(""), ptr(""), true},
+		// quote_ident quotes col_name keywords, model.Ident does not; the two
+		// forms must still compare equal.
+		{"quoted vs bare name", ptr(`public."int"`), ptr(`public.int`), true},
+		{"quoted vs bare schema", ptr(`"int"."C"`), ptr(`int."C"`), true},
+		{"case folding", ptr(`public.mycoll`), ptr(`public.MyColl`), true},
+		{"quoted case is significant", ptr(`public."MyColl"`), ptr(`public.mycoll`), false},
 	}
 
 	for _, tt := range tests {

--- a/diff/composite_types.go
+++ b/diff/composite_types.go
@@ -2,7 +2,6 @@ package diff
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/winebarrel/orderedmap"
 	"github.com/winebarrel/pistachio/model"
@@ -76,25 +75,6 @@ func cloneCompositeAttributes(attrs []*model.CompositeAttribute) []*model.Compos
 		out[i] = &copied
 	}
 	return out
-}
-
-// equalCollation compares two attribute collations by their trailing name
-// component. The catalog reports a collation schema-qualified (e.g.
-// "pg_catalog.C"), while the parser keeps what the user wrote ("C"). Comparing
-// only the collation name avoids a spurious ALTER ATTRIBUTE on every plan when
-// the two forms differ but name the same collation.
-func equalCollation(a, b *string) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return collationName(*a) == collationName(*b)
-}
-
-func collationName(s string) string {
-	if i := strings.LastIndex(s, "."); i >= 0 {
-		return s[i+1:]
-	}
-	return s
 }
 
 func indexCompositeAttribute(attrs []*model.CompositeAttribute, name string) int {

--- a/diff/composite_types_test.go
+++ b/diff/composite_types_test.go
@@ -246,14 +246,14 @@ func TestDiffCompositeTypes_AttributeCommentRemoved(t *testing.T) {
 }
 
 func TestDiffCompositeTypes_CollationEquivalentForms(t *testing.T) {
-	// Catalog reports "pg_catalog.C"; the parser keeps the user's "C". They name
+	// Catalog reports pg_catalog."C"; the parser keeps the user's "C". They name
 	// the same collation, so no ALTER ATTRIBUTE should be emitted.
-	catalogColl := "pg_catalog.C"
+	catalogColl := `pg_catalog."C"`
 	current := newCompositeTypeMap(&model.CompositeType{
 		Schema: "public", Name: "ct",
 		Attributes: []*model.CompositeAttribute{{Name: "name", TypeName: "text", Collation: &catalogColl}},
 	})
-	desiredColl := "C"
+	desiredColl := `"C"`
 	desired := newCompositeTypeMap(&model.CompositeType{
 		Schema: "public", Name: "ct",
 		Attributes: []*model.CompositeAttribute{{Name: "name", TypeName: "text", Collation: &desiredColl}},
@@ -275,12 +275,12 @@ func TestDiffCompositeTypes_QualifiedAttributeTypeNoDiff(t *testing.T) {
 }
 
 func TestDiffCompositeTypes_CollationChange(t *testing.T) {
-	cColl := "pg_catalog.C"
+	cColl := `pg_catalog."C"`
 	current := newCompositeTypeMap(&model.CompositeType{
 		Schema: "public", Name: "ct",
 		Attributes: []*model.CompositeAttribute{{Name: "name", TypeName: "text", Collation: &cColl}},
 	})
-	newColl := "en_US"
+	newColl := `"en_US"`
 	desired := newCompositeTypeMap(&model.CompositeType{
 		Schema: "public", Name: "ct",
 		Attributes: []*model.CompositeAttribute{{Name: "name", TypeName: "text", Collation: &newColl}},

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -73,7 +73,7 @@ func diffDomain(fqdn string, current, desired *model.Domain) ([]string, error) {
 	}
 
 	// Collation change is not supported by PostgreSQL ALTER DOMAIN
-	if !equalPtr(current.Collation, desired.Collation) {
+	if !equalCollation(current.Collation, desired.Collation) {
 		return nil, fmt.Errorf("cannot change collation of domain %s: PostgreSQL does not support this", fqdn)
 	}
 

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -154,8 +154,8 @@ func TestDiffDomains_DropConstraint(t *testing.T) {
 }
 
 func TestDiffDomains_CollationChange_Error(t *testing.T) {
-	colA := "pg_catalog.C"
-	colB := "pg_catalog.POSIX"
+	colA := `pg_catalog."C"`
+	colB := `pg_catalog."POSIX"`
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "name", BaseType: "text", Collation: &colA})
 	desired := newDomainMap(&model.Domain{Schema: "public", Name: "name", BaseType: "text", Collation: &colB})
 	_, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -316,7 +316,7 @@ func addColumnSQL(fqtn string, col *model.Column) string {
 	sql := "ALTER TABLE " + fqtn + " ADD COLUMN " + model.Ident(col.Name) + " " + col.TypeName
 
 	if col.Collation != nil {
-		sql += " COLLATE " + model.Ident(*col.Collation)
+		sql += " COLLATE " + *col.Collation
 	}
 
 	if col.Identity.IsGeneratedAlways() {
@@ -348,10 +348,10 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 	// Type or collation change. Collation is altered via SET DATA TYPE
 	// because PostgreSQL has no separate "set collation" syntax; re-issuing
 	// SET DATA TYPE without COLLATE reverts to the type's default collation.
-	if !equalTypeName(current.TypeName, desired.TypeName, schemaOf(fqtn)) || !equalPtr(current.Collation, desired.Collation) {
+	if !equalTypeName(current.TypeName, desired.TypeName, schemaOf(fqtn)) || !equalCollation(current.Collation, desired.Collation) {
 		sql := "ALTER TABLE " + fqtn + " ALTER COLUMN " + colIdent + " SET DATA TYPE " + desired.TypeName
 		if desired.Collation != nil {
-			sql += " COLLATE " + model.Ident(*desired.Collation)
+			sql += " COLLATE " + *desired.Collation
 		}
 		stmts = append(stmts, sql+";")
 	}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -352,7 +352,7 @@ func TestDiffColumns_alterType_withCollation(t *testing.T) {
 	current.Set("name", &model.Column{Name: "name", TypeName: "varchar(100)"})
 
 	desired := orderedmap.New[string, *model.Column]()
-	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new(`"en_US"`)})
 
 	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
@@ -362,10 +362,10 @@ func TestDiffColumns_alterType_withCollation(t *testing.T) {
 
 func TestDiffColumns_alterCollation_change(t *testing.T) {
 	current := orderedmap.New[string, *model.Column]()
-	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new(`"en_US"`)})
 
 	desired := orderedmap.New[string, *model.Column]()
-	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("fr_FR")})
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new(`"fr_FR"`)})
 
 	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
@@ -377,7 +377,7 @@ func TestDiffColumns_alterCollation_add(t *testing.T) {
 	current.Set("name", &model.Column{Name: "name", TypeName: "text"})
 
 	desired := orderedmap.New[string, *model.Column]()
-	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new(`"en_US"`)})
 
 	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
@@ -386,7 +386,7 @@ func TestDiffColumns_alterCollation_add(t *testing.T) {
 
 func TestDiffColumns_alterCollation_drop(t *testing.T) {
 	current := orderedmap.New[string, *model.Column]()
-	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new(`"en_US"`)})
 
 	desired := orderedmap.New[string, *model.Column]()
 	desired.Set("name", &model.Column{Name: "name", TypeName: "text"})
@@ -398,10 +398,10 @@ func TestDiffColumns_alterCollation_drop(t *testing.T) {
 
 func TestDiffColumns_alterCollation_unchanged(t *testing.T) {
 	current := orderedmap.New[string, *model.Column]()
-	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
+	current.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new(`"en_US"`)})
 
 	desired := orderedmap.New[string, *model.Column]()
-	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")})
+	desired.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: new(`"en_US"`)})
 
 	stmts, _, _, err := diffColumns("public.users", current, desired, allowAllDrops{})
 	require.NoError(t, err)
@@ -608,7 +608,7 @@ func TestAddColumnSQL_withDefault(t *testing.T) {
 }
 
 func TestAddColumnSQL_withCollation(t *testing.T) {
-	col := &model.Column{Name: "name", TypeName: "text", Collation: new("en_US")}
+	col := &model.Column{Name: "name", TypeName: "text", Collation: new(`"en_US"`)}
 	assert.Contains(t, addColumnSQL("public.users", col), `COLLATE "en_US"`)
 }
 

--- a/model/column.go
+++ b/model/column.go
@@ -41,6 +41,8 @@ type Column struct {
 	Default     *string
 	Identity    ColumnIdentity
 	Generated   ColumnGenerated
+	// Collation is the column collation in quoted SQL form, ready to follow
+	// COLLATE (e.g. `pg_catalog."C"`). nil for the default collation.
 	Collation   *string
 	StorageType string
 	Comment     *string

--- a/model/column.go
+++ b/model/column.go
@@ -41,8 +41,8 @@ type Column struct {
 	Default     *string
 	Identity    ColumnIdentity
 	Generated   ColumnGenerated
-	// Collation is the column collation in quoted SQL form, ready to follow
-	// COLLATE (e.g. `pg_catalog."C"`). nil for the default collation.
+	// Collation in quoted SQL form, ready to follow COLLATE
+	// (e.g. `pg_catalog."C"`). nil for the default collation.
 	Collation   *string
 	StorageType string
 	Comment     *string

--- a/model/composite_type.go
+++ b/model/composite_type.go
@@ -10,9 +10,8 @@ import (
 type CompositeAttribute struct {
 	Name     string
 	TypeName string
-	// Collation is the attribute collation in quoted SQL form, ready to follow
-	// COLLATE (e.g. `pg_catalog."C"`). The catalog always qualifies it; a
-	// desired schema may leave it unqualified. nil for the default collation.
+	// Collation in quoted SQL form, ready to follow COLLATE
+	// (e.g. `pg_catalog."C"`). nil for the default collation.
 	Collation *string
 	// RenameFrom maps the attribute to the current attribute it renames. Set by
 	// the parser from an inline -- pista:renamed-from directive; always nil on
@@ -44,8 +43,7 @@ func (a CompositeAttribute) TypeSQL() string {
 	return a.TypeName + collateClause(a.Collation)
 }
 
-// collateClause renders a COLLATE clause, or "" when collation is nil. The
-// stored name is already quoted, so it is emitted as is.
+// collateClause renders a COLLATE clause. The stored name is already quoted.
 func collateClause(collation *string) string {
 	if collation == nil {
 		return ""

--- a/model/composite_type.go
+++ b/model/composite_type.go
@@ -10,8 +10,9 @@ import (
 type CompositeAttribute struct {
 	Name     string
 	TypeName string
-	// Collation is the attribute collation, schema-qualified (e.g.
-	// "pg_catalog.C"). nil when the attribute uses the default collation.
+	// Collation is the attribute collation in quoted SQL form, ready to follow
+	// COLLATE (e.g. `pg_catalog."C"`). The catalog always qualifies it; a
+	// desired schema may leave it unqualified. nil for the default collation.
 	Collation *string
 	// RenameFrom maps the attribute to the current attribute it renames. Set by
 	// the parser from an inline -- pista:renamed-from directive; always nil on
@@ -43,18 +44,13 @@ func (a CompositeAttribute) TypeSQL() string {
 	return a.TypeName + collateClause(a.Collation)
 }
 
-// collateClause renders a COLLATE clause for a possibly schema-qualified
-// collation name, or "" when collation is nil.
+// collateClause renders a COLLATE clause, or "" when collation is nil. The
+// stored name is already quoted, so it is emitted as is.
 func collateClause(collation *string) string {
 	if collation == nil {
 		return ""
 	}
-	parts := strings.Split(*collation, ".")
-	quoted := make([]string, len(parts))
-	for i, p := range parts {
-		quoted[i] = Ident(p)
-	}
-	return " COLLATE " + strings.Join(quoted, ".")
+	return " COLLATE " + *collation
 }
 
 func (ct CompositeType) SQL() string {

--- a/model/composite_type_test.go
+++ b/model/composite_type_test.go
@@ -35,7 +35,7 @@ func TestCompositeType_SQL(t *testing.T) {
 }
 
 func TestCompositeType_SQL_Collation(t *testing.T) {
-	coll := "pg_catalog.C"
+	coll := `pg_catalog."C"`
 	ct := &model.CompositeType{
 		Schema: "public",
 		Name:   "t",
@@ -51,7 +51,7 @@ func TestCompositeType_SQL_Collation(t *testing.T) {
 
 func TestCompositeAttribute_TypeSQL(t *testing.T) {
 	assert.Equal(t, "text", (model.CompositeAttribute{TypeName: "text"}).TypeSQL())
-	coll := "pg_catalog.C"
+	coll := `pg_catalog."C"`
 	assert.Equal(t, `text COLLATE pg_catalog."C"`, (model.CompositeAttribute{TypeName: "text", Collation: &coll}).TypeSQL())
 }
 

--- a/model/domain.go
+++ b/model/domain.go
@@ -20,8 +20,8 @@ type Domain struct {
 	BaseType   string
 	NotNull    bool
 	Default    *string
-	// Collation is the domain collation in quoted SQL form, ready to follow
-	// COLLATE (e.g. `pg_catalog."C"`). nil for the default collation.
+	// Collation in quoted SQL form, ready to follow COLLATE
+	// (e.g. `pg_catalog."C"`). nil for the default collation.
 	Collation   *string
 	Constraints []*DomainConstraint
 	Comment     *string

--- a/model/domain.go
+++ b/model/domain.go
@@ -13,13 +13,15 @@ type DomainConstraint struct {
 }
 
 type Domain struct {
-	OID         uint32
-	Schema      string
-	Name        string
-	RenameFrom  *string
-	BaseType    string
-	NotNull     bool
-	Default     *string
+	OID        uint32
+	Schema     string
+	Name       string
+	RenameFrom *string
+	BaseType   string
+	NotNull    bool
+	Default    *string
+	// Collation is the domain collation in quoted SQL form, ready to follow
+	// COLLATE (e.g. `pg_catalog."C"`). nil for the default collation.
 	Collation   *string
 	Constraints []*DomainConstraint
 	Comment     *string
@@ -37,13 +39,7 @@ func (d Domain) SQL() string {
 	sql := "CREATE DOMAIN " + Ident(d.Schema, d.Name) + " AS " + d.BaseType
 
 	if d.Collation != nil {
-		// Collation may be schema-qualified (e.g. "pg_catalog.default")
-		parts := strings.Split(*d.Collation, ".")
-		quotedParts := make([]string, len(parts))
-		for i, p := range parts {
-			quotedParts[i] = Ident(p)
-		}
-		sql += " COLLATE " + strings.Join(quotedParts, ".")
+		sql += " COLLATE " + *d.Collation
 	}
 
 	if d.Default != nil {

--- a/model/domain_test.go
+++ b/model/domain_test.go
@@ -30,7 +30,7 @@ func TestDomain_SQL_WithNotNull(t *testing.T) {
 }
 
 func TestDomain_SQL_WithCollation(t *testing.T) {
-	col := "en_US"
+	col := `"en_US"`
 	d := &model.Domain{Schema: "public", Name: "name", BaseType: "text", Collation: &col}
 	assert.Contains(t, d.SQL(), `COLLATE "en_US"`)
 }

--- a/model/table.go
+++ b/model/table.go
@@ -71,7 +71,7 @@ func (t Table) SQL() string {
 				orderedmap.TransformSlice(t.Columns, func(_ string, col *Column) string {
 					q := "    " + Ident(col.Name) + " " + col.TypeName
 					if col.Collation != nil {
-						q += " COLLATE " + Ident(*col.Collation)
+						q += " COLLATE " + *col.Collation
 					}
 					if col.Identity.IsGeneratedAlways() {
 						q += " GENERATED ALWAYS AS IDENTITY"

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -126,7 +126,7 @@ func TestTable_SQL_withDefault(t *testing.T) {
 
 func TestTable_SQL_withCollation(t *testing.T) {
 	tbl := newTable("public", "users")
-	coll := "en_US"
+	coll := `"en_US"`
 	tbl.Columns.Set("name", &model.Column{Name: "name", TypeName: "text", Collation: &coll})
 
 	assert.Contains(t, tbl.SQL(), `COLLATE "en_US"`)

--- a/model/util.go
+++ b/model/util.go
@@ -81,6 +81,16 @@ func SplitQualifiedName(s string) []string {
 	return parts
 }
 
+// UnquoteIdent is the inverse of quoteIdent: it strips the surrounding double
+// quotes and unescapes doubled ones. An unquoted identifier is folded to lower
+// case, the way PostgreSQL reads it.
+func UnquoteIdent(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return strings.ReplaceAll(s[1:len(s)-1], `""`, `"`)
+	}
+	return strings.ToLower(s)
+}
+
 func quote(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }

--- a/model/util.go
+++ b/model/util.go
@@ -50,9 +50,8 @@ func quoteIdent(name string) string {
 	}
 }
 
-// SplitQualifiedName splits a possibly schema-qualified name into its parts,
-// respecting quoted identifiers, so a dot inside quotes stays put:
-// `public."my.coll"` -> [`public`, `"my.coll"`].
+// SplitQualifiedName splits a qualified name into its parts, respecting
+// quoting: `public."my.coll"` -> [`public`, `"my.coll"`].
 func SplitQualifiedName(s string) []string {
 	var parts []string
 	var current strings.Builder

--- a/model/util.go
+++ b/model/util.go
@@ -50,6 +50,38 @@ func quoteIdent(name string) string {
 	}
 }
 
+// SplitQualifiedName splits a possibly schema-qualified name into its parts,
+// respecting quoted identifiers, so a dot inside quotes stays put:
+// `public."my.coll"` -> [`public`, `"my.coll"`].
+func SplitQualifiedName(s string) []string {
+	var parts []string
+	var current strings.Builder
+	inQuote := false
+
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch == '"':
+			if inQuote && i+1 < len(s) && s[i+1] == '"' {
+				current.WriteString(`""`)
+				i++
+			} else {
+				inQuote = !inQuote
+				current.WriteByte(ch)
+			}
+		case ch == '.' && !inQuote:
+			parts = append(parts, strings.TrimSpace(current.String()))
+			current.Reset()
+		default:
+			current.WriteByte(ch)
+		}
+	}
+	if current.Len() > 0 {
+		parts = append(parts, strings.TrimSpace(current.String()))
+	}
+	return parts
+}
+
 func quote(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -328,3 +328,25 @@ func loadKeywords(t *testing.T) []string {
 	require.NoError(t, scanner.Err())
 	return keywords
 }
+
+func TestSplitQualifiedName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []string
+	}{
+		{"users", []string{"users"}},
+		{"public.users", []string{"public", "users"}},
+		{`public."my.coll"`, []string{"public", `"my.coll"`}},
+		{`"C.utf8"`, []string{`"C.utf8"`}},
+		{`"My Schema"."Old Name"`, []string{`"My Schema"`, `"Old Name"`}},
+		{`public."a""b"`, []string{"public", `"a""b"`}},
+		{`a.b.c`, []string{"a", "b", "c"}},
+		{"", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SplitQualifiedName(tt.name))
+		})
+	}
+}

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -341,12 +341,35 @@ func TestSplitQualifiedName(t *testing.T) {
 		{`"My Schema"."Old Name"`, []string{`"My Schema"`, `"Old Name"`}},
 		{`public."a""b"`, []string{"public", `"a""b"`}},
 		{`a.b.c`, []string{"a", "b", "c"}},
+		{"public . users", []string{"public", "users"}},
 		{"", nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, SplitQualifiedName(tt.name))
+		})
+	}
+}
+
+func TestUnquoteIdent(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"users", "users"},
+		{"Users", "users"},
+		{`"Users"`, "Users"},
+		{`"my.coll"`, "my.coll"},
+		{`"a""b"`, `a"b`},
+		{`""`, ""},
+		{`"`, `"`},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, UnquoteIdent(tt.name))
 		})
 	}
 }

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -138,25 +138,14 @@ func FormatExecuteStmt(es *ExecuteStmt) string {
 // if it does not already contain a schema. Quoted identifiers containing
 // dots (e.g. `"a.b"`) are treated as a single identifier.
 func qualifyRenameFrom(value, defaultSchema string) string {
-	parts := splitQualifiedName(value)
+	parts := model.SplitQualifiedName(value)
 	for i, p := range parts {
-		parts[i] = unquoteIdent(p)
+		parts[i] = model.UnquoteIdent(p)
 	}
 	if len(parts) >= 2 {
 		return model.Ident(parts...)
 	}
 	return model.Ident(defaultSchema, parts[0])
-}
-
-// unquoteIdent strips surrounding double quotes from a SQL identifier and
-// unescapes doubled double-quotes ("" -> "). For unquoted identifiers,
-// folds to lowercase to match PostgreSQL's behavior.
-func unquoteIdent(s string) string {
-	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
-		inner := s[1 : len(s)-1]
-		return strings.ReplaceAll(inner, `""`, `"`)
-	}
-	return strings.ToLower(s)
 }
 
 // normalizeUnqualifiedDirective normalizes a renamed-from directive value
@@ -165,16 +154,10 @@ func unquoteIdent(s string) string {
 // (e.g. "public.old_idx"), only the last part is used.
 // The result matches the unquoted name used as orderedmap keys by the parser.
 func normalizeUnqualifiedDirective(s string) string {
-	parts := splitQualifiedName(s)
+	parts := model.SplitQualifiedName(s)
 	// Use the last part (the actual name, ignoring any schema prefix)
 	last := parts[len(parts)-1]
-	return unquoteIdent(last)
-}
-
-// splitQualifiedName splits a potentially schema-qualified name into parts,
-// respecting quoted identifiers. e.g. `"My Schema"."Old Name"` -> [`"My Schema"`, `"Old Name"`]
-func splitQualifiedName(s string) []string {
-	return model.SplitQualifiedName(s)
+	return model.UnquoteIdent(last)
 }
 
 // extractStmtDirectives scans raw SQL for `-- pista:renamed-from <name>` comments

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -174,33 +174,7 @@ func normalizeUnqualifiedDirective(s string) string {
 // splitQualifiedName splits a potentially schema-qualified name into parts,
 // respecting quoted identifiers. e.g. `"My Schema"."Old Name"` -> [`"My Schema"`, `"Old Name"`]
 func splitQualifiedName(s string) []string {
-	var parts []string
-	var current strings.Builder
-	inQuote := false
-
-	for i := 0; i < len(s); i++ {
-		ch := s[i]
-		if ch == '"' {
-			if inQuote && i+1 < len(s) && s[i+1] == '"' {
-				// Escaped double quote
-				current.WriteByte('"')
-				current.WriteByte('"')
-				i++
-			} else {
-				inQuote = !inQuote
-				current.WriteByte(ch)
-			}
-		} else if ch == '.' && !inQuote {
-			parts = append(parts, strings.TrimSpace(current.String()))
-			current.Reset()
-		} else {
-			current.WriteByte(ch)
-		}
-	}
-	if current.Len() > 0 {
-		parts = append(parts, strings.TrimSpace(current.String()))
-	}
-	return parts
+	return model.SplitQualifiedName(s)
 }
 
 // extractStmtDirectives scans raw SQL for `-- pista:renamed-from <name>` comments

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -184,11 +184,6 @@ func TestExtractConstraintName(t *testing.T) {
 	assert.Equal(t, "users_pkey", extractConstraintName("CONSTRAINT Users_Pkey PRIMARY KEY (id)"))
 }
 
-func TestSplitQualifiedName_SpacesAroundDot(t *testing.T) {
-	parts := splitQualifiedName("public . old_table")
-	assert.Equal(t, []string{"public", "old_table"}, parts)
-}
-
 func TestNormalizeUnqualifiedDirective(t *testing.T) {
 	assert.Equal(t, "old_name", normalizeUnqualifiedDirective("old_name"))
 	assert.Equal(t, "Old Name", normalizeUnqualifiedDirective(`"Old Name"`))

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -456,6 +456,29 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 	return table, nil
 }
 
+// collationFromClause builds the canonical collation form (quoted, ready to
+// follow COLLATE) from a COLLATE clause. It returns nil for the default
+// collation, which the catalog never reports, so writing it explicitly does
+// not read as a change.
+func collationFromClause(cc *pg_query.CollateClause) *string {
+	if cc == nil || len(cc.Collname) == 0 {
+		return nil
+	}
+
+	var parts []string
+	for _, n := range cc.Collname {
+		if str := n.GetString_(); str != nil {
+			parts = append(parts, str.Sval)
+		}
+	}
+	if len(parts) == 0 || parts[len(parts)-1] == "default" {
+		return nil
+	}
+
+	collation := model.Ident(parts...)
+	return &collation
+}
+
 func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 	col := &model.Column{
 		Name: cd.Colname,
@@ -469,18 +492,7 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 		col.TypeName = typeName
 	}
 
-	if cd.CollClause != nil && len(cd.CollClause.Collname) > 0 {
-		var parts []string
-		for _, n := range cd.CollClause.Collname {
-			if s := n.GetString_(); s != nil {
-				parts = append(parts, s.Sval)
-			}
-		}
-		if len(parts) > 0 {
-			collation := model.Ident(parts...)
-			col.Collation = &collation
-		}
-	}
+	col.Collation = collationFromClause(cd.CollClause)
 
 	for _, conNode := range cd.Constraints {
 		con := conNode.GetConstraint()
@@ -812,22 +824,7 @@ func parseCreateDomainStmt(ds *pg_query.CreateDomainStmt, rawStmt *pg_query.RawS
 	}
 
 	// Extract collation
-	if ds.CollClause != nil && len(ds.CollClause.Collname) > 0 {
-		var parts []string
-		for _, n := range ds.CollClause.Collname {
-			if s := n.GetString_(); s != nil {
-				parts = append(parts, s.Sval)
-			}
-		}
-		if len(parts) > 0 {
-			// Skip "default" collation (implicit for text types, excluded by catalog)
-			lastPart := parts[len(parts)-1]
-			if lastPart != "default" {
-				collation := model.Ident(parts...)
-				domain.Collation = &collation
-			}
-		}
-	}
+	domain.Collation = collationFromClause(ds.CollClause)
 
 	// Extract constraints from deparsed SQL
 	// Parse the deparsed statement to get normalized constraints
@@ -905,18 +902,7 @@ func parseCompositeTypeStmt(cts *pg_query.CompositeTypeStmt, defaultSchema strin
 			TypeName: typeName,
 		}
 
-		if cd.CollClause != nil && len(cd.CollClause.Collname) > 0 {
-			var parts []string
-			for _, n := range cd.CollClause.Collname {
-				if s := n.GetString_(); s != nil {
-					parts = append(parts, s.Sval)
-				}
-			}
-			if len(parts) > 0 && parts[len(parts)-1] != "default" {
-				collation := model.Ident(parts...)
-				attr.Collation = &collation
-			}
-		}
+		attr.Collation = collationFromClause(cd.CollClause)
 
 		compositeType.Attributes = append(compositeType.Attributes, attr)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -477,7 +477,7 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 			}
 		}
 		if len(parts) > 0 {
-			collation := strings.Join(parts, ".")
+			collation := model.Ident(parts...)
 			col.Collation = &collation
 		}
 	}
@@ -823,7 +823,7 @@ func parseCreateDomainStmt(ds *pg_query.CreateDomainStmt, rawStmt *pg_query.RawS
 			// Skip "default" collation (implicit for text types, excluded by catalog)
 			lastPart := parts[len(parts)-1]
 			if lastPart != "default" {
-				collation := strings.Join(parts, ".")
+				collation := model.Ident(parts...)
 				domain.Collation = &collation
 			}
 		}
@@ -913,7 +913,7 @@ func parseCompositeTypeStmt(cts *pg_query.CompositeTypeStmt, defaultSchema strin
 				}
 			}
 			if len(parts) > 0 && parts[len(parts)-1] != "default" {
-				collation := strings.Join(parts, ".")
+				collation := model.Ident(parts...)
 				attr.Collation = &collation
 			}
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1968,7 +1968,7 @@ func TestParseSQL_DomainWithCollation(t *testing.T) {
 	d := result.Domains.Get("public.name")
 	require.NotNil(t, d)
 	require.NotNil(t, d.Collation)
-	assert.Equal(t, "en_US", *d.Collation)
+	assert.Equal(t, `"en_US"`, *d.Collation)
 }
 
 func TestParseSQL_DomainDefaultCollationExcluded(t *testing.T) {

--- a/testdata/apply/alter_column_collation.yml
+++ b/testdata/apply/alter_column_collation.yml
@@ -14,6 +14,6 @@ applied: |
   -- public.users
   CREATE TABLE public.users (
       id integer NOT NULL,
-      name text COLLATE "POSIX" NOT NULL,
+      name text COLLATE pg_catalog."POSIX" NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/apply/alter_column_collation_add.yml
+++ b/testdata/apply/alter_column_collation_add.yml
@@ -14,6 +14,6 @@ applied: |
   -- public.users
   CREATE TABLE public.users (
       id integer NOT NULL,
-      name text COLLATE "C" NOT NULL,
+      name text COLLATE pg_catalog."C" NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/apply/collation_dotted_name.yml
+++ b/testdata/apply/collation_dotted_name.yml
@@ -1,0 +1,32 @@
+# The emitted COLLATE clause has to be accepted by PostgreSQL and leave no
+# drift on the next plan.
+init: |
+  CREATE COLLATION public."my.coll" FROM "C";
+desired: |
+  CREATE DOMAIN public.d AS text COLLATE public."my.coll";
+  CREATE TYPE public.ct AS (a text COLLATE public."my.coll");
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll"
+  );
+applied: |
+  -- public.d
+  CREATE DOMAIN public.d AS text COLLATE public."my.coll";
+
+  -- public.ct
+  CREATE TYPE public.ct AS (
+      a text COLLATE public."my.coll"
+  );
+
+  -- public.t
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll"
+  );
+applied_sql: |
+  CREATE TYPE public.ct AS (
+      a text COLLATE public."my.coll"
+  );
+  CREATE DOMAIN public.d AS text COLLATE public."my.coll";
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll"
+  );
+verify_no_drift: true

--- a/testdata/apply/collation_dotted_name_change.yml
+++ b/testdata/apply/collation_dotted_name_change.yml
@@ -1,0 +1,18 @@
+# Changing a column collation to one whose name contains a dot.
+init: |
+  CREATE COLLATION public."my.coll" FROM "C";
+  CREATE TABLE public.t (
+      c text COLLATE "C"
+  );
+desired: |
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll"
+  );
+applied: |
+  -- public.t
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll"
+  );
+applied_sql: |
+  ALTER TABLE public.t ALTER COLUMN c SET DATA TYPE text COLLATE public."my.coll";
+verify_no_drift: true

--- a/testdata/dump/collation_dotted_name.yml
+++ b/testdata/dump/collation_dotted_name.yml
@@ -1,0 +1,22 @@
+# A collation name can contain a dot ("C.utf8", "en_US.utf8"), so the
+# schema-qualified form has to be split on the quoting, not on the dot.
+init: |
+  CREATE COLLATION public."my.coll" FROM "C";
+  CREATE DOMAIN public.d AS text COLLATE public."my.coll";
+  CREATE TYPE public.ct AS (a text COLLATE public."my.coll");
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll"
+  );
+dump: |
+  -- public.d
+  CREATE DOMAIN public.d AS text COLLATE public."my.coll";
+
+  -- public.ct
+  CREATE TYPE public.ct AS (
+      a text COLLATE public."my.coll"
+  );
+
+  -- public.t
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll"
+  );

--- a/testdata/dump/column_collation.yml
+++ b/testdata/dump/column_collation.yml
@@ -8,6 +8,6 @@ dump: |
   -- public.users
   CREATE TABLE public.users (
       id integer NOT NULL,
-      name text COLLATE "C" NOT NULL,
+      name text COLLATE pg_catalog."C" NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );

--- a/testdata/dump/omit_schema_collation.yml
+++ b/testdata/dump/omit_schema_collation.yml
@@ -1,0 +1,15 @@
+# --omit-schema drops the schema of the dumped objects, not of the collation
+# they reference. The collation is a separate object pistachio does not manage.
+omit_schema: true
+init: |
+  CREATE COLLATION public."my.coll" FROM "C";
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll",
+      d text COLLATE pg_catalog."C"
+  );
+dump: |
+  -- t
+  CREATE TABLE t (
+      c text COLLATE public."my.coll",
+      d text COLLATE pg_catalog."C"
+  );

--- a/testdata/plan/collation_default_column_no_drift.yml
+++ b/testdata/plan/collation_default_column_no_drift.yml
@@ -1,0 +1,15 @@
+# COLLATE "default" is what a column gets implicitly, and the catalog never
+# reports it, so writing it explicitly is not a change.
+init: |
+  CREATE TABLE public.t (
+      c text COLLATE "default"
+  );
+  CREATE DOMAIN public.d AS text COLLATE "default";
+  CREATE TYPE public.ct AS (a text COLLATE "default");
+desired: |
+  CREATE TABLE public.t (
+      c text COLLATE "default"
+  );
+  CREATE DOMAIN public.d AS text COLLATE "default";
+  CREATE TYPE public.ct AS (a text COLLATE "default");
+plan: ""

--- a/testdata/plan/collation_domain_change_error.yml
+++ b/testdata/plan/collation_domain_change_error.yml
@@ -1,0 +1,8 @@
+# A real collation change on a domain is still rejected. Only forms that name
+# the same collation are treated as equal.
+init: |
+  CREATE DOMAIN public.d AS text COLLATE "C";
+desired: |
+  CREATE DOMAIN public.d AS text COLLATE "POSIX";
+plan: ""
+error: cannot change collation of domain public.d

--- a/testdata/plan/collation_dotted_name_composite_change.yml
+++ b/testdata/plan/collation_dotted_name_composite_change.yml
@@ -1,0 +1,8 @@
+# Changing a composite attribute collation to one whose name contains a dot.
+init: |
+  CREATE COLLATION public."my.coll" FROM "C";
+  CREATE TYPE public.ct AS (a text COLLATE "C");
+desired: |
+  CREATE TYPE public.ct AS (a text COLLATE public."my.coll");
+plan: |
+  ALTER TYPE public.ct ALTER ATTRIBUTE a TYPE text COLLATE public."my.coll";

--- a/testdata/plan/collation_dotted_name_no_drift.yml
+++ b/testdata/plan/collation_dotted_name_no_drift.yml
@@ -1,0 +1,16 @@
+# A collation whose name contains a dot, written unqualified in the desired
+# schema. The catalog reports it qualified; both name the same collation.
+init: |
+  CREATE COLLATION public."my.coll" FROM "C";
+  CREATE TABLE public.t (
+      c text COLLATE public."my.coll"
+  );
+  CREATE DOMAIN public.d AS text COLLATE public."my.coll";
+  CREATE TYPE public.ct AS (a text COLLATE public."my.coll");
+desired: |
+  CREATE TABLE public.t (
+      c text COLLATE "my.coll"
+  );
+  CREATE DOMAIN public.d AS text COLLATE "my.coll";
+  CREATE TYPE public.ct AS (a text COLLATE "my.coll");
+plan: ""

--- a/testdata/plan/collation_unqualified_no_drift.yml
+++ b/testdata/plan/collation_unqualified_no_drift.yml
@@ -1,0 +1,15 @@
+# The catalog reports a collation schema-qualified; the desired schema may
+# leave it unqualified. The two name the same collation, so there is no diff.
+init: |
+  CREATE TABLE public.t (
+      c text COLLATE "C"
+  );
+  CREATE DOMAIN public.d AS text COLLATE "C";
+  CREATE TYPE public.ct AS (a text COLLATE "C");
+desired: |
+  CREATE TABLE public.t (
+      c text COLLATE "C"
+  );
+  CREATE DOMAIN public.d AS text COLLATE "C";
+  CREATE TYPE public.ct AS (a text COLLATE "C");
+plan: ""


### PR DESCRIPTION
A collation name can contain a dot: `C.utf8` and `en_US.utf8` are the ones PostgreSQL ships. The catalog joined the schema and the name with a dot, and the model split the result back on every dot, so a domain or a composite attribute came out as `COLLATE pg_catalog."C".utf8`.

```
CREATE DOMAIN d AS text COLLATE pg_catalog."C".utf8;
ERROR:  cross-database references are not implemented: pg_catalog.C.utf8
```

Collation names are now carried in quoted SQL form, ready to follow `COLLATE`. The catalog quotes each part with `quote_ident`, the parser builds the same form with `model.Ident`, and the emitters print it verbatim. Comparison goes through `model.SplitQualifiedName` (moved from `parser/directive.go`), which respects quoting, and compares the schema only when both sides carry one, since the catalog always qualifies while a desired schema may not.

Three more defects fall out of the same change:

* Column collations lost their schema. `catalog/columns.go` selected `collname` alone, so a dump emitted `COLLATE mycoll`, which resolved only when the collation's schema was on `search_path`.
* A column collation written schema-qualified in the desired schema produced a no-op `ALTER COLUMN ... SET DATA TYPE` on every plan, because the parser kept the qualified name while the catalog kept the bare one.
* A domain collation written unqualified failed the plan with `cannot change collation of domain ...`, because the two forms were compared as plain strings. Composite attributes already had a name-only comparison; domains and columns now share it.

## Output change

Column collations are now schema-qualified: `COLLATE "C"` becomes `COLLATE pg_catalog."C"`. Domains and composite types were already qualified, so the three now agree, and it matches what `pg_dump` emits. Three fixtures and one catalog unit test were updated for it.

## Tests

Written first and confirmed failing against `main`: the dump fixture emitted `public.my.coll`, the apply fixture failed against PostgreSQL with the cross-database reference error, and the unqualified-collation plan fixture failed with `cannot change collation`.

Covered per object kind (table column, domain, composite attribute) and per operation (create, add, change, drop, no-drift):

* `testdata/dump/collation_dotted_name.yml`, `omit_schema_collation.yml`
* `testdata/apply/collation_dotted_name.yml`, `collation_dotted_name_change.yml` (both `verify_no_drift`)
* `testdata/plan/collation_dotted_name_no_drift.yml`, `collation_unqualified_no_drift.yml`, `collation_dotted_name_composite_change.yml`, `collation_domain_change_error.yml`
* `diff/collation_test.go` for `equalCollation`, `model/util_test.go` for `SplitQualifiedName`

`--omit-schema` keeps the collation's schema, since a collation is a separate object pistachio does not manage. `omit_schema_collation.yml` pins that.

The fixtures create `public."my.coll"` with `CREATE COLLATION ... FROM "C"` rather than relying on a system locale, so they run the same on PostgreSQL 15 through 18.