### PR TITLE
Add the wso2apim sample schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ koji|sample-db-url-schema|URL=https://raw.githubusercontent.com/koji-project/koj
 kea|sample-db-url-schema|URL=https://raw.githubusercontent.com/isc-projects/kea/82440eddc70089a55892a42ca96b78a92eb3e484/src/share/database/scripts/pgsql/dhcpdb_create.pgsql SCHEMA=kea CLIENT_MIN_MESSAGES=warning|kea
 dolphinscheduler|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/dolphinscheduler/51057477b815eef59c68f1b76563567814c72a93/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql SCHEMA=dolphinscheduler CLIENT_MIN_MESSAGES=warning|dolphinscheduler
 camunda|sample-db-camunda||camunda
+wso2apim|sample-db-url-schema|URL=https://raw.githubusercontent.com/wso2/carbon-apimgt/5dd6e3084a35228b7542c4ff6a9071af1c7476fa/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/sql/postgresql.sql SCHEMA=wso2apim CLIENT_MIN_MESSAGES=warning|wso2apim
 discourse|sample-db-discourse|URL=https://raw.githubusercontent.com/discourse/discourse/f3c568cfd26a427e9cae32063732a56bc7d334b9/db/structure.sql SCHEMA=discourse|discourse
 endef
 
@@ -157,9 +158,10 @@ sample-db-mimiciv:
 # gets its own schema instead.
 #
 # CLIENT_MIN_MESSAGES defaults to notice, the server default; a sample whose
-# dump is noisy on a fresh database can raise it from its SAMPLES record. Only
-# ranger does, which drops every object with IF EXISTS and commits outside a
-# transaction before it creates anything.
+# dump is noisy on a fresh database can raise it from its SAMPLES record. kea,
+# dolphinscheduler, and wso2apim raise it to warning, since each drops what it
+# is about to create with IF EXISTS, and ranger to error, since it does the same
+# and commits outside a transaction, which adds a warning per statement.
 CLIENT_MIN_MESSAGES ?= notice
 
 .PHONY: sample-db-url-schema

--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -112,6 +112,7 @@ the SHA in the Makefile, and re-run `make test-samples`.
 | kea | kea | [isc-projects/kea](https://github.com/isc-projects/kea) |
 | dolphinscheduler | dolphinscheduler | [apache/dolphinscheduler](https://github.com/apache/dolphinscheduler) |
 | camunda | camunda | [camunda/camunda-bpm-platform](https://github.com/camunda/camunda-bpm-platform) |
+| wso2apim | wso2apim | [wso2/carbon-apimgt](https://github.com/wso2/carbon-apimgt) |
 | discourse | discourse | [discourse/discourse](https://github.com/discourse/discourse) |
 
 ## Coverage
@@ -164,13 +165,14 @@ and pistachio does not read them either.
 | kea | 64 | 475 | 172 | 73 | 71 | 0 | 0 |
 | dolphinscheduler | 64 | 623 | 149 | 0 | 80 | 0 | 0 |
 | camunda | 49 | 681 | 281 | 42 | 56 | 0 | 0 |
+| wso2apim | 247 | 1,495 | 421 | 168 | 353 | 0 | 0 |
 | discourse | 354 | 3,173 | 1,114 | 23 | 336 | 1 | 2 |
-| **Total** | **3,870** | **33,309** | **12,290** | **5,144** | **7,572** | **86** | **35** |
+| **Total** | **4,117** | **34,804** | **12,711** | **5,312** | **7,925** | **86** | **35** |
 
-The 39 dumps come to about 71,800 lines of SQL, and gitlab is 27,600 of them.
-It is still over half of the indexes and constraints and around 40% of the
-tables, columns, and foreign keys; musicbrainz and discourse are the largest of
-what remains. gitlab is also why
+The 40 dumps come to about 75,900 lines of SQL, and gitlab is 27,600 of them.
+It is still half of the indexes and constraints and over a third of the tables,
+columns, and foreign keys; musicbrainz, discourse, and wso2apim are the largest
+of what remains. gitlab is also why
 `clean-schema` drops tables a batch at a time rather than cascading through
 `DROP SCHEMA`: a single statement takes locks on every object it reaches, and
 gitlab's 1,422 tables and their indexes run the server out of lock table space
@@ -189,7 +191,8 @@ installed at once), materialized views (adventureworks, pagila), tsvector
 columns (dvdrental, pagila), a non-default
 collation (musicbrainz), composite types (ovirt declares 10 of them, more than
 any other sample, and sourcegraph 2), standalone sequences rather than serial
-columns (ranger, whose 85 tables come with 84 of them), a schema written
+columns (ranger, whose 85 tables come with 84 of them, and wso2apim, which
+mixes 104 of them in with serial columns), a schema written
 entirely in quoted mixed-case identifiers, so every name is case-sensitive
 (hive's 84 tables, where chinook has 11), an index-heavy schema of 192 indexes
 over 64 tables (mediawiki), partitioned tables at scale (gitlab declares 100 of them and
@@ -236,11 +239,12 @@ strip only what is irrelevant to a schema round trip:
   the `hive` schema.
 - **imdb**: the schema and its foreign key indexes ship as two files, so
   `schema.sql` and `fkindexes.sql` are concatenated.
-- **kea**, **dolphinscheduler**: both dumps drop what they are about to create
-  with `IF EXISTS`, so `client_min_messages` is raised to `warning` for the load.
+- **kea**, **dolphinscheduler**, **wso2apim**: each dump drops what it is about
+  to create with `IF EXISTS`, so `client_min_messages` is raised to `warning`
+  for the load.
 - **mediawiki**, **synapse**, **temporal**, **icingadb**, **rt**, **znuny**,
   **ranger**, **ambari**, **ovirt**, **gitlab**, **ledgersmb**, **koji**,
-  **kea**, **dolphinscheduler**: these dumps name no schema at
+  **kea**, **dolphinscheduler**, **wso2apim**: these dumps name no schema at
   all, so whichever schema comes first in `search_path` gets them. Each is
   loaded into a schema of its own instead of
   `public`, so that `make schema`, which puts every sample in one database, does


### PR DESCRIPTION
Adds WSO2 API Manager to the sample database check.

Outside gitlab, musicbrainz, and discourse, no sample reached 200 tables. WSO2
API Manager ([wso2/carbon-apimgt](https://github.com/wso2/carbon-apimgt)) ships
its PostgreSQL DDL as one plain file, which fills that gap: 247 tables, 1,495
columns, 421 indexes, 168 foreign keys, and 353 other constraints. The totals
become 40 schemas and 4,117 tables.

The dump names no schema, so it loads through `sample-db-url-schema` like the
other single-file dumps and needs no loader of its own. It only raises
`client_min_messages` to warning, since it drops what it is about to create
with `IF EXISTS`. It is also the sample with the most standalone sequences,
104, which it mixes in with serial columns where ranger uses them throughout.

The Makefile comment on `CLIENT_MIN_MESSAGES` still said ranger was the only
sample that raises it, which kea and dolphinscheduler had already made stale,
so it now names all four and says why each one raises it.

`make test-samples` passes on PostgreSQL 15.18 and 18: 40 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nv7w41jx51xTsPsiogZ2Zg