### PR TITLE
Name the container user pistachio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ FROM alpine:3
 RUN apk add --no-cache ca-certificates
 
 COPY --from=build /src/pista /usr/local/bin/
-RUN adduser -D -u 1000 app
-USER app
-WORKDIR /home/app
+RUN adduser -D -u 1000 pistachio
+USER pistachio
+WORKDIR /home/pistachio
 
 ENTRYPOINT ["pista"]


### PR DESCRIPTION
Renames the container user #401 added from `app` to `pistachio`, and moves `WORKDIR` with it. The uid stays 1000.

Verified by building the image and checking the user, the cwd and that writing there still works:

```
uid=1000(pistachio) gid=1000(pistachio) groups=1000(pistachio)
/home/pistachio
write ok
```
