### PR TITLE
Add CI check that pista handles sample schemas correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,28 @@ jobs:
           # Each matrix job uploads its own coverage; Codecov merges them so
           # PG-version-specific paths (e.g. PG18-only catalog reads) are
           # counted as covered when any matrix entry exercises them.
+
+  samples:
+    runs-on: ubuntu-latest
+    # Checks pista against real-world sample schemas: downloads each from its
+    # external host, loads it into an isolated database, then verifies that
+    # `pista dump` plans back to "No changes". A diff means the catalog reader
+    # and parser disagree.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - run: make test-samples

--- a/Makefile
+++ b/Makefile
@@ -43,39 +43,56 @@ deadcode:
 keywords:
 	bash scripts/gen-keywords.sh
 
+# Single source of the real-world sample schemas, consumed by both `schema`
+# (loads them all into one database) and `test-samples` (loads each into an
+# isolated database and checks pista round-trips it). One record per line:
+#   name | loader-target | VAR=value ... | schemas for pista -n (blank = public)
+define SAMPLES
+chinook|sample-db|SQL_FILE=chinook.sql|
+happiness_index|sample-db|SQL_FILE=happiness_index.sql|
+lego|sample-db|SQL_FILE=lego.sql|
+netflix|sample-db|SQL_FILE=netflix.sql|
+pagila|sample-db|SQL_FILE=pagila.sql|
+periodic_table|sample-db|SQL_FILE=periodic_table.sql|
+titanic|sample-db|SQL_FILE=titanic.sql|
+world|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/world/world-1.0/world-1.0.tar.gz TAR_SQL_PATH=dbsamples-0.1/world/world.sql|
+usda|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/usda/usda-r18-1.0/usda-r18-1.0.tar.gz TAR_SQL_PATH=usda-r18-1.0/usda.sql|
+northwind|sample-db-url|URL=https://raw.githubusercontent.com/pthom/northwind_psql/master/northwind.sql|
+employees|sample-db-url|URL=https://raw.githubusercontent.com/h8/employees-database/master/employees_schema.sql|employees
+adventureworks|sample-db-adventureworks||person,humanresources,production,purchasing,sales
+endef
+
+# Print the sample manifest, one record per line, for shell consumers.
+.PHONY: print-samples
+print-samples:
+	$(info $(SAMPLES))@:
+
 .PHONY: schema
 schema: clean-schema
-	$(MAKE) sample-db SQL_FILE=chinook.sql
-	$(MAKE) sample-db SQL_FILE=happiness_index.sql
-	$(MAKE) sample-db SQL_FILE=lego.sql
-	$(MAKE) sample-db SQL_FILE=netflix.sql
-	$(MAKE) sample-db SQL_FILE=pagila.sql
-	$(MAKE) sample-db SQL_FILE=periodic_table.sql
-	$(MAKE) sample-db SQL_FILE=titanic.sql
-	$(MAKE) sample-db-tar TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/world/world-1.0/world-1.0.tar.gz TAR_SQL_PATH=dbsamples-0.1/world/world.sql
-	$(MAKE) sample-db-tar TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/usda/usda-r18-1.0/usda-r18-1.0.tar.gz TAR_SQL_PATH=usda-r18-1.0/usda.sql
-	$(MAKE) sample-db-url URL=https://raw.githubusercontent.com/pthom/northwind_psql/master/northwind.sql
-	$(MAKE) sample-db-url URL=https://raw.githubusercontent.com/h8/employees-database/master/employees_schema.sql
-	$(MAKE) sample-db-adventureworks
+	@$(MAKE) -s print-samples | while IFS='|' read -r name target args schemas; do \
+	  [ -n "$$name" ] || continue; \
+	  echo "==> $$name"; \
+	  $(MAKE) $$target $$args; \
+	done
 
 .PHONY: sample-db
 sample-db:
-	curl -sSf https://raw.githubusercontent.com/neondatabase/postgres-sample-dbs/refs/heads/main/$(SQL_FILE) | psql
+	curl -sSf --retry 3 --retry-delay 2 https://raw.githubusercontent.com/neondatabase/postgres-sample-dbs/refs/heads/main/$(SQL_FILE) | psql
 
 .PHONY: sample-db-tar
 sample-db-tar:
-	curl -sSfL $(TAR_URL) | tar xzO $(TAR_SQL_PATH) | psql
+	curl -sSfL --retry 3 --retry-delay 2 $(TAR_URL) | tar xzO $(TAR_SQL_PATH) | psql
 
 .PHONY: sample-db-url
 sample-db-url:
-	curl -sSfL $(URL) | psql
+	curl -sSfL --retry 3 --retry-delay 2 $(URL) | psql
 
 # AdventureWorks (lorint/AdventureWorks-for-Postgres, MIT). Schema-only load:
 # strip \copy lines (data lives in CSVs we don't fetch) and the inline
 # Production.ProductReview INSERT (FK target rows aren't loaded).
 .PHONY: sample-db-adventureworks
 sample-db-adventureworks:
-	curl -sSfL https://raw.githubusercontent.com/lorint/AdventureWorks-for-Postgres/master/install.sql \
+	curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/lorint/AdventureWorks-for-Postgres/master/install.sql \
 	  | awk '/^\\copy/ { next } /^INSERT INTO Production.ProductReview/ { skip=1 } skip { if (/\);[[:space:]]*$$/) skip=0; next } { print }' \
 	  | psql
 
@@ -83,9 +100,19 @@ sample-db-adventureworks:
 test-scenario:
 	bash test/scenario/run.sh
 
+.PHONY: test-samples
+test-samples:
+	bash test/samples/run.sh
+
 .PHONY: clean-schema
 clean-schema:
 	psql -c 'DROP SCHEMA IF EXISTS person, humanresources, production, purchasing, sales, employees CASCADE ; DROP SCHEMA public CASCADE ; CREATE SCHEMA public'
+
+# Drop every user schema (not just public), so a prior sample's schemas can't
+# leak into the next check. Used by test-samples between samples.
+.PHONY: reset-db
+reset-db:
+	psql -X -q -v ON_ERROR_STOP=1 -c "SET client_min_messages TO warning; DO \$$\$$ DECLARE s text; BEGIN FOR s IN SELECT nspname FROM pg_namespace WHERE nspname NOT LIKE 'pg_%' AND nspname <> 'information_schema' LOOP EXECUTE format('DROP SCHEMA IF EXISTS %I CASCADE', s); END LOOP; END \$$\$$; CREATE SCHEMA public"
 
 .PHONY: demo
 demo: clean-schema

--- a/test/samples/run.sh
+++ b/test/samples/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Check that pista handles real-world sample schemas correctly.
+#
+# The sample list, downloads, and DB setup all live in the Makefile. This
+# script only drives the check: for each sample it asks make to reset the
+# database and load the sample, runs `pista dump` to capture pista's model of
+# the schema, then runs `pista plan` against the dump. A faithful round-trip
+# must plan to "No changes"; any diff means pista's catalog reader and parser
+# disagree.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+export PGHOST="${PGHOST:-localhost}"
+export PGUSER="${PGUSER:-postgres}"
+
+: "${PISTA:=./pista}"
+
+_pass=0
+_fail=0
+
+# Indent stdin by four spaces for readable failure output.
+indent() {
+  # shellcheck disable=SC2001  # per-line prefix; parameter expansion can't do it
+  sed 's/^/    /'
+}
+
+# check <name> <schemas>
+# <schemas> is passed to pista -n; empty means default (public).
+check() {
+  local name="$1" schemas="$2"
+  local dump="${TMPDIR:-/tmp}/pista-sample-${name}.sql"
+  printf "  %-20s " "$name"
+
+  local ns=()
+  [ -n "$schemas" ] && ns=(-n "$schemas")
+
+  if ! "$PISTA" dump "${ns[@]}" >"$dump" 2>"${dump}.err"; then
+    echo "FAIL (dump)"
+    indent <"${dump}.err" >&2
+    _fail=$((_fail + 1))
+    return
+  fi
+
+  local out
+  out=$("$PISTA" plan "${ns[@]}" "$dump" 2>&1) || {
+    echo "FAIL (plan)"
+    echo "$out" | indent >&2
+    _fail=$((_fail + 1))
+    return
+  }
+
+  if echo "$out" | grep -q 'No changes'; then
+    echo "PASS"
+    _pass=$((_pass + 1))
+  else
+    echo "DRIFT"
+    echo "$out" | grep -v '^--' | indent >&2
+    _fail=$((_fail + 1))
+  fi
+}
+
+echo "Building pista..."
+go build -o pista ./cmd/pista
+PISTA="./pista"
+
+echo ""
+echo "Sample schema check (dump then plan; expect No changes):"
+
+# Iterate the sample manifest from the Makefile. For each sample let make
+# reset the database and load the schema, then run the drift check here.
+while IFS='|' read -r name target args schemas; do
+  [ -n "$name" ] || continue
+
+  make -s reset-db >/dev/null
+  # shellcheck disable=SC2086  # $args must word-split into make VAR=value pairs
+  if ! make -s "$target" $args >/dev/null; then
+    printf "  %-20s FAIL (load)\n" "$name"
+    _fail=$((_fail + 1))
+    continue
+  fi
+
+  check "$name" "$schemas"
+done < <(make -s print-samples)
+
+echo ""
+echo "  ${_pass} passed, ${_fail} failed"
+[ "$_fail" -eq 0 ]


### PR DESCRIPTION
Load each real-world sample schema (the same set as the Makefile `schema` target) into an isolated database, run `pista dump`, then verify the dump plans back to "No changes". A diff means the catalog reader and parser disagree on that schema.

Adds test/samples/run.sh, a `make test-samples` target, and a `samples` job in ci.yml.


Claude-Session: https://claude.ai/code/session_01YF1MmBy1bx9JjMbToRCGtJ