### PR TITLE
Update Go to 1.27 and orderedmap to v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Weekly, matching what the default setup ran on.
+    - cron: '21 3 * * 0'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # The CodeQL Go extractor runs go tooling with GOTOOLCHAIN=local, so it
+      # cannot download the toolchain go.mod asks for. Install that version
+      # ourselves before init, or extraction fails whenever the runner image
+      # ships an older Go than go.mod requires.
+      - if: matrix.language == 'go'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          category: /language:${{ matrix.language }}

--- a/catalog/composite_types.go
+++ b/catalog/composite_types.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/catalog/domains.go
+++ b/catalog/domains.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/catalog/enums.go
+++ b/catalog/enums.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/catalog/sequences.go
+++ b/catalog/sequences.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/catalog/tables.go
+++ b/catalog/tables.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/catalog/views.go
+++ b/catalog/views.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/composite_types.go
+++ b/diff/composite_types.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/composite_types_test.go
+++ b/diff/composite_types_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/diff"
 	"github.com/winebarrel/pistachio/model"
 )

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/diff"
 	"github.com/winebarrel/pistachio/model"
 )

--- a/diff/enums.go
+++ b/diff/enums.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/diff"
 	"github.com/winebarrel/pistachio/model"
 )

--- a/diff/persistence_test.go
+++ b/diff/persistence_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/policies.go
+++ b/diff/policies.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/policies_test.go
+++ b/diff/policies_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/internal/pgast"
 	"github.com/winebarrel/pistachio/model"
 )

--- a/diff/rename_test.go
+++ b/diff/rename_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/sequences.go
+++ b/diff/sequences.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/sequences_test.go
+++ b/diff/sequences_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/diff"
 	"github.com/winebarrel/pistachio/model"
 )

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/internal/pgast"
 	"github.com/winebarrel/pistachio/model"
 	"google.golang.org/protobuf/proto"

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -6,7 +6,7 @@ import (
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff/views.go
+++ b/diff/views.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/internal/pgast"
 	"github.com/winebarrel/pistachio/model"
 )

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/diff_all.go
+++ b/diff_all.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/catalog"
 	"github.com/winebarrel/pistachio/diff"
 	"github.com/winebarrel/pistachio/model"

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio"
 	"github.com/winebarrel/pistachio/diff"
 	"github.com/winebarrel/pistachio/model"

--- a/dump.go
+++ b/dump.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/catalog"
 	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/toposort"

--- a/dump_test.go
+++ b/dump_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio"
 	"github.com/winebarrel/pistachio/internal/testutil"
 	"github.com/winebarrel/pistachio/model"

--- a/export_test.go
+++ b/export_test.go
@@ -1,7 +1,7 @@
 package pistachio
 
 import (
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/filter.go
+++ b/filter.go
@@ -1,7 +1,7 @@
 package pistachio
 
 import (
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/pganalyze/pg_query_go/v6 v6.2.2
 	github.com/stretchr/testify v1.12.0
-	github.com/winebarrel/orderedmap v1.7.0
 	github.com/winebarrel/orderedmap/v2 v2.0.0
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v3 v3.0.1
@@ -18,6 +17,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/winebarrel/linkedlist v1.0.0 // indirect
 	golang.org/x/mod v0.39.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/winebarrel/pistachio
 
-go 1.26
+go 1.27
 
 require (
 	github.com/alecthomas/kong v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
 github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
-github.com/winebarrel/orderedmap v1.7.0 h1:SWe+CApXxqqWiXT+G9KoSy15YMNzgJbBMNU4IhP15rA=
-github.com/winebarrel/orderedmap v1.7.0/go.mod h1:/LvVD4ZrMGgzoV9UkbzWSTy1yGVjnBImC6SmJvH1eeM=
+github.com/winebarrel/linkedlist v1.0.0 h1:O0xX3QprOQx7nzjybWiqzmAFslEAr5OlN4Erw0SGu7w=
+github.com/winebarrel/linkedlist v1.0.0/go.mod h1:q0tVx3lAnFjUE7qUzWo9sR3LVUQ3sLNZ4Ccm50AnxX4=
+github.com/winebarrel/orderedmap/v2 v2.0.0 h1:HARE+qAmkwMQ3Wl6bCwMxB+RKPPv6tNaTG4EYJQ/w/Q=
 github.com/winebarrel/orderedmap/v2 v2.0.0/go.mod h1:q3cXdPJW6JJ2+g3IVSkqRD+56aXF/rWYdi+IfMHm55U=
 golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
 golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=

--- a/model/composite_type.go
+++ b/model/composite_type.go
@@ -3,7 +3,7 @@ package model
 import (
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 )
 
 // CompositeAttribute is one field of a composite type (CREATE TYPE ... AS (...)).

--- a/model/composite_type_test.go
+++ b/model/composite_type_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/model/domain.go
+++ b/model/domain.go
@@ -3,7 +3,7 @@ package model
 import (
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 )
 
 type DomainConstraint struct {

--- a/model/domain_test.go
+++ b/model/domain_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/model/enum.go
+++ b/model/enum.go
@@ -3,7 +3,7 @@ package model
 import (
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 )
 
 type Enum struct {

--- a/model/enum_test.go
+++ b/model/enum_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/model/sequence.go
+++ b/model/sequence.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 )
 
 // Sequence holds metadata for a standalone PostgreSQL sequence (one created by

--- a/model/sequence_test.go
+++ b/model/sequence_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/model/table.go
+++ b/model/table.go
@@ -4,7 +4,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 )
 
 type Table struct {

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/model/view.go
+++ b/model/view.go
@@ -3,7 +3,7 @@ package model
 import (
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 )
 
 type View struct {

--- a/model/view_test.go
+++ b/model/view_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -10,7 +10,7 @@ import (
 	"unicode/utf8"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/parser/policy.go
+++ b/parser/policy.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/parser/validate.go
+++ b/parser/validate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/internal/pgast"
 	"github.com/winebarrel/pistachio/model"
 )

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/remap.go
+++ b/remap.go
@@ -3,7 +3,7 @@ package pistachio
 import (
 	"strings"
 
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/schema_filter.go
+++ b/schema_filter.go
@@ -1,7 +1,7 @@
 package pistachio
 
 import (
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/parser"
 )

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 )
 

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/winebarrel/orderedmap"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/toposort"
 )


### PR DESCRIPTION
Three related changes.

**Update Go to 1.27.** `go.mod` moves from `go 1.26` to `go 1.27`. No new language features are used, so this is only a floor bump.

**Switch imports to `orderedmap/v2`.** The v2 module was already required in `go.mod` (#397) but nothing imported it, so `go mod tidy` kept dropping it. This rewrites the 49 files that import it. The public API of v1.7.0 and v2.0.0 is identical; v2 only replaces the internal `container/list` plus type assertions with a generic `linkedlist.List[*Pair[K, V]]`, so no call sites change. `github.com/winebarrel/linkedlist` is picked up as an indirect dependency.

**Run CodeQL from a workflow.** The Go bump broke CodeQL, which was on default setup:

```
go: go.mod requires go >= 1.27 (running go 1.26.6; GOTOOLCHAIN=local)
```

The default setup autobuild uses the Go preinstalled on the runner and sets `GOTOOLCHAIN=local`, so it cannot pick up the toolchain `go.mod` asks for, and extraction fails whenever the runner image ships an older Go. CI does not hit this because it runs `actions/setup-go` with `go-version-file: go.mod`.

`.github/workflows/codeql.yml` switches to advanced setup and does the same, running `setup-go` before `codeql-action/init` on the Go job. It keeps the coverage default setup had: both `actions` and `go`, on push to main, on pull requests, and weekly. Default setup has been disabled on the repository, since the two cannot be enabled at once.

Verified with `make build`, `make vet`, and `make test` against PostgreSQL 15. One pre-existing failure, `TestApply_ExecuteFirstCheckSQLError`, reproduces on `main` and is unrelated.
