### PR TITLE
Add trigger counts to the sample database coverage table

### DIFF
--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -126,64 +126,68 @@ the SHA in `sample-db.mk`, and re-run `make test-samples`.
 
 Object counts of the loaded schemas, as of 2026-08-08 on PostgreSQL 15.18
 (16.13 for icingadb, rt, znuny, gitlab, hive, ranger, ambari, and ovirt; the
-Sequences column was counted on 15.18 throughout). "Constraints" excludes
-foreign keys; "Types" counts enums and domains; "Sequences" counts standalone
-sequences only, since pistachio manages the sequence behind a serial or
-identity column as an attribute of that column rather than as an object of its
-own. Counting those too would add 1,996 more, 886 of them gitlab's. All counts
-are limited to the schemas the sample is checked with, and exclude what an
-extension owns: the two views `pg_stat_statements` adds to sourcegraph's schema
-are not sourcegraph's schema and pistachio does not read them either.
+Sequences column was counted on 15.18 throughout, and Triggers, added
+2026-08-24, on 15.18 for every sample). "Constraints" excludes foreign keys;
+"Types" counts enums and domains; "Sequences" counts standalone sequences
+only, since pistachio manages the sequence behind a serial or identity column
+as an attribute of that column rather than as an object of its own. Counting
+those too would add 1,996 more, 886 of them gitlab's. "Triggers" excludes the
+internal triggers a foreign key installs and the clones PostgreSQL puts on
+each partition of a partitioned table's trigger, the same as what pistachio
+reads and dump writes. All counts are limited to the schemas the sample is
+checked with, and exclude what an extension owns: the two views
+`pg_stat_statements` adds to sourcegraph's schema are not sourcegraph's schema
+and pistachio does not read them either.
 
-| Sample | Tables | Columns | Indexes | FKs | Constraints | Views | Types | Sequences |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|
-| chinook | 11 | 64 | 21 | 11 | 11 | 0 | 0 | 0 |
-| dvdrental | 15 | 86 | 32 | 18 | 16 | 7 | 2 | 13 |
-| happiness_index | 1 | 9 | 1 | 0 | 1 | 0 | 0 | 0 |
-| lego | 8 | 28 | 6 | 0 | 6 | 0 | 0 | 0 |
-| netflix | 1 | 12 | 1 | 0 | 1 | 0 | 0 | 0 |
-| pagila | 22 | 129 | 55 | 36 | 23 | 8 | 3 | 13 |
-| periodic_table | 1 | 28 | 1 | 0 | 1 | 0 | 0 | 0 |
-| titanic | 1 | 21 | 1 | 0 | 1 | 0 | 0 | 0 |
-| world | 3 | 24 | 3 | 2 | 4 | 0 | 0 | 0 |
-| usda | 10 | 67 | 15 | 10 | 9 | 0 | 0 | 0 |
-| dellstore2 | 8 | 52 | 11 | 3 | 5 | 0 | 0 | 0 |
-| french_towns | 3 | 14 | 9 | 2 | 9 | 0 | 0 | 0 |
-| iso_3166 | 2 | 7 | 2 | 1 | 2 | 0 | 0 | 0 |
-| northwind | 14 | 92 | 14 | 13 | 14 | 0 | 0 | 0 |
-| employees | 6 | 24 | 9 | 6 | 6 | 0 | 1 | 0 |
-| mimiciv | 31 | 342 | 67 | 51 | 24 | 0 | 0 | 0 |
-| mediawiki | 64 | 389 | 192 | 0 | 60 | 0 | 1 | 0 |
-| synapse | 134 | 624 | 236 | 14 | 86 | 0 | 0 | 10 |
-| temporal | 37 | 217 | 44 | 0 | 40 | 0 | 0 | 0 |
-| icingadb | 66 | 634 | 179 | 7 | 74 | 0 | 13 | 0 |
-| rt | 38 | 407 | 88 | 1 | 38 | 0 | 0 | 32 |
-| sourcegraph | 180 | 1,715 | 453 | 362 | 273 | 18 | 8 | 1 |
-| imdb | 21 | 108 | 44 | 0 | 21 | 0 | 0 | 0 |
-| adventureworks | 68 | 456 | 71 | 90 | 157 | 21 | 0 | 0 |
-| clubdata | 3 | 19 | 10 | 3 | 3 | 0 | 0 | 0 |
-| demodb | 9 | 45 | 15 | 8 | 21 | 3 | 0 | 0 |
-| musicbrainz | 374 | 2,469 | 907 | 770 | 1,032 | 10 | 7 | 0 |
-| znuny | 126 | 1,103 | 326 | 286 | 190 | 0 | 0 | 0 |
-| hive | 84 | 546 | 141 | 55 | 91 | 0 | 0 | 0 |
-| ranger | 85 | 889 | 305 | 213 | 130 | 1 | 0 | 84 |
-| ambari | 113 | 693 | 172 | 124 | 140 | 0 | 0 | 0 |
-| ovirt | 152 | 1,386 | 377 | 165 | 167 | 1 | 0 | 9 |
-| gitlab | 1,422 | 14,293 | 6,353 | 2,325 | 3,949 | 15 | 0 | 8 |
-| ledgersmb | 158 | 950 | 263 | 247 | 265 | 1 | 0 | 2 |
-| koji | 68 | 415 | 150 | 183 | 159 | 0 | 0 | 0 |
-| kea | 64 | 475 | 172 | 73 | 71 | 0 | 0 | 0 |
-| dolphinscheduler | 64 | 623 | 149 | 0 | 80 | 0 | 0 | 30 |
-| camunda | 49 | 681 | 281 | 42 | 56 | 0 | 0 | 0 |
-| wso2apim | 247 | 1,495 | 421 | 168 | 353 | 0 | 0 | 104 |
-| discourse | 354 | 3,173 | 1,114 | 23 | 336 | 1 | 2 | 0 |
-| icinga_director | 121 | 872 | 381 | 171 | 236 | 0 | 21 | 0 |
-| flowable | 62 | 844 | 222 | 60 | 66 | 0 | 0 | 0 |
-| ejabberd | 42 | 258 | 78 | 5 | 15 | 0 | 0 | 0 |
-| guacamole | 23 | 104 | 61 | 30 | 29 | 0 | 5 | 0 |
-| dotcms | 167 | 1,373 | 346 | 113 | 190 | 0 | 0 | 22 |
-| osm | 57 | 391 | 155 | 71 | 55 | 0 | 8 | 0 |
-| **Total** | **4,589** | **38,646** | **13,954** | **5,762** | **8,516** | **86** | **69** | **328** |
+| Sample | Tables | Columns | Indexes | FKs | Constraints | Views | Types | Sequences | Triggers |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| chinook | 11 | 64 | 21 | 11 | 11 | 0 | 0 | 0 | 0 |
+| dvdrental | 15 | 86 | 32 | 18 | 16 | 7 | 2 | 13 | 15 |
+| happiness_index | 1 | 9 | 1 | 0 | 1 | 0 | 0 | 0 | 0 |
+| lego | 8 | 28 | 6 | 0 | 6 | 0 | 0 | 0 | 0 |
+| netflix | 1 | 12 | 1 | 0 | 1 | 0 | 0 | 0 | 0 |
+| pagila | 22 | 129 | 55 | 36 | 23 | 8 | 3 | 13 | 15 |
+| periodic_table | 1 | 28 | 1 | 0 | 1 | 0 | 0 | 0 | 0 |
+| titanic | 1 | 21 | 1 | 0 | 1 | 0 | 0 | 0 | 0 |
+| world | 3 | 24 | 3 | 2 | 4 | 0 | 0 | 0 | 0 |
+| usda | 10 | 67 | 15 | 10 | 9 | 0 | 0 | 0 | 0 |
+| dellstore2 | 8 | 52 | 11 | 3 | 5 | 0 | 0 | 0 | 0 |
+| french_towns | 3 | 14 | 9 | 2 | 9 | 0 | 0 | 0 | 0 |
+| iso_3166 | 2 | 7 | 2 | 1 | 2 | 0 | 0 | 0 | 0 |
+| northwind | 14 | 92 | 14 | 13 | 14 | 0 | 0 | 0 | 0 |
+| employees | 6 | 24 | 9 | 6 | 6 | 0 | 1 | 0 | 0 |
+| mimiciv | 31 | 342 | 67 | 51 | 24 | 0 | 0 | 0 | 0 |
+| mediawiki | 64 | 389 | 192 | 0 | 60 | 0 | 1 | 0 | 0 |
+| synapse | 134 | 624 | 236 | 14 | 86 | 0 | 0 | 10 | 1 |
+| temporal | 37 | 217 | 44 | 0 | 40 | 0 | 0 | 0 | 0 |
+| icingadb | 66 | 634 | 179 | 7 | 74 | 0 | 13 | 0 | 0 |
+| rt | 38 | 407 | 88 | 1 | 38 | 0 | 0 | 32 | 0 |
+| sourcegraph | 180 | 1,715 | 453 | 362 | 273 | 18 | 8 | 1 | 29 |
+| imdb | 21 | 108 | 44 | 0 | 21 | 0 | 0 | 0 | 0 |
+| adventureworks | 68 | 456 | 71 | 90 | 157 | 21 | 0 | 0 | 0 |
+| clubdata | 3 | 19 | 10 | 3 | 3 | 0 | 0 | 0 | 0 |
+| demodb | 9 | 45 | 15 | 8 | 21 | 3 | 0 | 0 | 0 |
+| musicbrainz | 374 | 2,469 | 907 | 770 | 1,032 | 10 | 7 | 0 | 0 |
+| znuny | 126 | 1,103 | 326 | 286 | 190 | 0 | 0 | 0 | 0 |
+| hive | 84 | 546 | 141 | 55 | 91 | 0 | 0 | 0 | 0 |
+| ranger | 85 | 889 | 305 | 213 | 130 | 1 | 0 | 84 | 0 |
+| ambari | 113 | 693 | 172 | 124 | 140 | 0 | 0 | 0 | 0 |
+| ovirt | 152 | 1,386 | 377 | 165 | 167 | 1 | 0 | 9 | 0 |
+| gitlab | 1,422 | 14,293 | 6,353 | 2,325 | 3,949 | 15 | 0 | 8 | 388 |
+| ledgersmb | 158 | 950 | 263 | 247 | 265 | 1 | 0 | 2 | 11 |
+| koji | 68 | 415 | 150 | 183 | 159 | 0 | 0 | 0 | 0 |
+| kea | 64 | 475 | 172 | 73 | 71 | 0 | 0 | 0 | 81 |
+| dolphinscheduler | 64 | 623 | 149 | 0 | 80 | 0 | 0 | 30 | 0 |
+| camunda | 49 | 681 | 281 | 42 | 56 | 0 | 0 | 0 | 0 |
+| wso2apim | 247 | 1,495 | 421 | 168 | 353 | 0 | 0 | 104 | 1 |
+| discourse | 354 | 3,173 | 1,114 | 23 | 336 | 1 | 2 | 0 | 4 |
+| icinga_director | 121 | 872 | 381 | 171 | 236 | 0 | 21 | 0 | 0 |
+| flowable | 62 | 844 | 222 | 60 | 66 | 0 | 0 | 0 | 0 |
+| ejabberd | 42 | 258 | 78 | 5 | 15 | 0 | 0 | 0 | 0 |
+| guacamole | 23 | 104 | 61 | 30 | 29 | 0 | 5 | 0 | 0 |
+| dotcms | 167 | 1,373 | 346 | 113 | 190 | 0 | 0 | 22 | 10 |
+| osm | 57 | 391 | 155 | 71 | 55 | 0 | 8 | 0 | 0 |
+| **Total** | **4,589** | **38,646** | **13,954** | **5,762** | **8,516** | **86** | **69** | **328** | **555** |
 
 The 46 dumps come to about 87,600 lines of SQL, and gitlab is 27,600 of them.
 It is still nearly half of the indexes and constraints, a third of the tables,
@@ -227,7 +231,10 @@ does), four unique indexes declared `NULLS NOT DISTINCT` and one index with an
 modifier any sample reports in mixed case), and
 foreign keys that cross a schema boundary: 20 of adventureworks' 90 span its
 five schemas, 12 of mimiciv's 51 point from `mimiciv_icu` into `mimiciv_hosp`,
-and every one of gitlab's partitions is attached across one.
+and every one of gitlab's partitions is attached across one; and triggers
+(gitlab's 388, more than any other sample, one of them held in `ENABLE ALWAYS`
+state; kea's 81 outnumber its 64 tables; ledgersmb's 11 and dotcms's 10 come
+next).
 
 ## Load-time adjustments
 


### PR DESCRIPTION
Triggers joined the object types pistachio manages in #416, but `sample-db-test.md`'s coverage table still listed only the object counts from before that.

Added a `Triggers` column, counted the way the catalog reader counts them: excluding the internal triggers a foreign key installs and the clones PostgreSQL puts on each partition of a partitioned table's trigger. Counted by loading all 46 samples and running `pista dump` against each, the same method the existing columns use, rather than a text search over the upstream source (checked against gitlab, where both methods agree at 388, and kea, where they disagree at 81 vs 89, since the raw file's text has some duplication the loaded catalog does not).

gitlab carries the most at 388 (one of them held in `ENABLE ALWAYS` state), kea's 81 are the only sample where triggers outnumber tables, and ledgersmb (11) and dotcms (10) round out the rest; the other 41 samples carry 0 or 1. No sample uses `CREATE CONSTRAINT TRIGGER` or an `INSTEAD OF` trigger.

Docs only, no code changes.