### PR TITLE
Update note on unnamed constraints in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ pista dump --split ./schema/
 
 ## Constraint naming
 
-> [!NOTE]
+> [!IMPORTANT]
 > Unnamed constraints (e.g. `id integer PRIMARY KEY`, `name text UNIQUE`, `col integer REFERENCES other(id)`) are auto-named by pistachio following PostgreSQL's convention (`{table}_pkey`, `{table}_{col}_key`, `{table}_{col}_check`, `{table}_{col}_fkey`, `{table}_{col}_excl`). The auto-naming has two limitations:
 > - When multiple constraints would generate the same name, PostgreSQL appends a numeric suffix (e.g. `_1`) that pistachio cannot predict.
 > - PostgreSQL truncates identifier names to 63 bytes (NAMEDATALEN - 1). pistachio does not apply this truncation, so very long table/column names may produce mismatched constraint names.


### PR DESCRIPTION
This pull request updates the constraint naming documentation in `README.md` to clarify the importance of how unnamed constraints are auto-named by pistachio, replacing a less prominent note with a more visible callout.

Documentation improvement:

* Changed the callout for constraint naming from `[!NOTE]` to `[!IMPORTANT]` to emphasize the significance of the auto-naming behavior and its limitations.