### PR TITLE
Drop the ca-certificates install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN CGO_ENABLED=1 go build -o pista -ldflags "-X main.version=${PISTA_VERSION#v}
 
 FROM alpine:3
 
-RUN apk add --no-cache ca-certificates
-
 COPY --from=build /src/pista /usr/local/bin/
 RUN adduser -D -u 1000 app
 USER app


### PR DESCRIPTION
`alpine:3` already has `ca-certificates-bundle` installed, and that is what provides `/etc/ssl/certs/ca-certificates.crt`, the first path Go's `crypto/x509` reads its roots from on Linux. Installing `ca-certificates` on top leaves that file untouched:

```
--- installed ca pkgs (base) ---
ca-certificates-bundle
--- bundle before ---
303c2fae18d81c0b78fcbadea85b0074  /etc/ssl/certs/ca-certificates.crt
--- bundle after ---
303c2fae18d81c0b78fcbadea85b0074  /etc/ssl/certs/ca-certificates.crt
```

A CGO-enabled Go binary dropped into a plain `alpine:3` verifies fine without it:

```
system roots: 119
tls verify ok
```

What the package does add is `update-ca-certificates`, `c_rehash` and the individual `/usr/share/ca-certificates/mozilla/*.crt` files, which matter only for installing extra CAs into the image. pista connects out to PostgreSQL, so `sslmode=verify-ca` and `verify-full` against a publicly trusted certificate work off the bundle alone.

The image goes from 54.8MB to 53.3MB.

Worth noting for anyone relying on it: if you mount a private CA into `/usr/local/share/ca-certificates/` and run `update-ca-certificates`, that command is gone after this. Passing the CA through `sslrootcert` in the connection string still works.
