### PR TITLE
Add the dotcms and osm samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,14 +162,14 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      # The discourse sample declares `CREATE EXTENSION vector`, which the
-      # official image does not ship. Install pgvector from PGDG into the
-      # running service container; CREATE EXTENSION reads the control file when
-      # it is called, so the server does not need a restart. compose.yaml does
-      # the same for local runs.
-      - name: Install pgvector
+      # The discourse sample declares `CREATE EXTENSION vector` and the osm
+      # sample `CREATE EXTENSION postgis`, neither of which the official image
+      # ships. Install both from PGDG into the running service container;
+      # CREATE EXTENSION reads the control file when it is called, so the server
+      # does not need a restart. compose.yaml does the same for local runs.
+      - name: Install pgvector and PostGIS
         run: |
           cid=$(docker ps --filter ancestor=postgres:18 --format '{{.ID}}')
           [ -n "$cid" ] || { echo "postgres service container not found" >&2; exit 1; }
-          docker exec -u root "$cid" bash -c 'apt-get update -qq && apt-get install -y -qq --no-install-recommends postgresql-18-pgvector'
+          docker exec -u root "$cid" bash -c 'apt-get update -qq && apt-get install -y -qq --no-install-recommends postgresql-18-pgvector postgresql-18-postgis-3'
       - run: make test-samples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * Drop `ca-certificates` from the Docker image. `alpine:3` already ships the bundle Go reads its roots from. `update-ca-certificates` goes with it.
 
+* Compare a type modifier without regard to case. PostgreSQL downcases an unquoted keyword in a modifier as it parses the DDL, while `format_type` prints it the way the type writes it back, so a PostGIS `geometry(Polygon,4326)` column planned `SET DATA TYPE geometry(polygon,4326)` on every run, and a domain over the same type failed with `cannot change base type`.
+
 ## [1.27.0] - 2026-08-23
 
 * Name an index written without one, the way PostgreSQL names it. `CREATE INDEX ON public.items (qty)` reached the diff with an empty name, which matched no index in the database, so every run planned the index again and PostgreSQL numbered each copy: three `apply` runs left `items_qty_idx`, `items_qty_idx1` and `items_qty_idx2` behind, and the plan never came back empty. The name follows `ChooseRelationName`: the table, then one name per index element joined with underscores, then `_idx`, shortened by `makeObjectName` when it does not fit. An element is named after its column, and an expression after the function it calls (`(lower(c))` gives `t_lower_idx`), a field selection's field, the column under a subscript, a cast's type, or `CASE`, falling back to `expr` for anything with no name of its own; the `INCLUDE` list joins the name too, and a name repeated within one index takes a number. Two unnamed indexes that produce one name are now rejected as a duplicate index name, which PostgreSQL would have resolved by numbering the second.

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,12 +7,12 @@
 #   docker compose up -d pg17         # 17 only
 #   docker compose --profile all up -d
 #
-# The discourse sample declares `CREATE EXTENSION vector`, which the official
-# image does not ship, so install pgvector from PGDG before starting the
-# server. The image's entrypoint runs as root and drops to postgres itself, so
-# apt runs first and hands over with exec. Starting a container therefore needs
-# network access; the samples CI job installs the same package into its service
-# container.
+# The discourse sample declares `CREATE EXTENSION vector` and the osm sample
+# `CREATE EXTENSION postgis`, neither of which the official image ships, so
+# install pgvector and PostGIS from PGDG before starting the server. The image's
+# entrypoint runs as root and drops to postgres itself, so apt runs first and
+# hands over with exec. Starting a container therefore needs network access; the
+# samples CI job installs the same packages into its service container.
 x-postgres: &postgres
   environment:
     POSTGRES_HOST_AUTH_METHOD: trust
@@ -21,7 +21,8 @@ x-postgres: &postgres
     - -c
     - >-
       apt-get update -qq && apt-get install -y -qq --no-install-recommends
-      postgresql-$${PG_MAJOR}-pgvector && exec docker-entrypoint.sh postgres
+      postgresql-$${PG_MAJOR}-pgvector postgresql-$${PG_MAJOR}-postgis-3
+      && exec docker-entrypoint.sh postgres
 
 services:
   pg15:

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -67,8 +67,10 @@ func DiffDomains(current, desired *orderedmap.Map[string, *model.Domain], dc Dro
 func diffDomain(fqdn string, current, desired *model.Domain) ([]string, error) {
 	var stmts []string
 
-	// Base type change is not supported by PostgreSQL ALTER DOMAIN
-	if current.BaseType != desired.BaseType {
+	// Base type change is not supported by PostgreSQL ALTER DOMAIN. The
+	// modifier is folded first, so a base type the catalog reports in mixed
+	// case (geometry(Polygon,4326)) matches the declaration it was read from.
+	if foldTypeMod(current.BaseType) != foldTypeMod(desired.BaseType) {
 		return nil, fmt.Errorf("cannot change base type of domain %s from %s to %s: PostgreSQL does not support this", fqdn, current.BaseType, desired.BaseType)
 	}
 

--- a/diff/domains_test.go
+++ b/diff/domains_test.go
@@ -171,6 +171,16 @@ func TestDiffDomains_BaseTypeChange_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot change base type")
 }
 
+func TestDiffDomains_BaseTypeModCaseOnly_NoChange(t *testing.T) {
+	// The catalog reports the modifier the way the type writes it back, the
+	// desired schema the way PostgreSQL parsed it. The base type is the same.
+	current := newDomainMap(&model.Domain{Schema: "public", Name: "zone", BaseType: "geometry(Polygon,4326)"})
+	desired := newDomainMap(&model.Domain{Schema: "public", Name: "zone", BaseType: "geometry(polygon,4326)"})
+	result, err := diff.DiffDomains(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Stmts)
+}
+
 func TestDiffDomains_AddComment(t *testing.T) {
 	comment := "Positive int"
 	current := newDomainMap(&model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"})

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -1278,8 +1278,8 @@ var serialBaseTypes = map[string]string{
 
 // equalTypeName compares two type names, treating serial types as equal to their base types.
 func equalTypeName(a, b, schema string) bool {
-	a = stripTypeSchema(a, schema)
-	b = stripTypeSchema(b, schema)
+	a = foldTypeMod(stripTypeSchema(a, schema))
+	b = foldTypeMod(stripTypeSchema(b, schema))
 	if a == b {
 		return true
 	}
@@ -1290,6 +1290,22 @@ func equalTypeName(a, b, schema string) bool {
 		return t
 	}
 	return normalize(a) == normalize(b)
+}
+
+// foldTypeMod lowercases a type name's modifier, leaving the type name itself
+// alone. PostgreSQL downcases an unquoted keyword in a modifier as it parses
+// the DDL, while format_type prints the modifier the way the type writes it
+// back, which need not be lower case: a column declared
+// `geometry(Polygon,4326)` reads back from the catalog with the capital P that
+// PostGIS gives it, and the desired side of the same declaration reaches the
+// diff as `geometry(polygon,4326)`. The type name is left as it is, since it
+// is case-sensitive when quoted.
+func foldTypeMod(typeName string) string {
+	i := strings.Index(typeName, "(")
+	if i < 0 {
+		return typeName
+	}
+	return typeName[:i] + strings.ToLower(typeName[i:])
 }
 
 // stripTypeSchema removes a redundant "<schema>." qualifier from a column type

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -347,6 +347,18 @@ func TestDiffColumns_alterType(t *testing.T) {
 	assert.Equal(t, "ALTER TABLE public.users ALTER COLUMN name SET DATA TYPE text;", stmts[0])
 }
 
+func TestDiffColumns_typeModCaseOnly_noChange(t *testing.T) {
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("zone", &model.Column{Name: "zone", TypeName: "geometry(Polygon,4326)"})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("zone", &model.Column{Name: "zone", TypeName: "geometry(polygon,4326)"})
+
+	stmts, _, _, err := diffColumns("public.moderation_zones", current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
 func TestDiffColumns_alterType_withCollation(t *testing.T) {
 	current := orderedmap.New[string, *model.Column]()
 	current.Set("name", &model.Column{Name: "name", TypeName: "varchar(100)"})
@@ -1228,6 +1240,26 @@ func TestEqualTypeName(t *testing.T) {
 	assert.False(t, equalTypeName("public.addr", "public.other", "public"))
 	// A quoted schema qualifier is stripped too.
 	assert.True(t, equalTypeName(`"My Schema".addr`, "addr", `"My Schema"`))
+	// The catalog reports a modifier the way the type writes it back, which
+	// need not match the case PostgreSQL parsed the declaration with.
+	assert.True(t, equalTypeName("geometry(Polygon,4326)", "geometry(polygon,4326)", "public"))
+	assert.True(t, equalTypeName("geometry(Polygon,4326)[]", "geometry(polygon,4326)[]", "public"))
+	assert.True(t, equalTypeName("public.geometry(Polygon,4326)", "geometry(polygon,4326)", "public"))
+	assert.False(t, equalTypeName("geometry(Polygon,4326)", "geometry(point,4326)", "public"))
+	// The type name is not folded, so two quoted names differing in case are
+	// still two types.
+	assert.False(t, equalTypeName(`"Addr"`, `"addr"`, "public"))
+}
+
+func TestFoldTypeMod(t *testing.T) {
+	assert.Equal(t, "geometry(polygon,4326)", foldTypeMod("geometry(Polygon,4326)"))
+	// A type name without a modifier is untouched, quoted or not.
+	assert.Equal(t, "integer", foldTypeMod("integer"))
+	assert.Equal(t, `"MyType"`, foldTypeMod(`"MyType"`))
+	// Only the modifier is folded; the type name keeps its case.
+	assert.Equal(t, `"MyType"(3)`, foldTypeMod(`"MyType"(3)`))
+	// An array bound follows the modifier and is folded with it.
+	assert.Equal(t, "geometry(polygon,4326)[]", foldTypeMod("geometry(Polygon,4326)[]"))
 }
 
 func TestSchemaOf(t *testing.T) {

--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -16,12 +16,13 @@ check. It needs a running PostgreSQL instance (`PGHOST=localhost`,
 `PGUSER=postgres`, exported by the Makefile), plus `psql`, `curl`, and network
 access to the upstream hosts. The same target runs in CI as the `samples` job.
 
-The server also needs pgvector, which the discourse sample's `halfvec` columns
-are typed by and the official postgres image does not ship. compose.yaml
-installs `postgresql-<major>-pgvector` from PGDG when a container starts, and
-the samples CI job installs the same package into its service container, so
-both keep the official image and add the extension to it. The runner checks for
-it up front and says so if it is missing; recreate the container with
+The server also needs pgvector for the discourse sample's `halfvec` columns and
+PostGIS for the osm sample's `geometry` column. The official postgres image
+ships neither. compose.yaml installs `postgresql-<major>-pgvector` and
+`postgresql-<major>-postgis-3` from PGDG when a container starts, and the
+samples CI job installs the same packages into its service container, so both
+keep the official image and add the extensions to it. The runner checks for them
+up front and says so if one is missing; recreate the container with
 `docker compose down && docker compose up -d`.
 
 To load every sample into one database for manual inspection instead of
@@ -118,6 +119,8 @@ the SHA in `sample-db.mk`, and re-run `make test-samples`.
 | flowable | flowable | [flowable/flowable-engine](https://github.com/flowable/flowable-engine) |
 | ejabberd | ejabberd | [processone/ejabberd](https://github.com/processone/ejabberd) |
 | guacamole | guacamole | [apache/guacamole-client](https://github.com/apache/guacamole-client) |
+| dotcms | dotcms | [dotCMS/core](https://github.com/dotCMS/core) |
+| osm | osm | [openstreetmap/openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website) |
 
 ## Coverage
 
@@ -178,9 +181,11 @@ are not sourcegraph's schema and pistachio does not read them either.
 | flowable | 62 | 844 | 222 | 60 | 66 | 0 | 0 | 0 |
 | ejabberd | 42 | 258 | 78 | 5 | 15 | 0 | 0 | 0 |
 | guacamole | 23 | 104 | 61 | 30 | 29 | 0 | 5 | 0 |
-| **Total** | **4,365** | **36,882** | **13,453** | **5,578** | **8,271** | **86** | **61** | **306** |
+| dotcms | 167 | 1,373 | 346 | 113 | 190 | 0 | 0 | 22 |
+| osm | 57 | 391 | 155 | 71 | 55 | 0 | 8 | 0 |
+| **Total** | **4,589** | **38,646** | **13,954** | **5,762** | **8,516** | **86** | **69** | **328** |
 
-The 44 dumps come to about 81,100 lines of SQL, and gitlab is 27,600 of them.
+The 46 dumps come to about 87,600 lines of SQL, and gitlab is 27,600 of them.
 It is still nearly half of the indexes and constraints, a third of the tables,
 and about 40 percent of the columns and foreign keys; musicbrainz, discourse,
 and wso2apim are the largest of what remains. gitlab is also why
@@ -202,7 +207,9 @@ that all declare their referential actions (all 171 of icinga_director's name
 both ON UPDATE and ON DELETE, in six combinations), unique indexes
 over an expression and a gin index over `to_tsvector` (rt), columns typed by a
 contrib extension (sourcegraph, with 49 `citext` columns, and six extensions
-installed at once), materialized views (adventureworks, pagila), tsvector
+installed at once), two gist indexes that name an `inet_ops` operator class and
+one over four columns, which needs `btree_gist` (osm), materialized
+views (adventureworks, pagila), tsvector
 columns (dvdrental, pagila), a non-default
 collation (musicbrainz), composite types (ovirt declares 10 of them, more than
 any other sample, and sourcegraph 2), standalone sequences rather than serial
@@ -215,7 +222,9 @@ attaches 2,054 partitions, all of which live in schemas of their own), table
 inheritance (ledgersmb attaches 21 children with INHERITS, the only sample that
 does), four unique indexes declared `NULLS NOT DISTINCT` and one index with an
 `INCLUDE` column (discourse), columns typed by an extension that is not contrib
-(discourse's three `halfvec` columns, which need pgvector), and
+(discourse's three `halfvec` columns, which need pgvector, and osm's one
+`geometry(Polygon,4326)` column, which needs PostGIS and is the only type
+modifier any sample reports in mixed case), and
 foreign keys that cross a schema boundary: 20 of adventureworks' 90 span its
 five schemas, 12 of mimiciv's 51 point from `mimiciv_icu` into `mimiciv_hosp`,
 and every one of gitlab's partitions is attached across one.
@@ -237,17 +246,17 @@ strip only what is irrelevant to a schema round trip:
   `cd` schema itself.
 - **demodb**: `btree_gist` is created first for the `bookings.routes` exclusion
   constraint, and the `\copy` lines are dropped.
-- **discourse**: the dump belongs in a schema of its own like the group below,
-  but it is `pg_dump` output that empties `search_path` and qualifies every
-  object with `public`, so neither `PGOPTIONS` nor hive's one-line rewrite
-  reaches it. The line that empties `search_path` is dropped and the `public.`
-  qualifier is stripped, which leaves every name unqualified for `search_path`
-  to place. The four `CREATE EXTENSION` lines say `WITH SCHEMA public` without a
-  dot, so they are untouched and the types they own still resolve from `public`,
-  which stays second in the search path. The tail of the file is Rails' own
-  `SET search_path` followed by the migration versions it inserts into
-  `schema_migrations`, which is data, so everything from that line on is
-  dropped.
+- **discourse**, **osm**: both ship their schema as Rails' `db/structure.sql`,
+  which belongs in a schema of its own like the group below but is `pg_dump`
+  output that empties `search_path` and qualifies every object with `public`, so
+  neither `PGOPTIONS` nor hive's one-line rewrite reaches it. The line that
+  empties `search_path` is dropped and the `public.` qualifier is stripped,
+  which leaves every name unqualified for `search_path` to place. The `CREATE
+  EXTENSION` lines say `WITH SCHEMA public` without a dot, so they are untouched
+  and the types they own still resolve from `public`, which stays second in the
+  search path. The tail of the file is Rails' own `SET search_path` followed by
+  the migration versions it inserts into `schema_migrations`, which is data, so
+  everything from that line on is dropped.
 - **hive**: the dump belongs in a schema of its own like the group below, but
   it is `pg_dump` output that sets `search_path` to `public` itself, which
   overrides anything `PGOPTIONS` passes in. That one line is rewritten to name
@@ -260,9 +269,9 @@ strip only what is irrelevant to a schema round trip:
 - **mediawiki**, **synapse**, **temporal**, **icingadb**, **rt**, **znuny**,
   **ranger**, **ambari**, **ovirt**, **gitlab**, **ledgersmb**, **koji**,
   **kea**, **dolphinscheduler**, **wso2apim**, **icinga_director**,
-  **flowable**, **ejabberd**, **guacamole**: these dumps name no schema at
-  all, so whichever schema comes first in `search_path` gets them. Each is
-  loaded into a schema of its own instead of
+  **flowable**, **ejabberd**, **guacamole**, **dotcms**: these dumps name no
+  schema at all, so whichever schema comes first in `search_path` gets them.
+  Each is loaded into a schema of its own instead of
   `public`, so that `make schema`, which puts every sample in one database, does
   not stack them on top of the other public samples (mediawiki and pagila both
   define `actor` and `category`). gitlab creates `gitlab_partitions_static` and

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -56,11 +56,13 @@ kea|sample-db-url-schema|URL=https://raw.githubusercontent.com/isc-projects/kea/
 dolphinscheduler|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/dolphinscheduler/51057477b815eef59c68f1b76563567814c72a93/dolphinscheduler-dao/src/main/resources/sql/dolphinscheduler_postgresql.sql SCHEMA=dolphinscheduler CLIENT_MIN_MESSAGES=warning|dolphinscheduler
 camunda|sample-db-camunda||camunda
 wso2apim|sample-db-url-schema|URL=https://raw.githubusercontent.com/wso2/carbon-apimgt/5dd6e3084a35228b7542c4ff6a9071af1c7476fa/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/sql/postgresql.sql SCHEMA=wso2apim CLIENT_MIN_MESSAGES=warning|wso2apim
-discourse|sample-db-discourse|URL=https://raw.githubusercontent.com/discourse/discourse/f3c568cfd26a427e9cae32063732a56bc7d334b9/db/structure.sql SCHEMA=discourse|discourse
+discourse|sample-db-pgdump-schema|URL=https://raw.githubusercontent.com/discourse/discourse/f3c568cfd26a427e9cae32063732a56bc7d334b9/db/structure.sql SCHEMA=discourse|discourse
 icinga_director|sample-db-url-schema|URL=https://raw.githubusercontent.com/Icinga/icingaweb2-module-director/b2e4a4e4180b0a160461a773ca8b8b5874e0fba7/schema/pgsql.sql SCHEMA=icinga_director|icinga_director
 flowable|sample-db-url-schema|URL=https://raw.githubusercontent.com/flowable/flowable-engine/53e93b6681e86dccea720efaa3c0fc2a96f57366/distro/sql/create/all/flowable.postgres.all.create.sql SCHEMA=flowable|flowable
 ejabberd|sample-db-url-schema|URL=https://raw.githubusercontent.com/processone/ejabberd/f42a49c1e83ad2399743dd46c6cf1e43d39d303b/sql/pg.new.sql SCHEMA=ejabberd|ejabberd
 guacamole|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/guacamole-client/5be18be1eeadc4cc544c737c54bd761261d2ad65/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql SCHEMA=guacamole|guacamole
+dotcms|sample-db-url-schema|URL=https://raw.githubusercontent.com/dotCMS/core/b0095c0c3920e236efcc16ceb136cd5dd88804b7/dotCMS/src/main/resources/postgres.sql SCHEMA=dotcms|dotcms
+osm|sample-db-pgdump-schema|URL=https://raw.githubusercontent.com/openstreetmap/openstreetmap-website/9da0fa5ecbff8adc5e6e91c7cf22546755a91f77/db/structure.sql SCHEMA=osm|osm
 endef
 
 # Print the sample manifest, one record per line, for shell consumers.
@@ -245,25 +247,27 @@ sample-db-camunda:
 	  echo; \
 	done | PGOPTIONS='-c search_path=camunda' psql
 
-# Discourse (discourse/discourse, GPL-2.0). Like the sample-db-url-schema dumps
-# this one belongs in a schema of its own, but it is pg_dump output: it empties
+# A pg_dump-style dump loaded into a schema of its own. discourse and osm ship
+# their schema as Rails' db/structure.sql, which belongs in a schema of its own
+# like the sample-db-url-schema dumps but is pg_dump output: it empties
 # search_path and qualifies every object it creates with `public`, so neither
 # PGOPTIONS nor the hive-style search_path rewrite reaches it. Drop the line
 # that empties search_path and strip the `public.` qualifier instead, which
-# leaves every name unqualified and lets search_path place it. The four
-# CREATE EXTENSION lines say `WITH SCHEMA public` without a dot, so they are
-# untouched and the types they own (halfvec, hstore, the trgm operator classes)
-# still resolve from `public`, which stays second in the search path. Column
-# names that merely start with "public" (`public`, `public_version`) are not
-# qualifiers and are left alone. The tail of the file is Rails' own
-# `SET search_path TO "$user", public` followed by the migration versions it
-# inserts into schema_migrations, which is data and would land in the wrong
-# schema anyway, so everything from that line on is dropped.
+# leaves every name unqualified and lets search_path place it. The CREATE
+# EXTENSION lines say `WITH SCHEMA public` without a dot, so they are untouched
+# and the types they own (discourse's halfvec, hstore, and trgm operator
+# classes, osm's geometry) still resolve from `public`, which stays second in
+# the search path. Column names that merely start with "public" (`public`,
+# `public_version`) are not qualifiers and are left alone. The tail of the file
+# is Rails' own `SET search_path TO "$user", public` followed by the migration
+# versions it inserts into schema_migrations, which is data and would land in
+# the wrong schema anyway, so everything from that line on is dropped.
 #
-# The vector extension is pgvector, which the official postgres image does not
-# ship; compose.yaml and the samples CI job install it. See sample-db-test.md.
-.PHONY: sample-db-discourse
-sample-db-discourse:
+# discourse needs pgvector and osm needs PostGIS, neither of which the official
+# postgres image ships; compose.yaml and the samples CI job install both. See
+# sample-db-test.md.
+.PHONY: sample-db-pgdump-schema
+sample-db-pgdump-schema:
 	psql -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
 	  | sed -E "/^SELECT pg_catalog.set_config\('search_path', '', false\);\$$/d; /^SET search_path TO /,\$$d; s/^public\.//; s/([^A-Za-z0-9_])public\./\1/g" \

--- a/test/samples/run.sh
+++ b/test/samples/run.sh
@@ -65,15 +65,22 @@ check() {
   fi
 }
 
-# The discourse sample needs pgvector, which the official postgres image does
-# not ship. Say so up front: without this the sample fails at load time and the
-# reason is buried in psql's output.
-if [ -z "$(psql -X -q -At -c "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'")" ]; then
-  echo "pgvector is not installed on this server, and the discourse sample needs it." >&2
-  echo "compose.yaml installs it at container start; recreate the container with" >&2
-  echo "  docker compose down && docker compose up -d" >&2
-  exit 1
-fi
+# require_extension <extension> <package> <sample>
+# The discourse sample needs pgvector and the osm sample needs PostGIS, neither
+# of which the official postgres image ships. Say so up front: without them the
+# sample fails at load time and the reason is buried in psql's output.
+require_extension() {
+  local ext="$1" pkg="$2" sample="$3"
+  if [ -z "$(psql -X -q -At -c "SELECT 1 FROM pg_available_extensions WHERE name = '$ext'")" ]; then
+    echo "$pkg is not installed on this server, and the $sample sample needs it." >&2
+    echo "compose.yaml installs it at container start; recreate the container with" >&2
+    echo "  docker compose down && docker compose up -d" >&2
+    exit 1
+  fi
+}
+
+require_extension vector pgvector discourse
+require_extension postgis PostGIS osm
 
 echo "Building pista..."
 go build -o pista ./cmd/pista


### PR DESCRIPTION
Two more real-world sample schemas, and the fix the second one turned up.

## Samples

| Sample | Tables | Columns | Indexes | FKs | Constraints | Types | Sequences |
|---|---:|---:|---:|---:|---:|---:|---:|
| dotcms | 167 | 1,373 | 346 | 113 | 190 | 0 | 22 |
| osm | 57 | 391 | 155 | 71 | 55 | 8 | 0 |

- **dotcms** ([dotCMS/core](https://github.com/dotCMS/core)) ships one `postgres.sql` that names no schema, so it reuses `sample-db-url-schema` and loads with no rewrite. Its 167 tables make it the sixth largest sample.
- **osm** ([openstreetmap/openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website)) ships its schema as Rails' `db/structure.sql`, the same shape discourse does, so `sample-db-discourse` is now `sample-db-pgdump-schema` and both use it. It brings 8 enums, two gist indexes that name an `inet_ops` operator class, one gist index over four columns through `btree_gist`, and one PostGIS `geometry(Polygon,4326)` column.

osm needs PostGIS, which the official postgres image does not ship, so compose.yaml, the samples CI job, and the runner's up-front check take it alongside pgvector.

## Fix

The osm round trip did not plan clean. PostgreSQL downcases an unquoted keyword in a type modifier as it parses the DDL, while `format_type` prints the modifier the way the type writes it back, which need not be lower case. A column declared `geometry(Polygon,4326)` reads back from the catalog with the capital P that PostGIS gives it and reaches the diff from the desired side as `geometry(polygon,4326)`, so every plan emitted a no-op `SET DATA TYPE`. A domain over the same type failed with `cannot change base type`, which is the same cause since the base type comes from `format_type` too.

`equalTypeName` and the domain base type comparison now fold the modifier before comparing. The type name itself is left alone, since it is case-sensitive when quoted.

A cast to such a type inside a CHECK or index expression, `(x)::geometry(Polygon,4326)`, still compares by the deparsed AST and would drift the same way. That needs type normalization inside expressions, no sample hits it, and it is left out.

## Checks

- `make vet`, `make lint`: clean
- `make test`, `make test-scenario`: pass
- `make test-samples`: 46 passed, 0 failed
- `diff` package coverage: 96.591% -> 96.598%