### PR TITLE
Run every supported PostgreSQL version side by side

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
     # cross-built with mingw-w64 via goreleaser-cross (.goreleaser.yml).
     env:
       CGO_ENABLED: "1"
+      # The runner's PostgreSQL listens on the default port; the Makefile
+      # otherwise defaults to the port compose.yaml publishes locally.
+      PGPORT: "5432"
     steps:
       # Keep LF line endings; test fixtures are compared byte for byte.
       - run: git config --global core.autocrlf false
@@ -99,6 +102,10 @@ jobs:
       fail-fast: false
       matrix:
         postgres: [15, 16, 17, 18]
+    env:
+      # One version per job, so the service can keep the default port; the
+      # Makefile otherwise defaults to the port compose.yaml publishes locally.
+      PGPORT: "5432"
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}
@@ -134,6 +141,10 @@ jobs:
     # external host, loads it into an isolated database, then verifies that
     # `pista dump` plans back to "No changes". A diff means the catalog reader
     # and parser disagree.
+    env:
+      # The service keeps the default port; the Makefile otherwise defaults to
+      # the port compose.yaml publishes locally.
+      PGPORT: "5432"
     services:
       postgres:
         image: postgres:18

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,9 @@ make lint           # golangci-lint run
 make fix            # golangci-lint run --fix (auto-fix lint errors)
 ```
 
-- Tests require a running PostgreSQL instance (default: `postgres://postgres@localhost/postgres`, override with `TEST_PISTA_CONN_STR`).
+- Tests require a running PostgreSQL instance. `compose.yaml` publishes each version of the CI matrix on its own port (15 -> 5415, 16 -> 5416, 17 -> 5417, 18 -> 5418), so several can run side by side; `PGPORT` (default 5415) selects which one every `psql`- and test-based target uses. The Makefile builds `TEST_PISTA_CONN_STR` from it; set that variable to point somewhere else entirely.
 - Tests run with `-p 1` (sequential packages) because integration tests share a single database.
-- `make schema` and other `psql`-based targets rely on `PGHOST=localhost` / `PGUSER=postgres` (exported from the Makefile).
+- `make schema` and other `psql`-based targets rely on `PGHOST=localhost` / `PGUSER=postgres` / `PGPORT` (exported from the Makefile).
 
 ## Project structure
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
+# The server every psql- and test-based target talks to. compose.yaml
+# publishes each PostgreSQL version of the CI matrix on its own port, so all
+# four can run side by side and PGPORT picks which one is used: 5415 for 15,
+# 5416 for 16, 5417 for 17, 5418 for 18. Any other port works too (e.g.
+# PGPORT=5432 for a local install), and TEST_PISTA_CONN_STR bypasses both.
 export PGHOST := localhost
 export PGUSER := postgres
+export PGPORT ?= 5415
+
+TEST_PISTA_CONN_STR ?= postgres://postgres@localhost:$(PGPORT)/postgres
+export TEST_PISTA_CONN_STR
 
 # Ensure failures in any stage of a piped recipe (e.g. curl | awk | psql)
 # fail the target. Default /bin/sh on most systems lacks pipefail, so a

--- a/README.md
+++ b/README.md
@@ -831,6 +831,21 @@ docker compose up -d
 make test
 ```
 
+`compose.yaml` carries one service per PostgreSQL version in the CI matrix,
+each published on its own port, so several versions can run side by side:
+
+```bash
+docker compose up -d               # 15 only, on port 5415
+docker compose up -d pg17          # 17 only, on port 5417
+docker compose --profile all up -d # 15, 16, 17 and 18
+```
+
+`PGPORT` selects the one the tests use, and defaults to 5415:
+
+```bash
+make PGPORT=5417 test
+```
+
 ## Related projects
 
 - [ridgepole](https://github.com/ridgepole/ridgepole): DB schema

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,36 @@
+# One service per PostgreSQL version in the CI matrix, each on its own port
+# 54<version>, so several versions can run side by side and a test run picks
+# one by port. pg15 is the default and starts with a bare `up`; the others are
+# held back by a profile, which naming one on the command line also enables.
+#
+#   docker compose up -d              # 15 only
+#   docker compose up -d pg17         # 17 only
+#   docker compose --profile all up -d
+x-postgres: &postgres
+  environment:
+    POSTGRES_HOST_AUTH_METHOD: trust
+
 services:
-  postgresql:
-    image: postgres:${PG_VERSION:-15}
+  pg15:
+    <<: *postgres
+    image: postgres:15
     ports:
-      - "5432:5432"
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
+      - "5415:5432"
+  pg16:
+    <<: *postgres
+    image: postgres:16
+    profiles: ["all"]
+    ports:
+      - "5416:5432"
+  pg17:
+    <<: *postgres
+    image: postgres:17
+    profiles: ["all"]
+    ports:
+      - "5417:5432"
+  pg18:
+    <<: *postgres
+    image: postgres:18
+    profiles: ["all"]
+    ports:
+      - "5418:5432"

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -13,7 +13,10 @@ func ConnectDB(t *testing.T) *pgx.Conn {
 	t.Helper()
 	connString := os.Getenv("TEST_PISTA_CONN_STR")
 	if connString == "" {
-		connString = "postgres://postgres@localhost/postgres"
+		// The port compose.yaml publishes PostgreSQL 15 on. `make test`
+		// exports TEST_PISTA_CONN_STR built from PGPORT, so this default
+		// only applies to a bare `go test`.
+		connString = "postgres://postgres@localhost:5415/postgres"
 	}
 	conn, err := pgx.Connect(context.Background(), connString)
 	require.NoError(t, err)

--- a/test/samples/run.sh
+++ b/test/samples/run.sh
@@ -13,6 +13,7 @@ cd "$(dirname "$0")/../.."
 
 export PGHOST="${PGHOST:-localhost}"
 export PGUSER="${PGUSER:-postgres}"
+export PGPORT="${PGPORT:-5415}"
 
 : "${PISTA:=./pista}"
 

--- a/test/scenario/helper.sh
+++ b/test/scenario/helper.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 : "${PISTA:=./pista}"
-export PISTA_CONN_STR="${PISTA_CONN_STR:-${TEST_PISTA_CONN_STR:-postgres://postgres@localhost/postgres}}"
+export PISTA_CONN_STR="${PISTA_CONN_STR:-${TEST_PISTA_CONN_STR:-postgres://postgres@localhost:5415/postgres}}"
 
 _pass=0
 _fail=0


### PR DESCRIPTION
`compose.yaml` carried a single service on the default port, so checking a change against another major version meant editing the file or swapping the container out. Now each version of the CI matrix gets its own service on port `54<version>`, and they can all run at once.

```
docker compose up -d               # 15 only, on 5415
docker compose up -d pg17          # 17 only, on 5417
docker compose --profile all up -d # 15, 16, 17 and 18
```

15 is the bare `up` default; the others sit behind an `all` profile, which naming the service on the command line also enables, so no per-version profile is needed.

`PGPORT` (default 5415) picks which server every psql- and test-based Makefile target talks to, and `TEST_PISTA_CONN_STR` is built from it:

```
make PGPORT=5417 test
```

Both are `?=`, so a port outside compose's range works (`PGPORT=5432` for a local install) and a hand-set `TEST_PISTA_CONN_STR` still wins.

Since the default is no longer 5432, the fallbacks in `internal/testutil`, `test/scenario/helper.sh` and `test/samples/run.sh` follow it — those only apply to a bare `go test` or a script run outside make. The CI services keep the default port, so the workflow jobs set `PGPORT: "5432"` explicitly.

## Testing

`make test` and `make test-scenario` both pass against 5415 (PG15) and 5417 (PG17); scenarios 11/11 each. `make vet` and `make lint` are clean. `make test-samples` was not run, as it downloads the sample schemas from their external hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwYbYsukKPZDx47EY4dcNa