### PR TITLE
Manage triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Manage triggers. `CREATE TRIGGER`, `CREATE CONSTRAINT TRIGGER` and `INSTEAD OF` triggers on views are read from `pg_trigger`, written by `dump`, and diffed. A definition change uses `CREATE OR REPLACE TRIGGER`; switching a trigger to or from a constraint trigger runs as `DROP` and `CREATE`, gated by `--allow-drop trigger`. The enable state is carried as `ALTER TABLE ... ENABLE/DISABLE TRIGGER`, and `-- pista:renamed-from` renames a trigger. The function a trigger calls stays unmanaged, so it belongs in a `-- pista:execute-first` statement.
+
 * Keep a constraint trigger out of the table's constraints. `CREATE CONSTRAINT TRIGGER` also writes a `pg_constraint` row, and the catalog read it as a table constraint. `dump` then emitted `CONSTRAINT x TRIGGER ...`, which does not parse, and `plan` proposed dropping the trigger. Triggers remain unmanaged.
 
 ## [1.28.0] - 2026-08-23

--- a/README.md
+++ b/README.md
@@ -869,7 +869,7 @@ CREATE TRIGGER events_stamp BEFORE UPDATE ON public.events
 
 A trigger names the table or view it sits on, so that relation has to be declared earlier in the file, or in an earlier file when the schema is split across several.
 
-A definition change is applied with `CREATE OR REPLACE TRIGGER`, which takes a lighter lock than dropping and recreating. Turning a trigger into a constraint trigger, or back, is the one change PostgreSQL rejects in place; it runs as `DROP TRIGGER` and `CREATE TRIGGER` and needs `--allow-drop trigger`.
+A definition change is applied with `CREATE OR REPLACE TRIGGER`, which takes a lighter lock than dropping and recreating. Turning a trigger into a constraint trigger, or back, is the one change PostgreSQL rejects in place; it runs as `DROP TRIGGER` and `CREATE TRIGGER` and needs `--allow-drop trigger`, the same as any other trigger drop. Without it the trigger keeps its current definition.
 
 `CREATE TRIGGER` has no syntax for a disabled trigger, so a desired schema asks for one the way `dump` writes it:
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ pista apply ./schema/*.sql         # apply it
 - Indexes (unique, partial, expression, hash, multi-column)
 - Comments (on tables, columns, views, types, domains, composite types, composite attributes, sequences)
 - Row-level security (`ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY`, policies via `CREATE POLICY` / `ALTER POLICY` / `DROP POLICY`)
-- Renaming (tables, views, enums, enum values, domains, composite types, composite attributes, sequences, columns, constraints, foreign keys, indexes, policies via `-- pista:renamed-from` directive)
+- Triggers (`CREATE TRIGGER`, `CREATE CONSTRAINT TRIGGER`, `INSTEAD OF` triggers on views, and the enable state via `ALTER TABLE ... ENABLE/DISABLE TRIGGER`). The function a trigger calls is not managed; see [Triggers](#triggers).
+- Renaming (tables, views, enums, enum values, domains, composite types, composite attributes, sequences, columns, constraints, foreign keys, indexes, policies, triggers via `-- pista:renamed-from` directive)
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 
@@ -518,7 +519,7 @@ pista plan --assume-validated schema.sql
 pista apply --assume-validated schema.sql
 ```
 
-By default, `plan` and `apply` do not drop tables, views, enums, domains, composite types, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `composite_type`, `column`, `constraint`, `foreign_key`, `index`, `policy`). Also available as `$PISTA_ALLOW_DROP`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately. `composite_type` also gates `DROP ATTRIBUTE` on a composite type.
+By default, `plan` and `apply` do not drop tables, views, enums, domains, composite types, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `composite_type`, `column`, `constraint`, `foreign_key`, `index`, `policy`, `trigger`). Also available as `$PISTA_ALLOW_DROP`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately. `composite_type` also gates `DROP ATTRIBUTE` on a composite type.
 
 ```bash
 # Allow all drops
@@ -842,6 +843,43 @@ pista dump --split ./schema/
 # -- Wrote 4 file(s) to ./schema/
 # (writes ./schema/public.status.sql, ./schema/public.users.sql, ./schema/public.orders.sql, ...)
 ```
+
+## Triggers
+
+pistachio manages triggers, not the functions they call. Write the function with `-- pista:execute-first` so it exists before the `CREATE TRIGGER` that references it runs:
+
+```sql
+-- pista:execute-first
+CREATE OR REPLACE FUNCTION public.stamp() RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE public.events (
+    id integer NOT NULL,
+    updated_at timestamptz,
+    CONSTRAINT events_pkey PRIMARY KEY (id)
+);
+
+CREATE TRIGGER events_stamp BEFORE UPDATE ON public.events
+    FOR EACH ROW EXECUTE FUNCTION public.stamp();
+```
+
+A definition change is applied with `CREATE OR REPLACE TRIGGER`, which takes a lighter lock than dropping and recreating. Turning a trigger into a constraint trigger, or back, is the one change PostgreSQL rejects in place, so that one runs as `DROP TRIGGER` and `CREATE TRIGGER` and needs `--allow-drop trigger`.
+
+`CREATE TRIGGER` has no syntax for a disabled trigger, so a desired schema asks for one the way `dump` writes it:
+
+```sql
+ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+```
+
+`ENABLE ALWAYS` and `ENABLE REPLICA` work the same way. PostgreSQL rejects the statement on a view, so a view's triggers have no state to set. `CREATE OR REPLACE TRIGGER` leaves a trigger enabled, so a definition change on a trigger that is held in another state is followed by the `ALTER TABLE` that puts it back.
+
+A trigger on a partitioned table is cloned onto every partition. pistachio reads and writes the parent's trigger alone, and PostgreSQL keeps the clones in step.
+
+The `ALL` and `USER` forms of `ENABLE TRIGGER` name no single trigger and are ignored, as are event triggers, which belong to the database rather than to a schema.
 
 ## Constraint and index naming
 

--- a/README.md
+++ b/README.md
@@ -867,7 +867,9 @@ CREATE TRIGGER events_stamp BEFORE UPDATE ON public.events
     FOR EACH ROW EXECUTE FUNCTION public.stamp();
 ```
 
-A definition change is applied with `CREATE OR REPLACE TRIGGER`, which takes a lighter lock than dropping and recreating. Turning a trigger into a constraint trigger, or back, is the one change PostgreSQL rejects in place, so that one runs as `DROP TRIGGER` and `CREATE TRIGGER` and needs `--allow-drop trigger`.
+A trigger names the table or view it sits on, so that relation has to be declared earlier in the file, or in an earlier file when the schema is split across several.
+
+A definition change is applied with `CREATE OR REPLACE TRIGGER`, which takes a lighter lock than dropping and recreating. Turning a trigger into a constraint trigger, or back, is the one change PostgreSQL rejects in place; it runs as `DROP TRIGGER` and `CREATE TRIGGER` and needs `--allow-drop trigger`.
 
 `CREATE TRIGGER` has no syntax for a disabled trigger, so a desired schema asks for one the way `dump` writes it:
 
@@ -875,7 +877,9 @@ A definition change is applied with `CREATE OR REPLACE TRIGGER`, which takes a l
 ALTER TABLE public.events DISABLE TRIGGER events_stamp;
 ```
 
-`ENABLE ALWAYS` and `ENABLE REPLICA` work the same way. PostgreSQL rejects the statement on a view, so a view's triggers have no state to set. `CREATE OR REPLACE TRIGGER` leaves a trigger enabled, so a definition change on a trigger that is held in another state is followed by the `ALTER TABLE` that puts it back.
+`ENABLE ALWAYS` and `ENABLE REPLICA` work the same way. PostgreSQL rejects the statement on a view, so a view's triggers have no state to set. Both `CREATE OR REPLACE TRIGGER` and a recreate leave a trigger enabled, so pistachio re-applies any other state right after.
+
+The catalog reports a trigger's function without its schema when `search_path` reaches it, the same as any other name pistachio reads back. A desired schema that writes `public.stamp()` while the default `--search-path=public` is in effect therefore differs on every run; `--search-path=` keeps every schema and matches a `pg_dump`-style file.
 
 A trigger on a partitioned table is cloned onto every partition. pistachio reads and writes the parent's trigger alone, and PostgreSQL keeps the clones in step.
 

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,22 @@ Resolving these requires cross-object awareness in the diff phase.
 
 Origin: [#123](https://github.com/winebarrel/pistachio/pull/123).
 
+## Trigger definitions are not rewritten on a column rename
+
+When a column is renamed via `-- pista:renamed-from`, the rewriter updates the
+same-table dependents it knows about (indexes, constraints, FKs). A trigger on
+the same table is not among them, so a `UPDATE OF <col>` list or a `WHEN`
+expression naming the old column reads as a definition change and the first
+plan emits a redundant `CREATE OR REPLACE TRIGGER`. PostgreSQL applies
+`RENAME COLUMN` to the trigger itself, so the second run after the rename is
+clean.
+
+Same class as the view and cross-table FK entry above, and the fix is the same
+shape: run the column-rename rewriter over `Table.Triggers` and
+`View.Triggers`.
+
+Origin: trigger support.
+
 ## Validation of column refs in GENERATED / DEFAULT expressions
 
 `ValidateColumnRefs` checks index / constraint / FK definitions against

--- a/catalog/tables.go
+++ b/catalog/tables.go
@@ -32,6 +32,17 @@ func (c *Catalog) Tables(ctx context.Context) (*orderedmap.Map[string, *model.Ta
 		}
 	}
 
+	triggers, err := c.ListTriggers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, trg := range triggers {
+		if t, ok := tableByKey.GetOk(trg.FQTN()); ok {
+			t.Triggers.Set(trg.Name, trg)
+		}
+	}
+
 	return tableByKey, nil
 }
 
@@ -142,6 +153,7 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 		t.Constraints = orderedmap.New[string, *model.Constraint]()
 		t.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 		t.Policies = orderedmap.New[string, *model.Policy]()
+		t.Triggers = orderedmap.New[string, *model.Trigger]()
 		tables = append(tables, &t)
 	}
 	if err := rows.Err(); err != nil {

--- a/catalog/triggers.go
+++ b/catalog/triggers.go
@@ -1,0 +1,90 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// ListTriggers returns the triggers on the tables and views in the catalog's
+// schemas. Both relation kinds come from one query, the way ListIndexes serves
+// tables and materialized views together.
+func (c *Catalog) ListTriggers(ctx context.Context) ([]*model.Trigger, error) {
+	q := `
+		WITH
+			-- https://www.postgresql.org/docs/current/catalog-pg-depend.html
+			dependency_extension AS (
+				SELECT DISTINCT
+					d.objid
+				FROM
+					pg_catalog.pg_depend d
+				WHERE
+					d.deptype = 'e'
+			)
+		SELECT
+			n.nspname,
+			c.relname,
+			t.tgname,
+			-- The pretty form keeps the WHEN expression free of the parentheses
+			-- the plain one wraps every operator in, and adds no line breaks of
+			-- its own, so the definition stays on one line either way.
+			pg_catalog.pg_get_triggerdef(t.oid, true) AS definition,
+			t.tgenabled
+		FROM
+			-- https://www.postgresql.org/docs/current/catalog-pg-trigger.html
+			pg_catalog.pg_trigger t
+			JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
+			JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+			LEFT JOIN dependency_extension de ON de.objid = t.oid
+		WHERE
+			n.nspname = ANY(@schemas)
+			AND de.objid IS NULL
+			-- The triggers behind a foreign key or a deferred unique
+			-- constraint. PostgreSQL installs and drops them with the
+			-- constraint, so they are not part of the schema.
+			AND NOT t.tgisinternal
+			-- A trigger on a partitioned table is cloned onto every partition
+			-- with tgparentid pointing back at the parent. The clone cannot be
+			-- dropped on its own, and the parent's definition already covers
+			-- it, so only the parent's row belongs to the model.
+			AND t.tgparentid = 0
+		ORDER BY
+			n.nspname,
+			c.relname,
+			t.tgname
+	`
+
+	args := pgx.NamedArgs{
+		"schemas": c.schemas,
+	}
+
+	rows, err := c.conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get trigger info: %w", err)
+	}
+	defer rows.Close()
+
+	var triggers []*model.Trigger
+	for rows.Next() {
+		var trg model.Trigger
+		err := rows.Scan(
+			&trg.Schema,
+			&trg.Table,
+			&trg.Name,
+			&trg.Definition,
+			&trg.State,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("catalog: failed to scan trigger info: %w", err)
+		}
+		triggers = append(triggers, &trg)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: failed to scan trigger info rows: %w", err)
+	}
+
+	return triggers, nil
+}

--- a/catalog/triggers_test.go
+++ b/catalog/triggers_test.go
@@ -1,0 +1,145 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/catalog"
+	"github.com/winebarrel/pistachio/internal/testutil"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestListTriggers(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	t.Run("table triggers", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+			CREATE TABLE public.events (
+				id integer NOT NULL,
+				name text,
+				CONSTRAINT events_pkey PRIMARY KEY (id)
+			);
+			CREATE TRIGGER events_audit AFTER UPDATE OF name ON public.events
+				FOR EACH ROW WHEN (old.name IS DISTINCT FROM new.name)
+				EXECUTE FUNCTION public.noop();
+			CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events
+				DEFERRABLE INITIALLY DEFERRED
+				FOR EACH ROW EXECUTE FUNCTION public.noop();
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.events")
+		assert.Equal(t, []string{"events_audit", "events_check"}, tbl.Triggers.CollectKeys())
+
+		// pg_get_triggerdef drops the schema from a relation and a function
+		// the session reaches through search_path, the way pg_get_viewdef
+		// does. The test connection leaves search_path at the server default,
+		// which carries public, so nothing here is qualified. Schema and
+		// Table come from pg_class and stay right either way.
+		audit := tbl.Triggers.Get("events_audit")
+		assert.Equal(t,
+			"CREATE TRIGGER events_audit AFTER UPDATE OF name ON events FOR EACH ROW WHEN (old.name IS DISTINCT FROM new.name) EXECUTE FUNCTION noop()",
+			audit.Definition)
+		assert.True(t, audit.State.IsDefault())
+
+		check := tbl.Triggers.Get("events_check")
+		assert.Equal(t,
+			"CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION noop()",
+			check.Definition)
+	})
+
+	// A foreign key installs its own triggers on both tables. PostgreSQL
+	// maintains them, and pg_get_triggerdef writes them as constraint
+	// triggers on internal RI functions, so they must not reach the model.
+	t.Run("internal triggers excluded", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.parents (
+				id integer NOT NULL,
+				CONSTRAINT parents_pkey PRIMARY KEY (id)
+			);
+			CREATE TABLE public.children (
+				id integer NOT NULL,
+				parent_id integer,
+				CONSTRAINT children_pkey PRIMARY KEY (id),
+				CONSTRAINT children_parent_fkey FOREIGN KEY (parent_id) REFERENCES public.parents(id)
+			);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		assert.Empty(t, tables.Get("public.parents").Triggers.CollectKeys())
+		assert.Empty(t, tables.Get("public.children").Triggers.CollectKeys())
+	})
+
+	// A trigger on a partitioned table is cloned onto every partition. The
+	// clone cannot be dropped on its own, and the parent's definition already
+	// covers it, so only the parent's row belongs to the model.
+	t.Run("partition clones excluded", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+			CREATE TABLE public.logs (id integer NOT NULL, at date NOT NULL) PARTITION BY RANGE (at);
+			CREATE TABLE public.logs_2026 PARTITION OF public.logs FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+			CREATE TRIGGER logs_audit BEFORE INSERT ON public.logs
+				FOR EACH ROW EXECUTE FUNCTION public.noop();
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"logs_audit"}, tables.Get("public.logs").Triggers.CollectKeys())
+		assert.Empty(t, tables.Get("public.logs_2026").Triggers.CollectKeys())
+	})
+
+	t.Run("enable state", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+			CREATE TABLE public.events (id integer NOT NULL);
+			CREATE TRIGGER events_off BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.noop();
+			CREATE TRIGGER events_always BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.noop();
+			CREATE TRIGGER events_replica BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.noop();
+			ALTER TABLE public.events DISABLE TRIGGER events_off;
+			ALTER TABLE public.events ENABLE ALWAYS TRIGGER events_always;
+			ALTER TABLE public.events ENABLE REPLICA TRIGGER events_replica;
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		triggers := tables.Get("public.events").Triggers
+		assert.Equal(t, model.TriggerState('D'), triggers.Get("events_off").State)
+		assert.Equal(t, model.TriggerState('A'), triggers.Get("events_always").State)
+		assert.Equal(t, model.TriggerState('R'), triggers.Get("events_replica").State)
+	})
+
+	t.Run("view trigger", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+			CREATE TABLE public.events (id integer NOT NULL);
+			CREATE VIEW public.recent_events AS SELECT id FROM public.events;
+			CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events
+				FOR EACH ROW EXECUTE FUNCTION public.noop();
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		views, err := cat.Views(ctx)
+		require.NoError(t, err)
+
+		vw := views.Get("public.recent_events")
+		assert.Equal(t, []string{"recent_events_insert"}, vw.Triggers.CollectKeys())
+		assert.Equal(t,
+			"CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON recent_events FOR EACH ROW EXECUTE FUNCTION noop()",
+			vw.Triggers.Get("recent_events_insert").Definition)
+	})
+}

--- a/catalog/views.go
+++ b/catalog/views.go
@@ -33,6 +33,19 @@ func (c *Catalog) Views(ctx context.Context) (*orderedmap.Map[string, *model.Vie
 		}
 	}
 
+	// INSTEAD OF triggers sit on plain views. A materialized view cannot carry
+	// a trigger at all, so the lookup covers both without a kind check.
+	triggers, err := c.ListTriggers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, trg := range triggers {
+		if v, ok := viewByKey.GetOk(trg.FQTN()); ok {
+			v.Triggers.Set(trg.Name, trg)
+		}
+	}
+
 	return viewByKey, nil
 }
 
@@ -94,6 +107,7 @@ func (c *Catalog) ListViews(ctx context.Context) ([]*model.View, error) {
 			return nil, fmt.Errorf("catalog: failed to scan view info: %w", err)
 		}
 		v.Indexes = orderedmap.New[string, *model.Index]()
+		v.Triggers = orderedmap.New[string, *model.Trigger]()
 		views = append(views, &v)
 	}
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -122,6 +122,9 @@ func newTableExtras(t *model.Table) (stmts []string, fkStmts []string, hasConcur
 	if rlsSQL := t.RLSSQL(); rlsSQL != "" {
 		stmts = append(stmts, strings.Split(rlsSQL, "\n")...)
 	}
+	if trigSQL := t.TrigSQL(); trigSQL != "" {
+		stmts = append(stmts, strings.Split(trigSQL, "\n")...)
+	}
 	if commentSQL := t.CommentSQL(); commentSQL != "" {
 		stmts = append(stmts, strings.Split(commentSQL, "\n")...)
 	}
@@ -171,6 +174,13 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		}
 		result.Stmts = append(result.Stmts, polStmts...)
 		result.DisallowedDropStmts = append(result.DisallowedDropStmts, polDisallowed...)
+
+		trgStmts, trgDisallowed, err := diffTriggers(fqtn, current.Triggers, desired.Triggers, dc)
+		if err != nil {
+			return nil, err
+		}
+		result.Stmts = append(result.Stmts, trgStmts...)
+		result.DisallowedDropStmts = append(result.DisallowedDropStmts, trgDisallowed...)
 
 		result.Stmts = append(result.Stmts, diffComments(current, withInheritedColumns(current, desired))...)
 
@@ -234,6 +244,13 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	}
 	result.Stmts = append(result.Stmts, polStmts...)
 	result.DisallowedDropStmts = append(result.DisallowedDropStmts, polDisallowed...)
+
+	trgStmts, trgDisallowed, err := diffTriggers(fqtn, current.Triggers, desired.Triggers, dc)
+	if err != nil {
+		return nil, err
+	}
+	result.Stmts = append(result.Stmts, trgStmts...)
+	result.DisallowedDropStmts = append(result.DisallowedDropStmts, trgDisallowed...)
 
 	result.Stmts = append(result.Stmts, diffComments(current, desired)...)
 

--- a/diff/triggers.go
+++ b/diff/triggers.go
@@ -14,11 +14,11 @@ import (
 // A definition change goes through CREATE OR REPLACE TRIGGER, which PostgreSQL
 // has carried since 14 and which takes a lighter lock than DROP TRIGGER. It
 // refuses to turn a constraint trigger into a plain one or back, so that pair
-// falls back to DROP and CREATE. Either way PostgreSQL leaves the new trigger
-// enabled, so a desired state other than the default is re-applied after the
-// statement that reset it.
-//
-// Pure removals honor the trigger-drop policy via dc.
+// falls back to DROP and CREATE, honoring the trigger-drop policy via dc the
+// same as a removal: with the drop denied, the trigger keeps its current
+// definition rather than running the CREATE half alone. Either way PostgreSQL
+// leaves the new trigger enabled, so a desired state other than the default is
+// re-applied after the statement that reset it.
 func diffTriggers(
 	fqtn string,
 	current, desired *orderedmap.Map[string, *model.Trigger],
@@ -58,8 +58,23 @@ func diffTriggers(
 		}
 	}
 
+	triggerAllowed := dc.IsDropAllowed("trigger")
+
+	// A recreate crossing the constraint-trigger line needs the same drop the
+	// removal branch below honors: nothing else about the trigger can change
+	// while the drop that clears the way for it is denied, so it stays
+	// exactly as it is, the way DiffViews leaves a view alone when its own
+	// recreate is denied.
+	recreateDenied := map[string]bool{}
+	if !triggerAllowed {
+		for name := range recreated {
+			recreateDenied[name] = true
+		}
+	}
+
 	// A trigger that is both renamed and recreated skips the RENAME, since the
-	// CREATE below already puts the new name in place.
+	// CREATE below already puts the new name in place. One whose recreate is
+	// denied keeps its old name too, recreated[name] being true either way.
 	for name := range desired.Keys() {
 		oldName, renamed := renamedFrom[name]
 		if !renamed || recreated[name] {
@@ -67,8 +82,6 @@ func diffTriggers(
 		}
 		stmts = append(stmts, renameTriggerSQL(fqtn, oldName, name))
 	}
-
-	triggerAllowed := dc.IsDropAllowed("trigger")
 
 	// Drop the triggers the desired schema no longer declares, then the ones
 	// the recreate needs out of the way. A recreate whose RENAME was skipped
@@ -88,11 +101,20 @@ func diffTriggers(
 			if oldName, ok := renamedFrom[name]; ok {
 				dropName = oldName
 			}
-			stmts = append(stmts, dropTriggerSQL(fqtn, dropName))
+			drop := dropTriggerSQL(fqtn, dropName)
+			if recreateDenied[name] {
+				disallowed = append(disallowed, "-- skipped: "+drop)
+				continue
+			}
+			stmts = append(stmts, drop)
 		}
 	}
 
 	for name, des := range desired.All() {
+		if recreateDenied[name] {
+			continue
+		}
+
 		cur, ok := current.GetOk(name)
 		if !ok || recreated[name] {
 			stmts = append(stmts, des.SQL())
@@ -192,7 +214,7 @@ func renameTriggerSQL(fqtn, oldName, newName string) string {
 }
 
 func alterTriggerStateSQL(fqtn string, trg *model.Trigger) string {
-	return "ALTER TABLE " + fqtn + " " + trg.State.Action() + " TRIGGER " + model.Ident(trg.Name) + ";"
+	return model.TriggerStateSQL(fqtn, trg.Name, trg.State)
 }
 
 // parseTriggerDef parses a CREATE TRIGGER statement and takes out the wording
@@ -271,6 +293,9 @@ func renameTriggerDef(def, newName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse the current trigger definition: %w", err)
 	}
+	if len(result.Stmts) != 1 {
+		return "", fmt.Errorf("unexpected parse result for trigger definition: %s", def)
+	}
 	ct := result.Stmts[0].Stmt.GetCreateTrigStmt()
 	if ct == nil {
 		return "", fmt.Errorf("unexpected parse result for trigger definition: %s", def)
@@ -289,6 +314,9 @@ func replaceTriggerSQL(def string) (string, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse the desired trigger definition: %w", err)
+	}
+	if len(result.Stmts) != 1 {
+		return "", fmt.Errorf("unexpected parse result for trigger definition: %s", def)
 	}
 	ct := result.Stmts[0].Stmt.GetCreateTrigStmt()
 	if ct == nil {

--- a/diff/triggers.go
+++ b/diff/triggers.go
@@ -1,0 +1,303 @@
+package diff
+
+import (
+	"fmt"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/winebarrel/orderedmap/v2"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// diffTriggers emits the statements that bring one relation's triggers to the
+// desired state.
+//
+// A definition change goes through CREATE OR REPLACE TRIGGER, which PostgreSQL
+// has carried since 14 and which takes a lighter lock than DROP TRIGGER. It
+// refuses to turn a constraint trigger into a plain one or back, so that pair
+// falls back to DROP and CREATE. Either way PostgreSQL leaves the new trigger
+// enabled, so a desired state other than the default is re-applied after the
+// statement that reset it.
+//
+// Pure removals honor the trigger-drop policy via dc.
+func diffTriggers(
+	fqtn string,
+	current, desired *orderedmap.Map[string, *model.Trigger],
+	dc DropChecker,
+) (stmts []string, disallowed []string, err error) {
+	dc = normalizeDropChecker(dc)
+	current = triggerMap(current)
+	desired = triggerMap(desired)
+
+	// Detect renames first so the steps below see the renamed trigger under
+	// its new name in the adjusted current map.
+	current, renamedFrom, err := detectTriggerRenames(fqtn, current, desired)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Compare once. The loops below need both whether the definition changed
+	// and whether the change crosses the constraint-trigger line, which is the
+	// one PostgreSQL will not replace in place.
+	changed := map[string]bool{}
+	recreated := map[string]bool{}
+	for name, des := range desired.All() {
+		cur, ok := current.GetOk(name)
+		if !ok {
+			continue
+		}
+		same, err := equalTriggerDef(cur.Definition, des.Definition, des.Schema)
+		if err != nil {
+			return nil, nil, err
+		}
+		if same {
+			continue
+		}
+		changed[name] = true
+		if isConstraintTrigger(cur.Definition) != isConstraintTrigger(des.Definition) {
+			recreated[name] = true
+		}
+	}
+
+	// A trigger that is both renamed and recreated skips the RENAME, since the
+	// CREATE below already puts the new name in place.
+	for name := range desired.Keys() {
+		oldName, renamed := renamedFrom[name]
+		if !renamed || recreated[name] {
+			continue
+		}
+		stmts = append(stmts, renameTriggerSQL(fqtn, oldName, name))
+	}
+
+	triggerAllowed := dc.IsDropAllowed("trigger")
+
+	// Drop the triggers the desired schema no longer declares, then the ones
+	// the recreate needs out of the way. A recreate whose RENAME was skipped
+	// still has to drop the old name.
+	for name := range current.Keys() {
+		if _, ok := desired.GetOk(name); !ok {
+			drop := dropTriggerSQL(fqtn, name)
+			if !triggerAllowed {
+				disallowed = append(disallowed, "-- skipped: "+drop)
+				continue
+			}
+			stmts = append(stmts, drop)
+			continue
+		}
+		if recreated[name] {
+			dropName := name
+			if oldName, ok := renamedFrom[name]; ok {
+				dropName = oldName
+			}
+			stmts = append(stmts, dropTriggerSQL(fqtn, dropName))
+		}
+	}
+
+	for name, des := range desired.All() {
+		cur, ok := current.GetOk(name)
+		if !ok || recreated[name] {
+			stmts = append(stmts, des.SQL())
+			if s := des.StateSQL(); s != "" {
+				stmts = append(stmts, s)
+			}
+			continue
+		}
+
+		if !changed[name] {
+			if cur.State.Action() != des.State.Action() {
+				stmts = append(stmts, alterTriggerStateSQL(fqtn, des))
+			}
+			continue
+		}
+
+		replace, err := replaceTriggerSQL(des.Definition)
+		if err != nil {
+			return nil, nil, err
+		}
+		stmts = append(stmts, replace)
+		if s := des.StateSQL(); s != "" {
+			stmts = append(stmts, s)
+		}
+	}
+
+	return stmts, disallowed, nil
+}
+
+// detectTriggerRenames reads the -- pista:renamed-from directives on the
+// desired triggers and returns the current map rekeyed under the new names,
+// plus the new name to old name pairs the caller renders as ALTER TRIGGER.
+func detectTriggerRenames(
+	fqtn string,
+	current, desired *orderedmap.Map[string, *model.Trigger],
+) (*orderedmap.Map[string, *model.Trigger], map[string]string, error) {
+	adjusted := cloneMap(current)
+	renamedFrom := map[string]string{}
+
+	for newName, des := range desired.All() {
+		if des.RenameFrom == nil {
+			continue
+		}
+		oldName := *des.RenameFrom
+		if oldName == newName {
+			continue
+		}
+
+		old, ok := adjusted.GetOk(oldName)
+		if !ok {
+			// The rename has already been applied on an earlier run, so the
+			// directive can stay in the file until the next cleanup.
+			if _, exists := adjusted.GetOk(newName); exists {
+				continue
+			}
+			return nil, nil, fmt.Errorf("rename source trigger %s not found on %s", model.Ident(oldName), fqtn)
+		}
+		if _, exists := adjusted.GetOk(newName); exists {
+			return nil, nil, fmt.Errorf("cannot rename trigger %s to %s on %s: destination already exists", model.Ident(oldName), model.Ident(newName), fqtn)
+		}
+
+		// ALTER TRIGGER ... RENAME changes the name pg_get_triggerdef writes,
+		// so carry the new name into the definition too. Without it the
+		// comparison below reads the old name as a definition change and adds
+		// a redundant CREATE OR REPLACE.
+		def, err := renameTriggerDef(old.Definition, newName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		renamedFrom[newName] = oldName
+		adjusted.Delete(oldName)
+		renamed := *old
+		renamed.Name = newName
+		renamed.Definition = def
+		adjusted.Set(newName, &renamed)
+	}
+
+	return adjusted, renamedFrom, nil
+}
+
+// triggerMap returns m, or an empty map when the caller built its model
+// without one.
+func triggerMap(m *orderedmap.Map[string, *model.Trigger]) *orderedmap.Map[string, *model.Trigger] {
+	if m == nil {
+		return orderedmap.New[string, *model.Trigger]()
+	}
+	return m
+}
+
+func dropTriggerSQL(fqtn, name string) string {
+	return "DROP TRIGGER " + model.Ident(name) + " ON " + fqtn + ";"
+}
+
+func renameTriggerSQL(fqtn, oldName, newName string) string {
+	return "ALTER TRIGGER " + model.Ident(oldName) + " ON " + fqtn + " RENAME TO " + model.Ident(newName) + ";"
+}
+
+func alterTriggerStateSQL(fqtn string, trg *model.Trigger) string {
+	return "ALTER TABLE " + fqtn + " " + trg.State.Action() + " TRIGGER " + model.Ident(trg.Name) + ";"
+}
+
+// parseTriggerDef parses a CREATE TRIGGER statement and takes out the wording
+// that says nothing about the trigger's state: an implicit relation schema is
+// filled in from the owning relation, OR REPLACE is cleared, and the WHEN
+// expression goes through the normalization constraint CHECK bodies use, since
+// pg_get_triggerdef adds casts there the way pg_get_constraintdef does. It
+// returns the whole result so the caller can deparse it back.
+func parseTriggerDef(def, schema string) (*pg_query.ParseResult, *pg_query.CreateTrigStmt, error) {
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(result.Stmts) != 1 {
+		return nil, nil, fmt.Errorf("unexpected parse result for trigger definition: %s", def)
+	}
+	ct := result.Stmts[0].Stmt.GetCreateTrigStmt()
+	if ct == nil {
+		return nil, nil, fmt.Errorf("unexpected parse result for trigger definition: %s", def)
+	}
+	if ct.Relation != nil && ct.Relation.Schemaname == "" {
+		ct.Relation.Schemaname = schema
+	}
+	ct.Replace = false
+	if ct.WhenClause != nil {
+		ct.WhenClause = normalizeCheckExpr(ct.WhenClause)
+	}
+	return result, ct, nil
+}
+
+// equalTriggerDef compares two CREATE TRIGGER definitions by deparsing their
+// normalized parse trees. pg_get_triggerdef and the deparser disagree on
+// wording that carries no meaning (the AS in REFERENCING, an explicit FOR EACH
+// STATEMENT), so the definitions cannot be compared as they arrive, and the
+// trees themselves carry the byte offset of every token, which differs as soon
+// as the two spellings differ in length. schema fills in a relation the
+// catalog wrote bare because search_path reached it.
+func equalTriggerDef(current, desired, schema string) (bool, error) {
+	if current == desired {
+		return true, nil
+	}
+	curResult, _, err := parseTriggerDef(current, schema)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse the current trigger definition: %w", err)
+	}
+	desResult, _, err := parseTriggerDef(desired, schema)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse the desired trigger definition: %w", err)
+	}
+	cur, err := pg_query.Deparse(curResult)
+	if err != nil {
+		return false, fmt.Errorf("failed to deparse the current trigger definition: %w", err)
+	}
+	des, err := pg_query.Deparse(desResult)
+	if err != nil {
+		return false, fmt.Errorf("failed to deparse the desired trigger definition: %w", err)
+	}
+	return cur == des, nil
+}
+
+// isConstraintTrigger reports whether a definition is a CREATE CONSTRAINT
+// TRIGGER. PostgreSQL will not replace one with a plain trigger or the other
+// way round, so the two need a DROP in between.
+func isConstraintTrigger(def string) bool {
+	_, ct, err := parseTriggerDef(def, "")
+	if err != nil {
+		return false
+	}
+	return ct.Isconstraint
+}
+
+// renameTriggerDef rewrites a CREATE TRIGGER definition to carry a new trigger
+// name, the way the catalog reports it after ALTER TRIGGER ... RENAME.
+func renameTriggerDef(def, newName string) (string, error) {
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the current trigger definition: %w", err)
+	}
+	ct := result.Stmts[0].Stmt.GetCreateTrigStmt()
+	if ct == nil {
+		return "", fmt.Errorf("unexpected parse result for trigger definition: %s", def)
+	}
+	ct.Trigname = newName
+	sql, err := pg_query.Deparse(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to deparse the current trigger definition: %w", err)
+	}
+	return sql, nil
+}
+
+// replaceTriggerSQL rewrites a CREATE TRIGGER definition into the
+// CREATE OR REPLACE TRIGGER that updates the trigger in place.
+func replaceTriggerSQL(def string) (string, error) {
+	result, err := pg_query.Parse(def)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the desired trigger definition: %w", err)
+	}
+	ct := result.Stmts[0].Stmt.GetCreateTrigStmt()
+	if ct == nil {
+		return "", fmt.Errorf("unexpected parse result for trigger definition: %s", def)
+	}
+	ct.Replace = true
+	sql, err := pg_query.Deparse(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to deparse the desired trigger definition: %w", err)
+	}
+	return sql + ";", nil
+}

--- a/diff/triggers_test.go
+++ b/diff/triggers_test.go
@@ -224,6 +224,31 @@ func TestDiffTriggers_ConstraintSwitch(t *testing.T) {
 	}, stmts)
 }
 
+// A denied recreate leaves the trigger exactly as it was: no DROP, no
+// CREATE, nothing else touches it either.
+func TestDiffTriggers_ConstraintSwitchDenied(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", conDef))
+	des := triggers(newTrigger("events_stamp", insertDef))
+	stmts, disallowed, err := diffTriggers("public.events", cur, des, nil)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+	assert.Equal(t, []string{"-- skipped: DROP TRIGGER events_stamp ON public.events;"}, disallowed)
+}
+
+// A rename bundled with a denied constraint switch keeps the old name too:
+// the RENAME is suppressed the same way it is for a recreate that goes
+// through, and nothing steps in to run it on its own.
+func TestDiffTriggers_RenameWithRecreateDenied(t *testing.T) {
+	cur := triggers(newTrigger("events_old", conDef))
+	des := triggers(newTrigger("events_new",
+		"CREATE TRIGGER events_new AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()",
+		withTriggerRenameFrom("events_old")))
+	stmts, disallowed, err := diffTriggers("public.events", cur, des, nil)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+	assert.Equal(t, []string{"-- skipped: DROP TRIGGER events_old ON public.events;"}, disallowed)
+}
+
 func TestDiffTriggers_Rename(t *testing.T) {
 	cur := triggers(newTrigger("events_old",
 		"CREATE TRIGGER events_old BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()"))
@@ -345,6 +370,10 @@ func TestReplaceTriggerSQL_Unparseable(t *testing.T) {
 	_, err = replaceTriggerSQL("SELECT 1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected parse result")
+
+	_, err = replaceTriggerSQL(insertDef + "; " + insertDef)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected parse result")
 }
 
 func TestRenameTriggerDef_Unparseable(t *testing.T) {
@@ -352,6 +381,10 @@ func TestRenameTriggerDef_Unparseable(t *testing.T) {
 	require.Error(t, err)
 
 	_, err = renameTriggerDef("SELECT 1", "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected parse result")
+
+	_, err = renameTriggerDef(insertDef+"; "+insertDef, "x")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected parse result")
 }

--- a/diff/triggers_test.go
+++ b/diff/triggers_test.go
@@ -1,0 +1,301 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap/v2"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func newTrigger(name, def string, opts ...func(*model.Trigger)) *model.Trigger {
+	trg := &model.Trigger{
+		Schema:     "public",
+		Table:      "events",
+		Name:       name,
+		Definition: def,
+		State:      model.TriggerStateDefault,
+	}
+	for _, o := range opts {
+		o(trg)
+	}
+	return trg
+}
+
+func withState(s model.TriggerState) func(*model.Trigger) {
+	return func(trg *model.Trigger) { trg.State = s }
+}
+
+func withTriggerRenameFrom(s string) func(*model.Trigger) {
+	return func(trg *model.Trigger) { trg.RenameFrom = &s }
+}
+
+func triggers(list ...*model.Trigger) *orderedmap.Map[string, *model.Trigger] {
+	m := orderedmap.New[string, *model.Trigger]()
+	for _, trg := range list {
+		m.Set(trg.Name, trg)
+	}
+	return m
+}
+
+const (
+	insertDef = "CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()"
+	updateDef = "CREATE TRIGGER events_stamp BEFORE UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()"
+	conDef    = "CREATE CONSTRAINT TRIGGER events_stamp AFTER INSERT ON public.events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION stamp()"
+)
+
+func allowTriggerDrops() DropChecker {
+	return &fakeDropChecker{allowed: map[string]bool{"trigger": true}}
+}
+
+type fakeDropChecker struct {
+	allowed map[string]bool
+}
+
+func (f *fakeDropChecker) IsDropAllowed(objectType string) bool { return f.allowed[objectType] }
+
+func TestDiffTriggers_NoChange(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", insertDef))
+	des := triggers(newTrigger("events_stamp", insertDef))
+	stmts, disallowed, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+	assert.Empty(t, disallowed)
+}
+
+// The catalog leaves out a schema search_path reaches and spells out the parts
+// the deparser omits. None of that is a change.
+func TestDiffTriggers_NoChangeAcrossRenderings(t *testing.T) {
+	cur := triggers(newTrigger("events_batch",
+		"CREATE TRIGGER events_batch AFTER INSERT ON events REFERENCING NEW TABLE AS added FOR EACH STATEMENT EXECUTE FUNCTION stamp()"))
+	des := triggers(newTrigger("events_batch",
+		"CREATE TRIGGER events_batch AFTER INSERT ON public.events REFERENCING NEW TABLE added EXECUTE FUNCTION stamp()"))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffTriggers_Add(t *testing.T) {
+	stmts, _, err := diffTriggers("public.events", triggers(), triggers(newTrigger("events_stamp", insertDef)), allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{insertDef + ";"}, stmts)
+}
+
+func TestDiffTriggers_AddDisabled(t *testing.T) {
+	des := triggers(newTrigger("events_stamp", insertDef, withState('D')))
+	stmts, _, err := diffTriggers("public.events", triggers(), des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		insertDef + ";",
+		"ALTER TABLE public.events DISABLE TRIGGER events_stamp;",
+	}, stmts)
+}
+
+func TestDiffTriggers_Drop(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", insertDef))
+	stmts, disallowed, err := diffTriggers("public.events", cur, triggers(), allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DROP TRIGGER events_stamp ON public.events;"}, stmts)
+	assert.Empty(t, disallowed)
+}
+
+func TestDiffTriggers_DropDisallowed(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", insertDef))
+	stmts, disallowed, err := diffTriggers("public.events", cur, triggers(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+	assert.Equal(t, []string{"-- skipped: DROP TRIGGER events_stamp ON public.events;"}, disallowed)
+}
+
+func TestDiffTriggers_Replace(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", insertDef))
+	des := triggers(newTrigger("events_stamp", updateDef))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"CREATE OR REPLACE TRIGGER events_stamp BEFORE UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();",
+	}, stmts)
+}
+
+// CREATE OR REPLACE TRIGGER re-enables the trigger, so a state other than the
+// default has to be set again behind it.
+func TestDiffTriggers_ReplaceKeepsState(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", insertDef, withState('D')))
+	des := triggers(newTrigger("events_stamp", updateDef, withState('D')))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"CREATE OR REPLACE TRIGGER events_stamp BEFORE UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();",
+		"ALTER TABLE public.events DISABLE TRIGGER events_stamp;",
+	}, stmts)
+}
+
+func TestDiffTriggers_StateOnly(t *testing.T) {
+	cases := []struct {
+		name  string
+		cur   model.TriggerState
+		des   model.TriggerState
+		stmts []string
+	}{
+		{"enable", 'D', model.TriggerStateDefault, []string{"ALTER TABLE public.events ENABLE TRIGGER events_stamp;"}},
+		{"disable", model.TriggerStateDefault, 'D', []string{"ALTER TABLE public.events DISABLE TRIGGER events_stamp;"}},
+		{"always", model.TriggerStateDefault, 'A', []string{"ALTER TABLE public.events ENABLE ALWAYS TRIGGER events_stamp;"}},
+		{"replica", model.TriggerStateDefault, 'R', []string{"ALTER TABLE public.events ENABLE REPLICA TRIGGER events_stamp;"}},
+		{"unchanged", 'A', 'A', nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cur := triggers(newTrigger("events_stamp", insertDef, withState(tc.cur)))
+			des := triggers(newTrigger("events_stamp", insertDef, withState(tc.des)))
+			stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+			require.NoError(t, err)
+			assert.Equal(t, tc.stmts, stmts)
+		})
+	}
+}
+
+// PostgreSQL rejects CREATE OR REPLACE TRIGGER across the constraint-trigger
+// line, so the change runs as DROP and CREATE.
+func TestDiffTriggers_ConstraintSwitch(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", conDef))
+	des := triggers(newTrigger("events_stamp", insertDef))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DROP TRIGGER events_stamp ON public.events;",
+		insertDef + ";",
+	}, stmts)
+}
+
+func TestDiffTriggers_Rename(t *testing.T) {
+	cur := triggers(newTrigger("events_old",
+		"CREATE TRIGGER events_old BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()"))
+	des := triggers(newTrigger("events_new",
+		"CREATE TRIGGER events_new BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()",
+		withTriggerRenameFrom("events_old")))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER TRIGGER events_old ON public.events RENAME TO events_new;"}, stmts)
+}
+
+// A rename that also crosses the constraint-trigger line drops the old name
+// and creates the new one, so the RENAME would have nothing left to rename.
+func TestDiffTriggers_RenameWithRecreate(t *testing.T) {
+	cur := triggers(newTrigger("events_old",
+		"CREATE CONSTRAINT TRIGGER events_old AFTER INSERT ON public.events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION stamp()"))
+	des := triggers(newTrigger("events_new",
+		"CREATE TRIGGER events_new AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()",
+		withTriggerRenameFrom("events_old")))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DROP TRIGGER events_old ON public.events;",
+		"CREATE TRIGGER events_new AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();",
+	}, stmts)
+}
+
+// The directive stays in the file after the rename has been applied, so the
+// source being gone while the destination exists is not an error.
+func TestDiffTriggers_RenameAlreadyApplied(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", insertDef))
+	des := triggers(newTrigger("events_stamp", insertDef, withTriggerRenameFrom("events_old")))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffTriggers_RenameSameName(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", insertDef))
+	des := triggers(newTrigger("events_stamp", insertDef, withTriggerRenameFrom("events_stamp")))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+func TestDiffTriggers_RenameSourceMissing(t *testing.T) {
+	des := triggers(newTrigger("events_new", insertDef, withTriggerRenameFrom("events_old")))
+	_, _, err := diffTriggers("public.events", triggers(), des, allowTriggerDrops())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename source trigger events_old not found")
+}
+
+func TestDiffTriggers_RenameDestinationExists(t *testing.T) {
+	cur := triggers(
+		newTrigger("events_old", insertDef),
+		newTrigger("events_new", insertDef),
+	)
+	des := triggers(newTrigger("events_new", insertDef, withTriggerRenameFrom("events_old")))
+	_, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+}
+
+// The rename runs before any comparison, so a current definition that does not
+// parse surfaces there rather than in equalTriggerDef.
+func TestDiffTriggers_RenameUnparseableCurrent(t *testing.T) {
+	cur := triggers(newTrigger("events_old", "NOT A TRIGGER"))
+	des := triggers(newTrigger("events_new", insertDef, withTriggerRenameFrom("events_old")))
+	_, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse the current trigger definition")
+}
+
+func TestDiffTriggers_NilMaps(t *testing.T) {
+	stmts, disallowed, err := diffTriggers("public.events", nil, nil, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+	assert.Empty(t, disallowed)
+}
+
+func TestDiffTriggers_UnparseableDefinition(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", "NOT A TRIGGER"))
+	des := triggers(newTrigger("events_stamp", insertDef))
+	_, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse the current trigger definition")
+}
+
+func TestDiffTriggers_UnparseableDesiredDefinition(t *testing.T) {
+	cur := triggers(newTrigger("events_stamp", insertDef))
+	des := triggers(newTrigger("events_stamp", "NOT A TRIGGER"))
+	_, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse the desired trigger definition")
+}
+
+// A definition that parses as something other than CREATE TRIGGER cannot be
+// compared, and neither can a file holding more than one statement.
+func TestParseTriggerDef_WrongStatement(t *testing.T) {
+	_, _, err := parseTriggerDef("SELECT 1", "public")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected parse result")
+
+	_, _, err = parseTriggerDef(insertDef+"; "+insertDef, "public")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected parse result")
+}
+
+func TestIsConstraintTrigger(t *testing.T) {
+	assert.True(t, isConstraintTrigger(conDef))
+	assert.False(t, isConstraintTrigger(insertDef))
+	assert.False(t, isConstraintTrigger("NOT A TRIGGER"))
+}
+
+func TestReplaceTriggerSQL_Unparseable(t *testing.T) {
+	_, err := replaceTriggerSQL("NOT A TRIGGER")
+	require.Error(t, err)
+
+	_, err = replaceTriggerSQL("SELECT 1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected parse result")
+}
+
+func TestRenameTriggerDef_Unparseable(t *testing.T) {
+	_, err := renameTriggerDef("NOT A TRIGGER", "x")
+	require.Error(t, err)
+
+	_, err = renameTriggerDef("SELECT 1", "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected parse result")
+}

--- a/diff/triggers_test.go
+++ b/diff/triggers_test.go
@@ -76,6 +76,62 @@ func TestDiffTriggers_NoChangeAcrossRenderings(t *testing.T) {
 	assert.Empty(t, stmts)
 }
 
+// pg_get_triggerdef casts a string literal in the WHEN expression the way
+// pg_get_constraintdef casts one in a CHECK body, and writes = ANY (ARRAY[...])
+// where the file says IN. Neither is a change.
+func TestDiffTriggers_NoChangeAcrossWhenRenderings(t *testing.T) {
+	cases := []struct {
+		name string
+		cur  string
+		des  string
+	}{
+		{
+			"text cast",
+			"CREATE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW WHEN (new.name <> 'skip'::text) EXECUTE FUNCTION stamp()",
+			"CREATE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW WHEN (new.name <> 'skip') EXECUTE FUNCTION stamp()",
+		},
+		{
+			"any array",
+			"CREATE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW WHEN (new.kind = ANY (ARRAY[1, 2])) EXECUTE FUNCTION stamp()",
+			"CREATE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW WHEN (new.kind IN (1, 2)) EXECUTE FUNCTION stamp()",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cur := triggers(newTrigger("events_audit", tc.cur))
+			des := triggers(newTrigger("events_audit", tc.des))
+			stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+			require.NoError(t, err)
+			assert.Empty(t, stmts)
+		})
+	}
+}
+
+// A WHEN expression that really differs is a definition change.
+func TestDiffTriggers_WhenChanged(t *testing.T) {
+	cur := triggers(newTrigger("events_audit",
+		"CREATE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW WHEN (new.name <> 'skip'::text) EXECUTE FUNCTION stamp()"))
+	des := triggers(newTrigger("events_audit",
+		"CREATE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW WHEN (new.name <> 'keep') EXECUTE FUNCTION stamp()"))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"CREATE OR REPLACE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW WHEN (new.name <> 'keep') EXECUTE FUNCTION stamp();",
+	}, stmts)
+}
+
+// The catalog renders every trigger argument as a string, so an integer in the
+// file is not a change.
+func TestDiffTriggers_NoChangeAcrossArgumentRenderings(t *testing.T) {
+	cur := triggers(newTrigger("events_audit",
+		"CREATE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp('a', '1')"))
+	des := triggers(newTrigger("events_audit",
+		"CREATE TRIGGER events_audit AFTER UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp('a', 1)"))
+	stmts, _, err := diffTriggers("public.events", cur, des, allowTriggerDrops())
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
 func TestDiffTriggers_Add(t *testing.T) {
 	stmts, _, err := diffTriggers("public.events", triggers(), triggers(newTrigger("events_stamp", insertDef)), allowTriggerDrops())
 	require.NoError(t, err)

--- a/diff/views.go
+++ b/diff/views.go
@@ -268,6 +268,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 		if !ok {
 			// New view
 			result.CreateStmts = append(result.CreateStmts, desiredView.SQL())
+			result.CreateStmts = append(result.CreateStmts, viewTriggerStmts(desiredView)...)
 			// Add indexes for new materialized views
 			if desiredView.Materialized && desiredView.Indexes != nil {
 				for _, idx := range desiredView.Indexes.CollectValues() {
@@ -312,6 +313,9 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 						result.DropStmts = append(result.DropStmts, "DROP VIEW "+dropName+";")
 					}
 					result.CreateStmts = append(result.CreateStmts, desiredView.SQL())
+					// DROP VIEW takes the view's triggers with it, so the
+					// recreate has to put them back.
+					result.CreateStmts = append(result.CreateStmts, viewTriggerStmts(desiredView)...)
 					if desiredView.Materialized && desiredView.Indexes != nil {
 						for _, idx := range desiredView.Indexes.CollectValues() {
 							stmt, err := createIndexSQL(idx.Definition, idx.Concurrently)
@@ -348,6 +352,19 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			if viewIdxHasConcurrently {
 				result.HasConcurrently = true
 			}
+		}
+
+		// A view that stayed in place, whether its definition was replaced or
+		// left alone, kept its triggers, so they are diffed. The branches that
+		// created the view already emitted them, and a denied recreate left
+		// the view as it was.
+		if ok && !recreated[k] && !recreateDenied[k] {
+			trgStmts, trgDisallowed, err := diffTriggers(k, currentView.Triggers, desiredView.Triggers, dc)
+			if err != nil {
+				return nil, err
+			}
+			result.CreateStmts = append(result.CreateStmts, trgStmts...)
+			result.DisallowedDropStmts = append(result.DisallowedDropStmts, trgDisallowed...)
 		}
 	}
 
@@ -409,6 +426,20 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 	}
 
 	return result, nil
+}
+
+// viewTriggerStmts renders the CREATE TRIGGER statements for a view that is
+// about to be created. A materialized view cannot carry a trigger, so the map
+// is empty there.
+func viewTriggerStmts(v *model.View) []string {
+	if v.Triggers == nil {
+		return nil
+	}
+	var stmts []string
+	for _, trg := range v.Triggers.CollectValues() {
+		stmts = append(stmts, trg.SQL())
+	}
+	return stmts
 }
 
 // diffViewIndexes generates DDL for index changes on materialized views.

--- a/diff_all.go
+++ b/diff_all.go
@@ -560,6 +560,11 @@ func extractObjectName(sql string) string {
 		{"CREATE POLICY "},
 		{"ALTER POLICY "},
 		{"DROP POLICY "},
+		{"CREATE OR REPLACE TRIGGER "},
+		{"CREATE CONSTRAINT TRIGGER "},
+		{"CREATE TRIGGER "},
+		{"DROP TRIGGER "},
+		{"ALTER TRIGGER "},
 		{"ALTER TABLE ONLY "},
 		{"ALTER TABLE "},
 		{"ALTER TYPE "},
@@ -611,6 +616,12 @@ func extractObjectName(sql string) string {
 			strings.HasPrefix(upper, "ALTER POLICY ") ||
 			strings.HasPrefix(upper, "DROP POLICY ") {
 			// {CREATE,ALTER,DROP} POLICY name ON schema.table ...
+			return extractIndexTable(sql)
+		}
+
+		if strings.HasSuffix(strings.TrimSpace(p.prefix), "TRIGGER") {
+			// CREATE [OR REPLACE|CONSTRAINT] TRIGGER name <events> ON
+			// schema.table ..., and {DROP,ALTER} TRIGGER name ON schema.table.
 			return extractIndexTable(sql)
 		}
 

--- a/directives.md
+++ b/directives.md
@@ -4,7 +4,7 @@ pistachio reads directives from SQL comments in schema files. A directive is a l
 
 | Directive | Arguments | Applies to | Purpose |
 |---|---|---|---|
-| `renamed-from` | old name (required) | tables, views, enums, enum values, domains, composite types, composite attributes, columns, constraints, foreign keys, indexes, policies | Rename instead of drop and create |
+| `renamed-from` | old name (required) | tables, views, enums, enum values, domains, composite types, composite attributes, columns, constraints, foreign keys, indexes, policies, triggers | Rename instead of drop and create |
 | `execute` | check SQL (optional) | any statement | Run non-managed SQL after the managed DDL |
 | `execute-first` | check SQL (optional) | any statement | Run non-managed SQL before the managed DDL |
 | `concurrently` | none | `CREATE INDEX` | Create and drop the index with `CONCURRENTLY` |
@@ -13,7 +13,7 @@ pistachio reads directives from SQL comments in schema files. A directive is a l
 
 ## -- pista:renamed-from
 
-Renames an object instead of dropping and recreating it. The argument is the old name. For tables, views, enums, domains, and composite types, the old name may be schema-qualified; without a schema it defaults to the default schema. For composite attributes, columns, constraints, foreign keys, indexes, and policies, the old name is unqualified.
+Renames an object instead of dropping and recreating it. The argument is the old name. For tables, views, enums, domains, and composite types, the old name may be schema-qualified; without a schema it defaults to the default schema. For composite attributes, columns, constraints, foreign keys, indexes, policies, and triggers, the old name is unqualified.
 
 ```sql
 -- pista:renamed-from public.old_users

--- a/drop_policy.go
+++ b/drop_policy.go
@@ -7,7 +7,7 @@ import "slices"
 // If AllowDrop contains "all", all drops are allowed.
 // Otherwise, only the listed object types are allowed to be dropped.
 type DropPolicy struct {
-	AllowDrop []string `enum:"all,table,view,enum,domain,composite_type,sequence,column,constraint,foreign_key,index,policy" env:"PISTA_ALLOW_DROP" help:"Allow dropping these object types (repeatable; 'all' allows everything)."`
+	AllowDrop []string `enum:"all,table,view,enum,domain,composite_type,sequence,column,constraint,foreign_key,index,policy,trigger" env:"PISTA_ALLOW_DROP" help:"Allow dropping these object types (repeatable; 'all' allows everything)."`
 }
 
 func (p *DropPolicy) IsDropAllowed(objectType string) bool {

--- a/dump.go
+++ b/dump.go
@@ -32,14 +32,15 @@ type DumpResult struct {
 	Count          ObjectCount
 }
 
-// stripIndexSchemaPrefix removes the schema qualification from the relation an
-// index targets, for --omit-schema. pg_get_indexdef emits
+// stripRelationSchemaPrefix removes the schema qualification from the relation
+// an index or a trigger targets, for --omit-schema. pg_get_indexdef emits
 // "... ON <schema>.<rel> ..." for ordinary indexes and
 // "... ON ONLY <schema>.<rel> ..." for indexes on partitioned-table parents,
 // so both forms are rewritten. The two patterns are mutually exclusive per
 // occurrence (the ONLY form has "ONLY " between "ON " and the relation), so
 // applying both replacers never double-processes a match.
-func stripIndexSchemaPrefix(definition, fqrn, relName string) string {
+// pg_get_triggerdef writes the same "... ON <schema>.<rel> ..." shape.
+func stripRelationSchemaPrefix(definition, fqrn, relName string) string {
 	definition = strings.ReplaceAll(definition, " ON ONLY "+fqrn+" ", " ON ONLY "+relName+" ")
 	return strings.ReplaceAll(definition, " ON "+fqrn+" ", " ON "+relName+" ")
 }
@@ -78,7 +79,7 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 			for _, idx := range copied.Indexes.CollectValues() {
 				idxCopied := *idx
 				idxCopied.Schema = ""
-				idxCopied.Definition = stripIndexSchemaPrefix(idx.Definition, fqtn, tableName)
+				idxCopied.Definition = stripRelationSchemaPrefix(idx.Definition, fqtn, tableName)
 				idxs.Set(idx.Name, &idxCopied)
 			}
 			copied.Indexes = idxs
@@ -92,6 +93,7 @@ func (r *DumpResult) tables() *orderedmap.Map[string, *model.Table] {
 			}
 			copied.Policies = policies
 		}
+		copied.Triggers = stripTriggerSchemas(copied.Triggers, fqtn, tableName)
 		tables.Set(tableName, &copied)
 	}
 	return tables
@@ -115,14 +117,35 @@ func (r *DumpResult) views() *orderedmap.Map[string, *model.View] {
 			for _, idx := range copied.Indexes.CollectValues() {
 				idxCopied := *idx
 				idxCopied.Schema = ""
-				idxCopied.Definition = stripIndexSchemaPrefix(idx.Definition, fqvn, viewName)
+				idxCopied.Definition = stripRelationSchemaPrefix(idx.Definition, fqvn, viewName)
 				idxs.Set(idx.Name, &idxCopied)
 			}
 			copied.Indexes = idxs
 		}
+		copied.Triggers = stripTriggerSchemas(copied.Triggers, fqvn, viewName)
 		views.Set(viewName, &copied)
 	}
 	return views
+}
+
+// stripTriggerSchemas drops the schema from a relation's triggers, for
+// --omit-schema. The trigger keeps whatever schema the definition gives the
+// function it calls, which may sit outside the schema being dumped.
+func stripTriggerSchemas(
+	triggers *orderedmap.Map[string, *model.Trigger],
+	fqrn, relName string,
+) *orderedmap.Map[string, *model.Trigger] {
+	if triggers == nil || triggers.Len() == 0 {
+		return triggers
+	}
+	out := orderedmap.New[string, *model.Trigger]()
+	for _, trg := range triggers.CollectValues() {
+		copied := *trg
+		copied.Schema = ""
+		copied.Definition = stripRelationSchemaPrefix(trg.Definition, fqrn, relName)
+		out.Set(trg.Name, &copied)
+	}
+	return out
 }
 
 func (r *DumpResult) enums() *orderedmap.Map[string, *model.Enum] {

--- a/model/table.go
+++ b/model/table.go
@@ -30,6 +30,7 @@ type Table struct {
 	ForeignKeys      *orderedmap.Map[string, *ForeignKey]
 	Indexes          *orderedmap.Map[string, *Index]
 	Policies         *orderedmap.Map[string, *Policy]
+	Triggers         *orderedmap.Map[string, *Trigger]
 	Comment          *string
 }
 
@@ -144,6 +145,21 @@ func (t Table) RLSSQL() string {
 	return strings.Join(stmts, "\n")
 }
 
+// TrigSQL renders the table's triggers, each followed by the ALTER TABLE that
+// puts it in a non-default enable state.
+func (t Table) TrigSQL() string {
+	var stmts []string
+	if t.Triggers != nil {
+		for _, trg := range t.Triggers.CollectValues() {
+			stmts = append(stmts, trg.SQL())
+			if s := trg.StateSQL(); s != "" {
+				stmts = append(stmts, s)
+			}
+		}
+	}
+	return strings.Join(stmts, "\n")
+}
+
 func (t Table) CommentSQL() string {
 	var stmts []string
 	if t.Comment != nil {
@@ -166,6 +182,9 @@ func TableToSQL(t *Table) string {
 		parts = append(parts, "\n"+s)
 	}
 	if s := t.RLSSQL(); s != "" {
+		parts = append(parts, "\n"+s)
+	}
+	if s := t.TrigSQL(); s != "" {
 		parts = append(parts, "\n"+s)
 	}
 	if s := t.CommentSQL(); s != "" {

--- a/model/trigger.go
+++ b/model/trigger.go
@@ -40,7 +40,8 @@ type Trigger struct {
 	// Definition is the whole CREATE TRIGGER statement without its
 	// terminator: what pg_get_triggerdef writes on the catalog side, and what
 	// pg_query deparses on the desired side. The two renderings differ in
-	// places, so the diff compares parse trees rather than this text.
+	// places, so the diff cannot compare this text directly; see
+	// diff.equalTriggerDef.
 	Definition string
 	State      TriggerState
 }
@@ -64,5 +65,13 @@ func (trg Trigger) StateSQL() string {
 	if trg.State.IsDefault() {
 		return ""
 	}
-	return "ALTER TABLE " + trg.FQTN() + " " + trg.State.Action() + " TRIGGER " + Ident(trg.Name) + ";"
+	return TriggerStateSQL(trg.FQTN(), trg.Name, trg.State)
+}
+
+// TriggerStateSQL renders the ALTER TABLE that puts a trigger in the given
+// state. Exported so diff can reuse it for the case StateSQL suppresses: a
+// trigger going back to the default state after CREATE OR REPLACE TRIGGER
+// reset it, which still needs the statement CREATE TRIGGER alone would not.
+func TriggerStateSQL(fqtn, name string, state TriggerState) string {
+	return "ALTER TABLE " + fqtn + " " + state.Action() + " TRIGGER " + Ident(name) + ";"
 }

--- a/model/trigger.go
+++ b/model/trigger.go
@@ -70,8 +70,7 @@ func (trg Trigger) StateSQL() string {
 
 // TriggerStateSQL renders the ALTER TABLE that puts a trigger in the given
 // state. Exported so diff can reuse it for the case StateSQL suppresses: a
-// trigger going back to the default state after CREATE OR REPLACE TRIGGER
-// reset it, which still needs the statement CREATE TRIGGER alone would not.
+// trigger whose definition did not change going back to the default state.
 func TriggerStateSQL(fqtn, name string, state TriggerState) string {
 	return "ALTER TABLE " + fqtn + " " + state.Action() + " TRIGGER " + Ident(name) + ";"
 }

--- a/model/trigger.go
+++ b/model/trigger.go
@@ -1,0 +1,68 @@
+package model
+
+import "fmt"
+
+// TriggerState mirrors pg_trigger.tgenabled:
+//
+//	'O' fires in origin and local sessions, which is where CREATE TRIGGER
+//	leaves a new trigger, 'D' never fires, 'R' fires in replica mode only,
+//	and 'A' fires in every mode.
+type TriggerState byte
+
+// TriggerStateDefault is the state CREATE TRIGGER leaves behind.
+const TriggerStateDefault TriggerState = 'O'
+
+// IsDefault reports the state a bare CREATE TRIGGER produces. The zero value
+// counts, so a trigger built without a state reads as enabled.
+func (s TriggerState) IsDefault() bool {
+	return s == 0 || s == TriggerStateDefault
+}
+
+// Action returns the ALTER TABLE action that puts a trigger in the state.
+func (s TriggerState) Action() string {
+	switch s {
+	case 'D':
+		return "DISABLE"
+	case 'R':
+		return "ENABLE REPLICA"
+	case 'A':
+		return "ENABLE ALWAYS"
+	default:
+		return "ENABLE"
+	}
+}
+
+type Trigger struct {
+	Schema     string
+	Table      string
+	Name       string
+	RenameFrom *string
+	// Definition is the whole CREATE TRIGGER statement without its
+	// terminator: what pg_get_triggerdef writes on the catalog side, and what
+	// pg_query deparses on the desired side. The two renderings differ in
+	// places, so the diff compares parse trees rather than this text.
+	Definition string
+	State      TriggerState
+}
+
+func (trg *Trigger) String() string {
+	return fmt.Sprintf("%#v", *trg)
+}
+
+// FQTN returns the qualified name of the table or view the trigger is on.
+func (trg Trigger) FQTN() string {
+	return Ident(trg.Schema, trg.Table)
+}
+
+func (trg Trigger) SQL() string {
+	return trg.Definition + ";"
+}
+
+// StateSQL renders the ALTER TABLE that leaves the trigger in a non-default
+// state, and "" for the default one, which CREATE TRIGGER already produces.
+func (trg Trigger) StateSQL() string {
+	if trg.State.IsDefault() {
+		return ""
+	}
+	return "ALTER TABLE " + trg.FQTN() + " " + trg.State.Action() + " TRIGGER " + Ident(trg.Name) + ";"
+}

--- a/model/trigger_test.go
+++ b/model/trigger_test.go
@@ -1,0 +1,111 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/orderedmap/v2"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestTriggerState(t *testing.T) {
+	assert.True(t, model.TriggerStateDefault.IsDefault())
+	// A trigger built without a state reads as enabled.
+	assert.True(t, model.TriggerState(0).IsDefault())
+	assert.False(t, model.TriggerState('D').IsDefault())
+
+	assert.Equal(t, "ENABLE", model.TriggerStateDefault.Action())
+	assert.Equal(t, "ENABLE", model.TriggerState(0).Action())
+	assert.Equal(t, "DISABLE", model.TriggerState('D').Action())
+	assert.Equal(t, "ENABLE REPLICA", model.TriggerState('R').Action())
+	assert.Equal(t, "ENABLE ALWAYS", model.TriggerState('A').Action())
+}
+
+func TestTrigger_SQL(t *testing.T) {
+	trg := model.Trigger{
+		Schema:     "public",
+		Table:      "events",
+		Name:       "events_stamp",
+		Definition: "CREATE TRIGGER events_stamp BEFORE INSERT ON events FOR EACH ROW EXECUTE FUNCTION stamp()",
+	}
+	assert.Equal(t, "public.events", trg.FQTN())
+	assert.Equal(t,
+		"CREATE TRIGGER events_stamp BEFORE INSERT ON events FOR EACH ROW EXECUTE FUNCTION stamp();",
+		trg.SQL())
+}
+
+func TestTrigger_StateSQL(t *testing.T) {
+	trg := model.Trigger{Schema: "public", Table: "events", Name: "events_stamp"}
+
+	// The default state is what CREATE TRIGGER leaves behind, so it needs no
+	// statement of its own.
+	assert.Empty(t, trg.StateSQL())
+
+	trg.State = model.TriggerStateDefault
+	assert.Empty(t, trg.StateSQL())
+
+	trg.State = 'D'
+	assert.Equal(t, "ALTER TABLE public.events DISABLE TRIGGER events_stamp;", trg.StateSQL())
+
+	trg.State = 'A'
+	assert.Equal(t, "ALTER TABLE public.events ENABLE ALWAYS TRIGGER events_stamp;", trg.StateSQL())
+}
+
+func TestTrigger_String(t *testing.T) {
+	trg := &model.Trigger{Name: "events_stamp"}
+	assert.Contains(t, trg.String(), "events_stamp")
+}
+
+// orderedmapOf files triggers under their names, the way the parser and the
+// catalog do.
+func orderedmapOf(list ...*model.Trigger) *orderedmap.Map[string, *model.Trigger] {
+	m := orderedmap.New[string, *model.Trigger]()
+	for _, trg := range list {
+		m.Set(trg.Name, trg)
+	}
+	return m
+}
+
+func TestTable_TrigSQL(t *testing.T) {
+	tbl := &model.Table{
+		Schema:      "public",
+		Name:        "events",
+		Columns:     orderedmap.New[string, *model.Column](),
+		Constraints: orderedmap.New[string, *model.Constraint](),
+		Indexes:     orderedmap.New[string, *model.Index](),
+		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+		Triggers: orderedmapOf(
+			&model.Trigger{Schema: "public", Table: "events", Name: "a", Definition: "CREATE TRIGGER a BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()"},
+			&model.Trigger{Schema: "public", Table: "events", Name: "b", Definition: "CREATE TRIGGER b BEFORE UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp()", State: 'D'},
+		),
+	}
+	assert.Equal(t,
+		"CREATE TRIGGER a BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();\n"+
+			"CREATE TRIGGER b BEFORE UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();\n"+
+			"ALTER TABLE public.events DISABLE TRIGGER b;",
+		tbl.TrigSQL())
+	assert.Contains(t, model.TableToSQL(tbl), "CREATE TRIGGER a BEFORE INSERT")
+}
+
+func TestTable_TrigSQL_None(t *testing.T) {
+	tbl := &model.Table{Schema: "public", Name: "events"}
+	assert.Empty(t, tbl.TrigSQL())
+}
+
+func TestView_TrigSQL(t *testing.T) {
+	v := &model.View{
+		Schema:     "public",
+		Name:       "recent_events",
+		Definition: "SELECT id FROM events",
+		Triggers:   orderedmapOf(&model.Trigger{Schema: "public", Table: "recent_events", Name: "v_ins", Definition: "CREATE TRIGGER v_ins INSTEAD OF INSERT ON recent_events FOR EACH ROW EXECUTE FUNCTION stamp()"}),
+	}
+	assert.Equal(t,
+		"CREATE TRIGGER v_ins INSTEAD OF INSERT ON recent_events FOR EACH ROW EXECUTE FUNCTION stamp();",
+		v.TrigSQL())
+	assert.Contains(t, model.ViewToSQL(v), "CREATE TRIGGER v_ins INSTEAD OF INSERT")
+}
+
+func TestView_TrigSQL_None(t *testing.T) {
+	v := &model.View{Schema: "public", Name: "recent_events", Definition: "SELECT 1"}
+	assert.Empty(t, v.TrigSQL())
+}

--- a/model/view.go
+++ b/model/view.go
@@ -14,6 +14,7 @@ type View struct {
 	Definition   string
 	Materialized bool
 	Indexes      *orderedmap.Map[string, *Index]
+	Triggers     *orderedmap.Map[string, *Trigger]
 	Comment      *string
 	// Ignore marks the view as unmanaged (set by -- pista:ignore). Ignored
 	// objects are not created, altered, or dropped; always false on the
@@ -34,6 +35,18 @@ func (v View) SQL() string {
 	return "CREATE OR REPLACE VIEW " + Ident(v.Schema, v.Name) + " AS\n" + def + ";"
 }
 
+// TrigSQL renders the view's INSTEAD OF triggers. PostgreSQL rejects
+// ALTER TABLE ... DISABLE TRIGGER on a view, so there is no state to write.
+func (v View) TrigSQL() string {
+	var stmts []string
+	if v.Triggers != nil {
+		for _, trg := range v.Triggers.CollectValues() {
+			stmts = append(stmts, trg.SQL())
+		}
+	}
+	return strings.Join(stmts, "\n")
+}
+
 func (v View) CommentSQL() string {
 	objType := "VIEW"
 	if v.Materialized {
@@ -51,6 +64,9 @@ func ViewToSQL(v *View) string {
 		for _, idx := range v.Indexes.CollectValues() {
 			parts = append(parts, idx.SQL())
 		}
+	}
+	if s := v.TrigSQL(); s != "" {
+		parts = append(parts, "\n"+s)
 	}
 	if s := v.CommentSQL(); s != "" {
 		parts = append(parts, s)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -347,11 +347,12 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				continue
 			}
 
-			// RLS toggles and constraint subcommands can coexist in one
-			// ALTER TABLE statement. applyAlterTableRLS picks up only the RLS
-			// subtypes; parseAlterTableConstraints picks up AT_AddConstraint.
-			// They walk the same cmd list independently, so run both.
+			// RLS toggles, trigger states and constraint subcommands can
+			// coexist in one ALTER TABLE statement. Each helper picks up only
+			// its own subtypes and walks the cmd list independently, so run
+			// all three.
 			applyAlterTableRLS(as, t)
+			applyAlterTableTriggerState(as, t)
 
 			cons, fks, err := parseAlterTableConstraints(as, defaultSchema)
 			if err != nil {
@@ -389,6 +390,19 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			if renameFrom != "" {
 				unquoted := normalizeUnqualifiedDirective(renameFrom)
 				policy.RenameFrom = &unquoted
+			}
+
+		case node.GetCreateTrigStmt() != nil:
+			trg, err := parseCreateTrigStmt(node.GetCreateTrigStmt(), defaultSchema)
+			if err != nil {
+				return nil, err
+			}
+			if renameFrom != "" {
+				unquoted := normalizeUnqualifiedDirective(renameFrom)
+				trg.RenameFrom = &unquoted
+			}
+			if err := attachTrigger(trg, tables, views); err != nil {
+				return nil, err
 			}
 
 		case node.GetCreateSeqStmt() != nil:
@@ -448,6 +462,7 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 		ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
 		Indexes:     orderedmap.New[string, *model.Index](),
 		Policies:    orderedmap.New[string, *model.Policy](),
+		Triggers:    orderedmap.New[string, *model.Trigger](),
 	}
 
 	if cs.Tablespacename != "" {
@@ -1097,6 +1112,7 @@ func parseViewStmt(vs *pg_query.ViewStmt, defaultSchema string) (*model.View, er
 		Name:       vs.View.Relname,
 		Definition: def,
 		Indexes:    orderedmap.New[string, *model.Index](),
+		Triggers:   orderedmap.New[string, *model.Trigger](),
 	}, nil
 }
 
@@ -1128,6 +1144,7 @@ func parseCreateMatViewStmt(as *pg_query.CreateTableAsStmt, defaultSchema string
 		Definition:   def,
 		Materialized: true,
 		Indexes:      orderedmap.New[string, *model.Index](),
+		Triggers:     orderedmap.New[string, *model.Trigger](),
 	}, nil
 }
 

--- a/parser/trigger.go
+++ b/parser/trigger.go
@@ -1,0 +1,97 @@
+package parser
+
+import (
+	"fmt"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"github.com/winebarrel/orderedmap/v2"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// parseCreateTrigStmt converts a CreateTrigStmt into a model.Trigger. The
+// relation is qualified with defaultSchema when the statement leaves it bare,
+// so the stored definition names the same relation whatever search_path the
+// plan runs under. OR REPLACE is dropped: it says how to reach the state, not
+// what the state is, and the diff decides that.
+func parseCreateTrigStmt(ct *pg_query.CreateTrigStmt, defaultSchema string) (*model.Trigger, error) {
+	if ct.Relation == nil {
+		return nil, fmt.Errorf("CREATE TRIGGER %s: missing table reference", ct.Trigname)
+	}
+	schema := ct.Relation.Schemaname
+	if schema == "" {
+		schema = defaultSchema
+	}
+
+	// The statement is deparsed from the node itself. Nothing reads the parse
+	// tree after this case, so the two fields are set in place rather than on
+	// a copy.
+	ct.Relation.Schemaname = schema
+	ct.Replace = false
+
+	def, err := pg_query.Deparse(&pg_query.ParseResult{
+		Stmts: []*pg_query.RawStmt{
+			{Stmt: &pg_query.Node{Node: &pg_query.Node_CreateTrigStmt{CreateTrigStmt: ct}}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("CREATE TRIGGER %s: failed to deparse: %w", ct.Trigname, err)
+	}
+
+	return &model.Trigger{
+		Schema:     schema,
+		Table:      ct.Relation.Relname,
+		Name:       ct.Trigname,
+		Definition: def,
+		State:      model.TriggerStateDefault,
+	}, nil
+}
+
+// attachTrigger files a parsed trigger under the table or view it is on. A
+// trigger names its relation, so the relation has to be declared first, the
+// way CREATE POLICY needs its table.
+func attachTrigger(
+	trg *model.Trigger,
+	tables *orderedmap.Map[string, *model.Table],
+	views *orderedmap.Map[string, *model.View],
+) error {
+	fqtn := trg.FQTN()
+	if t, ok := tables.GetOk(fqtn); ok {
+		return setUnique(t.Triggers, trg.Name, "trigger", trg)
+	}
+	if v, ok := views.GetOk(fqtn); ok {
+		return setUnique(v.Triggers, trg.Name, "trigger", trg)
+	}
+	return fmt.Errorf("CREATE TRIGGER %s: relation %s not defined", trg.Name, fqtn)
+}
+
+// applyAlterTableTriggerState picks up the ENABLE / DISABLE TRIGGER
+// subcommands and records the state on the named trigger. CREATE TRIGGER has
+// no syntax for a disabled trigger, so this is the only way a desired schema
+// can ask for one, and it is what dump writes. The ALL and USER forms name no
+// single trigger and are left alone.
+func applyAlterTableTriggerState(as *pg_query.AlterTableStmt, t *model.Table) {
+	for _, cmdNode := range as.Cmds {
+		cmd := cmdNode.GetAlterTableCmd()
+		if cmd == nil {
+			continue
+		}
+		var state model.TriggerState
+		switch cmd.Subtype {
+		case pg_query.AlterTableType_AT_EnableTrig:
+			state = model.TriggerStateDefault
+		case pg_query.AlterTableType_AT_DisableTrig:
+			state = 'D'
+		case pg_query.AlterTableType_AT_EnableAlwaysTrig:
+			state = 'A'
+		case pg_query.AlterTableType_AT_EnableReplicaTrig:
+			state = 'R'
+		default:
+			continue
+		}
+		// A state for a trigger the file does not declare has nothing to sit
+		// on, the same as an index on a table declared elsewhere.
+		if trg, ok := t.Triggers.GetOk(cmd.Name); ok {
+			trg.State = state
+		}
+	}
+}

--- a/parser/trigger_test.go
+++ b/parser/trigger_test.go
@@ -1,0 +1,150 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func TestParseSQL_Trigger(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int, name text);
+CREATE TRIGGER t_audit AFTER UPDATE OF name ON public.t FOR EACH ROW WHEN (OLD.name IS DISTINCT FROM NEW.name) EXECUTE FUNCTION public.stamp();`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	trg, ok := result.Tables.Get("public.t").Triggers.GetOk("t_audit")
+	require.True(t, ok)
+	assert.Equal(t, "public", trg.Schema)
+	assert.Equal(t, "t", trg.Table)
+	assert.Equal(t,
+		"CREATE TRIGGER t_audit AFTER UPDATE OF name ON public.t FOR EACH ROW WHEN (old.name IS DISTINCT FROM new.name) EXECUTE FUNCTION public.stamp()",
+		trg.Definition)
+	assert.True(t, trg.State.IsDefault())
+}
+
+func TestParseSQL_Trigger_DefaultSchemaFallback(t *testing.T) {
+	// The relation is written bare, so the schema falls back to the default
+	// one and the stored definition comes out qualified.
+	sql := `CREATE TABLE public.t (id int);
+CREATE TRIGGER t_ins BEFORE INSERT ON t FOR EACH ROW EXECUTE FUNCTION stamp();`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	trg := result.Tables.Get("public.t").Triggers.Get("t_ins")
+	assert.Equal(t, "public", trg.Schema)
+	assert.Equal(t,
+		"CREATE TRIGGER t_ins BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp()",
+		trg.Definition)
+}
+
+func TestParseSQL_Trigger_ConstraintTrigger(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+CREATE CONSTRAINT TRIGGER t_check AFTER INSERT ON public.t DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION stamp();`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	trg := result.Tables.Get("public.t").Triggers.Get("t_check")
+	assert.Equal(t,
+		"CREATE CONSTRAINT TRIGGER t_check AFTER INSERT ON public.t DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION stamp()",
+		trg.Definition)
+}
+
+func TestParseSQL_Trigger_OrReplaceNormalized(t *testing.T) {
+	// OR REPLACE says how to get to the state, not what the state is, so the
+	// stored definition drops it and the diff decides.
+	sql := `CREATE TABLE public.t (id int);
+CREATE OR REPLACE TRIGGER t_ins BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	trg := result.Tables.Get("public.t").Triggers.Get("t_ins")
+	assert.Equal(t,
+		"CREATE TRIGGER t_ins BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp()",
+		trg.Definition)
+}
+
+func TestParseSQL_Trigger_OnView(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+CREATE VIEW public.v AS SELECT id FROM public.t;
+CREATE TRIGGER v_ins INSTEAD OF INSERT ON public.v FOR EACH ROW EXECUTE FUNCTION stamp();`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	trg, ok := result.Views.Get("public.v").Triggers.GetOk("v_ins")
+	require.True(t, ok)
+	assert.Equal(t, "v", trg.Table)
+}
+
+func TestParseSQL_Trigger_UnknownRelation(t *testing.T) {
+	sql := `CREATE TRIGGER t_ins BEFORE INSERT ON public.missing FOR EACH ROW EXECUTE FUNCTION stamp();`
+	_, err := parseSQLWithPublicSchema(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "public.missing")
+}
+
+func TestParseSQL_Trigger_Duplicate(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+CREATE TRIGGER t_ins BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();
+CREATE TRIGGER t_ins BEFORE DELETE ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();`
+	_, err := parseSQLWithPublicSchema(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate trigger")
+}
+
+// The same trigger name on two tables is legal: a trigger name is unique
+// within its relation, not within the schema.
+func TestParseSQL_Trigger_SameNameOnTwoTables(t *testing.T) {
+	sql := `CREATE TABLE public.a (id int);
+CREATE TABLE public.b (id int);
+CREATE TRIGGER stamped BEFORE INSERT ON public.a FOR EACH ROW EXECUTE FUNCTION stamp();
+CREATE TRIGGER stamped BEFORE INSERT ON public.b FOR EACH ROW EXECUTE FUNCTION stamp();`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	assert.Equal(t, "a", result.Tables.Get("public.a").Triggers.Get("stamped").Table)
+	assert.Equal(t, "b", result.Tables.Get("public.b").Triggers.Get("stamped").Table)
+}
+
+func TestParseSQL_Trigger_EnableState(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+CREATE TRIGGER t_off BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();
+CREATE TRIGGER t_always BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();
+CREATE TRIGGER t_replica BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();
+CREATE TRIGGER t_on BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();
+ALTER TABLE public.t DISABLE TRIGGER t_off;
+ALTER TABLE public.t ENABLE ALWAYS TRIGGER t_always;
+ALTER TABLE public.t ENABLE REPLICA TRIGGER t_replica;
+ALTER TABLE public.t ENABLE TRIGGER t_on;`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	triggers := result.Tables.Get("public.t").Triggers
+	assert.Equal(t, model.TriggerState('D'), triggers.Get("t_off").State)
+	assert.Equal(t, model.TriggerState('A'), triggers.Get("t_always").State)
+	assert.Equal(t, model.TriggerState('R'), triggers.Get("t_replica").State)
+	assert.Equal(t, model.TriggerStateDefault, triggers.Get("t_on").State)
+}
+
+// An enable state named for a trigger the file does not declare is ignored,
+// the way an index on an undeclared table is.
+func TestParseSQL_Trigger_EnableStateUnknownTrigger(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+ALTER TABLE public.t DISABLE TRIGGER nowhere;`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+	assert.Zero(t, result.Tables.Get("public.t").Triggers.Len())
+}
+
+func TestParseSQL_Trigger_RenamedFrom(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+-- pista:renamed-from t_old
+CREATE TRIGGER t_new BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	trg := result.Tables.Get("public.t").Triggers.Get("t_new")
+	require.NotNil(t, trg.RenameFrom)
+	assert.Equal(t, "t_old", *trg.RenameFrom)
+}

--- a/parser/trigger_test.go
+++ b/parser/trigger_test.go
@@ -65,6 +65,21 @@ CREATE OR REPLACE TRIGGER t_ins BEFORE INSERT ON public.t FOR EACH ROW EXECUTE F
 		trg.Definition)
 }
 
+// EXECUTE PROCEDURE is the spelling PostgreSQL kept for compatibility, and
+// several real schemas still use it. The catalog always writes EXECUTE
+// FUNCTION, and so does the deparser, so the two meet.
+func TestParseSQL_Trigger_ExecuteProcedure(t *testing.T) {
+	sql := `CREATE TABLE public.t (id int);
+CREATE TRIGGER t_ins BEFORE INSERT ON public.t FOR EACH ROW EXECUTE PROCEDURE stamp();`
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	trg := result.Tables.Get("public.t").Triggers.Get("t_ins")
+	assert.Equal(t,
+		"CREATE TRIGGER t_ins BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp()",
+		trg.Definition)
+}
+
 func TestParseSQL_Trigger_OnView(t *testing.T) {
 	sql := `CREATE TABLE public.t (id int);
 CREATE VIEW public.v AS SELECT id FROM public.t;

--- a/remap.go
+++ b/remap.go
@@ -59,6 +59,7 @@ func (client *Client) remapTableSchemas(tables *orderedmap.Map[string, *model.Ta
 		}
 
 		remapPolicies(t.Policies, client.RemapSchema, replacer)
+		remapTriggers(t.Triggers, client.RemapSchema, replacer)
 
 		remapped.Set(t.FQTN(), t)
 	}
@@ -89,6 +90,21 @@ func remapPolicies(
 	}
 }
 
+// remapTriggers rewrites the Schema field on each trigger and applies the
+// schema replacer to the definition, which names the relation the trigger is
+// on and may name a function in another schema. `triggers` is always non-nil
+// because both parser and catalog initialize the map.
+func remapTriggers(
+	triggers *orderedmap.Map[string, *model.Trigger],
+	mapSchema func(string) string,
+	replacer *strings.Replacer,
+) {
+	for _, trg := range triggers.CollectValues() {
+		trg.Schema = mapSchema(trg.Schema)
+		trg.Definition = replacer.Replace(trg.Definition)
+	}
+}
+
 func (client *Client) remapViewSchemas(views *orderedmap.Map[string, *model.View]) *orderedmap.Map[string, *model.View] {
 	if len(client.SchemaMap) == 0 {
 		return views
@@ -100,6 +116,7 @@ func (client *Client) remapViewSchemas(views *orderedmap.Map[string, *model.View
 	for _, v := range views.CollectValues() {
 		v.Schema = client.RemapSchema(v.Schema)
 		v.Definition = replacer.Replace(v.Definition)
+		remapTriggers(v.Triggers, client.RemapSchema, replacer)
 		remapped.Set(v.FQVN(), v)
 	}
 
@@ -132,6 +149,7 @@ func (client *Client) reverseRemapTableSchemas(tables *orderedmap.Map[string, *m
 		}
 
 		remapPolicies(t.Policies, client.ReverseRemapSchema, replacer)
+		remapTriggers(t.Triggers, client.ReverseRemapSchema, replacer)
 
 		remapped.Set(t.FQTN(), t)
 	}
@@ -150,6 +168,7 @@ func (client *Client) reverseRemapViewSchemas(views *orderedmap.Map[string, *mod
 	for _, v := range views.CollectValues() {
 		v.Schema = client.ReverseRemapSchema(v.Schema)
 		v.Definition = replacer.Replace(v.Definition)
+		remapTriggers(v.Triggers, client.ReverseRemapSchema, replacer)
 		remapped.Set(v.FQVN(), v)
 	}
 

--- a/remap_test.go
+++ b/remap_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -217,6 +218,37 @@ CREATE SEQUENCE myschema.order_seq;
 	// The sequence schema is remapped to "public" (exercises remapSequenceSchemas).
 	assert.Contains(t, got.String(), "CREATE SEQUENCE public.order_seq")
 	assert.NotContains(t, got.String(), "myschema.order_seq")
+}
+
+// TestPlan_WithSchemaMap_Trigger covers the trigger arm of the table remap.
+// The desired trigger is written against public, so both its Schema field and
+// the relation inside its definition have to come back as myschema before the
+// diff sees them.
+func TestPlan_WithSchemaMap_Trigger(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE FUNCTION myschema.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+CREATE TABLE myschema.events (id integer);
+`)
+
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte(
+		"CREATE TABLE public.events (id integer);\n"+
+			"CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();\n"), 0o644))
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"CREATE TRIGGER events_stamp BEFORE INSERT ON myschema.events FOR EACH ROW EXECUTE FUNCTION myschema.stamp();",
+		strings.TrimSpace(got.SQL))
 }
 
 func TestPlan_WithSchemaMap_Sequence(t *testing.T) {

--- a/testdata/apply/constraint_trigger_idempotent.yml
+++ b/testdata/apply/constraint_trigger_idempotent.yml
@@ -1,6 +1,6 @@
-# The desired schema does not mention the constraint trigger, so apply must
-# run nothing. Drops are allowed, so a trigger read as a table constraint would
-# be dropped here instead of suppressed.
+# The desired schema matches, so apply must run nothing. Drops are allowed, so
+# a constraint trigger read as a table constraint would be dropped here instead
+# of suppressed.
 init: |
   CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
   CREATE TABLE public.events (
@@ -15,12 +15,15 @@ desired: |
       id integer NOT NULL,
       CONSTRAINT events_pkey PRIMARY KEY (id)
   );
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION noop();
 applied: |
   -- public.events
   CREATE TABLE public.events (
       id integer NOT NULL,
       CONSTRAINT events_pkey PRIMARY KEY (id)
   );
+
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION noop();
 applied_sql: ""
 drop_policy:
   allow_drop:

--- a/testdata/apply/trigger_add.yml
+++ b/testdata/apply/trigger_add.yml
@@ -1,0 +1,23 @@
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+applied: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+
+  CREATE TRIGGER events_stamp BEFORE INSERT ON events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+verify_no_drift: true

--- a/testdata/apply/trigger_constraint_switch.yml
+++ b/testdata/apply/trigger_constraint_switch.yml
@@ -1,0 +1,20 @@
+# A plain trigger becoming a constraint trigger, which PostgreSQL will not do
+# in place.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_check AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION stamp();
+drop_policy:
+  allow_drop:
+    - trigger
+applied: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL
+  );
+
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION stamp();
+verify_no_drift: true

--- a/testdata/apply/trigger_partition_replace.yml
+++ b/testdata/apply/trigger_partition_replace.yml
@@ -1,0 +1,25 @@
+# CREATE OR REPLACE TRIGGER on a partitioned parent recurses into every
+# partition's clone, so comparing only the parent's catalog row after apply
+# must not find a per-run replace loop.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.logs (id integer NOT NULL, at date NOT NULL) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2026 PARTITION OF public.logs FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+  CREATE TRIGGER logs_stamp BEFORE INSERT ON public.logs FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.logs (id integer NOT NULL, at date NOT NULL) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2026 PARTITION OF public.logs FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+  CREATE TRIGGER logs_stamp BEFORE INSERT OR UPDATE ON public.logs FOR EACH ROW EXECUTE FUNCTION stamp();
+applied: |
+  -- public.logs
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      at date NOT NULL
+  )
+  PARTITION BY RANGE (at);
+
+  CREATE TRIGGER logs_stamp BEFORE INSERT OR UPDATE ON logs FOR EACH ROW EXECUTE FUNCTION stamp();
+
+  -- public.logs_2026
+  CREATE TABLE public.logs_2026 PARTITION OF public.logs FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+verify_no_drift: true

--- a/testdata/apply/trigger_replace.yml
+++ b/testdata/apply/trigger_replace.yml
@@ -1,0 +1,20 @@
+# The replace resets the enable state, and the ALTER TABLE after it puts the
+# trigger back where the desired schema wants it.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+  ALTER TABLE public.events ENABLE ALWAYS TRIGGER events_stamp;
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT OR UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events ENABLE ALWAYS TRIGGER events_stamp;
+applied: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL
+  );
+
+  CREATE TRIGGER events_stamp BEFORE INSERT OR UPDATE ON events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events ENABLE ALWAYS TRIGGER events_stamp;
+verify_no_drift: true

--- a/testdata/dump/constraint_trigger.yml
+++ b/testdata/dump/constraint_trigger.yml
@@ -1,5 +1,6 @@
-# A CREATE CONSTRAINT TRIGGER leaves a pg_constraint row with contype='t'.
-# The trigger is unmanaged, so the dump must leave it out.
+# A CREATE CONSTRAINT TRIGGER leaves a pg_constraint row with contype='t'
+# alongside the pg_trigger row. It is written as the trigger it is, and never
+# inside CREATE TABLE as a table constraint.
 init: |
   CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
   CREATE TABLE public.events (
@@ -15,3 +16,5 @@ dump: |
       id integer NOT NULL,
       CONSTRAINT events_pkey PRIMARY KEY (id)
   );
+
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION noop();

--- a/testdata/dump/trigger.yml
+++ b/testdata/dump/trigger.yml
@@ -1,0 +1,27 @@
+# The trigger function is not managed, so the dump writes the trigger without
+# it. pg_get_triggerdef drops the schema from names the search_path reaches,
+# which under the default path is both the table and the function.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_audit AFTER UPDATE OF name ON public.events
+      FOR EACH ROW WHEN (old.name IS DISTINCT FROM new.name)
+      EXECUTE FUNCTION public.stamp();
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events
+      FOR EACH ROW EXECUTE FUNCTION public.stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+dump: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+
+  CREATE TRIGGER events_audit AFTER UPDATE OF name ON events FOR EACH ROW WHEN (old.name IS DISTINCT FROM new.name) EXECUTE FUNCTION stamp();
+  CREATE TRIGGER events_stamp BEFORE INSERT ON events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;

--- a/testdata/dump/trigger_omit_schema.yml
+++ b/testdata/dump/trigger_omit_schema.yml
@@ -1,0 +1,17 @@
+# --omit-schema drops the schema from the relation the trigger is on and from
+# the ALTER TABLE that holds its state. The function keeps whatever the catalog
+# gave it, since it may sit outside the schema being dumped.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+omit_schema: true
+dump: |
+  -- events
+  CREATE TABLE events (
+      id integer NOT NULL
+  );
+
+  CREATE TRIGGER events_stamp BEFORE INSERT ON events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE events DISABLE TRIGGER events_stamp;

--- a/testdata/dump/trigger_partitioned.yml
+++ b/testdata/dump/trigger_partitioned.yml
@@ -1,0 +1,20 @@
+# A trigger on a partitioned table is cloned onto each partition. Only the
+# parent's row belongs to the dump; the clone cannot be dropped on its own and
+# PostgreSQL recreates it from the parent.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.logs (id integer NOT NULL, at date NOT NULL) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2026 PARTITION OF public.logs FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+  CREATE TRIGGER logs_stamp BEFORE INSERT ON public.logs FOR EACH ROW EXECUTE FUNCTION public.stamp();
+dump: |
+  -- public.logs
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      at date NOT NULL
+  )
+  PARTITION BY RANGE (at);
+
+  CREATE TRIGGER logs_stamp BEFORE INSERT ON logs FOR EACH ROW EXECUTE FUNCTION stamp();
+
+  -- public.logs_2026
+  CREATE TABLE public.logs_2026 PARTITION OF public.logs FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');

--- a/testdata/dump/trigger_view.yml
+++ b/testdata/dump/trigger_view.yml
@@ -1,0 +1,40 @@
+# An INSTEAD OF trigger belongs to the view, so it follows the view's
+# definition rather than the table's. PostgreSQL 16 stopped qualifying a view's
+# output column with its table, hence the second expected dump.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.recent_events AS SELECT id FROM public.events;
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events
+      FOR EACH ROW EXECUTE FUNCTION public.stamp();
+dump: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+
+  -- public.recent_events
+  CREATE OR REPLACE VIEW public.recent_events AS
+  SELECT events.id
+     FROM events;
+
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON recent_events FOR EACH ROW EXECUTE FUNCTION stamp();
+dump_pg16: &dump_pg16plus |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+
+  -- public.recent_events
+  CREATE OR REPLACE VIEW public.recent_events AS
+  SELECT id
+     FROM events;
+
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON recent_events FOR EACH ROW EXECUTE FUNCTION stamp();
+dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus

--- a/testdata/plan/constraint_trigger_no_diff.yml
+++ b/testdata/plan/constraint_trigger_no_diff.yml
@@ -1,6 +1,6 @@
-# A desired schema that does not mention the constraint trigger must not plan
-# a DROP CONSTRAINT for it. Drops are allowed so the statement would reach the
-# plan instead of the skipped list.
+# The pg_constraint row a constraint trigger leaves behind must not reach the
+# table's constraints. Drops are allowed, so a DROP CONSTRAINT would show up in
+# the plan rather than in the skipped list.
 init: |
   CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
   CREATE TABLE public.events (
@@ -15,6 +15,7 @@ desired: |
       id integer NOT NULL,
       CONSTRAINT events_pkey PRIMARY KEY (id)
   );
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION noop();
 drop_policy:
   allow_drop:
     - all

--- a/testdata/plan/trigger_add.yml
+++ b/testdata/plan/trigger_add.yml
@@ -1,0 +1,14 @@
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();

--- a/testdata/plan/trigger_args.yml
+++ b/testdata/plan/trigger_args.yml
@@ -1,0 +1,11 @@
+# pg_get_triggerdef renders every trigger argument as a string literal, so an
+# integer written in the file is not a change.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events
+      FOR EACH ROW EXECUTE FUNCTION public.stamp('kind', 1, 'it''s');
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp('kind', 1, 'it''s');
+plan: ""

--- a/testdata/plan/trigger_constraint_switch.yml
+++ b/testdata/plan/trigger_constraint_switch.yml
@@ -1,0 +1,20 @@
+# PostgreSQL refuses to replace a constraint trigger with a plain one, so the
+# change goes through DROP and CREATE.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE CONSTRAINT TRIGGER events_check AFTER INSERT ON public.events
+      DEFERRABLE INITIALLY DEFERRED
+      FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_check AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  DROP TRIGGER events_check ON public.events;
+  CREATE TRIGGER events_check AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();

--- a/testdata/plan/trigger_constraint_switch_disallowed.yml
+++ b/testdata/plan/trigger_constraint_switch_disallowed.yml
@@ -1,6 +1,6 @@
-# PostgreSQL refuses to replace a constraint trigger with a plain one, so the
-# change goes through DROP and CREATE, gated by the trigger drop policy like
-# any other trigger drop.
+# With the default drop policy (nothing allowed), the constraint switch is
+# denied entirely: no DROP, and no CREATE either, since that would apply the
+# change the DROP was meant to clear the way for.
 init: |
   CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
   CREATE TABLE public.events (
@@ -17,8 +17,7 @@ desired: |
   );
   CREATE TRIGGER events_check AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
 drop_policy:
-  allow_drop:
-    - trigger
-plan: |
-  DROP TRIGGER events_check ON public.events;
-  CREATE TRIGGER events_check AFTER INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+  allow_drop: []
+plan: ""
+disallowed_drops: |
+  -- skipped: DROP TRIGGER events_check ON public.events;

--- a/testdata/plan/trigger_disable.yml
+++ b/testdata/plan/trigger_disable.yml
@@ -1,0 +1,12 @@
+# CREATE TRIGGER has no syntax for a disabled trigger, so the desired schema
+# asks for one with the ALTER TABLE that dump writes.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+plan: |
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;

--- a/testdata/plan/trigger_drop.yml
+++ b/testdata/plan/trigger_drop.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop:
+    - trigger
+plan: |
+  DROP TRIGGER events_stamp ON public.events;

--- a/testdata/plan/trigger_drop_disallowed.yml
+++ b/testdata/plan/trigger_drop_disallowed.yml
@@ -1,0 +1,18 @@
+# With no object type allowed to be dropped, the drop is reported and left out.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+drop_policy:
+  allow_drop: []
+plan: ""
+disallowed_drops: |
+  -- skipped: DROP TRIGGER events_stamp ON public.events;

--- a/testdata/plan/trigger_enable.yml
+++ b/testdata/plan/trigger_enable.yml
@@ -1,0 +1,12 @@
+# A disabled trigger the desired schema no longer holds down goes back to the
+# state CREATE TRIGGER leaves behind.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+  ALTER TABLE public.events ENABLE ALWAYS TRIGGER events_stamp;
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  ALTER TABLE public.events ENABLE TRIGGER events_stamp;

--- a/testdata/plan/trigger_new_table.yml
+++ b/testdata/plan/trigger_new_table.yml
@@ -1,0 +1,17 @@
+# A table and its trigger arrive together.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+plan: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;

--- a/testdata/plan/trigger_no_diff.yml
+++ b/testdata/plan/trigger_no_diff.yml
@@ -1,0 +1,23 @@
+# What dump writes, fed back. pg_get_triggerdef spells out FOR EACH STATEMENT
+# and the AS in REFERENCING, and adds a cast in the WHEN expression, none of
+# which the deparser writes, so the comparison runs on the parse trees.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_audit AFTER UPDATE OF name ON public.events
+      FOR EACH ROW WHEN (new.name <> 'skip') EXECUTE FUNCTION public.stamp();
+  CREATE TRIGGER events_batch AFTER INSERT ON public.events
+      REFERENCING NEW TABLE AS added FOR EACH STATEMENT EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_audit AFTER UPDATE OF name ON events FOR EACH ROW WHEN (new.name <> 'skip'::text) EXECUTE FUNCTION stamp();
+  CREATE TRIGGER events_batch AFTER INSERT ON events REFERENCING NEW TABLE AS added FOR EACH STATEMENT EXECUTE FUNCTION stamp();
+plan: ""

--- a/testdata/plan/trigger_partition_child.yml
+++ b/testdata/plan/trigger_partition_child.yml
@@ -1,0 +1,15 @@
+# A partition carries its own triggers, so the partition-child branch of the
+# table diff has to reach them. The parent's trigger is cloned onto the child
+# and stays out of the model on both sides.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.logs (id integer NOT NULL, at date NOT NULL) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2026 PARTITION OF public.logs FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+  CREATE TRIGGER logs_stamp BEFORE INSERT ON public.logs FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.logs (id integer NOT NULL, at date NOT NULL) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2026 PARTITION OF public.logs FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+  CREATE TRIGGER logs_stamp BEFORE INSERT ON public.logs FOR EACH ROW EXECUTE FUNCTION stamp();
+  CREATE TRIGGER logs_2026_only AFTER INSERT ON public.logs_2026 FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  CREATE TRIGGER logs_2026_only AFTER INSERT ON public.logs_2026 FOR EACH ROW EXECUTE FUNCTION stamp();

--- a/testdata/plan/trigger_rename.yml
+++ b/testdata/plan/trigger_rename.yml
@@ -1,0 +1,10 @@
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_old BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  -- pista:renamed-from events_old
+  CREATE TRIGGER events_new BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  ALTER TRIGGER events_old ON public.events RENAME TO events_new;

--- a/testdata/plan/trigger_replace.yml
+++ b/testdata/plan/trigger_replace.yml
@@ -1,0 +1,19 @@
+# A definition change goes through CREATE OR REPLACE TRIGGER, which needs no
+# DROP and takes a lighter lock.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT events_pkey PRIMARY KEY (id)
+  );
+  CREATE TRIGGER events_stamp BEFORE INSERT OR UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  CREATE OR REPLACE TRIGGER events_stamp BEFORE INSERT OR UPDATE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();

--- a/testdata/plan/trigger_replace_keeps_state.yml
+++ b/testdata/plan/trigger_replace_keeps_state.yml
@@ -1,0 +1,14 @@
+# CREATE OR REPLACE TRIGGER puts the trigger back in the default state, so a
+# definition change on a disabled trigger has to disable it again.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT ON public.events FOR EACH ROW EXECUTE FUNCTION public.stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE TRIGGER events_stamp BEFORE INSERT OR DELETE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;
+plan: |
+  CREATE OR REPLACE TRIGGER events_stamp BEFORE INSERT OR DELETE ON public.events FOR EACH ROW EXECUTE FUNCTION stamp();
+  ALTER TABLE public.events DISABLE TRIGGER events_stamp;

--- a/testdata/plan/trigger_view.yml
+++ b/testdata/plan/trigger_view.yml
@@ -1,0 +1,12 @@
+# An INSTEAD OF trigger on a view. CREATE OR REPLACE VIEW leaves the view's
+# triggers in place, so a definition change alongside does not disturb them.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL, name text);
+  CREATE VIEW public.recent_events AS SELECT id FROM public.events;
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL, name text);
+  CREATE VIEW public.recent_events AS SELECT id FROM public.events;
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events FOR EACH ROW EXECUTE FUNCTION stamp();

--- a/testdata/plan/trigger_view_drop.yml
+++ b/testdata/plan/trigger_view_drop.yml
@@ -1,0 +1,16 @@
+# A view keeps its triggers through CREATE OR REPLACE VIEW, so one the desired
+# schema drops has to be dropped on its own.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE VIEW public.recent_events AS SELECT id FROM public.events;
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events
+      FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE VIEW public.recent_events AS SELECT id FROM public.events;
+drop_policy:
+  allow_drop:
+    - trigger
+plan: |
+  DROP TRIGGER recent_events_insert ON public.recent_events;

--- a/testdata/plan/trigger_view_new.yml
+++ b/testdata/plan/trigger_view_new.yml
@@ -1,0 +1,13 @@
+# The view and its trigger arrive together, so the CREATE TRIGGER follows the
+# CREATE VIEW rather than being diffed against anything.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL);
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL);
+  CREATE VIEW public.recent_events AS SELECT id FROM public.events;
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  CREATE OR REPLACE VIEW public.recent_events AS
+  SELECT id FROM public.events;
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events FOR EACH ROW EXECUTE FUNCTION stamp();

--- a/testdata/plan/trigger_view_recreate.yml
+++ b/testdata/plan/trigger_view_recreate.yml
@@ -1,0 +1,17 @@
+# Dropping a column from a view's output forces DROP and CREATE, which takes
+# the view's triggers with it, so the recreate has to put them back.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.events (id integer NOT NULL, name text);
+  CREATE VIEW public.recent_events AS SELECT id, name FROM public.events;
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events
+      FOR EACH ROW EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.events (id integer NOT NULL, name text);
+  CREATE VIEW public.recent_events AS SELECT id FROM public.events;
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events FOR EACH ROW EXECUTE FUNCTION stamp();
+plan: |
+  DROP VIEW public.recent_events;
+  CREATE OR REPLACE VIEW public.recent_events AS
+  SELECT id FROM public.events;
+  CREATE TRIGGER recent_events_insert INSTEAD OF INSERT ON public.recent_events FOR EACH ROW EXECUTE FUNCTION stamp();


### PR DESCRIPTION
Triggers were the largest object still left to `-- pista:execute`. They are now read from `pg_trigger`, written by `dump`, and diffed: plain triggers, `CREATE CONSTRAINT TRIGGER`, and `INSTEAD OF` triggers on views.

## Reading

The catalog reads `pg_get_triggerdef` in its pretty form, which keeps the `WHEN` expression free of the parentheses the plain form wraps every operator in and adds no line breaks of its own. Three kinds of row are left out:

* The internal triggers a foreign key installs. PostgreSQL creates and drops them with the constraint.
* The clones a partitioned table's trigger leaves on each partition. `DROP TRIGGER` on one fails with `cannot drop trigger ... because trigger ... requires it`, and the parent's definition already covers them.
* Anything an extension owns, the same `pg_depend` check `ListIndexes` uses.

## Comparing

The two sides render the same trigger differently. `pg_get_triggerdef` spells out `FOR EACH STATEMENT` and the `AS` in `REFERENCING`, adds casts in the `WHEN` expression, and drops a schema `search_path` reaches; the deparser does none of that. So the comparison parses both definitions, fills in an implicit relation schema the way `normalizeFKSchema` does for a foreign key, clears `OR REPLACE`, runs the `WHEN` expression through `normalizeCheckExpr`, and compares the deparsed result. Comparing the trees directly does not work: every node carries the byte offset of its token, so two spellings of the same trigger differ as soon as their lengths do.

The schema a definition gives the function it calls is left alone, so it follows `search_path` like every other name the catalog's deparsers write. `--search-path=` qualifies everything, as documented.

## Writing

A definition change is applied with `CREATE OR REPLACE TRIGGER`, which PostgreSQL has carried since 14 and which takes `SHARE ROW EXCLUSIVE` rather than the `ACCESS EXCLUSIVE` that `DROP TRIGGER` takes. Turning a trigger into a constraint trigger or back is the one change PostgreSQL rejects in place (`trigger "x" for relation "t" is a constraint trigger`), so that runs as `DROP` and `CREATE` under the new `trigger` drop policy.

Either statement leaves the trigger enabled, so a state other than the default is set again behind it. `CREATE TRIGGER` cannot express a disabled trigger, so the state travels as the `ALTER TABLE ... DISABLE TRIGGER` that PostgreSQL uses and `dump` writes, the way RLS already travels as `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`. A view has no state to carry: PostgreSQL rejects `DISABLE TRIGGER` on one.

`DROP VIEW` takes the view's triggers with it, so the recreate path puts them back, next to where it already re-emits a materialized view's indexes. `CREATE OR REPLACE VIEW` keeps them, so that path diffs them instead.

`-- pista:renamed-from` renames a trigger. The rename also rewrites the name inside the definition, since that is what the catalog reports afterwards and the comparison would otherwise read the old name as a definition change.

`-m` and `--omit-schema` reach a trigger's schema and its definition, alongside the indexes and policies they already reached.

## Out of scope

The function a trigger calls stays unmanaged; `-- pista:execute-first` exists for exactly this and the README now says so. Event triggers belong to the database rather than to a schema. The `ALL` and `USER` forms of `ENABLE TRIGGER` name no single trigger.

A column rename does not rewrite a trigger's `UPDATE OF` list or `WHEN` expression, so the first plan after one emits a redundant `CREATE OR REPLACE TRIGGER` and the second is clean. Same class as the view and cross-table FK entry already in TODO.md, and recorded there.

## Tests

* `catalog/triggers_test.go`: definitions and enable state, internal triggers, partition clones, a view's trigger.
* `parser/trigger_test.go`: the default-schema fallback, constraint triggers, `OR REPLACE` normalization, a trigger on a view, duplicates, the same name on two tables, the four enable states, the rename directive.
* `diff/triggers_test.go`: add, drop, suppressed drop, replace, replace keeping a non-default state, each state transition, the constraint switch, four rename cases, and the parse-error paths.
* `model/trigger_test.go`, plus 13 plan fixtures, 3 apply fixtures with `verify_no_drift`, and 3 dump fixtures including `--omit-schema`.

`make lint`, `make vet`, `make test` and `make test-scenario` pass. The suite was run against 15, 16, 17 and 18. `make test-samples` passes all 46 real-world schemas, which between them carry 55 triggers (pagila 15, dvdrental 15, ledgersmb 11, dotcms 10, discourse 4).

Coverage: `model` 99.6 -> 99.7, `diff` 96.6 -> 96.3, `catalog` 88.9 -> 88.8, `parser` 92.0 -> 91.9. What is left uncovered in the new files is the deparse-after-a-successful-parse and `Query`/`Scan`/`rows.Err` wrappers, the same defensive paths already uncovered in every neighbouring file.