### PR TITLE
Give the app user a working directory it can write to

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ RUN apk add --no-cache ca-certificates
 COPY --from=build /src/pista /usr/local/bin/
 RUN adduser -D -u 1000 app
 USER app
+WORKDIR /home/app
 
 ENTRYPOINT ["pista"]


### PR DESCRIPTION
#401 made the image run as `app` instead of root, but the final stage has no `WORKDIR`, so the cwd stays `/`. Alpine ships that root-owned and 755, and `app` cannot write there:

```
$ docker run --rm --entrypoint sh pista -c 'id; pwd; touch ./out.sql'
uid=1000(app) gid=1000(app) groups=1000(app)
/
touch: ./out.sql: Permission denied
```

So anything writing relative to the cwd fails, `dump --split` among them. It worked before #401 because root could write to `/`.

`adduser -D` already created `/home/app` owned by `app`, so this just points `WORKDIR` at it. Nothing new to create.

Verified by building the image and checking that the cwd is `/home/app`, that `touch ./out.sql` succeeds there, and that the CLI still starts.
