### PR TITLE
Document the resume problem after a failed CONCURRENTLY apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,16 @@ The skipped transaction is recorded in the output:
 CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);
 ```
 
-An apply that skips the transaction is not all-or-nothing. A failure leaves the statements that already ran in place, and re-running `pista apply` applies the rest. A failed `CREATE INDEX CONCURRENTLY` also leaves an invalid index that must be dropped by hand.
+An apply that skips the transaction is not all-or-nothing. A failure leaves the statements that already ran in place, and re-running `pista apply` resumes the work: `pista` re-reads the current schema, regenerates the diff, and applies only what is still missing.
+
+Resuming after a failed `CREATE INDEX CONCURRENTLY` needs manual care. When `CREATE INDEX CONCURRENTLY` fails, PostgreSQL leaves behind an invalid index (a `pg_index` row with `indisvalid = false`). `pista` reads the current schema from the catalog and cannot tell an invalid index from a valid one, so it treats the index as already present. The regenerated diff shows no change for it, and both `pista plan` and a resumed `pista apply` report nothing to do even though the index is unusable. Re-running `pista apply` therefore does not repair it. Drop the invalid index by hand before resuming, so the next apply recreates it:
+
+```sql
+DROP INDEX CONCURRENTLY idx_users_name;
+```
+
+> [!WARNING]
+> This applies to `DROP INDEX CONCURRENTLY` as well: a failed drop can also leave the index marked invalid. `pista` still sees the index in the catalog and plans no change, so a resumed apply does not retry the drop. Finish the drop by hand before the next apply.
 
 To apply `CONCURRENTLY` to individual indexes, either write `CREATE INDEX CONCURRENTLY` directly or use the `-- pista:concurrently` directive before the `CREATE INDEX` statement. Both are treated equivalently:
 


### PR DESCRIPTION
## Summary

Expand the CONCURRENTLY section of the README to document the "resume" problem: re-running `pista apply` after a failed non-transactional apply does **not** repair an invalid index left by a failed `CREATE INDEX CONCURRENTLY`.

## Why

A non-transactional apply is not all-or-nothing, and re-running it resumes by re-reading the catalog and reapplying the remaining diff. But when `CREATE INDEX CONCURRENTLY` fails, PostgreSQL leaves an invalid index (`pg_index.indisvalid = false`). The catalog reader filters only on `i.indislive` (`catalog/indexes.go`), not `indisvalid`, so `pista` cannot distinguish an invalid index from a valid one and treats it as already present. As a result:

- `pista plan` and a resumed `pista apply` both report no change for it.
- The unusable index is silently left in place.

The fix is manual: drop the invalid index by hand (`DROP INDEX CONCURRENTLY ...`) before resuming so the next apply recreates it. A `> [!WARNING]` note covers the same caveat for a failed `DROP INDEX CONCURRENTLY`.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)