### PR TITLE
Link GitHub release notes to the CHANGELOG

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,9 @@ version: 2
 before:
   hooks:
     - go mod tidy
+release:
+  footer: |
+    see https://github.com/winebarrel/pistachio/blob/{{ .Tag }}/CHANGELOG.md
 builds:
   - &build
     id: darwin-amd64


### PR DESCRIPTION
Add a goreleaser `release.footer` so each GitHub release page links to the CHANGELOG at that tag.

```yaml
release:
  footer: |
    see https://github.com/winebarrel/pistachio/blob/{{ .Tag }}/CHANGELOG.md
```

`{{ .Tag }}` expands to the release tag (e.g. `v1.23.0`), so the release notes footer points to the CHANGELOG as of that release. No per-release maintenance is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019h5sF2iEtR6NPbjEjC8g73