### PR TITLE
Add french_towns, iso_3166, imdb, clubdata, and musicbrainz sample schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,15 @@ titanic|sample-db|SQL_FILE=titanic.sql|
 world|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/world/world-1.0/world-1.0.tar.gz TAR_SQL_PATH=dbsamples-0.1/world/world.sql|
 usda|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/usda/usda-r18-1.0/usda-r18-1.0.tar.gz TAR_SQL_PATH=usda-r18-1.0/usda.sql|
 dellstore2|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/dellstore2/dellstore2-normal-1.0/dellstore2-normal-1.0.tar.gz TAR_SQL_PATH=dellstore2-normal-1.0/dellstore2-normal-1.0.sql|
+french_towns|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/french-towns-communes-francais/french-towns-communes-francaises-1.0/french-towns-communes-francaises-1.0.tar.gz TAR_SQL_PATH=french-towns-communes-francaises.sql|
+iso_3166|sample-db-tar|TAR_URL=https://ftp.postgresql.org/pub/projects/pgFoundry/dbsamples/iso-3166/iso-3166-1.0/iso-3166-1.0.tar.gz TAR_SQL_PATH=iso-3166/iso-3166.sql|
 northwind|sample-db-url|URL=https://raw.githubusercontent.com/pthom/northwind_psql/master/northwind.sql|
 employees|sample-db-url|URL=https://raw.githubusercontent.com/h8/employees-database/master/employees_schema.sql|employees
+imdb|sample-db-imdb||
 adventureworks|sample-db-adventureworks||person,humanresources,production,purchasing,sales
+clubdata|sample-db-clubdata|URL=https://pgexercises.com/dbfiles/clubdata.sql|cd
 demodb|sample-db-demodb|URL=https://raw.githubusercontent.com/postgrespro/demodb/master/tables.sql|bookings
+musicbrainz|sample-db-musicbrainz||musicbrainz
 endef
 
 # Print the sample manifest, one record per line, for shell consumers.
@@ -90,6 +95,16 @@ sample-db-tar:
 sample-db-url:
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) | psql
 
+# Join Order Benchmark (gregrahn/join-order-benchmark), the IMDB schema used by
+# the JOB query set. The tables and their indexes ship as two separate files, so
+# concatenate them: schema.sql first, then the foreign-key indexes.
+.PHONY: sample-db-imdb
+sample-db-imdb:
+	for f in schema.sql fkindexes.sql; do \
+	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/gregrahn/join-order-benchmark/master/$$f || exit 1; \
+	  echo; \
+	done | psql
+
 # AdventureWorks (lorint/AdventureWorks-for-Postgres, MIT). Schema-only load:
 # strip \copy lines (data lives in CSVs we don't fetch) and the inline
 # Production.ProductReview INSERT (FK target rows aren't loaded).
@@ -97,6 +112,16 @@ sample-db-url:
 sample-db-adventureworks:
 	curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/lorint/AdventureWorks-for-Postgres/master/install.sql \
 	  | awk '/^\\copy/ { next } /^INSERT INTO Production.ProductReview/ { skip=1 } skip { if (/\);[[:space:]]*$$/) skip=0; next } { print }' \
+	  | psql
+
+# PostgreSQL Exercises club data (pgexercises.com). The dump creates its own
+# database and reconnects to it, which we cannot do mid-pipe; strip those two
+# lines and load the rest into the current database. The remaining SQL creates
+# the `cd` schema and sets search_path itself.
+.PHONY: sample-db-clubdata
+sample-db-clubdata:
+	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
+	  | awk '/^CREATE DATABASE exercises;/ { next } /^\\c exercises/ { next } { print }' \
 	  | psql
 
 # Postgres Pro demo database (postgrespro/demodb, PostgreSQL License). The repo
@@ -112,6 +137,34 @@ sample-db-demodb:
 	  | awk '/^[[:space:]]*\\copy/ { next } { print }' \
 	  | psql
 
+# MusicBrainz (metabrainz/musicbrainz-server, GPL-2.0). The schema ships as one
+# file per object kind and none of them create the schema, so create
+# `musicbrainz` up front, point search_path at it, and concatenate the files in
+# dependency order: extensions and the ICU collation first (tables reference
+# both), then the text search configuration and types, the tables, the functions
+# (CHECK constraints and views call them), and finally keys, indexes,
+# constraints, and views.
+MUSICBRAINZ_SQL_FILES = \
+	Extensions.sql \
+	CreateCollations.sql \
+	CreateSearchConfiguration.sql \
+	CreateTypes.sql \
+	CreateTables.sql \
+	CreateFunctions.sql \
+	CreatePrimaryKeys.sql \
+	CreateFKConstraints.sql \
+	CreateIndexes.sql \
+	CreateConstraints.sql \
+	CreateViews.sql
+
+.PHONY: sample-db-musicbrainz
+sample-db-musicbrainz:
+	psql -c 'CREATE SCHEMA IF NOT EXISTS musicbrainz'
+	for f in $(MUSICBRAINZ_SQL_FILES); do \
+	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/metabrainz/musicbrainz-server/master/admin/sql/$$f || exit 1; \
+	  echo; \
+	done | PGOPTIONS='-c search_path=musicbrainz,public -c client_min_messages=warning' psql
+
 .PHONY: test-scenario
 test-scenario:
 	bash test/scenario/run.sh
@@ -120,15 +173,30 @@ test-scenario:
 test-samples:
 	bash test/samples/run.sh
 
+# Every schema the samples create, plus public. Dropped one statement at a
+# time: cascading through all of them in a single transaction runs the server
+# out of lock table space, since musicbrainz alone owns ~1000 objects.
+SAMPLE_SCHEMAS = \
+	person humanresources production purchasing sales pe hr pr pu sa \
+	employees bookings gen cd musicbrainz public
+
 .PHONY: clean-schema
 clean-schema:
-	psql -c 'DROP SCHEMA IF EXISTS person, humanresources, production, purchasing, sales, employees, bookings, gen CASCADE ; DROP SCHEMA public CASCADE ; CREATE SCHEMA public'
+	for s in $(SAMPLE_SCHEMAS); do \
+	  psql -q -c "SET client_min_messages TO warning; DROP SCHEMA IF EXISTS $$s CASCADE" || exit 1; \
+	done
+	psql -q -c 'CREATE SCHEMA public'
 
 # Drop every user schema (not just public), so a prior sample's schemas can't
-# leak into the next check. Used by test-samples between samples.
+# leak into the next check. Used by test-samples between samples. One DROP per
+# psql statement, for the same lock table reason as clean-schema.
 .PHONY: reset-db
 reset-db:
-	psql -X -q -v ON_ERROR_STOP=1 -c "SET client_min_messages TO warning; DO \$$\$$ DECLARE s text; BEGIN FOR s IN SELECT nspname FROM pg_namespace WHERE nspname NOT LIKE 'pg_%' AND nspname <> 'information_schema' LOOP EXECUTE format('DROP SCHEMA IF EXISTS %I CASCADE', s); END LOOP; END \$$\$$; CREATE SCHEMA public"
+	psql -X -q -At -v ON_ERROR_STOP=1 -c "SELECT quote_ident(nspname) FROM pg_namespace WHERE nspname NOT LIKE 'pg_%' AND nspname <> 'information_schema'" \
+	  | while read -r s; do \
+	      psql -X -q -v ON_ERROR_STOP=1 -c "SET client_min_messages TO warning; DROP SCHEMA IF EXISTS $$s CASCADE" || exit 1; \
+	    done
+	psql -X -q -v ON_ERROR_STOP=1 -c 'CREATE SCHEMA public'
 
 .PHONY: demo
 demo: clean-schema


### PR DESCRIPTION
Extends the sample manifest from 15 to 20 real-world schemas, so `make test-samples` covers more of what pista's catalog reader and parser have to agree on.

## Added samples

| name | source | size | `pista -n` |
| --- | --- | --- | --- |
| `french_towns` | pgFoundry french-towns-communes-francaises | 3 tables | public |
| `iso_3166` | pgFoundry iso-3166 | 2 tables | public |
| `imdb` | gregrahn/join-order-benchmark (JOB) | 21 tables + FK indexes | public |
| `clubdata` | pgexercises.com | 3 tables, quoted index names containing dots | `cd` |
| `musicbrainz` | metabrainz/musicbrainz-server | 374 tables, 10 views, 7 enums | `musicbrainz` |

`french_towns` and `iso_3166` complete the pgFoundry dbsamples set and load with the existing `sample-db-tar` target. The other three need their own loaders:

- `sample-db-imdb`: tables and their indexes ship as two separate files, so concatenate them.
- `sample-db-clubdata`: the dump opens with `CREATE DATABASE exercises` / `\c exercises`, which cannot run mid-pipe. Strip those two lines; the rest creates the `cd` schema and sets search_path itself.
- `sample-db-musicbrainz`: the schema is split across one file per object kind and none of them create the schema or set search_path. Create `musicbrainz` up front, point search_path at it with `PGOPTIONS`, and concatenate the files in dependency order (extensions and the ICU collation first, since table definitions reference both; functions right after the tables, since CHECK constraints and views call them).

musicbrainz exercises collated columns, an `ll_to_earth()` expression index, and constraint names truncated at 63 characters. It round-trips with no drift.

## Teardown fix

Adding musicbrainz made `clean-schema` fail with `ERROR: out of shared memory` (`max_locks_per_transaction`): cascading through every sample in one transaction overflows the lock table, since musicbrainz alone owns ~1000 objects. `clean-schema` and `reset-db` now drop one schema per statement. While there, `clean-schema` picks up the schemas it was missing: adventureworks' `pe`/`hr`/`pr`/`pu`/`sa` aliases, plus the new `cd` and `musicbrainz`.

## Verification

Run against a postgres:18 container, matching the `samples` CI job.

- `make test-samples`: 20 passed, 0 failed
- `make schema` (all samples into one database): rc=0
- `make clean-schema`: leaves only `public`, and is idempotent on re-run
- `make lint` / `make vet`: clean
- The five new samples also round-trip on PostgreSQL 15

Note: `make schema` loads everything into one database, so `iso_3166`'s `country` collides with `world`'s `country`. This is the same situation as the existing pagila/dvdrental overlap and does not affect `test-samples`, which isolates each sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)