### PR TITLE
Add four real-world sample schemas, and count sequences in the coverage table

### DIFF
--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -122,60 +122,63 @@ the SHA in `sample-db.mk`, and re-run `make test-samples`.
 ## Coverage
 
 Object counts of the loaded schemas, as of 2026-08-08 on PostgreSQL 15.18
-(16.13 for icingadb, rt, znuny, gitlab, hive, ranger, ambari, and ovirt).
-"Constraints" excludes foreign keys;
-"Types" counts enums and domains. All counts are limited to the schemas the
-sample is checked with, and exclude what an extension owns: the two views
-`pg_stat_statements` adds to sourcegraph's schema are not sourcegraph's schema
-and pistachio does not read them either.
+(16.13 for icingadb, rt, znuny, gitlab, hive, ranger, ambari, and ovirt; the
+Sequences column was counted on 15.18 throughout). "Constraints" excludes
+foreign keys; "Types" counts enums and domains; "Sequences" counts standalone
+sequences only, since pistachio manages the sequence behind a serial or
+identity column as an attribute of that column rather than as an object of its
+own. Counting those too would add 1,996 more, 886 of them gitlab's. All counts
+are limited to the schemas the sample is checked with, and exclude what an
+extension owns: the two views `pg_stat_statements` adds to sourcegraph's schema
+are not sourcegraph's schema and pistachio does not read them either.
 
-| Sample | Tables | Columns | Indexes | FKs | Constraints | Views | Types |
-|---|---:|---:|---:|---:|---:|---:|---:|
-| chinook | 11 | 64 | 21 | 11 | 11 | 0 | 0 |
-| dvdrental | 15 | 86 | 32 | 18 | 16 | 7 | 2 |
-| happiness_index | 1 | 9 | 1 | 0 | 1 | 0 | 0 |
-| lego | 8 | 28 | 6 | 0 | 6 | 0 | 0 |
-| netflix | 1 | 12 | 1 | 0 | 1 | 0 | 0 |
-| pagila | 22 | 129 | 55 | 36 | 23 | 8 | 3 |
-| periodic_table | 1 | 28 | 1 | 0 | 1 | 0 | 0 |
-| titanic | 1 | 21 | 1 | 0 | 1 | 0 | 0 |
-| world | 3 | 24 | 3 | 2 | 4 | 0 | 0 |
-| usda | 10 | 67 | 15 | 10 | 9 | 0 | 0 |
-| dellstore2 | 8 | 52 | 11 | 3 | 5 | 0 | 0 |
-| french_towns | 3 | 14 | 9 | 2 | 9 | 0 | 0 |
-| iso_3166 | 2 | 7 | 2 | 1 | 2 | 0 | 0 |
-| northwind | 14 | 92 | 14 | 13 | 14 | 0 | 0 |
-| employees | 6 | 24 | 9 | 6 | 6 | 0 | 1 |
-| mimiciv | 31 | 342 | 67 | 51 | 24 | 0 | 0 |
-| mediawiki | 64 | 389 | 192 | 0 | 60 | 0 | 1 |
-| synapse | 134 | 624 | 236 | 14 | 86 | 0 | 0 |
-| temporal | 37 | 217 | 44 | 0 | 40 | 0 | 0 |
-| icingadb | 66 | 634 | 179 | 7 | 74 | 0 | 13 |
-| rt | 38 | 407 | 88 | 1 | 38 | 0 | 0 |
-| sourcegraph | 180 | 1,715 | 453 | 362 | 273 | 18 | 8 |
-| imdb | 21 | 108 | 44 | 0 | 21 | 0 | 0 |
-| adventureworks | 68 | 456 | 71 | 90 | 157 | 21 | 0 |
-| clubdata | 3 | 19 | 10 | 3 | 3 | 0 | 0 |
-| demodb | 9 | 45 | 15 | 8 | 21 | 3 | 0 |
-| musicbrainz | 374 | 2,469 | 907 | 770 | 1,032 | 10 | 7 |
-| znuny | 126 | 1,103 | 326 | 286 | 190 | 0 | 0 |
-| hive | 84 | 546 | 141 | 55 | 91 | 0 | 0 |
-| ranger | 85 | 889 | 305 | 213 | 130 | 1 | 0 |
-| ambari | 113 | 693 | 172 | 124 | 140 | 0 | 0 |
-| ovirt | 152 | 1,386 | 377 | 165 | 167 | 1 | 0 |
-| gitlab | 1,422 | 14,293 | 6,353 | 2,325 | 3,949 | 15 | 0 |
-| ledgersmb | 158 | 950 | 263 | 247 | 265 | 1 | 0 |
-| koji | 68 | 415 | 150 | 183 | 159 | 0 | 0 |
-| kea | 64 | 475 | 172 | 73 | 71 | 0 | 0 |
-| dolphinscheduler | 64 | 623 | 149 | 0 | 80 | 0 | 0 |
-| camunda | 49 | 681 | 281 | 42 | 56 | 0 | 0 |
-| wso2apim | 247 | 1,495 | 421 | 168 | 353 | 0 | 0 |
-| discourse | 354 | 3,173 | 1,114 | 23 | 336 | 1 | 2 |
-| icinga_director | 121 | 872 | 381 | 171 | 236 | 0 | 21 |
-| flowable | 62 | 844 | 222 | 60 | 66 | 0 | 0 |
-| ejabberd | 42 | 258 | 78 | 5 | 15 | 0 | 0 |
-| guacamole | 23 | 104 | 61 | 30 | 29 | 0 | 5 |
-| **Total** | **4,365** | **36,882** | **13,453** | **5,578** | **8,271** | **86** | **61** |
+| Sample | Tables | Columns | Indexes | FKs | Constraints | Views | Types | Sequences |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| chinook | 11 | 64 | 21 | 11 | 11 | 0 | 0 | 0 |
+| dvdrental | 15 | 86 | 32 | 18 | 16 | 7 | 2 | 13 |
+| happiness_index | 1 | 9 | 1 | 0 | 1 | 0 | 0 | 0 |
+| lego | 8 | 28 | 6 | 0 | 6 | 0 | 0 | 0 |
+| netflix | 1 | 12 | 1 | 0 | 1 | 0 | 0 | 0 |
+| pagila | 22 | 129 | 55 | 36 | 23 | 8 | 3 | 13 |
+| periodic_table | 1 | 28 | 1 | 0 | 1 | 0 | 0 | 0 |
+| titanic | 1 | 21 | 1 | 0 | 1 | 0 | 0 | 0 |
+| world | 3 | 24 | 3 | 2 | 4 | 0 | 0 | 0 |
+| usda | 10 | 67 | 15 | 10 | 9 | 0 | 0 | 0 |
+| dellstore2 | 8 | 52 | 11 | 3 | 5 | 0 | 0 | 0 |
+| french_towns | 3 | 14 | 9 | 2 | 9 | 0 | 0 | 0 |
+| iso_3166 | 2 | 7 | 2 | 1 | 2 | 0 | 0 | 0 |
+| northwind | 14 | 92 | 14 | 13 | 14 | 0 | 0 | 0 |
+| employees | 6 | 24 | 9 | 6 | 6 | 0 | 1 | 0 |
+| mimiciv | 31 | 342 | 67 | 51 | 24 | 0 | 0 | 0 |
+| mediawiki | 64 | 389 | 192 | 0 | 60 | 0 | 1 | 0 |
+| synapse | 134 | 624 | 236 | 14 | 86 | 0 | 0 | 10 |
+| temporal | 37 | 217 | 44 | 0 | 40 | 0 | 0 | 0 |
+| icingadb | 66 | 634 | 179 | 7 | 74 | 0 | 13 | 0 |
+| rt | 38 | 407 | 88 | 1 | 38 | 0 | 0 | 32 |
+| sourcegraph | 180 | 1,715 | 453 | 362 | 273 | 18 | 8 | 1 |
+| imdb | 21 | 108 | 44 | 0 | 21 | 0 | 0 | 0 |
+| adventureworks | 68 | 456 | 71 | 90 | 157 | 21 | 0 | 0 |
+| clubdata | 3 | 19 | 10 | 3 | 3 | 0 | 0 | 0 |
+| demodb | 9 | 45 | 15 | 8 | 21 | 3 | 0 | 0 |
+| musicbrainz | 374 | 2,469 | 907 | 770 | 1,032 | 10 | 7 | 0 |
+| znuny | 126 | 1,103 | 326 | 286 | 190 | 0 | 0 | 0 |
+| hive | 84 | 546 | 141 | 55 | 91 | 0 | 0 | 0 |
+| ranger | 85 | 889 | 305 | 213 | 130 | 1 | 0 | 84 |
+| ambari | 113 | 693 | 172 | 124 | 140 | 0 | 0 | 0 |
+| ovirt | 152 | 1,386 | 377 | 165 | 167 | 1 | 0 | 9 |
+| gitlab | 1,422 | 14,293 | 6,353 | 2,325 | 3,949 | 15 | 0 | 8 |
+| ledgersmb | 158 | 950 | 263 | 247 | 265 | 1 | 0 | 2 |
+| koji | 68 | 415 | 150 | 183 | 159 | 0 | 0 | 0 |
+| kea | 64 | 475 | 172 | 73 | 71 | 0 | 0 | 0 |
+| dolphinscheduler | 64 | 623 | 149 | 0 | 80 | 0 | 0 | 30 |
+| camunda | 49 | 681 | 281 | 42 | 56 | 0 | 0 | 0 |
+| wso2apim | 247 | 1,495 | 421 | 168 | 353 | 0 | 0 | 104 |
+| discourse | 354 | 3,173 | 1,114 | 23 | 336 | 1 | 2 | 0 |
+| icinga_director | 121 | 872 | 381 | 171 | 236 | 0 | 21 | 0 |
+| flowable | 62 | 844 | 222 | 60 | 66 | 0 | 0 | 0 |
+| ejabberd | 42 | 258 | 78 | 5 | 15 | 0 | 0 | 0 |
+| guacamole | 23 | 104 | 61 | 30 | 29 | 0 | 5 | 0 |
+| **Total** | **4,365** | **36,882** | **13,453** | **5,578** | **8,271** | **86** | **61** | **306** |
 
 The 44 dumps come to about 81,100 lines of SQL, and gitlab is 27,600 of them.
 It is still nearly half of the indexes and constraints, a third of the tables,

--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -114,6 +114,10 @@ the SHA in `sample-db.mk`, and re-run `make test-samples`.
 | camunda | camunda | [camunda/camunda-bpm-platform](https://github.com/camunda/camunda-bpm-platform) |
 | wso2apim | wso2apim | [wso2/carbon-apimgt](https://github.com/wso2/carbon-apimgt) |
 | discourse | discourse | [discourse/discourse](https://github.com/discourse/discourse) |
+| icinga_director | icinga_director | [Icinga/icingaweb2-module-director](https://github.com/Icinga/icingaweb2-module-director) |
+| flowable | flowable | [flowable/flowable-engine](https://github.com/flowable/flowable-engine) |
+| ejabberd | ejabberd | [processone/ejabberd](https://github.com/processone/ejabberd) |
+| guacamole | guacamole | [apache/guacamole-client](https://github.com/apache/guacamole-client) |
 
 ## Coverage
 
@@ -167,12 +171,16 @@ and pistachio does not read them either.
 | camunda | 49 | 681 | 281 | 42 | 56 | 0 | 0 |
 | wso2apim | 247 | 1,495 | 421 | 168 | 353 | 0 | 0 |
 | discourse | 354 | 3,173 | 1,114 | 23 | 336 | 1 | 2 |
-| **Total** | **4,117** | **34,804** | **12,711** | **5,312** | **7,925** | **86** | **35** |
+| icinga_director | 121 | 872 | 381 | 171 | 236 | 0 | 21 |
+| flowable | 62 | 844 | 222 | 60 | 66 | 0 | 0 |
+| ejabberd | 42 | 258 | 78 | 5 | 15 | 0 | 0 |
+| guacamole | 23 | 104 | 61 | 30 | 29 | 0 | 5 |
+| **Total** | **4,365** | **36,882** | **13,453** | **5,578** | **8,271** | **86** | **61** |
 
-The 40 dumps come to about 75,900 lines of SQL, and gitlab is 27,600 of them.
-It is still half of the indexes and constraints and over a third of the tables,
-columns, and foreign keys; musicbrainz, discourse, and wso2apim are the largest
-of what remains. gitlab is also why
+The 44 dumps come to about 81,100 lines of SQL, and gitlab is 27,600 of them.
+It is still nearly half of the indexes and constraints, a third of the tables,
+and about 40 percent of the columns and foreign keys; musicbrainz, discourse,
+and wso2apim are the largest of what remains. gitlab is also why
 `clean-schema` drops tables a batch at a time rather than cascading through
 `DROP SCHEMA`: a single statement takes locks on every object it reaches, and
 gitlab's 1,422 tables and their indexes run the server out of lock table space
@@ -184,7 +192,11 @@ always reach: partial and expression indexes and gin, gist, hash, and brin
 methods (musicbrainz, plus 12 partial and 2 gin indexes in synapse), exclusion
 constraints and unlogged tables (demodb, which needs `btree_gist`), enums and
 domains (dvdrental, pagila, employees, mediawiki, and icingadb, whose 13 types
-are 6 enums and 7 domains, each domain carrying a named CHECK), unique indexes
+are 6 enums and 7 domains, each domain carrying a named CHECK, plus
+icinga_director, whose 20 enums are more than any other sample and whose one
+domain carries two anonymous CHECKs, and guacamole's 5 enums), foreign keys
+that all declare their referential actions (all 171 of icinga_director's name
+both ON UPDATE and ON DELETE, in six combinations), unique indexes
 over an expression and a gin index over `to_tsvector` (rt), columns typed by a
 contrib extension (sourcegraph, with 49 `citext` columns, and six extensions
 installed at once), materialized views (adventureworks, pagila), tsvector
@@ -244,7 +256,8 @@ strip only what is irrelevant to a schema round trip:
   for the load.
 - **mediawiki**, **synapse**, **temporal**, **icingadb**, **rt**, **znuny**,
   **ranger**, **ambari**, **ovirt**, **gitlab**, **ledgersmb**, **koji**,
-  **kea**, **dolphinscheduler**, **wso2apim**: these dumps name no schema at
+  **kea**, **dolphinscheduler**, **wso2apim**, **icinga_director**,
+  **flowable**, **ejabberd**, **guacamole**: these dumps name no schema at
   all, so whichever schema comes first in `search_path` gets them. Each is
   loaded into a schema of its own instead of
   `public`, so that `make schema`, which puts every sample in one database, does

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -57,6 +57,10 @@ dolphinscheduler|sample-db-url-schema|URL=https://raw.githubusercontent.com/apac
 camunda|sample-db-camunda||camunda
 wso2apim|sample-db-url-schema|URL=https://raw.githubusercontent.com/wso2/carbon-apimgt/5dd6e3084a35228b7542c4ff6a9071af1c7476fa/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/sql/postgresql.sql SCHEMA=wso2apim CLIENT_MIN_MESSAGES=warning|wso2apim
 discourse|sample-db-discourse|URL=https://raw.githubusercontent.com/discourse/discourse/f3c568cfd26a427e9cae32063732a56bc7d334b9/db/structure.sql SCHEMA=discourse|discourse
+icinga_director|sample-db-url-schema|URL=https://raw.githubusercontent.com/Icinga/icingaweb2-module-director/b2e4a4e4180b0a160461a773ca8b8b5874e0fba7/schema/pgsql.sql SCHEMA=icinga_director|icinga_director
+flowable|sample-db-url-schema|URL=https://raw.githubusercontent.com/flowable/flowable-engine/53e93b6681e86dccea720efaa3c0fc2a96f57366/distro/sql/create/all/flowable.postgres.all.create.sql SCHEMA=flowable|flowable
+ejabberd|sample-db-url-schema|URL=https://raw.githubusercontent.com/processone/ejabberd/f42a49c1e83ad2399743dd46c6cf1e43d39d303b/sql/pg.new.sql SCHEMA=ejabberd|ejabberd
+guacamole|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/guacamole-client/5be18be1eeadc4cc544c737c54bd761261d2ad65/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql SCHEMA=guacamole|guacamole
 endef
 
 # Print the sample manifest, one record per line, for shell consumers.


### PR DESCRIPTION
## Samples

Four more real-world schemas for `make test-samples`. Each is a single SQL file
that names no schema, so all four reuse `sample-db-url-schema` and none needs a
rewrite on the way in. Every source is pinned to the tip of its default branch.

| Sample | Tables | Columns | Indexes | FKs | Constraints | Types | Source |
|---|---:|---:|---:|---:|---:|---:|---|
| icinga_director | 121 | 872 | 381 | 171 | 236 | 21 | Icinga/icingaweb2-module-director |
| flowable | 62 | 844 | 222 | 60 | 66 | 0 | flowable/flowable-engine |
| ejabberd | 42 | 258 | 78 | 5 | 15 | 0 | processone/ejabberd |
| guacamole | 23 | 104 | 61 | 30 | 29 | 5 | apache/guacamole-client |

icinga_director is the reason for the group. Its 20 enums are more than any
other sample, its one domain carries two anonymous CHECKs where icingadb's
carry one named CHECK each, and every one of its 171 foreign keys declares both
ON UPDATE and ON DELETE, in six combinations. No other sample states a
referential action that consistently.

apache/linkis was considered and left out. Its `linkis_ddl_pg.sql` carries
MySQL leftovers, and an unbalanced `USING btree (keywords(191);` swallows the
rest of the file into one statement, so 24 of its 77 tables load and the round
trip passes on a third of the schema.

## Sequences column

The coverage table said nothing about sequences, though pistachio reads and
diffs them. The new column counts standalone sequences only, matching what the
catalog reader treats as an object: a sequence a serial or identity column owns
is managed as an attribute of that column. Eleven samples have any, 306 in
total, with wso2apim's 104 and ranger's 84 most of it. The definition
reproduces the counts the page already quoted in prose for those two samples.

## Test

`make test-samples` on PostgreSQL 15.18: 44 passed, 0 failed. All four new
samples load without a single error from psql.