### PR TITLE
Build the image with Go 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS build
+FROM golang:1.27-alpine AS build
 
 RUN apk add --no-cache gcc musl-dev
 


### PR DESCRIPTION
`go.mod` has required `go 1.27` since #400, but the builder stage was still `golang:1.26-alpine`. The build kept working only because the image lets Go fetch a newer toolchain on its own, which is a download on every build.

Verified with `docker build` and by running `pista --version` from the resulting image.
