### PR TITLE
Say that corner cases do not come first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Drift that appears only with a desired schema written some other way is low prio
 
 Avoid normalization that makes the diff complex.
 
+Do not chase corner cases. A rare input is not worth an implementation that is hard to follow, and the schemas people actually write come first.
+
 ## Build & test
 
 ```sh


### PR DESCRIPTION
The design policy already ranks the `pista dump` round trip above drift that only shows up when the desired schema is written some other way, and warns off normalization that complicates the diff. Both say the same thing about complexity that buys little, but neither covers an input that is simply rare. This adds that line:

> Do not chase corner cases. A rare input is not worth an implementation that is hard to follow, and the schemas people actually write come first.

It is a statement of priority, not a rule against ever handling a rare input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwYbYsukKPZDx47EY4dcNa