### PR TITLE
Fix possible by not specifying a USER, a program in the container may run as 'root' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,7 @@ FROM alpine:3
 RUN apk add --no-cache ca-certificates
 
 COPY --from=build /src/pista /usr/local/bin/
+RUN adduser -D -u 1000 app
+USER app
 
 ENTRYPOINT ["pista"]


### PR DESCRIPTION
Small change to `Dockerfile` — a scan flagged the code below and it looked genuine. It is around line 19.

The Dockerfile does not set a USER directive, so the container’s main process (pista) runs as root. Running as root provides unrestricted privileges inside the container; an attacker who can control the process could take full control of the container. This is an improper privilege management issue (CWE‑269) and poses a high security risk.

Added a non‑root USER to prevent the container from running as root.

For reference: rule `dockerfile.security.missing-user-entrypoint.missing-user-entrypoint`, [CWE-269 (Improper Privilege Management)](https://cwe.mitre.org/data/definitions/269.html). Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
