### PR TITLE
Add six real-world sample schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,4 +162,14 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+      # The discourse sample declares `CREATE EXTENSION vector`, which the
+      # official image does not ship. Install pgvector from PGDG into the
+      # running service container; CREATE EXTENSION reads the control file when
+      # it is called, so the server does not need a restart. compose.yaml does
+      # the same for local runs.
+      - name: Install pgvector
+        run: |
+          cid=$(docker ps --filter ancestor=postgres:18 --format '{{.ID}}')
+          [ -n "$cid" ] || { echo "postgres service container not found" >&2; exit 1; }
+          docker exec -u root "$cid" bash -c 'apt-get update -qq && apt-get install -y -qq --no-install-recommends postgresql-18-pgvector'
       - run: make test-samples

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ ranger|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/ranger/
 ambari|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/ambari/0347dc4503c09b0593d9cb12815e2f9784b6a86a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql SCHEMA=ambari|ambari
 ovirt|sample-db-url-schema|URL=https://raw.githubusercontent.com/oVirt/ovirt-engine/be1f6647db1ebbf39186bbe4dd6b1a777376815b/packaging/dbscripts/create_tables.sql SCHEMA=ovirt|ovirt
 gitlab|sample-db-url-schema|URL=https://raw.githubusercontent.com/gitlabhq/gitlabhq/35e789d8f1173a11a7724ae360a80d1f19ec92dc/db/structure.sql SCHEMA=gitlab|gitlab,gitlab_partitions_static,gitlab_partitions_dynamic|--assume-validated
+ledgersmb|sample-db-url-schema|URL=https://raw.githubusercontent.com/ledgersmb/LedgerSMB/34a05e7b58c161e008561e36a74dbede860fe4d9/sql/Pg-database.sql SCHEMA=ledgersmb|ledgersmb
+koji|sample-db-url-schema|URL=https://raw.githubusercontent.com/koji-project/koji/c3239d46c1abdcbda509739eb0182031b71d9f01/schemas/schema.sql SCHEMA=koji|koji
+kea|sample-db-url-schema|URL=https://raw.githubusercontent.com/isc-projects/kea/82440eddc70089a55892a42ca96b78a92eb3e484/src/share/database/scripts/pgsql/dhcpdb_create.pgsql SCHEMA=kea CLIENT_MIN_MESSAGES=warning|kea
+dolphinscheduler|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/dolphinscheduler/51057477b815eef59c68f1b76563567814c72a93/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql SCHEMA=dolphinscheduler CLIENT_MIN_MESSAGES=warning|dolphinscheduler
+camunda|sample-db-camunda||camunda
+discourse|sample-db-discourse|URL=https://raw.githubusercontent.com/discourse/discourse/f3c568cfd26a427e9cae32063732a56bc7d334b9/db/structure.sql SCHEMA=discourse|discourse
 endef
 
 # Print the sample manifest, one record per line, for shell consumers.
@@ -259,6 +265,53 @@ sample-db-znuny:
 	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/znuny/Znuny/0b894348ebc458621545ccdab5f3d24d1b396a70/scripts/database/$$f || exit 1; \
 	  echo; \
 	done | PGOPTIONS='-c search_path=znuny' psql
+
+# Camunda 7 (camunda/camunda-bpm-platform, Apache-2.0). The schema ships as one
+# file per engine component and none of them create a schema, so create
+# `camunda` up front and concatenate the files in dependency order: the process
+# engine first, then history, identity, and the case and decision engines with
+# their history, each of which keys back into the tables the engine file
+# creates.
+CAMUNDA_SQL_FILES = \
+	activiti.postgres.create.engine.sql \
+	activiti.postgres.create.history.sql \
+	activiti.postgres.create.identity.sql \
+	activiti.postgres.create.case.engine.sql \
+	activiti.postgres.create.case.history.sql \
+	activiti.postgres.create.decision.engine.sql \
+	activiti.postgres.create.decision.history.sql
+
+.PHONY: sample-db-camunda
+sample-db-camunda:
+	psql -c 'CREATE SCHEMA IF NOT EXISTS camunda'
+	for f in $(CAMUNDA_SQL_FILES); do \
+	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/camunda/camunda-bpm-platform/ee4826e5e76c2348a1510ef46a2f4ccd3b080e48/engine/src/main/resources/org/camunda/bpm/engine/db/create/$$f || exit 1; \
+	  echo; \
+	done | PGOPTIONS='-c search_path=camunda' psql
+
+# Discourse (discourse/discourse, GPL-2.0). Like the sample-db-url-schema dumps
+# this one belongs in a schema of its own, but it is pg_dump output: it empties
+# search_path and qualifies every object it creates with `public`, so neither
+# PGOPTIONS nor the hive-style search_path rewrite reaches it. Drop the line
+# that empties search_path and strip the `public.` qualifier instead, which
+# leaves every name unqualified and lets search_path place it. The four
+# CREATE EXTENSION lines say `WITH SCHEMA public` without a dot, so they are
+# untouched and the types they own (halfvec, hstore, the trgm operator classes)
+# still resolve from `public`, which stays second in the search path. Column
+# names that merely start with "public" (`public`, `public_version`) are not
+# qualifiers and are left alone. The tail of the file is Rails' own
+# `SET search_path TO "$user", public` followed by the migration versions it
+# inserts into schema_migrations, which is data and would land in the wrong
+# schema anyway, so everything from that line on is dropped.
+#
+# The vector extension is pgvector, which the official postgres image does not
+# ship; compose.yaml and the samples CI job install it. See sample-db-test.md.
+.PHONY: sample-db-discourse
+sample-db-discourse:
+	psql -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'
+	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
+	  | sed -E "/^SELECT pg_catalog.set_config\('search_path', '', false\);\$$/d; /^SET search_path TO /,\$$d; s/^public\.//; s/([^A-Za-z0-9_])public\./\1/g" \
+	  | PGOPTIONS='-c search_path=$(SCHEMA),public' psql
 
 .PHONY: test-scenario
 test-scenario:

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,9 +6,22 @@
 #   docker compose up -d              # 15 only
 #   docker compose up -d pg17         # 17 only
 #   docker compose --profile all up -d
+#
+# The discourse sample declares `CREATE EXTENSION vector`, which the official
+# image does not ship, so install pgvector from PGDG before starting the
+# server. The image's entrypoint runs as root and drops to postgres itself, so
+# apt runs first and hands over with exec. Starting a container therefore needs
+# network access; the samples CI job installs the same package into its service
+# container.
 x-postgres: &postgres
   environment:
     POSTGRES_HOST_AUTH_METHOD: trust
+  entrypoint:
+    - bash
+    - -c
+    - >-
+      apt-get update -qq && apt-get install -y -qq --no-install-recommends
+      postgresql-$${PG_MAJOR}-pgvector && exec docker-entrypoint.sh postgres
 
 services:
   pg15:

--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -16,6 +16,14 @@ check. It needs a running PostgreSQL instance (`PGHOST=localhost`,
 `PGUSER=postgres`, exported by the Makefile), plus `psql`, `curl`, and network
 access to the upstream hosts. The same target runs in CI as the `samples` job.
 
+The server also needs pgvector, which the discourse sample's `halfvec` columns
+are typed by and the official postgres image does not ship. compose.yaml
+installs `postgresql-<major>-pgvector` from PGDG when a container starts, and
+the samples CI job installs the same package into its service container, so
+both keep the official image and add the extension to it. The runner checks for
+it up front and says so if it is missing; recreate the container with
+`docker compose down && docker compose up -d`.
+
 To load every sample into one database for manual inspection instead of
 checking them one at a time, use `make schema`.
 
@@ -99,10 +107,16 @@ the SHA in the Makefile, and re-run `make test-samples`.
 | ambari | ambari | [apache/ambari](https://github.com/apache/ambari) |
 | ovirt | ovirt | [oVirt/ovirt-engine](https://github.com/oVirt/ovirt-engine) |
 | gitlab | gitlab, gitlab_partitions_static, gitlab_partitions_dynamic | [gitlabhq/gitlabhq](https://github.com/gitlabhq/gitlabhq) |
+| ledgersmb | ledgersmb | [ledgersmb/LedgerSMB](https://github.com/ledgersmb/LedgerSMB) |
+| koji | koji | [koji-project/koji](https://github.com/koji-project/koji) |
+| kea | kea | [isc-projects/kea](https://github.com/isc-projects/kea) |
+| dolphinscheduler | dolphinscheduler | [apache/dolphinscheduler](https://github.com/apache/dolphinscheduler) |
+| camunda | camunda | [camunda/camunda-bpm-platform](https://github.com/camunda/camunda-bpm-platform) |
+| discourse | discourse | [discourse/discourse](https://github.com/discourse/discourse) |
 
 ## Coverage
 
-Object counts of the loaded schemas, as of 2026-08-05 on PostgreSQL 15.18
+Object counts of the loaded schemas, as of 2026-08-08 on PostgreSQL 15.18
 (16.13 for icingadb, rt, znuny, gitlab, hive, ranger, ambari, and ovirt).
 "Constraints" excludes foreign keys;
 "Types" counts enums and domains. All counts are limited to the schemas the
@@ -145,11 +159,18 @@ and pistachio does not read them either.
 | ambari | 113 | 693 | 172 | 124 | 140 | 0 | 0 |
 | ovirt | 152 | 1,386 | 377 | 165 | 167 | 1 | 0 |
 | gitlab | 1,422 | 14,293 | 6,353 | 2,325 | 3,949 | 15 | 0 |
-| **Total** | **3,113** | **26,992** | **10,161** | **4,576** | **6,605** | **84** | **35** |
+| ledgersmb | 158 | 950 | 263 | 247 | 265 | 1 | 0 |
+| koji | 68 | 415 | 150 | 183 | 159 | 0 | 0 |
+| kea | 64 | 475 | 172 | 73 | 71 | 0 | 0 |
+| dolphinscheduler | 64 | 623 | 149 | 0 | 80 | 0 | 0 |
+| camunda | 49 | 681 | 281 | 42 | 56 | 0 | 0 |
+| discourse | 354 | 3,173 | 1,114 | 23 | 336 | 1 | 2 |
+| **Total** | **3,870** | **33,309** | **12,290** | **5,144** | **7,572** | **86** | **35** |
 
-The 33 dumps come to about 59,000 lines of SQL, and gitlab is 27,600 of them.
-It is over half of the tables, columns, indexes, foreign keys, and constraints,
-and musicbrainz is the largest of what remains. gitlab is also why
+The 39 dumps come to about 71,800 lines of SQL, and gitlab is 27,600 of them.
+It is still over half of the indexes and constraints and around 40% of the
+tables, columns, and foreign keys; musicbrainz and discourse are the largest of
+what remains. gitlab is also why
 `clean-schema` drops tables a batch at a time rather than cascading through
 `DROP SCHEMA`: a single statement takes locks on every object it reaches, and
 gitlab's 1,422 tables and their indexes run the server out of lock table space
@@ -172,7 +193,11 @@ columns (ranger, whose 85 tables come with 84 of them), a schema written
 entirely in quoted mixed-case identifiers, so every name is case-sensitive
 (hive's 84 tables, where chinook has 11), an index-heavy schema of 192 indexes
 over 64 tables (mediawiki), partitioned tables at scale (gitlab declares 100 of them and
-attaches 2,054 partitions, all of which live in schemas of their own), and
+attaches 2,054 partitions, all of which live in schemas of their own), table
+inheritance (ledgersmb attaches 21 children with INHERITS, the only sample that
+does), four unique indexes declared `NULLS NOT DISTINCT` and one index with an
+`INCLUDE` column (discourse), columns typed by an extension that is not contrib
+(discourse's three `halfvec` columns, which need pgvector), and
 foreign keys that cross a schema boundary: 20 of adventureworks' 90 span its
 five schemas, 12 of mimiciv's 51 point from `mimiciv_icu` into `mimiciv_hosp`,
 and every one of gitlab's partitions is attached across one.
@@ -185,19 +210,37 @@ strip only what is irrelevant to a schema round trip:
 - **adventureworks**: `\copy` lines are dropped (the data lives in CSVs that are
   not fetched), along with the inline `Production.ProductReview` INSERT, whose
   foreign key targets would be missing.
+- **camunda**: the schema ships as one file per engine component and none of
+  them create a schema, so `camunda` is created up front and the files are
+  concatenated in dependency order (process engine, history, identity, then the
+  case and decision engines with their history).
 - **clubdata**: the dump creates its own database and reconnects to it, which
   cannot be done mid-pipe. Those two lines are dropped; the rest creates the
   `cd` schema itself.
 - **demodb**: `btree_gist` is created first for the `bookings.routes` exclusion
   constraint, and the `\copy` lines are dropped.
+- **discourse**: the dump belongs in a schema of its own like the group below,
+  but it is `pg_dump` output that empties `search_path` and qualifies every
+  object with `public`, so neither `PGOPTIONS` nor hive's one-line rewrite
+  reaches it. The line that empties `search_path` is dropped and the `public.`
+  qualifier is stripped, which leaves every name unqualified for `search_path`
+  to place. The four `CREATE EXTENSION` lines say `WITH SCHEMA public` without a
+  dot, so they are untouched and the types they own still resolve from `public`,
+  which stays second in the search path. The tail of the file is Rails' own
+  `SET search_path` followed by the migration versions it inserts into
+  `schema_migrations`, which is data, so everything from that line on is
+  dropped.
 - **hive**: the dump belongs in a schema of its own like the group below, but
   it is `pg_dump` output that sets `search_path` to `public` itself, which
   overrides anything `PGOPTIONS` passes in. That one line is rewritten to name
   the `hive` schema.
 - **imdb**: the schema and its foreign key indexes ship as two files, so
   `schema.sql` and `fkindexes.sql` are concatenated.
+- **kea**, **dolphinscheduler**: both dumps drop what they are about to create
+  with `IF EXISTS`, so `client_min_messages` is raised to `warning` for the load.
 - **mediawiki**, **synapse**, **temporal**, **icingadb**, **rt**, **znuny**,
-  **ranger**, **ambari**, **ovirt**, **gitlab**: these dumps name no schema at
+  **ranger**, **ambari**, **ovirt**, **gitlab**, **ledgersmb**, **koji**,
+  **kea**, **dolphinscheduler**: these dumps name no schema at
   all, so whichever schema comes first in `search_path` gets them. Each is
   loaded into a schema of its own instead of
   `public`, so that `make schema`, which puts every sample in one database, does

--- a/test/samples/run.sh
+++ b/test/samples/run.sh
@@ -65,6 +65,16 @@ check() {
   fi
 }
 
+# The discourse sample needs pgvector, which the official postgres image does
+# not ship. Say so up front: without this the sample fails at load time and the
+# reason is buried in psql's output.
+if [ -z "$(psql -X -q -At -c "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'")" ]; then
+  echo "pgvector is not installed on this server, and the discourse sample needs it." >&2
+  echo "compose.yaml installs it at container start; recreate the container with" >&2
+  echo "  docker compose down && docker compose up -d" >&2
+  exit 1
+fi
+
 echo "Building pista..."
 go build -o pista ./cmd/pista
 PISTA="./pista"


### PR DESCRIPTION
The sample check was 33 schemas and 3,113 tables, more than half of them gitlab's; without gitlab the next largest after musicbrainz was ovirt at 152. These six upstream schemas ship a plain PostgreSQL DDL, fill out that middle, and bring shapes no sample had. The totals become 39 schemas and 3,870 tables.

| Sample | Tables | Columns | Indexes | FKs | Constraints | Views | Types |
|---|---:|---:|---:|---:|---:|---:|---:|
| ledgersmb | 158 | 950 | 263 | 247 | 265 | 1 | 0 |
| koji | 68 | 415 | 150 | 183 | 159 | 0 | 0 |
| kea | 64 | 475 | 172 | 73 | 71 | 0 | 0 |
| dolphinscheduler | 64 | 623 | 149 | 0 | 80 | 0 | 0 |
| camunda | 49 | 681 | 281 | 42 | 56 | 0 | 0 |
| discourse | 354 | 3,173 | 1,114 | 23 | 336 | 1 | 2 |

ledgersmb is the first sample with table inheritance, attaching 21 children with `INHERITS`, and discourse the first with unique indexes declared `NULLS NOT DISTINCT`, an index with an `INCLUDE` column, and columns typed by an extension that is not contrib. koji, kea, and dolphinscheduler reuse `sample-db-url-schema` as they are; kea and dolphinscheduler only raise `client_min_messages`, since both dumps drop what they are about to create with `IF EXISTS`. camunda ships one file per engine component, so its loader concatenates them in dependency order the way znuny and musicbrainz do.

## discourse

discourse is `pg_dump` output that empties `search_path` and qualifies every object with `public`, so neither `PGOPTIONS` nor hive's one-line rewrite reaches it. Its loader drops the line that empties `search_path` and strips the `public.` qualifier, which leaves every name unqualified for `search_path` to place in the `discourse` schema. The four `CREATE EXTENSION` lines say `WITH SCHEMA public` without a dot, so they are untouched and the types they own still resolve from `public`, second in the search path. Column names that merely start with "public" (`public`, `public_version`) are not qualifiers and are left alone. The tail of the file is Rails' own `SET search_path` and the migration versions it inserts into `schema_migrations`, which is data, so everything from that line on is dropped.

## pgvector

discourse's three `halfvec` columns need pgvector, which the official postgres image does not ship. compose.yaml installs `postgresql-$PG_MAJOR-pgvector` from PGDG when a container starts, and the samples job installs the same package into its service container with `docker exec`, so both keep the official image rather than swap in another one. `CREATE EXTENSION` reads the control file when it is called, so the CI server needs no restart. run.sh checks for the extension up front, because without it only discourse fails and the reason is buried in psql's output.

Local containers therefore need network access at start. `docker compose down && docker compose up -d` picks the change up.

## Test

`make test-samples` reports 39 passed, 0 failed on PostgreSQL 15.18, and every new sample plans back to "No changes" on the first try, so nothing in pista had to change. `make schema` loads all 39 into one database and exits clean at 40 schemas and 3,916 tables, discourse included, even though an earlier sample has already taken hstore and pg_trgm into its own schema. `make vet` and `make lint` (0 issues) pass; no Go code changed.

The coverage counts in sample-db-test.md were remeasured for the new rows on 15.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUUSXBCfMCLXhTuEEbtxDf