### PR TITLE
Say where normalization stops being worth it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ Pistachio is a declarative schema management tool for PostgreSQL, written in Go.
 
 Drift that appears only with a desired schema written some other way is low priority, since matching what `dump` writes avoids it.
 
+Avoid normalization that makes the diff complex.
+
 ## Build & test
 
 ```sh


### PR DESCRIPTION
The round-trip rule says which drift matters. It does not say how hard to work to remove the rest. A rule that needs the search_path, type inference, or name resolution the model does not carry is worth less than the TODO entry it would replace.


Claude-Session: https://claude.ai/code/session_019QhNKuDKKb4ooGEBLKicgA