### PR TITLE
Add dvdrental, dellstore2, and demodb sample schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ keywords:
 #   name | loader-target | VAR=value ... | schemas for pista -n (blank = public)
 define SAMPLES
 chinook|sample-db|SQL_FILE=chinook.sql|
+dvdrental|sample-db|SQL_FILE=dvdrental.sql|
 happiness_index|sample-db|SQL_FILE=happiness_index.sql|
 lego|sample-db|SQL_FILE=lego.sql|
 netflix|sample-db|SQL_FILE=netflix.sql|
@@ -57,9 +58,11 @@ periodic_table|sample-db|SQL_FILE=periodic_table.sql|
 titanic|sample-db|SQL_FILE=titanic.sql|
 world|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/world/world-1.0/world-1.0.tar.gz TAR_SQL_PATH=dbsamples-0.1/world/world.sql|
 usda|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/usda/usda-r18-1.0/usda-r18-1.0.tar.gz TAR_SQL_PATH=usda-r18-1.0/usda.sql|
+dellstore2|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/dellstore2/dellstore2-normal-1.0/dellstore2-normal-1.0.tar.gz TAR_SQL_PATH=dellstore2-normal-1.0/dellstore2-normal-1.0.sql|
 northwind|sample-db-url|URL=https://raw.githubusercontent.com/pthom/northwind_psql/master/northwind.sql|
 employees|sample-db-url|URL=https://raw.githubusercontent.com/h8/employees-database/master/employees_schema.sql|employees
 adventureworks|sample-db-adventureworks||person,humanresources,production,purchasing,sales
+demodb|sample-db-demodb|URL=https://raw.githubusercontent.com/postgrespro/demodb/master/tables.sql|bookings
 endef
 
 # Print the sample manifest, one record per line, for shell consumers.
@@ -96,6 +99,19 @@ sample-db-adventureworks:
 	  | awk '/^\\copy/ { next } /^INSERT INTO Production.ProductReview/ { skip=1 } skip { if (/\);[[:space:]]*$$/) skip=0; next } { print }' \
 	  | psql
 
+# Postgres Pro demo database (postgrespro/demodb, PostgreSQL License). The repo
+# ships a schema-generation script, not a plain dump: tables.sql defines the
+# `gen` and `bookings` schemas and \copy-loads reference data from .dat files we
+# don't fetch. We only need the schema, so strip the \copy lines (their data is
+# irrelevant to a round-trip check) and enable btree_gist first, which the
+# bookings.routes exclusion constraint requires.
+.PHONY: sample-db-demodb
+sample-db-demodb:
+	psql -c 'CREATE EXTENSION IF NOT EXISTS btree_gist'
+	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
+	  | awk '/^[[:space:]]*\\copy/ { next } { print }' \
+	  | psql
+
 .PHONY: test-scenario
 test-scenario:
 	bash test/scenario/run.sh
@@ -106,7 +122,7 @@ test-samples:
 
 .PHONY: clean-schema
 clean-schema:
-	psql -c 'DROP SCHEMA IF EXISTS person, humanresources, production, purchasing, sales, employees CASCADE ; DROP SCHEMA public CASCADE ; CREATE SCHEMA public'
+	psql -c 'DROP SCHEMA IF EXISTS person, humanresources, production, purchasing, sales, employees, bookings, gen CASCADE ; DROP SCHEMA public CASCADE ; CREATE SCHEMA public'
 
 # Drop every user schema (not just public), so a prior sample's schemas can't
 # leak into the next check. Used by test-samples between samples.


### PR DESCRIPTION
## Summary

Add three real-world sample schemas to the `SAMPLES` manifest so `make schema` and `make test-samples` exercise pista's parser/catalog round-trip (dump then plan should report "No changes") against more DDL.

| Name | Kind | Loader | Schema | Notable features |
|------|------|--------|--------|------------------|
| dvdrental | classic | existing `sample-db` (neon) | public | 15 tables / 7 views / enum / domain |
| dellstore2 | classic | existing `sample-db-tar` (pgFoundry) | public | retail DB with functions/triggers |
| demodb | advanced | new `sample-db-demodb` (postgrespro) | bookings | jsonb, `tstzrange`, identity columns, GiST exclusion constraint, CHECK |

## Notes

- **demodb** ships a schema-generation script rather than a plain dump, so a new `sample-db-demodb` loader:
  - enables `btree_gist` first (required by the `bookings.routes` exclusion constraint), and
  - strips the `\copy` lines (their `.dat` reference data is irrelevant to a schema round-trip), following the `awk` strip style of the existing `sample-db-adventureworks` loader.
- Added `bookings, gen` to `clean-schema`'s drop list (used by `make schema`; `test-samples` already drops all user schemas via `reset-db`).

## Verification

All three load and round-trip via their actual make targets (`reset-db` -> load -> `pista dump` -> `pista plan`), each reporting `No changes`. demodb round-trips faithfully including the GiST exclusion constraint, jsonb, `tstzrange`, and identity columns. `make print-samples` parses and `go vet ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)