### PR TITLE
Update CHANGELOG for version 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.26.0] - 2026-08-08
 
 * Fix `dump` dropping the `PARTITION BY` of a partition that is itself partitioned. The `CREATE TABLE` was finished right after the `PARTITION OF ... FOR VALUES` clause, so the middle level of a multi-level partitioned table was written as a leaf, and reloading that dump failed at the level below it, which still said `PARTITION OF` that table. The same code builds the `CREATE TABLE` a plan emits, so adding such a partition through `apply` created it unpartitioned and the partition under it failed with `is not partitioned`. The partition key is read from the catalog and parsed from the desired schema either way; it was only left out of the output.
 


### PR DESCRIPTION
This pull request updates the changelog to document a bug fix related to multi-level partitioned tables. The fix ensures that the `dump` command correctly preserves the `PARTITION BY` clause for partitions that are themselves partitioned, preventing errors during reloads or when adding partitions via `apply`.

Changelog update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3): Added an entry for version `1.26.0` (2026-08-08) describing a fix for `dump` dropping the `PARTITION BY` clause of a partitioned partition, which previously caused reload and `apply` failures.