### PR TITLE
Write down where drift matters and where it does not

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@
 
 Pistachio is a declarative schema management tool for PostgreSQL, written in Go. It parses desired schema definitions from SQL files and generates DDL diffs to bring the current database in line with the desired state.
 
+## Design policy
+
+`pista dump` output fed back as the desired schema must plan clean. A break in that round trip is a bug.
+
+Drift that appears only with a desired schema written some other way is low priority, since matching what `dump` writes avoids it.
+
 ## Build & test
 
 ```sh


### PR DESCRIPTION
Adds a Design policy section to AGENTS.md.

`pista dump` output fed back as the desired schema has to plan clean, and a break in that round trip is a bug. Drift that appears only with a desired schema written some other way is low priority, since matching what `dump` writes avoids it.

The trigger was the schema-qualified CHECK constraint entry in TODO.md. Confirmed against a local PostgreSQL: `pg_get_constraintdef` drops the qualification for a schema on the search_path, so `pista dump` never emits `public.lower_v(v)` and the round trip plans clean. Only a hand-written desired file hits the drift. The serial and `SELECT *` view entries in TODO.md fall in the same bucket.

CLAUDE.md is a symlink to AGENTS.md, so both pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QhNKuDKKb4ooGEBLKicgA