### PR TITLE
Keep a constraint trigger out of the table's constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Keep a constraint trigger out of the table's constraints. `CREATE CONSTRAINT TRIGGER` also writes a `pg_constraint` row, which the catalog read as a table constraint, so `dump` emitted `CONSTRAINT x TRIGGER ...`, which does not parse, and `plan` proposed dropping the trigger. Triggers stay unmanaged.
+
 ## [1.28.0] - 2026-08-23
 
 * Require Go 1.27 to build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Keep a constraint trigger out of the table's constraints. `CREATE CONSTRAINT TRIGGER` also writes a `pg_constraint` row, which the catalog read as a table constraint, so `dump` emitted `CONSTRAINT x TRIGGER ...`, which does not parse, and `plan` proposed dropping the trigger. Triggers stay unmanaged.
+* Keep a constraint trigger out of the table's constraints. `CREATE CONSTRAINT TRIGGER` also writes a `pg_constraint` row, and the catalog read it as a table constraint. `dump` then emitted `CONSTRAINT x TRIGGER ...`, which does not parse, and `plan` proposed dropping the trigger. Triggers remain unmanaged.
 
 ## [1.28.0] - 2026-08-23
 

--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -59,10 +59,12 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 			-- query only returns table-level constraints.
 			AND con.contype <> 'n'
 			-- CREATE CONSTRAINT TRIGGER records the trigger in pg_constraint
-			-- too (contype='t'), and pg_get_constraintdef renders it as the
-			-- bare word TRIGGER. It is a trigger, not a table constraint, so
-			-- reading it here made dump write invalid SQL and plan propose a
-			-- DROP CONSTRAINT for it. Triggers are not managed.
+			-- too (contype='t'), where pg_get_constraintdef renders it as the
+			-- bare word TRIGGER, followed by the deferral clause when it has
+			-- one. Reading that as a table constraint made dump write a
+			-- CREATE TABLE that does not parse, and plan propose a DROP
+			-- CONSTRAINT for the trigger. Triggers are unmanaged, so this
+			-- query skips the row.
 			AND con.contype <> 't'
 		ORDER BY
 			array_position('{p,u,c,x,f}'::"char"[], con.contype),

--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -54,18 +54,19 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 			LEFT JOIN column_t col ON col.con_oid = con.oid
 		WHERE
 			con.conrelid = @table_oid
-			-- PG18's per-column NOT NULL rows (contype='n') are read into
-			-- Column.NotNull / Column.NotNullName by ListColumnsByTable; this
-			-- query only returns table-level constraints.
-			AND con.contype <> 'n'
-			-- CREATE CONSTRAINT TRIGGER records the trigger in pg_constraint
-			-- too (contype='t'), where pg_get_constraintdef renders it as the
-			-- bare word TRIGGER, followed by the deferral clause when it has
-			-- one. Reading that as a table constraint made dump write a
-			-- CREATE TABLE that does not parse, and plan propose a DROP
-			-- CONSTRAINT for the trigger. Triggers are unmanaged, so this
-			-- query skips the row.
-			AND con.contype <> 't'
+			-- The table-level constraint types, listed the way the ORDER BY
+			-- below lists them. Two other types share the catalog and belong
+			-- elsewhere. PG18's per-column NOT NULL rows (contype='n') are
+			-- read into Column.NotNull / Column.NotNullName by
+			-- ListColumnsByTable. CREATE CONSTRAINT TRIGGER records the
+			-- trigger here too (contype='t'), where pg_get_constraintdef
+			-- renders it as the bare word TRIGGER, followed by the deferral
+			-- clause when it has one; reading that as a table constraint made
+			-- dump write a CREATE TABLE that does not parse, and plan propose
+			-- a DROP CONSTRAINT for the trigger. Naming the types pistachio
+			-- manages also keeps a type a later major version adds out until
+			-- the model has somewhere to put it.
+			AND con.contype = ANY ('{p,u,c,x,f}'::"char"[])
 		ORDER BY
 			array_position('{p,u,c,x,f}'::"char"[], con.contype),
 			con.conname

--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -58,6 +58,12 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 			-- Column.NotNull / Column.NotNullName by ListColumnsByTable; this
 			-- query only returns table-level constraints.
 			AND con.contype <> 'n'
+			-- CREATE CONSTRAINT TRIGGER records the trigger in pg_constraint
+			-- too (contype='t'), and pg_get_constraintdef renders it as the
+			-- bare word TRIGGER. It is a trigger, not a table constraint, so
+			-- reading it here made dump write invalid SQL and plan propose a
+			-- DROP CONSTRAINT for it. Triggers are not managed.
+			AND con.contype <> 't'
 		ORDER BY
 			array_position('{p,u,c,x,f}'::"char"[], con.contype),
 			con.conname

--- a/catalog/constraints_test.go
+++ b/catalog/constraints_test.go
@@ -369,18 +369,24 @@ func TestListConstraintsByTable(t *testing.T) {
 	})
 
 	// Regression: CREATE CONSTRAINT TRIGGER adds a pg_constraint row with
-	// contype='t' whose pg_get_constraintdef is the bare word TRIGGER. Reading
-	// it as a table constraint made dump write invalid SQL and plan propose a
-	// DROP CONSTRAINT for the trigger.
+	// contype='t', which pg_get_constraintdef renders as the bare word
+	// TRIGGER, followed by the deferral clause when it has one. Reading that
+	// as a table constraint made dump write invalid SQL and plan propose a
+	// DROP CONSTRAINT for the trigger. Both shapes sit next to a primary key
+	// and a foreign key, which must still come through.
 	t.Run("constraint trigger excluded", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
 			CREATE TABLE public.events (
 				id integer NOT NULL,
-				CONSTRAINT events_pkey PRIMARY KEY (id)
+				parent_id integer,
+				CONSTRAINT events_pkey PRIMARY KEY (id),
+				CONSTRAINT events_parent_fkey FOREIGN KEY (parent_id) REFERENCES public.events(id)
 			);
-			CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events
+			CREATE CONSTRAINT TRIGGER events_deferred AFTER INSERT ON public.events
 				DEFERRABLE INITIALLY DEFERRED
+				FOR EACH ROW EXECUTE FUNCTION public.noop();
+			CREATE CONSTRAINT TRIGGER events_immediate AFTER INSERT ON public.events
 				FOR EACH ROW EXECUTE FUNCTION public.noop();
 		`)
 		cat, err := catalog.NewCatalog(conn, []string{"public"})
@@ -389,9 +395,8 @@ func TestListConstraintsByTable(t *testing.T) {
 		require.NoError(t, err)
 
 		tbl := tables.Get("public.events")
-		assert.Equal(t, 1, tbl.Constraints.Len())
 
-		_, ok := tbl.Constraints.GetOk("events_check")
-		assert.False(t, ok)
+		assert.Equal(t, []string{"events_pkey"}, tbl.Constraints.CollectKeys())
+		assert.Equal(t, []string{"events_parent_fkey"}, tbl.ForeignKeys.CollectKeys())
 	})
 }

--- a/catalog/constraints_test.go
+++ b/catalog/constraints_test.go
@@ -367,4 +367,31 @@ func TestListConstraintsByTable(t *testing.T) {
 		assert.True(t, excl.Type.IsExclusionConstraint())
 		assert.Equal(t, []string{"room", "during"}, excl.Columns)
 	})
+
+	// Regression: CREATE CONSTRAINT TRIGGER adds a pg_constraint row with
+	// contype='t' whose pg_get_constraintdef is the bare word TRIGGER. Reading
+	// it as a table constraint made dump write invalid SQL and plan propose a
+	// DROP CONSTRAINT for the trigger.
+	t.Run("constraint trigger excluded", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+			CREATE TABLE public.events (
+				id integer NOT NULL,
+				CONSTRAINT events_pkey PRIMARY KEY (id)
+			);
+			CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events
+				DEFERRABLE INITIALLY DEFERRED
+				FOR EACH ROW EXECUTE FUNCTION public.noop();
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.events")
+		assert.Equal(t, 1, tbl.Constraints.Len())
+
+		_, ok := tbl.Constraints.GetOk("events_check")
+		assert.False(t, ok)
+	})
 }

--- a/model/constraint.go
+++ b/model/constraint.go
@@ -26,10 +26,6 @@ func (b ConstraintType) IsUniqueConstraint() bool {
 	return b == 'u'
 }
 
-func (b ConstraintType) IsConstraintTrigger() bool {
-	return b == 't'
-}
-
 func (b ConstraintType) IsExclusionConstraint() bool {
 	return b == 'x'
 }

--- a/model/constraint_test.go
+++ b/model/constraint_test.go
@@ -13,7 +13,6 @@ func TestConstraintType(t *testing.T) {
 	assert.True(t, model.ConstraintType('n').IsNotNullConstraint())
 	assert.True(t, model.ConstraintType('p').IsPrimaryKeyConstraint())
 	assert.True(t, model.ConstraintType('u').IsUniqueConstraint())
-	assert.True(t, model.ConstraintType('t').IsConstraintTrigger())
 	assert.True(t, model.ConstraintType('x').IsExclusionConstraint())
 
 	assert.False(t, model.ConstraintType('c').IsPrimaryKeyConstraint())

--- a/testdata/apply/constraint_trigger_idempotent.yml
+++ b/testdata/apply/constraint_trigger_idempotent.yml
@@ -1,6 +1,6 @@
-# A desired schema that does not mention the constraint trigger must not plan
-# a DROP CONSTRAINT for it. Drops are allowed so the statement would reach the
-# plan instead of the skipped list.
+# The desired schema does not mention the constraint trigger, so apply must
+# run nothing. Drops are allowed, so a trigger read as a table constraint would
+# be dropped here instead of suppressed.
 init: |
   CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
   CREATE TABLE public.events (
@@ -15,7 +15,14 @@ desired: |
       id integer NOT NULL,
       CONSTRAINT events_pkey PRIMARY KEY (id)
   );
+applied: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+applied_sql: ""
 drop_policy:
   allow_drop:
     - all
-plan: ""
+verify_no_drift: true

--- a/testdata/dump/constraint_trigger.yml
+++ b/testdata/dump/constraint_trigger.yml
@@ -1,0 +1,17 @@
+# A CREATE CONSTRAINT TRIGGER leaves a pg_constraint row with contype='t'.
+# It is a trigger, not a table constraint, so the dump must leave it out.
+init: |
+  CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION public.noop();
+dump: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );

--- a/testdata/dump/constraint_trigger.yml
+++ b/testdata/dump/constraint_trigger.yml
@@ -1,5 +1,5 @@
 # A CREATE CONSTRAINT TRIGGER leaves a pg_constraint row with contype='t'.
-# It is a trigger, not a table constraint, so the dump must leave it out.
+# The trigger is unmanaged, so the dump must leave it out.
 init: |
   CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
   CREATE TABLE public.events (

--- a/testdata/plan/constraint_trigger_no_diff.yml
+++ b/testdata/plan/constraint_trigger_no_diff.yml
@@ -1,0 +1,21 @@
+# The constraint trigger is not a table constraint, so a desired schema that
+# does not mention it must not plan a DROP CONSTRAINT. Drops are allowed here
+# so the statement would show up in the plan rather than as a skipped drop.
+init: |
+  CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION public.noop();
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop:
+    - all
+plan: ""


### PR DESCRIPTION
`CREATE CONSTRAINT TRIGGER` writes a `pg_constraint` row with `contype='t'` alongside the `pg_trigger` row, and `pg_get_constraintdef` renders it as the bare word `TRIGGER`, followed by the deferral clause when it has one. `ListConstraintsByTable` excluded only `contype='n'`, so the trigger reached the model as a table constraint.

Two consequences, both reproduced on 15 through 18:

* `dump` wrote `CONSTRAINT x TRIGGER DEFERRABLE INITIALLY DEFERRED` inside `CREATE TABLE`. That does not parse, so feeding the dump back failed with `syntax error at or near "TRIGGER"`, breaking the round trip the design policy requires.
* `plan` proposed `ALTER TABLE ... DROP CONSTRAINT` for the trigger. The default drop policy suppressed it, but `--allow-drop all` dropped the user's trigger.

Triggers are unmanaged, so the query skips `contype='t'` too. The other `pg_constraint` readers already restrict themselves: `catalog/domains.go` to `contype='c'` and `catalog/indexes.go` to `contype IN ('p','u','x')`.

## Tests

Written first and confirmed failing against the old query.

* `catalog/constraints_test.go`: a table carrying both a deferrable and an immediate constraint trigger reports only its primary key and its foreign key.
* `testdata/dump/constraint_trigger.yml`: the dump leaves the trigger out.
* `testdata/plan/constraint_trigger_no_diff.yml`: the plan is empty under `allow_drop: [all]`, so the drop would land in the plan rather than in the skipped list.
* `testdata/apply/constraint_trigger_idempotent.yml`: apply runs no SQL and leaves no drift.

`make lint`, `make vet`, `make test` and `make test-scenario` pass. The suite was run against 15, 16, 17 and 18. Coverage is unchanged: the diff adds a SQL predicate and no Go branch, and the three blocks still uncovered in `constraints.go` are the `Query`, `Scan` and `rows.Err` error wrappers, matching every other catalog reader.