### PR TITLE
Stop dropping constraints, partition parents and column defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * Fix every `ADD CONSTRAINT` but the first being dropped from an `ALTER TABLE` that adds several in one statement, as `--bulk-alter` output does. The rest were discarded without an error, so `plan` offered to drop them from the database. A `-- pista:renamed-from` directive on such a statement is now an error, because it names one old object.
 
-* Fix `dump` emitting a partition's parent without its schema, as `PARTITION OF events`. The dump could not be reloaded when the parent was not on `search_path`, and attached the partition to a same-named table in another schema when one existed. The same missing schema hid the parent from the dependency graph, so dropping a partitioned table and its partitions in one run could drop the parent first and fail on the partition's own `DROP`.
+* Fix `dump` emitting a partition's parent, or an `INHERITS` parent, without its schema, as `PARTITION OF events`. The statement failed when the parent was not on `search_path`, and attached the partition to a same-named table in another schema when one existed. The same missing schema hid the parent from the dependency graph, so dropping a partitioned table and its partitions in one run could drop the parent first and fail on the partition's own `DROP`. Note that `dump` still emits objects in name order, so a parent that sorts after its child is written after it.
 
-* Fix `COMMENT ON TABLE` and `COMMENT ON COLUMN` never being applied to a partition. Comments belong to the individual relation and PostgreSQL accepts them on a partition, but they were skipped along with the inherited columns and constraints.
+* Fix `COMMENT ON TABLE` and `COMMENT ON COLUMN` never being applied to a partition. Comments belong to the individual relation and PostgreSQL accepts them on a partition, but they were skipped along with the inherited columns and constraints. Removing such a comment is diffed as well, even though the partition declares no columns of its own.
 
 * Fix a column being dumped as `serial` when a sequence is tied to it by a plain `ALTER SEQUENCE ... OWNED BY` while its default is something else. The real default was dropped from the dumped definition and no drift was reported. A column now counts as `serial` only when its default draws from the sequence it owns.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.22.0] - 2026-07-31
+
+* Fix every `ADD CONSTRAINT` but the first being dropped from an `ALTER TABLE` that adds several in one statement, as `--bulk-alter` output does. The rest were discarded without an error, so `plan` offered to drop them from the database. A `-- pista:renamed-from` directive on such a statement is now an error, because it names one old object.
+
+* Fix `dump` emitting a partition's parent without its schema, as `PARTITION OF events`. The dump could not be reloaded when the parent was not on `search_path`, and attached the partition to a same-named table in another schema when one existed. The same missing schema hid the parent from the dependency graph, so dropping a partitioned table and its partitions in one run could drop the parent first and fail on the partition's own `DROP`.
+
+* Fix `COMMENT ON TABLE` and `COMMENT ON COLUMN` never being applied to a partition. Comments belong to the individual relation and PostgreSQL accepts them on a partition, but they were skipped along with the inherited columns and constraints.
+
+* Fix a column being dumped as `serial` when a sequence is tied to it by a plain `ALTER SEQUENCE ... OWNED BY` while its default is something else. The real default was dropped from the dumped definition and no drift was reported. A column now counts as `serial` only when its default draws from the sequence it owns.
+
+* Fix `ALTER SEQUENCE ... OWNED BY` being ignored in the desired schema. The statement now marks the sequence unmanaged, as `CREATE SEQUENCE ... OWNED BY` already did. Before, every plan proposed creating a sequence that already existed and `apply` failed with `relation "..." already exists`. Detaching with `OWNED BY NONE` is still not supported.
+
 ## [1.21.1] - 2026-07-31
 
 * Fix broken DDL for a collation whose name contains a dot, such as the `C.utf8` and `en_US.utf8` family. The schema-qualified name was split on every dot, so a domain or composite attribute was emitted as `COLLATE pg_catalog."C".utf8`, which PostgreSQL rejects as a cross-database reference. Collation names are now split on the quoting instead.

--- a/TODO.md
+++ b/TODO.md
@@ -461,3 +461,45 @@ transitions. That widens the set of objects pistachio manages, so it is a
 feature rather than a fix. Workaround: detach the sequence by hand.
 
 Origin: bug audit, 2026-07-31.
+
+## `dump` output is not ordered by dependency
+
+Objects are emitted in catalog order, which is `nspname, relname`. Nothing
+sorts a parent before the table that needs it, so a dump reloads only when
+the names happen to sort that way. Three cases hit it: a partition whose
+parent sorts later (`Odd Child` before `Odd Parent`), an `INHERITS` child in
+the same position, and a foreign key, which is emitted as an `ALTER TABLE ...
+ADD CONSTRAINT` directly after its own table and so can precede the table it
+references. `plan` and `apply` already order statements through `toposort`;
+`dump` does not call it.
+
+Origin: bug audit, 2026-07-31.
+
+## `dump` drops `PARTITION BY` from a sub-partitioned partition
+
+`model.Table.SQL` returns right after the `PARTITION OF ... FOR VALUES`
+clause, so a partition that is itself partitioned loses its own
+`PARTITION BY`. The dump then defines it as a leaf, and reloading fails on
+the next level down, which still says `PARTITION OF` that table.
+`PartitionDef` is read from the catalog and available; it just is not
+emitted on that branch.
+
+Origin: bug audit, 2026-07-31.
+
+## Perpetual drift on a serial column written as an explicit default
+
+A serial column written the way `pg_dump` writes it, as
+`CREATE SEQUENCE s; CREATE TABLE t (id integer DEFAULT nextval('s'));
+ALTER SEQUENCE s OWNED BY t.id;`, plans
+`ALTER COLUMN id SET DEFAULT nextval(...)` on every run. The catalog reports
+such a column as `serial` with no default, which is what lets `id serial`
+round-trip, while the desired side keeps the explicit default. `equalTypeName`
+already treats `serial` and `integer` as equal; the defaults are what differ.
+
+Comparing them needs the sequence the current column draws from, which the
+model does not carry, since the catalog nulls the default for serial columns.
+Suppressing the statement whenever the current column is serial and the
+desired default is any `nextval` would also swallow a genuine change to a
+different sequence.
+
+Origin: bug audit, 2026-07-31.

--- a/TODO.md
+++ b/TODO.md
@@ -436,3 +436,28 @@ search-path schema, not just the container's own), which the diff does not
 thread today. Workaround: write such a reference unqualified.
 
 Origin: [#331](https://github.com/winebarrel/pistachio/pull/331).
+
+## Sequence ownership transitions: `OWNED BY NONE` plans an unusable CREATE
+
+Detaching a sequence from its column cannot be expressed. A desired schema
+that carries `ALTER SEQUENCE ... OWNED BY NONE` for a sequence the database
+still owns plans a `CREATE SEQUENCE` for a sequence that already exists, and
+apply fails with `relation "..." already exists` (SQLSTATE 42P07).
+
+`catalog.Sequences` drops every sequence with an owner, so the current side
+never sees it. After `OWNED BY NONE` the desired side holds no owner, which
+makes the sequence a managed standalone object, and the diff reads the
+missing current entry as "not created yet". The opposite direction is
+handled: `ALTER SEQUENCE ... OWNED BY <column>` marks the sequence unmanaged
+on the desired side, matching the catalog, so an owned sequence no longer
+replans forever.
+
+Closing this means letting the catalog surface sequences that are merely
+owned, kept apart from the serial and identity ones that stay column
+attributes (the distinction `catalog.ListColumnsByTable` already draws by
+checking that the column default draws from the sequence), and teaching the
+diff to emit `ALTER SEQUENCE ... OWNED BY` / `OWNED BY NONE` for the
+transitions. That widens the set of objects pistachio manages, so it is a
+feature rather than a fix. Workaround: detach the sequence by hand.
+
+Origin: bug audit, 2026-07-31.

--- a/TODO.md
+++ b/TODO.md
@@ -439,10 +439,12 @@ Origin: [#331](https://github.com/winebarrel/pistachio/pull/331).
 
 ## Sequence ownership transitions: `OWNED BY NONE` plans an unusable CREATE
 
-Detaching a sequence from its column cannot be expressed. A desired schema
-that carries `ALTER SEQUENCE ... OWNED BY NONE` for a sequence the database
-still owns plans a `CREATE SEQUENCE` for a sequence that already exists, and
-apply fails with `relation "..." already exists` (SQLSTATE 42P07).
+Detaching a sequence from its column cannot be expressed. The parser reads
+`ALTER SEQUENCE ... OWNED BY NONE` and clears the owner, so the statement is
+accepted, but nothing emits the detaching DDL. A desired schema carrying it
+for a sequence the database still owns plans a `CREATE SEQUENCE` for a
+sequence that already exists, and apply fails with
+`relation "..." already exists` (SQLSTATE 42P07).
 
 `catalog.Sequences` drops every sequence with an owner, so the current side
 never sees it. After `OWNED BY NONE` the desired side holds no owner, which
@@ -461,6 +463,22 @@ transitions. That widens the set of objects pistachio manages, so it is a
 feature rather than a fix. Workaround: detach the sequence by hand.
 
 Origin: bug audit, 2026-07-31.
+
+## `COMMENT ON COLUMN` on an inherited column of an INHERITS child
+
+A comment on a column an `INHERITS` child inherits from its parent is dropped
+at parse time. `parseCommentStmt` needs the column to be present on the
+table, and such a child declares only its own columns. A true partition child
+takes a different path: it declares no columns at all, so the comment creates
+the entry, and `diffTable` reaches that entry through a branch that never
+diffs columns. An INHERITS child goes through the regular column diff, where
+an entry holding only a name and a comment would be read as a new column and
+emit `ADD COLUMN`, so the same trick does not carry over.
+
+Closing this needs the inherited column set materialised on the child, which
+is the same prerequisite as the INHERITS plan / apply entry above.
+
+Origin: review of [#340](https://github.com/winebarrel/pistachio/pull/340).
 
 ## `dump` output is not ordered by dependency
 

--- a/TODO.md
+++ b/TODO.md
@@ -488,13 +488,20 @@ Origin: bug audit, 2026-07-31.
 
 ## Perpetual drift on a serial column written as an explicit default
 
-A serial column written the way `pg_dump` writes it, as
-`CREATE SEQUENCE s; CREATE TABLE t (id integer DEFAULT nextval('s'));
-ALTER SEQUENCE s OWNED BY t.id;`, plans
-`ALTER COLUMN id SET DEFAULT nextval(...)` on every run. The catalog reports
-such a column as `serial` with no default, which is what lets `id serial`
-round-trip, while the desired side keeps the explicit default. `equalTypeName`
-already treats `serial` and `integer` as equal; the defaults are what differ.
+A serial column written the way `pg_dump` writes it plans
+`ALTER COLUMN id SET DEFAULT nextval(...)` on every run. Applying it succeeds
+and changes nothing, so `plan --check` stays at exit code 2 forever. `pg_dump`
+never writes `serial`; it splits the column into a plain `integer`, a
+`CREATE SEQUENCE`, an `ALTER SEQUENCE ... OWNED BY`, and a separate
+`SET DEFAULT`. The catalog reports such a column as `serial` with no default,
+which is what lets `id serial` round-trip, while the desired side keeps the
+explicit default. `equalTypeName` already treats `serial` and `integer` as
+equal; the defaults are what differ.
+
+`dump` does not produce this shape, so a schema kept through `pista dump`
+never hits it. It shows up when a `pg_dump` output is used as the starting
+desired file, which is a normal way to adopt the tool on an existing
+database.
 
 Comparing them needs the sequence the current column draws from, which the
 model does not carry, since the catalog nulls the default for serial columns.

--- a/catalog/columns.go
+++ b/catalog/columns.go
@@ -15,7 +15,7 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 		SELECT
 			a.attname,
 			CASE
-				WHEN a.attidentity = '' AND pg_catalog.pg_get_serial_sequence(a.attrelid::regclass::text, a.attname) IS NOT NULL
+				WHEN s.is_serial
 				THEN CASE pg_catalog.format_type(a.atttypid, a.atttypmod)
 					WHEN 'integer' THEN 'serial'
 					WHEN 'bigint' THEN 'bigserial'
@@ -30,7 +30,7 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 			-- so the LEFT JOIN yields NULL there.
 			nn.conname AS not_null_name,
 			CASE
-				WHEN a.attidentity = '' AND pg_catalog.pg_get_serial_sequence(a.attrelid::regclass::text, a.attname) IS NOT NULL
+				WHEN s.is_serial
 				THEN NULL
 				ELSE pg_catalog.pg_get_expr(ad.adbin, ad.adrelid)
 			END AS default,
@@ -43,6 +43,24 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 			JOIN pg_catalog.pg_type t ON t.oid = a.atttypid
 			LEFT JOIN pg_catalog.pg_attrdef ad ON ad.adrelid = a.attrelid
 			AND ad.adnum = a.attnum
+			-- A column is serial only when it owns a sequence *and* its default
+			-- actually draws from that sequence. A plain
+			-- "ALTER SEQUENCE ... OWNED BY" creates the same dependency without
+			-- touching the default, and treating that as serial would drop the
+			-- real default from the dumped definition.
+			CROSS JOIN LATERAL (
+				SELECT COALESCE(
+					a.attidentity = ''
+					-- Round-trip the sequence name through regclass so it is
+					-- rendered the same way pg_get_expr renders it:
+					-- pg_get_serial_sequence always schema-qualifies, while
+					-- pg_get_expr omits the schema when it is on search_path.
+					AND pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) = 'nextval('
+						|| quote_literal(pg_catalog.pg_get_serial_sequence(a.attrelid::regclass::text, a.attname)::regclass::text)
+						|| '::regclass)',
+					false
+				) AS is_serial
+			) s
 			LEFT JOIN pg_catalog.pg_collation co ON co.OID = a.attcollation
 			AND co.oid != t.typcollation
 			LEFT JOIN pg_catalog.pg_namespace con ON con.oid = co.collnamespace

--- a/catalog/tables.go
+++ b/catalog/tables.go
@@ -42,10 +42,12 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 			partition AS (
 				SELECT
 					i.inhrelid,
-					c.relname
+					n.nspname AS parent_schema,
+					c.relname AS parent_name
 				FROM
 					pg_catalog.pg_inherits i
 					JOIN pg_catalog.pg_class c ON c.oid = i.inhparent
+					JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 				WHERE
 					i.inhseqno = 1
 			),
@@ -66,7 +68,8 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 			c.relpersistence = 'u' AS unlogged,
 			c.relkind = 'p' AS partitioned,
 			pg_catalog.pg_get_partkeydef(c.oid) AS partition_def,
-			p.relname AS partition_of,
+			p.parent_schema,
+			p.parent_name,
 			pg_catalog.pg_get_expr(c.relpartbound, c.oid) AS partition_bound,
 			c.relrowsecurity,
 			c.relforcerowsecurity,
@@ -103,6 +106,7 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 	var tables []*model.Table
 	for rows.Next() {
 		var t model.Table
+		var parentSchema, parentName *string
 		err := rows.Scan(
 			&t.OID,
 			&t.Schema,
@@ -111,7 +115,8 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 			&t.Unlogged,
 			&t.Partitioned,
 			&t.PartitionDef,
-			&t.PartitionOf,
+			&parentSchema,
+			&parentName,
 			&t.PartitionBound,
 			&t.RowSecurity,
 			&t.ForceRowSecurity,
@@ -119,6 +124,18 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 		)
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan table info: %w", err)
+		}
+		// Qualify the parent with its schema so PartitionOf matches the keys
+		// used elsewhere (Table.FQTN, the parser). A bare relname would not
+		// resolve in the dependency graph, and would reference the wrong
+		// relation when emitted as SQL under a different search_path.
+		if parentName != nil {
+			schema := ""
+			if parentSchema != nil {
+				schema = *parentSchema
+			}
+			parent := model.Ident(schema, *parentName)
+			t.PartitionOf = &parent
 		}
 		t.Columns = orderedmap.New[string, *model.Column]()
 		t.Indexes = orderedmap.New[string, *model.Index]()

--- a/catalog/tables_test.go
+++ b/catalog/tables_test.go
@@ -122,4 +122,51 @@ func TestTables(t *testing.T) {
 		require.NotNil(t, tbl.PartitionDef)
 		assert.Contains(t, *tbl.PartitionDef, "created_at")
 	})
+
+	t.Run("partition child records a schema-qualified parent", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.logs (
+				id integer NOT NULL,
+				created_at date NOT NULL
+			) PARTITION BY RANGE (created_at);
+			CREATE TABLE public.logs_2024 PARTITION OF public.logs
+				FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		child := tables.Get("public.logs_2024")
+		require.NotNil(t, child)
+		require.NotNil(t, child.PartitionOf)
+		// Must match Table.FQTN so the dependency graph and the emitted SQL
+		// both resolve the parent.
+		assert.Equal(t, "public.logs", *child.PartitionOf)
+		assert.Equal(t, tables.Get("public.logs").FQTN(), *child.PartitionOf)
+
+		parent := tables.Get("public.logs")
+		require.NotNil(t, parent)
+		assert.Nil(t, parent.PartitionOf)
+	})
+
+	t.Run("partition parent name is quoted when needed", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public."Odd Parent" (
+				id integer NOT NULL,
+				created_at date NOT NULL
+			) PARTITION BY RANGE (created_at);
+			CREATE TABLE public."Odd Child" PARTITION OF public."Odd Parent"
+				FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		child := tables.Get(`public."Odd Child"`)
+		require.NotNil(t, child)
+		require.NotNil(t, child.PartitionOf)
+		assert.Equal(t, `public."Odd Parent"`, *child.PartitionOf)
+	})
 }

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -130,9 +130,10 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	fqtn := desired.FQTN()
 
 	// Partition children inherit columns and constraints from the parent,
-	// so skip diffing them to avoid false DROP statements. RLS flags and
-	// policies are owned per-relation (children do not auto-inherit them),
-	// so they're still diffed here, mirroring how indexes and FKs work.
+	// so skip diffing them to avoid false DROP statements. RLS flags,
+	// policies and comments are owned per-relation (children do not
+	// auto-inherit them), so they're still diffed here, mirroring how
+	// indexes and FKs work.
 	if desired.PartitionOf != nil && desired.PartitionBound != nil {
 		idxResult, err := diffIndexes(current.Indexes, desired.Indexes, dc)
 		if err != nil {
@@ -158,6 +159,8 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		}
 		result.Stmts = append(result.Stmts, polStmts...)
 		result.DisallowedDropStmts = append(result.DisallowedDropStmts, polDisallowed...)
+
+		result.Stmts = append(result.Stmts, diffComments(current, desired)...)
 
 		return result, nil
 	}

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -160,7 +160,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		result.Stmts = append(result.Stmts, polStmts...)
 		result.DisallowedDropStmts = append(result.DisallowedDropStmts, polDisallowed...)
 
-		result.Stmts = append(result.Stmts, diffComments(current, desired)...)
+		result.Stmts = append(result.Stmts, diffComments(current, withInheritedColumns(current, desired))...)
 
 		return result, nil
 	}
@@ -1100,6 +1100,31 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 	}
 
 	return dropStmts, addStmts, disallowed, nil
+}
+
+// withInheritedColumns returns a copy of a partition child whose column set
+// also holds the inherited columns the desired definition never declares. Only
+// columns carrying an explicit COMMENT ON COLUMN reach the desired side, so
+// without the rest a dropped comment would compare against nothing and stay.
+func withInheritedColumns(current, desired *model.Table) *model.Table {
+	cols := orderedmap.New[string, *model.Column]()
+	for name := range current.Columns.All() {
+		if col, ok := desired.Columns.GetOk(name); ok {
+			cols.Set(name, col)
+		} else {
+			cols.Set(name, &model.Column{Name: name})
+		}
+	}
+	// A comment on a column the table does not have is kept so it still
+	// reaches PostgreSQL and fails there rather than disappearing here.
+	for name, col := range desired.Columns.All() {
+		if _, ok := cols.GetOk(name); !ok {
+			cols.Set(name, col)
+		}
+	}
+	clone := *desired
+	clone.Columns = cols
+	return &clone
 }
 
 func diffComments(current, desired *model.Table) []string {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1688,6 +1688,73 @@ func TestDiffTable_partitionChild(t *testing.T) {
 	assert.Contains(t, tableResult.Stmts[0], "CREATE INDEX idx_new")
 }
 
+func TestWithInheritedColumns(t *testing.T) {
+	comment := "kept"
+	current := newTable("public", "events_2024")
+	current.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", Comment: &comment})
+	current.Columns.Set("created_at", &model.Column{Name: "created_at", TypeName: "date"})
+
+	desired := newTable("public", "events_2024")
+	desired.Columns.Set("ghost", &model.Column{Name: "ghost"})
+
+	got := withInheritedColumns(current, desired)
+
+	// The child's own column set comes from the current side, with no comment
+	// attached, so a comment that was dropped from the desired side is diffed.
+	require.Equal(t, 3, got.Columns.Len())
+	id, ok := got.Columns.GetOk("id")
+	require.True(t, ok)
+	assert.Nil(t, id.Comment)
+	_, ok = got.Columns.GetOk("created_at")
+	assert.True(t, ok)
+	// A comment naming a column the table does not have survives.
+	_, ok = got.Columns.GetOk("ghost")
+	assert.True(t, ok)
+	// The originals are untouched.
+	assert.Equal(t, 1, desired.Columns.Len())
+	cur, ok := current.Columns.GetOk("id")
+	require.True(t, ok)
+	assert.Equal(t, &comment, cur.Comment)
+}
+
+func TestWithInheritedColumns_keepsDesiredComment(t *testing.T) {
+	want := "new"
+	current := newTable("public", "events_2024")
+	current.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
+
+	desired := newTable("public", "events_2024")
+	desired.Columns.Set("id", &model.Column{Name: "id", Comment: &want})
+
+	got := withInheritedColumns(current, desired)
+
+	require.Equal(t, 1, got.Columns.Len())
+	col, ok := got.Columns.GetOk("id")
+	require.True(t, ok)
+	assert.Equal(t, &want, col.Comment)
+}
+
+func TestDiffTable_partitionChild_comments(t *testing.T) {
+	parent := "public.events"
+	bound := "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')"
+	oldTable, oldCol := "old table", "old column"
+
+	current := newTable("public", "events_2024")
+	current.PartitionOf = &parent
+	current.PartitionBound = &bound
+	current.Comment = &oldTable
+	current.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", Comment: &oldCol})
+
+	desired := newTable("public", "events_2024")
+	desired.PartitionOf = &parent
+	desired.PartitionBound = &bound
+
+	tableResult, err := diffTable(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, tableResult.Stmts, 2)
+	assert.Equal(t, "COMMENT ON TABLE public.events_2024 IS NULL;", tableResult.Stmts[0])
+	assert.Equal(t, "COMMENT ON COLUMN public.events_2024.id IS NULL;", tableResult.Stmts[1])
+}
+
 func TestDiffTable_partitionChild_indexRenameError(t *testing.T) {
 	parent := "public.events"
 	bound := "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')"

--- a/dump.go
+++ b/dump.go
@@ -50,6 +50,12 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 		fqtn := t.FQTN()
 		tableName := model.Ident(t.Name)
 		copied.Schema = ""
+		// --omit-schema is restricted to a single schema, so a partition
+		// parent always lives in the schema being stripped.
+		if copied.PartitionOf != nil {
+			parent := strings.TrimPrefix(*copied.PartitionOf, model.Ident(t.Schema)+".")
+			copied.PartitionOf = &parent
+		}
 		if copied.ForeignKeys.Len() > 0 {
 			fks := orderedmap.New[string, *model.ForeignKey]()
 			for _, fk := range copied.ForeignKeys.CollectValues() {

--- a/dump.go
+++ b/dump.go
@@ -50,8 +50,9 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 		fqtn := t.FQTN()
 		tableName := model.Ident(t.Name)
 		copied.Schema = ""
-		// --omit-schema is restricted to a single schema, so a partition
-		// parent always lives in the schema being stripped.
+		// Strip the schema only when the parent is in the one being dumped.
+		// --omit-schema allows a single schema, but the parent may sit outside
+		// it, and such a reference has to keep its schema to resolve.
 		if copied.PartitionOf != nil {
 			parent := strings.TrimPrefix(*copied.PartitionOf, model.Ident(t.Schema)+".")
 			copied.PartitionOf = &parent

--- a/dump_test.go
+++ b/dump_test.go
@@ -516,6 +516,34 @@ func TestDump_OmitSchema_MultipleSchemas(t *testing.T) {
 	assert.Contains(t, err.Error(), "--omit-schema cannot be used with multiple schemas")
 }
 
+func TestDump_OmitSchema_PartitionParentInAnotherSchema(t *testing.T) {
+	ctx := context.Background()
+	// The dumped schema holds only the child; its parent stays in another one.
+	// Stripping the schema off the parent would point the statement at a table
+	// that does not exist, so the reference keeps it.
+	connStr := setupSchemaDB(t, ctx, "other", `
+		CREATE TABLE other.parent (
+			id integer NOT NULL,
+			d date NOT NULL
+		) PARTITION BY RANGE (d);
+	`)
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, `
+		CREATE TABLE public.child PARTITION OF other.parent
+			FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+	`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connStr,
+		Schemas:    []string{"public"},
+	})
+	result, err := client.Dump(ctx, &pistachio.DumpOptions{OmitSchema: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, result.String(), "CREATE TABLE child PARTITION OF other.parent")
+}
+
 func TestDumpResult_OmitSchema_ViewDefinition(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -288,15 +288,20 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 
 			// RLS toggles and constraint subcommands can coexist in one
 			// ALTER TABLE statement. applyAlterTableRLS picks up only the RLS
-			// subtypes; parseAlterTableConstraint picks up AT_AddConstraint.
+			// subtypes; parseAlterTableConstraints picks up AT_AddConstraint.
 			// They walk the same cmd list independently, so run both.
 			applyAlterTableRLS(as, t)
 
-			con, fk, err := parseAlterTableConstraint(as, defaultSchema)
+			cons, fks, err := parseAlterTableConstraints(as, defaultSchema)
 			if err != nil {
 				return nil, err
 			}
-			if fk != nil {
+			// A rename directive names a single old object, so it cannot be
+			// applied when one statement declares several constraints.
+			if renameFrom != "" && len(cons)+len(fks) > 1 {
+				return nil, fmt.Errorf("renameFrom is ambiguous: ALTER TABLE %s adds %d constraints in one statement", fqtn, len(cons)+len(fks))
+			}
+			for _, fk := range fks {
 				if renameFrom != "" {
 					unquoted := normalizeUnqualifiedDirective(renameFrom)
 					fk.RenameFrom = &unquoted
@@ -304,7 +309,8 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				if err := setUnique(t.ForeignKeys, fk.Name, "foreign key", fk); err != nil {
 					return nil, err
 				}
-			} else if con != nil {
+			}
+			for _, con := range cons {
 				if renameFrom != "" {
 					unquoted := normalizeUnqualifiedDirective(renameFrom)
 					con.RenameFrom = &unquoted
@@ -337,6 +343,9 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if err := setUnique(sequences, seq.FQN(), "sequence", seq); err != nil {
 				return nil, err
 			}
+
+		case node.GetAlterSeqStmt() != nil:
+			applyAlterSeqOwnedBy(node.GetAlterSeqStmt(), defaultSchema, sequences)
 
 		case node.GetCommentStmt() != nil:
 			cs := node.GetCommentStmt()
@@ -1133,6 +1142,32 @@ func defElemInt64(de *pg_query.DefElem) (int64, bool, error) {
 // OWNED BY NONE (list ["none"]) yields nil owner. The pipeline only manages
 // standalone sequences, so an owned sequence is filtered out downstream; the
 // values here just mark it as owned.
+// applyAlterSeqOwnedBy records the OWNED BY clause of an ALTER SEQUENCE
+// statement on the already-parsed sequence. An owned sequence is unmanaged, so
+// without this the desired side would keep the sequence while the catalog side
+// drops it, and every plan would propose creating a sequence that exists.
+// Other ALTER SEQUENCE options are not tracked.
+func applyAlterSeqOwnedBy(as *pg_query.AlterSeqStmt, defaultSchema string, sequences *orderedmap.Map[string, *model.Sequence]) {
+	if as.Sequence == nil {
+		return
+	}
+	schema := as.Sequence.Schemaname
+	if schema == "" {
+		schema = defaultSchema
+	}
+	seq, ok := sequences.GetOk(model.Ident(schema, as.Sequence.Relname))
+	if !ok {
+		return
+	}
+	for _, opt := range as.Options {
+		de := opt.GetDefElem()
+		if de == nil || de.Defname != "owned_by" {
+			continue
+		}
+		seq.OwnerTable, seq.OwnerColumn = parseSeqOwnedBy(de.Arg)
+	}
+}
+
 func parseSeqOwnedBy(arg *pg_query.Node) (*string, *string) {
 	list := arg.GetList()
 	if list == nil {
@@ -1232,6 +1267,16 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 		if t, ok := tables.GetOk(fqtn); ok {
 			if col, ok := t.Columns.GetOk(colName); ok {
 				col.Comment = comment
+				return
+			}
+			// A partition child declares no columns of its own, but comments
+			// are per-relation and can be set on an inherited column. Record
+			// the comment against a column entry so the diff can see it.
+			// Restricted to true partition children: an INHERITS-style child
+			// still goes through the regular column diff, where a bodyless
+			// entry would be mistaken for a new column.
+			if t.PartitionOf != nil && t.PartitionBound != nil {
+				t.Columns.Set(colName, &model.Column{Name: colName, Comment: comment})
 			}
 			return
 		}
@@ -1300,7 +1345,13 @@ func parseCommentOnType(cs *pg_query.CommentStmt, defaultSchema string, enums *o
 	}
 }
 
-func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string) (*model.Constraint, *model.ForeignKey, error) {
+// parseAlterTableConstraints collects every ADD CONSTRAINT subcommand of an
+// ALTER TABLE statement. PostgreSQL accepts comma-separated actions in one
+// statement, so a single statement can declare several constraints.
+func parseAlterTableConstraints(as *pg_query.AlterTableStmt, defaultSchema string) ([]*model.Constraint, []*model.ForeignKey, error) {
+	var constraints []*model.Constraint
+	var fks []*model.ForeignKey
+
 	for _, cmdNode := range as.Cmds {
 		cmd := cmdNode.GetAlterTableCmd()
 		if cmd == nil || cmd.Subtype != pg_query.AlterTableType_AT_AddConstraint {
@@ -1340,7 +1391,7 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 				}
 			}
 
-			fk := &model.ForeignKey{
+			fks = append(fks, &model.ForeignKey{
 				Constraint: model.Constraint{
 					Name:       con.Conname,
 					Type:       model.ConstraintType('f'),
@@ -1354,9 +1405,9 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 				Table:     as.Relation.Relname,
 				RefSchema: refSchema,
 				RefTable:  refTable,
-			}
+			})
 
-			return nil, fk, nil
+			continue
 		}
 
 		// Non-FK constraint (PRIMARY KEY, UNIQUE, CHECK, etc.)
@@ -1365,10 +1416,10 @@ func parseAlterTableConstraint(as *pg_query.AlterTableStmt, defaultSchema string
 			return nil, nil, err
 		}
 
-		return constraint, nil, nil
+		constraints = append(constraints, constraint)
 	}
 
-	return nil, nil, nil
+	return constraints, fks, nil
 }
 
 // parseInlineForeignKey builds a ForeignKey from an inline FOREIGN KEY

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -299,7 +299,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			// A rename directive names a single old object, so it cannot be
 			// applied when one statement declares several constraints.
 			if renameFrom != "" && len(cons)+len(fks) > 1 {
-				return nil, fmt.Errorf("renameFrom is ambiguous: ALTER TABLE %s adds %d constraints in one statement", fqtn, len(cons)+len(fks))
+				return nil, fmt.Errorf("pista:renamed-from is ambiguous: ALTER TABLE %s adds %d constraints in one statement", fqtn, len(cons)+len(fks))
 			}
 			for _, fk := range fks {
 				if renameFrom != "" {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1138,15 +1138,10 @@ func defElemInt64(de *pg_query.DefElem) (int64, bool, error) {
 	return 0, false, fmt.Errorf("unexpected value for sequence option %s", de.Defname)
 }
 
-// parseSeqOwnedBy extracts the owner table and column from an OWNED BY clause.
-// OWNED BY NONE (list ["none"]) yields nil owner. The pipeline only manages
-// standalone sequences, so an owned sequence is filtered out downstream; the
-// values here just mark it as owned.
-// applyAlterSeqOwnedBy records the OWNED BY clause of an ALTER SEQUENCE
-// statement on the already-parsed sequence. An owned sequence is unmanaged, so
-// without this the desired side would keep the sequence while the catalog side
-// drops it, and every plan would propose creating a sequence that exists.
-// Other ALTER SEQUENCE options are not tracked.
+// applyAlterSeqOwnedBy records an ALTER SEQUENCE OWNED BY clause on the
+// already-parsed sequence, marking it unmanaged. The catalog excludes owned
+// sequences, so without this every plan proposes creating a sequence that
+// already exists. Other ALTER SEQUENCE options are not tracked.
 func applyAlterSeqOwnedBy(as *pg_query.AlterSeqStmt, defaultSchema string, sequences *orderedmap.Map[string, *model.Sequence]) {
 	if as.Sequence == nil {
 		return
@@ -1168,6 +1163,10 @@ func applyAlterSeqOwnedBy(as *pg_query.AlterSeqStmt, defaultSchema string, seque
 	}
 }
 
+// parseSeqOwnedBy extracts the owner table and column from an OWNED BY clause.
+// OWNED BY NONE (list ["none"]) yields nil owner. The pipeline only manages
+// standalone sequences, so an owned sequence is filtered out downstream; the
+// values here just mark it as owned.
 func parseSeqOwnedBy(arg *pg_query.Node) (*string, *string) {
 	list := arg.GetList()
 	if list == nil {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2266,3 +2266,97 @@ CREATE INDEX idx_users_id ON public.users (id);`
 	require.True(t, ok)
 	assert.False(t, idx.Concurrently)
 }
+
+func TestParseAlterTableConstraints_Multiple(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.orders (id integer, amount integer, code text);
+		ALTER TABLE public.orders
+			ADD CONSTRAINT orders_amount_check CHECK (amount > 0),
+			ADD CONSTRAINT orders_code_key UNIQUE (code);
+	`)
+	require.NoError(t, err)
+	tbl, ok := result.Tables.GetOk("public.orders")
+	require.True(t, ok)
+	assert.Equal(t, 2, tbl.Constraints.Len())
+	_, ok = tbl.Constraints.GetOk("orders_amount_check")
+	assert.True(t, ok)
+	_, ok = tbl.Constraints.GetOk("orders_code_key")
+	assert.True(t, ok)
+}
+
+func TestParseAlterTableConstraints_MultipleWithForeignKey(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.users (id integer PRIMARY KEY);
+		CREATE TABLE public.orders (id integer, user_id integer, code text);
+		ALTER TABLE public.orders
+			ADD CONSTRAINT orders_code_key UNIQUE (code),
+			ADD CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users (id);
+	`)
+	require.NoError(t, err)
+	tbl, ok := result.Tables.GetOk("public.orders")
+	require.True(t, ok)
+	assert.Equal(t, 1, tbl.Constraints.Len())
+	assert.Equal(t, 1, tbl.ForeignKeys.Len())
+	fk, ok := tbl.ForeignKeys.GetOk("orders_user_id_fkey")
+	require.True(t, ok)
+	require.NotNil(t, fk.RefTable)
+	assert.Equal(t, "users", *fk.RefTable)
+}
+
+func TestParseAlterTableConstraints_AmbiguousRename(t *testing.T) {
+	_, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.orders (id integer, amount integer, code text);
+		-- pista:renamed-from orders_old
+		ALTER TABLE public.orders
+			ADD CONSTRAINT orders_amount_check CHECK (amount > 0),
+			ADD CONSTRAINT orders_code_key UNIQUE (code);
+	`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "renameFrom is ambiguous")
+}
+
+func TestParseAlterTableConstraints_SingleRenameStillApplies(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.orders (id integer, code text);
+		-- pista:renamed-from orders_old_key
+		ALTER TABLE public.orders ADD CONSTRAINT orders_code_key UNIQUE (code);
+	`)
+	require.NoError(t, err)
+	tbl, ok := result.Tables.GetOk("public.orders")
+	require.True(t, ok)
+	con, ok := tbl.Constraints.GetOk("orders_code_key")
+	require.True(t, ok)
+	require.NotNil(t, con.RenameFrom)
+	assert.Equal(t, "orders_old_key", *con.RenameFrom)
+}
+
+func TestParseCommentStmt_PartitionChildColumn(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.events (id integer, created_at date) PARTITION BY RANGE (created_at);
+		CREATE TABLE public.events_2024 PARTITION OF public.events
+			FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+		COMMENT ON COLUMN public.events_2024.id IS 'event id';
+	`)
+	require.NoError(t, err)
+	child, ok := result.Tables.GetOk("public.events_2024")
+	require.True(t, ok)
+	// The child declares no columns, so the comment creates the only entry.
+	col, ok := child.Columns.GetOk("id")
+	require.True(t, ok)
+	require.NotNil(t, col.Comment)
+	assert.Equal(t, "event id", *col.Comment)
+}
+
+func TestParseCommentStmt_InheritsChildColumnNotSynthesized(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.parent (id integer, name text);
+		CREATE TABLE public.child () INHERITS (public.parent);
+		COMMENT ON COLUMN public.child.id IS 'inherited';
+	`)
+	require.NoError(t, err)
+	child, ok := result.Tables.GetOk("public.child")
+	require.True(t, ok)
+	// An INHERITS child goes through the regular column diff, where a bodyless
+	// entry would look like a new column, so no entry is created.
+	assert.Equal(t, 0, child.Columns.Len())
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2312,7 +2312,7 @@ func TestParseAlterTableConstraints_AmbiguousRename(t *testing.T) {
 			ADD CONSTRAINT orders_code_key UNIQUE (code);
 	`)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "renameFrom is ambiguous")
+	assert.Contains(t, err.Error(), "pista:renamed-from is ambiguous")
 }
 
 func TestParseAlterTableConstraints_SingleRenameStillApplies(t *testing.T) {

--- a/parser/policy.go
+++ b/parser/policy.go
@@ -11,7 +11,7 @@ import (
 // applyAlterTableRLS scans an ALTER TABLE statement for row-level security
 // toggle subcommands (ENABLE / DISABLE / FORCE / NO FORCE) and applies them
 // to the table's flags. Non-RLS subcommands are ignored, so the caller can
-// invoke parseAlterTableConstraint on the same statement to pick up any
+// invoke parseAlterTableConstraints on the same statement to pick up any
 // AT_AddConstraint subcommands; PostgreSQL allows mixing the two in one
 // ALTER TABLE.
 func applyAlterTableRLS(as *pg_query.AlterTableStmt, t *model.Table) {

--- a/parser/sequences_test.go
+++ b/parser/sequences_test.go
@@ -93,3 +93,54 @@ func TestParseCreateSeqStmt_OwnedByNone(t *testing.T) {
 	assert.Nil(t, seq.OwnerTable)
 	assert.False(t, seq.Owned())
 }
+
+func TestApplyAlterSeqOwnedBy(t *testing.T) {
+	seq := parseOneSequence(t, `
+		CREATE SEQUENCE public.s;
+		CREATE TABLE public.t (id integer, val integer DEFAULT 42);
+		ALTER SEQUENCE public.s OWNED BY public.t.val;
+	`)
+	require.NotNil(t, seq.OwnerTable)
+	assert.Equal(t, "t", *seq.OwnerTable)
+	require.NotNil(t, seq.OwnerColumn)
+	assert.Equal(t, "val", *seq.OwnerColumn)
+	assert.True(t, seq.Owned())
+}
+
+func TestApplyAlterSeqOwnedBy_Unqualified(t *testing.T) {
+	seq := parseOneSequence(t, `
+		CREATE SEQUENCE s;
+		CREATE TABLE public.t (id integer, val integer DEFAULT 42);
+		ALTER SEQUENCE s OWNED BY public.t.val;
+	`)
+	assert.True(t, seq.Owned())
+}
+
+func TestApplyAlterSeqOwnedBy_None(t *testing.T) {
+	seq := parseOneSequence(t, `
+		CREATE SEQUENCE public.s OWNED BY public.t.val;
+		CREATE TABLE public.t (id integer, val integer DEFAULT 42);
+		ALTER SEQUENCE public.s OWNED BY NONE;
+	`)
+	assert.Nil(t, seq.OwnerTable)
+	assert.Nil(t, seq.OwnerColumn)
+	assert.False(t, seq.Owned())
+}
+
+func TestApplyAlterSeqOwnedBy_OtherOptionIgnored(t *testing.T) {
+	seq := parseOneSequence(t, `
+		CREATE SEQUENCE public.s;
+		ALTER SEQUENCE public.s RESTART WITH 10;
+	`)
+	assert.False(t, seq.Owned())
+	assert.Equal(t, int64(1), seq.Start)
+}
+
+func TestApplyAlterSeqOwnedBy_UnknownSequence(t *testing.T) {
+	seq := parseOneSequence(t, `
+		CREATE SEQUENCE public.s;
+		CREATE TABLE public.t (id integer, val integer DEFAULT 42);
+		ALTER SEQUENCE public.absent OWNED BY public.t.val;
+	`)
+	assert.False(t, seq.Owned())
+}

--- a/testdata/apply/bulk_alter_multiple_constraints_roundtrip.yml
+++ b/testdata/apply/bulk_alter_multiple_constraints_roundtrip.yml
@@ -1,0 +1,28 @@
+# --bulk-alter merges the ADD CONSTRAINT actions into one statement. Feeding
+# that statement back as the desired schema must be a no-op; before, every
+# constraint but the first was dropped on the way in.
+init: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text
+  );
+desired: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text
+  );
+  ALTER TABLE public.orders
+      ADD CONSTRAINT orders_amount_check CHECK (amount > 0),
+      ADD CONSTRAINT orders_code_key UNIQUE (code);
+applied: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text,
+      CONSTRAINT orders_code_key UNIQUE (code),
+      CONSTRAINT orders_amount_check CHECK (amount > 0)
+  );
+verify_no_drift: true

--- a/testdata/apply/create_partitioned_table.yml
+++ b/testdata/apply/create_partitioned_table.yml
@@ -18,4 +18,4 @@ applied: |
   PARTITION BY RANGE (created_at);
 
   -- public.events_2024
-  CREATE TABLE public.events_2024 PARTITION OF events FOR VALUES FROM ('2024-01-01 00:00:00+00') TO ('2025-01-01 00:00:00+00');
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01 00:00:00+00') TO ('2025-01-01 00:00:00+00');

--- a/testdata/apply/rls_partition_child.yml
+++ b/testdata/apply/rls_partition_child.yml
@@ -27,7 +27,7 @@ applied: |
   PARTITION BY RANGE (created_at);
 
   -- public.events_2024
-  CREATE TABLE public.events_2024 PARTITION OF events FOR VALUES FROM ('2024-01-01 00:00:00+00') TO ('2025-01-01 00:00:00+00');
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01 00:00:00+00') TO ('2025-01-01 00:00:00+00');
 
   ALTER TABLE public.events_2024 ENABLE ROW LEVEL SECURITY;
   CREATE POLICY owner_select ON public.events_2024 FOR SELECT USING ((owner = CURRENT_USER));

--- a/testdata/apply/sequence_alter_owned_by.yml
+++ b/testdata/apply/sequence_alter_owned_by.yml
@@ -1,0 +1,26 @@
+# ALTER SEQUENCE ... OWNED BY marks the sequence unmanaged on the desired side,
+# matching the catalog side. Applying must be a no-op: before, pista proposed
+# CREATE SEQUENCE for an existing sequence and apply failed with
+# "relation already exists".
+init: |
+  CREATE SEQUENCE public.my_seq;
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+  ALTER SEQUENCE public.my_seq OWNED BY public.t.val;
+desired: |
+  CREATE SEQUENCE public.my_seq;
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+  ALTER SEQUENCE public.my_seq OWNED BY public.t.val;
+applied: |
+  -- public.t
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+applied_sql: ""
+verify_no_drift: true

--- a/testdata/dump/omit_schema_partition_child.yml
+++ b/testdata/dump/omit_schema_partition_child.yml
@@ -1,0 +1,17 @@
+omit_schema: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at date NOT NULL
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+dump: |
+  -- events
+  CREATE TABLE events (
+      id integer NOT NULL,
+      created_at date NOT NULL
+  )
+  PARTITION BY RANGE (created_at);
+
+  -- events_2024
+  CREATE TABLE events_2024 PARTITION OF events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');

--- a/testdata/dump/partition_quoted_names.yml
+++ b/testdata/dump/partition_quoted_names.yml
@@ -1,0 +1,18 @@
+# The partition parent is quoted the same way the table names are, so a name
+# needing quotes round-trips instead of producing unparseable SQL.
+init: |
+  CREATE TABLE public."Odd Parent" (
+      id integer NOT NULL,
+      d date NOT NULL
+  ) PARTITION BY RANGE (d);
+  CREATE TABLE public."Odd Child" PARTITION OF public."Odd Parent" FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+dump: |
+  -- public."Odd Child"
+  CREATE TABLE public."Odd Child" PARTITION OF public."Odd Parent" FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+
+  -- public."Odd Parent"
+  CREATE TABLE public."Odd Parent" (
+      id integer NOT NULL,
+      d date NOT NULL
+  )
+  PARTITION BY RANGE (d);

--- a/testdata/dump/partitioned_list.yml
+++ b/testdata/dump/partitioned_list.yml
@@ -18,7 +18,7 @@ dump: |
   PARTITION BY LIST (level);
 
   -- public.logs_error
-  CREATE TABLE public.logs_error PARTITION OF logs FOR VALUES IN ('error', 'warning');
+  CREATE TABLE public.logs_error PARTITION OF public.logs FOR VALUES IN ('error', 'warning');
 
   -- public.logs_info
-  CREATE TABLE public.logs_info PARTITION OF logs FOR VALUES IN ('info', 'debug');
+  CREATE TABLE public.logs_info PARTITION OF public.logs FOR VALUES IN ('info', 'debug');

--- a/testdata/dump/sequence_owned_by_non_serial.yml
+++ b/testdata/dump/sequence_owned_by_non_serial.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE SEQUENCE public.my_seq;
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+  ALTER SEQUENCE public.my_seq OWNED BY public.t.val;
+dump: |
+  -- public.t
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );

--- a/testdata/dump/serial_quoted_table_name.yml
+++ b/testdata/dump/serial_quoted_table_name.yml
@@ -1,0 +1,14 @@
+# The serial check compares the column default against the sequence name
+# rendered through regclass. A table name needing quotes renders the sequence
+# quoted too, so the column must still come out as serial.
+init: |
+  CREATE TABLE public."Order" (
+      id serial NOT NULL,
+      big bigserial NOT NULL
+  );
+dump: |
+  -- public."Order"
+  CREATE TABLE public."Order" (
+      id serial NOT NULL,
+      big bigserial NOT NULL
+  );

--- a/testdata/plan/add_multiple_constraints_one_alter.yml
+++ b/testdata/plan/add_multiple_constraints_one_alter.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text
+  );
+desired: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text
+  );
+  ALTER TABLE public.orders
+      ADD CONSTRAINT orders_amount_check CHECK (amount > 0),
+      ADD CONSTRAINT orders_code_key UNIQUE (code);
+plan: |
+  ALTER TABLE public.orders ADD CONSTRAINT orders_amount_check CHECK (amount > 0);
+  ALTER TABLE public.orders ADD CONSTRAINT orders_code_key UNIQUE (code);

--- a/testdata/plan/add_multiple_constraints_one_alter_with_fk.yml
+++ b/testdata/plan/add_multiple_constraints_one_alter_with_fk.yml
@@ -1,0 +1,26 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      code text
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      code text
+  );
+  ALTER TABLE public.orders
+      ADD CONSTRAINT orders_code_key UNIQUE (code),
+      ADD CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users (id);
+plan: |
+  ALTER TABLE public.orders ADD CONSTRAINT orders_code_key UNIQUE (code);
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users (id);

--- a/testdata/plan/add_partition_child_with_comments.yml
+++ b/testdata/plan/add_partition_child_with_comments.yml
@@ -1,0 +1,19 @@
+# A partition child created together with its comments emits both, since the
+# create path does not go through the table diff.
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at date NOT NULL
+  ) PARTITION BY RANGE (created_at);
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at date NOT NULL
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  COMMENT ON TABLE public.events_2024 IS 'new child';
+  COMMENT ON COLUMN public.events_2024.id IS 'new child column';
+plan: |
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  COMMENT ON TABLE public.events_2024 IS 'new child';
+  COMMENT ON COLUMN public.events_2024.id IS 'new child column';

--- a/testdata/plan/alter_table_constraints_with_rls.yml
+++ b/testdata/plan/alter_table_constraints_with_rls.yml
@@ -1,0 +1,24 @@
+# RLS toggles and several ADD CONSTRAINT actions can share one ALTER TABLE.
+# Both walkers run over the same command list, so neither may swallow the other.
+init: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text,
+      owner text NOT NULL
+  );
+desired: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text,
+      owner text NOT NULL
+  );
+  ALTER TABLE public.orders
+      ENABLE ROW LEVEL SECURITY,
+      ADD CONSTRAINT orders_amount_check CHECK (amount > 0),
+      ADD CONSTRAINT orders_code_key UNIQUE (code);
+plan: |
+  ALTER TABLE public.orders ADD CONSTRAINT orders_amount_check CHECK (amount > 0);
+  ALTER TABLE public.orders ADD CONSTRAINT orders_code_key UNIQUE (code);
+  ALTER TABLE public.orders ENABLE ROW LEVEL SECURITY;

--- a/testdata/plan/alter_table_single_constraint_rename.yml
+++ b/testdata/plan/alter_table_single_constraint_rename.yml
@@ -1,0 +1,16 @@
+init: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      code text,
+      CONSTRAINT orders_code_key UNIQUE (code)
+  );
+desired: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      code text
+  );
+  -- pista:renamed-from orders_code_key
+  ALTER TABLE public.orders
+      ADD CONSTRAINT orders_code_unique UNIQUE (code);
+plan: |
+  ALTER TABLE public.orders RENAME CONSTRAINT orders_code_key TO orders_code_unique;

--- a/testdata/plan/drop_partition_parent_and_child.yml
+++ b/testdata/plan/drop_partition_parent_and_child.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.keep (
+      id integer NOT NULL
+  );
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.keep (
+      id integer NOT NULL
+  );
+plan: |
+  DROP TABLE public.events_2024;
+  DROP TABLE public.events;

--- a/testdata/plan/drop_partition_parent_and_child_reverse_name.yml
+++ b/testdata/plan/drop_partition_parent_and_child_reverse_name.yml
@@ -1,0 +1,16 @@
+init: |
+  CREATE TABLE public.keep (
+      id integer NOT NULL
+  );
+  CREATE TABLE public.z_parent (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.a_child PARTITION OF public.z_parent FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.keep (
+      id integer NOT NULL
+  );
+plan: |
+  DROP TABLE public.a_child;
+  DROP TABLE public.z_parent;

--- a/testdata/plan/drop_partition_three_levels.yml
+++ b/testdata/plan/drop_partition_three_levels.yml
@@ -1,0 +1,21 @@
+# A partition of a partition must be dropped before its parent, and that
+# parent before the root.
+init: |
+  CREATE TABLE public.keep (
+      id integer NOT NULL
+  );
+  CREATE TABLE public.z_root (
+      id integer NOT NULL,
+      r text NOT NULL,
+      c text NOT NULL
+  ) PARTITION BY RANGE (r);
+  CREATE TABLE public.m_mid PARTITION OF public.z_root FOR VALUES FROM ('a') TO ('m') PARTITION BY LIST (c);
+  CREATE TABLE public.a_leaf PARTITION OF public.m_mid FOR VALUES IN ('x');
+desired: |
+  CREATE TABLE public.keep (
+      id integer NOT NULL
+  );
+plan: |
+  DROP TABLE public.a_leaf;
+  DROP TABLE public.m_mid;
+  DROP TABLE public.z_root;

--- a/testdata/plan/error_multiple_constraints_ambiguous_rename.yml
+++ b/testdata/plan/error_multiple_constraints_ambiguous_rename.yml
@@ -15,4 +15,4 @@ desired: |
   ALTER TABLE public.orders
       ADD CONSTRAINT orders_amount_check CHECK (amount > 0),
       ADD CONSTRAINT orders_code_unique UNIQUE (code);
-error: "renameFrom is ambiguous"
+error: "pista:renamed-from is ambiguous"

--- a/testdata/plan/error_multiple_constraints_ambiguous_rename.yml
+++ b/testdata/plan/error_multiple_constraints_ambiguous_rename.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text,
+      CONSTRAINT orders_code_key UNIQUE (code)
+  );
+desired: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      amount integer,
+      code text
+  );
+  -- pista:renamed-from orders_code_key
+  ALTER TABLE public.orders
+      ADD CONSTRAINT orders_amount_check CHECK (amount > 0),
+      ADD CONSTRAINT orders_code_unique UNIQUE (code);
+error: "renameFrom is ambiguous"

--- a/testdata/plan/partition_child_comment.yml
+++ b/testdata/plan/partition_child_comment.yml
@@ -2,19 +2,18 @@ init: |
   CREATE TABLE public.events (
       id integer NOT NULL,
       created_at timestamp with time zone NOT NULL,
-      data text,
       CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
   ) PARTITION BY RANGE (created_at);
   CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
-dump: |
-  -- public.events
+desired: |
   CREATE TABLE public.events (
       id integer NOT NULL,
       created_at timestamp with time zone NOT NULL,
-      data text,
       CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
-  )
-  PARTITION BY RANGE (created_at);
-
-  -- public.events_2024
-  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01 00:00:00+00') TO ('2025-01-01 00:00:00+00');
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  COMMENT ON TABLE public.events_2024 IS 'partition for 2024';
+  COMMENT ON COLUMN public.events_2024.id IS 'event id';
+plan: |
+  COMMENT ON TABLE public.events_2024 IS 'partition for 2024';
+  COMMENT ON COLUMN public.events_2024.id IS 'event id';

--- a/testdata/plan/partition_child_comment_changed.yml
+++ b/testdata/plan/partition_child_comment_changed.yml
@@ -1,0 +1,22 @@
+# Changing a partition child's comments emits the new text, not a drop.
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  COMMENT ON TABLE public.events_2024 IS 'old table';
+  COMMENT ON COLUMN public.events_2024.id IS 'old column';
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  COMMENT ON TABLE public.events_2024 IS 'new table';
+  COMMENT ON COLUMN public.events_2024.id IS 'new column';
+plan: |
+  COMMENT ON TABLE public.events_2024 IS 'new table';
+  COMMENT ON COLUMN public.events_2024.id IS 'new column';

--- a/testdata/plan/partition_child_comment_removed.yml
+++ b/testdata/plan/partition_child_comment_removed.yml
@@ -1,0 +1,22 @@
+# A partition child declares no columns, so a column comment only reaches the
+# desired side when written explicitly. Dropping the statement must remove the
+# comment instead of leaving it in place.
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  COMMENT ON TABLE public.events_2024 IS 'partition for 2024';
+  COMMENT ON COLUMN public.events_2024.id IS 'event id';
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+plan: |
+  COMMENT ON TABLE public.events_2024 IS NULL;
+  COMMENT ON COLUMN public.events_2024.id IS NULL;

--- a/testdata/plan/partition_child_comment_unknown_column.yml
+++ b/testdata/plan/partition_child_comment_unknown_column.yml
@@ -1,0 +1,17 @@
+# A comment naming a column the partition does not have is passed through
+# rather than dropped, so PostgreSQL reports the mistake at apply time.
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at date NOT NULL
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at date NOT NULL
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  COMMENT ON COLUMN public.events_2024.nope IS 'typo';
+plan: |
+  COMMENT ON COLUMN public.events_2024.nope IS 'typo';

--- a/testdata/plan/sequence_alter_non_owned_by_option.yml
+++ b/testdata/plan/sequence_alter_non_owned_by_option.yml
@@ -1,0 +1,8 @@
+# ALTER SEQUENCE options other than OWNED BY are not tracked, so they neither
+# change the sequence nor stop it from being managed.
+init: |
+  CREATE SEQUENCE public.my_seq;
+desired: |
+  CREATE SEQUENCE public.my_seq;
+  ALTER SEQUENCE public.my_seq RESTART WITH 10;
+plan: ""

--- a/testdata/plan/sequence_alter_owned_by.yml
+++ b/testdata/plan/sequence_alter_owned_by.yml
@@ -1,0 +1,20 @@
+# ALTER SEQUENCE ... OWNED BY ties the sequence to a column just like
+# CREATE SEQUENCE ... OWNED BY, so the sequence is unmanaged and the plan is
+# empty. Without it the catalog side (which excludes owned sequences) and the
+# desired side disagree, and pista keeps proposing a CREATE for a sequence
+# that already exists.
+init: |
+  CREATE SEQUENCE public.my_seq;
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+  ALTER SEQUENCE public.my_seq OWNED BY public.t.val;
+desired: |
+  CREATE SEQUENCE public.my_seq;
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+  ALTER SEQUENCE public.my_seq OWNED BY public.t.val;
+plan: ""

--- a/testdata/plan/sequence_alter_owned_by_unknown.yml
+++ b/testdata/plan/sequence_alter_owned_by_unknown.yml
@@ -1,0 +1,14 @@
+# ALTER SEQUENCE against a sequence the desired schema never declares is
+# ignored rather than treated as a declaration.
+init: |
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+desired: |
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+  ALTER SEQUENCE public.absent_seq OWNED BY public.t.val;
+plan: ""

--- a/testdata/plan/sequence_alter_owned_by_unqualified.yml
+++ b/testdata/plan/sequence_alter_owned_by_unqualified.yml
@@ -1,0 +1,17 @@
+# The sequence name in ALTER SEQUENCE may omit the schema; it resolves to the
+# target schema, so the sequence is still marked unmanaged.
+init: |
+  CREATE SEQUENCE public.my_seq;
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+  ALTER SEQUENCE public.my_seq OWNED BY public.t.val;
+desired: |
+  CREATE SEQUENCE my_seq;
+  CREATE TABLE public.t (
+      id integer,
+      val integer DEFAULT 42
+  );
+  ALTER SEQUENCE my_seq OWNED BY public.t.val;
+plan: ""


### PR DESCRIPTION
Five places lost information between the SQL that was read and the model
that was built. Each is covered by a fixture that fails without the fix.

parseAlterTableConstraint returned on its first AT_AddConstraint
subcommand, so only the first constraint of a comma-separated ALTER TABLE
survived. The rest were discarded silently, and the plan then offered to
drop them from the database. It now collects every subcommand. A rename
directive names one old object, so it is rejected when the statement adds
more than one constraint.

The partition CTE in ListTables selected the parent's relname without its
namespace, while the parser qualifies the parent through model.Ident.
Nothing matched: the toposort edge from child to parent was never added,
so both were dropped in declaration order and the parent took its children
with it, leaving the child's own DROP to fail. Dumping was worse. The
unqualified name was emitted verbatim, so a dump of a partitioned table
outside the search_path could not be reloaded, and reattached the child to
a same-named table in another schema when one existed. The parent is now
qualified on the way out of the catalog, and --omit-schema strips it again
along with the rest.

diffTable returned from its partition-child branch before reaching
diffComments, so comments on a partition never diffed. Comments are per
relation and PostgreSQL accepts them on a partition. Column comments also
needed the parser to record them: a partition child declares no columns of
its own, so the entry they attach to did not exist. Only true partition
children get one, since an INHERITS child still goes through the regular
column diff, where a bodyless entry would read as a new column.

A column counted as serial whenever pg_get_serial_sequence found a
sequence, which a plain ALTER SEQUENCE ... OWNED BY is enough to create.
Such a column was dumped as serial and its real default was lost, with no
drift reported. The default now has to draw from that sequence. Both names
go through regclass first, because pg_get_serial_sequence always qualifies
and pg_get_expr does not qualify what is on the search_path.

ALTER SEQUENCE was not parsed at all, so its OWNED BY never marked the
sequence unmanaged the way CREATE SEQUENCE ... OWNED BY does. The catalog
excludes owned sequences, so every plan proposed creating a sequence that
already existed and apply failed on it.

Detaching an owned sequence with OWNED BY NONE still plans a CREATE that
cannot run. The catalog hides owned sequences entirely, so the transition
is invisible; modelling it is left alone here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012wjHTFmHXpkJWXAGaZu7bD