### PR TITLE
Record the Docker image changes in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Move to `orderedmap/v2`. The API is unchanged, so the CLI behaves the same, but the exported models hold `orderedmap.Map` and code that imports pistachio as a library has to switch import paths too.
 
+* Run the Docker image as `pistachio` (uid 1000) instead of root. A bind mount it writes to has to be writable by that uid, or pass `docker run --user`.
+
+* Drop `ca-certificates` from the Docker image. `alpine:3` already ships the bundle Go reads its roots from. `update-ca-certificates` goes with it.
+
 ## [1.27.0] - 2026-08-23
 
 * Name an index written without one, the way PostgreSQL names it. `CREATE INDEX ON public.items (qty)` reached the diff with an empty name, which matched no index in the database, so every run planned the index again and PostgreSQL numbered each copy: three `apply` runs left `items_qty_idx`, `items_qty_idx1` and `items_qty_idx2` behind, and the plan never came back empty. The name follows `ChooseRelationName`: the table, then one name per index element joined with underscores, then `_idx`, shortened by `makeObjectName` when it does not fit. An element is named after its column, and an expression after the function it calls (`(lower(c))` gives `t_lower_idx`), a field selection's field, the column under a subscript, a cast's type, or `CASE`, falling back to `expr` for anything with no name of its own; the `INCLUDE` list joins the name too, and a name repeated within one index takes a number. Two unnamed indexes that produce one name are now rejected as a duplicate index name, which PostgreSQL would have resolved by numbering the second.


### PR DESCRIPTION
Two entries for what landed in the Docker image since v1.27.0: the non-root user from #401, #406 and #407, and the `ca-certificates` removal from #408.

The Go 1.27 builder bumps (#404, #405) are already covered by the "Require Go 1.27 to build" entry. The CodeQL workflow is left out, since it only changes CI.
