### PR TITLE
Update CHANGELOG for versions 1.7.0 and 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,7 @@
 
 ## [1.7.0] - 2026-05-12
 
-* **Breaking:** Rename the CLI binary from `pist` to `pista`, environment variable prefix from `PIST_` to `PISTA_` (including `PISTA_CONN_STR`, `PISTA_PASSWORD`, `PISTA_SCHEMAS`, `PISTA_PRE_SQL`, `PISTA_PRE_SQL_FILE`, `PISTA_CONCURRENTLY_PRE_SQL`, `PISTA_CONCURRENTLY_PRE_SQL_FILE`, `PISTA_DISABLE_INDEX_CONCURRENTLY`, `PISTA_BULK_ALTER`, `PISTA_ALLOW_DROP`, `PISTA_INCLUDE`, `PISTA_EXCLUDE`, `PISTA_ENABLE`, `PISTA_DISABLE`), and SQL comment directives from `-- pist:` to `-- pista:` (the three directives `-- pista:renamed-from`, `-- pista:execute`, `-- pista:concurrently`). Old names are no longer recognized. Existing user SQL files and environment / CI configurations must be updated to the new names before upgrading.
+* **BREAKING:** Rename the CLI binary from `pist` to `pista`, environment variable prefix from `PIST_` to `PISTA_` (including `PISTA_CONN_STR`, `PISTA_PASSWORD`, `PISTA_SCHEMAS`, `PISTA_PRE_SQL`, `PISTA_PRE_SQL_FILE`, `PISTA_CONCURRENTLY_PRE_SQL`, `PISTA_CONCURRENTLY_PRE_SQL_FILE`, `PISTA_DISABLE_INDEX_CONCURRENTLY`, `PISTA_BULK_ALTER`, `PISTA_ALLOW_DROP`, `PISTA_INCLUDE`, `PISTA_EXCLUDE`, `PISTA_ENABLE`, `PISTA_DISABLE`), and SQL comment directives from `-- pist:` to `-- pista:` (the three directives `-- pista:renamed-from`, `-- pista:execute`, `-- pista:concurrently`). Old names are no longer recognized. Existing user SQL files and environment / CI configurations must be updated to the new names before upgrading.
 
 ## [1.6.2] - 2026-05-12
 


### PR DESCRIPTION
Update CHANGELOG.md to reflect breaking changes and fixes in versions 1.7.0 and 1.6.2, including CLI binary renaming and typmod placement corrections.