### PR TITLE
Build the demo image with Go 1.27

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -6,7 +6,7 @@
 # Run:
 #   docker run --rm -it pistachio-demo
 #
-FROM golang:1.26-alpine AS build
+FROM golang:1.27-alpine AS build
 RUN apk add --no-cache gcc musl-dev
 WORKDIR /src
 COPY go.* /src/


### PR DESCRIPTION
The same bump #404 made to the release image. `demo/Dockerfile` was the last `golang:1.26-alpine` left, and `go.mod` has required `go 1.27` since #400, so the builder was fetching a toolchain of its own on every build.

Verified with `docker build -f demo/Dockerfile` and by running `pista --version` from the resulting image.
