### PR TITLE
Cover more object types in the demo schema

### DIFF
--- a/demo/current.sql
+++ b/demo/current.sql
@@ -6,6 +6,12 @@
 -- Enum: post status
 CREATE TYPE post_status AS ENUM ('draft', 'published', 'archived');
 
+-- Composite type: author's links
+CREATE TYPE social_links AS (
+    website text,
+    github  text
+);
+
 -- Domain: simple email validation
 CREATE DOMAIN email_address AS text
     CHECK (VALUE ~ '^[^@]+@[^@]+\.[^@]+$');
@@ -13,11 +19,33 @@ CREATE DOMAIN email_address AS text
 -- Sequence: public-facing post reference numbers
 CREATE SEQUENCE post_ref_seq START 1000;
 
+-- ---------- trigger functions ----------
+--  Not managed by pistachio; created only when missing.
+
+-- pista:execute-first SELECT to_regprocedure('public.set_updated_at()') IS NULL
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$$;
+
+-- pista:execute-first SELECT to_regprocedure('public.notify_comment()') IS NULL
+CREATE OR REPLACE FUNCTION notify_comment() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM pg_notify('comments', NEW.post_id::text);
+    RETURN NULL;
+END;
+$$;
+
 -- ---------- users ----------
 CREATE TABLE users (
     id           bigserial PRIMARY KEY,
     email        email_address NOT NULL UNIQUE,
     display_name text NOT NULL,
+    links        social_links,
     created_at   timestamptz NOT NULL DEFAULT now()
 );
 
@@ -48,16 +76,27 @@ CREATE POLICY posts_visible ON posts
         OR author_id = current_setting('app.user_id', true)::bigint
     );
 
+COMMENT ON TABLE posts IS 'Blog posts';
+COMMENT ON COLUMN posts.status IS 'draft -> published -> archived';
+
 -- ---------- comments ----------
+--  trigger on a table, plus a second trigger to switch off later
 CREATE TABLE comments (
     id         bigserial PRIMARY KEY,
     post_id    bigint NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
     author_id  bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     body       text NOT NULL,
-    created_at timestamptz NOT NULL DEFAULT now()
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
 );
 
 CREATE INDEX comments_post_id_idx ON comments (post_id);
+
+CREATE TRIGGER comments_set_updated_at BEFORE UPDATE ON comments
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER comments_notify AFTER INSERT ON comments
+    FOR EACH ROW EXECUTE FUNCTION notify_comment();
 
 -- ---------- tags ----------
 CREATE TABLE tags (
@@ -72,9 +111,37 @@ CREATE TABLE post_tags (
     PRIMARY KEY (post_id, tag_id)
 );
 
+-- ---------- post_schedules (identity column, exclusion constraint) ----------
+CREATE TABLE post_schedules (
+    id      bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    post_id bigint NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    during  tstzrange NOT NULL,
+    EXCLUDE USING gist (during WITH &&)
+);
+
+-- ---------- post_views (partitioned table) ----------
+CREATE TABLE post_views (
+    post_id   bigint NOT NULL,
+    viewed_on date   NOT NULL,
+    views     integer NOT NULL DEFAULT 0,
+    PRIMARY KEY (viewed_on, post_id)
+) PARTITION BY RANGE (viewed_on);
+
+CREATE TABLE post_views_2025 PARTITION OF post_views
+    FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+
 -- ---------- view ----------
 CREATE VIEW published_posts AS
     SELECT p.id, p.title, p.body, p.published_at, u.display_name AS author
     FROM posts p
     JOIN users u ON u.id = p.author_id
     WHERE p.status = 'published';
+
+-- ---------- materialized view ----------
+CREATE MATERIALIZED VIEW tag_usage AS
+    SELECT t.id AS tag_id, t.name, count(pt.post_id) AS post_count
+    FROM tags t
+    LEFT JOIN post_tags pt ON pt.tag_id = t.id
+    GROUP BY t.id, t.name;
+
+CREATE UNIQUE INDEX tag_usage_tag_id_idx ON tag_usage (tag_id);

--- a/demo/desired.sql
+++ b/demo/desired.sql
@@ -6,11 +6,37 @@
 -- Added 'pinned' to the enum
 CREATE TYPE post_status AS ENUM ('draft', 'published', 'archived', 'pinned');
 
+CREATE TYPE social_links AS (
+    website text,
+    github  text
+);
+
 CREATE DOMAIN email_address AS text
     CHECK (VALUE ~ '^[^@]+@[^@]+\.[^@]+$');
 
 -- Sequence: post_ref_seq, increment bumped to 10
 CREATE SEQUENCE post_ref_seq START 1000 INCREMENT BY 10;
+
+-- ---------- trigger functions ----------
+--  Not managed by pistachio; created only when missing.
+
+-- pista:execute-first SELECT to_regprocedure('public.set_updated_at()') IS NULL
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$$;
+
+-- pista:execute-first SELECT to_regprocedure('public.notify_comment()') IS NULL
+CREATE OR REPLACE FUNCTION notify_comment() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM pg_notify('comments', NEW.post_id::text);
+    RETURN NULL;
+END;
+$$;
 
 -- ---------- users ----------
 --  +avatar_url
@@ -18,12 +44,14 @@ CREATE TABLE users (
     id           bigserial PRIMARY KEY,
     email        email_address NOT NULL UNIQUE,
     display_name text NOT NULL,
+    links        social_links,
     avatar_url   text,
     created_at   timestamptz NOT NULL DEFAULT now()
 );
 
 -- ---------- posts ----------
---  -word_count, +updated_at, +posts_created_idx, +posts_modifiable policy
+--  -word_count, +updated_at, +posts_created_idx, +posts_modifiable policy,
+--  +posts_set_updated_at trigger, reworded status comment
 CREATE TABLE posts (
     id           bigserial PRIMARY KEY,
     author_id    bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -53,16 +81,35 @@ CREATE POLICY posts_modifiable ON posts
     FOR UPDATE
     USING (author_id = current_setting('app.user_id', true)::bigint);
 
+CREATE TRIGGER posts_set_updated_at BEFORE UPDATE ON posts
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+COMMENT ON TABLE posts IS 'Blog posts';
+COMMENT ON COLUMN posts.status IS 'draft -> published -> archived, or pinned';
+
 -- ---------- comments ----------
+--  comments_set_updated_at now fires on INSERT too,
+--  comments_notify is switched off, +table comment
 CREATE TABLE comments (
     id         bigserial PRIMARY KEY,
     post_id    bigint NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
     author_id  bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     body       text NOT NULL,
-    created_at timestamptz NOT NULL DEFAULT now()
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
 );
 
 CREATE INDEX comments_post_id_idx ON comments (post_id);
+
+CREATE TRIGGER comments_set_updated_at BEFORE INSERT OR UPDATE ON comments
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER comments_notify AFTER INSERT ON comments
+    FOR EACH ROW EXECUTE FUNCTION notify_comment();
+
+ALTER TABLE comments DISABLE TRIGGER comments_notify;
+
+COMMENT ON TABLE comments IS 'Reader comments on a post';
 
 -- ---------- tags ----------
 --  +slug
@@ -79,6 +126,29 @@ CREATE TABLE post_tags (
     PRIMARY KEY (post_id, tag_id)
 );
 
+-- ---------- post_schedules ----------
+CREATE TABLE post_schedules (
+    id      bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    post_id bigint NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    during  tstzrange NOT NULL,
+    EXCLUDE USING gist (during WITH &&)
+);
+
+-- ---------- post_views ----------
+--  +post_views_2026 partition
+CREATE TABLE post_views (
+    post_id   bigint NOT NULL,
+    viewed_on date   NOT NULL,
+    views     integer NOT NULL DEFAULT 0,
+    PRIMARY KEY (viewed_on, post_id)
+) PARTITION BY RANGE (viewed_on);
+
+CREATE TABLE post_views_2025 PARTITION OF post_views
+    FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+
+CREATE TABLE post_views_2026 PARTITION OF post_views
+    FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+
 -- ---------- view ----------
 --  include updated_at (appended at the end so CREATE OR REPLACE works)
 CREATE VIEW published_posts AS
@@ -86,3 +156,14 @@ CREATE VIEW published_posts AS
     FROM posts p
     JOIN users u ON u.id = p.author_id
     WHERE p.status = 'published';
+
+-- ---------- materialized view ----------
+--  +tag_usage_post_count_idx
+CREATE MATERIALIZED VIEW tag_usage AS
+    SELECT t.id AS tag_id, t.name, count(pt.post_id) AS post_count
+    FROM tags t
+    LEFT JOIN post_tags pt ON pt.tag_id = t.id
+    GROUP BY t.id, t.name;
+
+CREATE UNIQUE INDEX tag_usage_tag_id_idx ON tag_usage (tag_id);
+CREATE INDEX tag_usage_post_count_idx ON tag_usage (post_count DESC);


### PR DESCRIPTION
The demo schema showed tables, indexes, constraints, policies, a view, an enum, a domain and a sequence. This adds the object types pistachio also manages, so the demo covers nearly all of them: triggers, comments, a composite type, a materialized view, a partitioned table, an identity column and an exclusion constraint.

`desired.sql` changes some of them, so `pista plan` shows a new trigger on `posts`, a `CREATE OR REPLACE TRIGGER` on `comments`, a `DISABLE TRIGGER`, a reworded column comment, a new table comment, a new partition and a new index on the materialized view, alongside the statements it showed before.

The functions the triggers call are not managed by pistachio, so they carry `-- pista:execute-first` with a `to_regprocedure(...) IS NULL` check. They are created on an empty database and left out of the plan once they exist, so a synced schema still reports `-- No changes` and the manual needs no explanation for them.

`post_views` has no foreign key to `posts`: PostgreSQL clones a partitioned table's foreign key onto each partition, `dump` writes the clone, and a hand-written file without it plans a drop on every run.

Verified on the built demo image:

* `pista plan current.sql` -> `-- No changes`
* `pista apply --allow-drop=column desired.sql`, then `pista plan desired.sql` -> `-- No changes`
* `pista apply current.sql` against an empty database creates the functions first, and the following plan is empty
* `pista dump` fed back as the desired schema plans clean
