### PR TITLE
Mention the Terraform-like plan/apply workflow in the README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/winebarrel/pistachio/actions/workflows/ci.yml/badge.svg)](https://github.com/winebarrel/pistachio/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/winebarrel/pistachio/branch/main/graph/badge.svg?token=lWmtTkDrbz)](https://codecov.io/gh/winebarrel/pistachio)
 
-Declarative schema management tool for PostgreSQL, built on [pg_query_go](https://github.com/pganalyze/pg_query_go). Define the desired schema in SQL; pistachio generates the DDL diff.
+Declarative schema management tool for PostgreSQL with a Terraform-like plan/apply workflow, built on [pg_query_go](https://github.com/pganalyze/pg_query_go). Define the desired schema in SQL; pistachio generates the DDL diff.
 
 See also: [Getting Started Guide](getting-started.md) / [Directives](directives.md) / [Performance](performance.md) / [Sample Database Tests](sample-db-test.md)
 


### PR DESCRIPTION
Add "with a Terraform-like plan/apply workflow" to the README's opening description. The GitHub repo description has been updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)