### PR TITLE
Add the chado sample

### DIFF
--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -121,21 +121,23 @@ the SHA in `sample-db.mk`, and re-run `make test-samples`.
 | guacamole | guacamole | [apache/guacamole-client](https://github.com/apache/guacamole-client) |
 | dotcms | dotcms | [dotCMS/core](https://github.com/dotCMS/core) |
 | osm | osm | [openstreetmap/openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website) |
+| chado | chado, genetic_code, so, frange | [GMOD/Chado](https://github.com/GMOD/Chado) |
 
 ## Coverage
 
 Object counts of the loaded schemas, as of 2026-08-08 on PostgreSQL 15.18
-(16.13 for icingadb, rt, znuny, gitlab, hive, ranger, ambari, and ovirt; the
-Sequences column was counted on 15.18 throughout, and Triggers, added
-2026-08-24, on 15.18 for every sample). "Constraints" excludes foreign keys;
-"Types" counts enums and domains; "Sequences" counts standalone sequences
-only, since pistachio manages the sequence behind a serial or identity column
-as an attribute of that column rather than as an object of its own. Counting
-those too would add 1,996 more, 886 of them gitlab's. "Triggers" excludes the
-internal triggers a foreign key installs and the clones PostgreSQL puts on
-each partition of a partitioned table's trigger, the same as what pistachio
-reads and dump writes. All counts are limited to the schemas the sample is
-checked with, and exclude what an extension owns: the two views
+(16.13 for icingadb, rt, znuny, gitlab, hive, ranger, ambari, ovirt, and chado,
+the last counted 2026-08-24; the Sequences column was counted on 15.18
+throughout, and Triggers, added 2026-08-24, on 15.18 for every sample).
+"Constraints" excludes foreign keys; "Types" counts enums and domains;
+"Sequences" counts standalone sequences only, since pistachio manages the
+sequence behind a serial or identity column as an attribute of that column
+rather than as an object of its own. Counting those too would add 2,206 more,
+886 of them gitlab's and 210 chado's. "Triggers" excludes the internal triggers
+a foreign key installs and the clones PostgreSQL puts on each partition of a
+partitioned table's trigger, the same as what pistachio reads and dump writes.
+All counts are limited to the schemas the sample is checked with, and exclude
+what an extension owns: the two views
 `pg_stat_statements` adds to sourcegraph's schema are not sourcegraph's schema
 and pistachio does not read them either.
 
@@ -187,12 +189,14 @@ and pistachio does not read them either.
 | guacamole | 23 | 104 | 61 | 30 | 29 | 0 | 5 | 0 | 0 |
 | dotcms | 167 | 1,373 | 346 | 113 | 190 | 0 | 0 | 22 | 10 |
 | osm | 57 | 391 | 155 | 71 | 55 | 0 | 8 | 0 | 0 |
-| **Total** | **4,589** | **38,646** | **13,954** | **5,762** | **8,516** | **86** | **69** | **328** | **555** |
+| chado | 213 | 1,017 | 837 | 472 | 399 | 1,864 | 0 | 1 | 0 |
+| **Total** | **4,802** | **39,663** | **14,791** | **6,234** | **8,915** | **1,950** | **69** | **329** | **555** |
 
-The 46 dumps come to about 87,600 lines of SQL, and gitlab is 27,600 of them.
-It is still nearly half of the indexes and constraints, a third of the tables,
-and about 40 percent of the columns and foreign keys; musicbrainz, discourse,
-and wso2apim are the largest of what remains. gitlab is also why
+The 47 dumps come to about 129,000 lines of SQL. chado is 41,400 of them, the
+longest dump of any sample, and gitlab 27,600. gitlab is still nearly half of
+the indexes and constraints, a third of the tables, and about 40 percent of the
+columns and foreign keys; musicbrainz, discourse, and wso2apim are the largest
+of what remains, and chado is nearly all of the views. gitlab is also why
 `clean-schema` drops tables a batch at a time rather than cascading through
 `DROP SCHEMA`: a single statement takes locks on every object it reaches, and
 gitlab's 1,422 tables and their indexes run the server out of lock table space
@@ -216,22 +220,27 @@ one over four columns, which needs `btree_gist` (osm), materialized
 views (adventureworks, pagila), tsvector
 columns (dvdrental, pagila), a non-default
 collation (musicbrainz), composite types (ovirt declares 10 of them, more than
-any other sample, and sourcegraph 2), standalone sequences rather than serial
-columns (ranger, whose 85 tables come with 84 of them, and wso2apim, which
-mixes 104 of them in with serial columns), a schema written
+any other sample, and sourcegraph and chado 2 each), standalone sequences
+rather than serial columns (ranger, whose 85 tables come with 84 of them, and
+wso2apim, which mixes 104 of them in with serial columns), a schema written
 entirely in quoted mixed-case identifiers, so every name is case-sensitive
 (hive's 84 tables, where chinook has 11), an index-heavy schema of 192 indexes
 over 64 tables (mediawiki), partitioned tables at scale (gitlab declares 100 of them and
 attaches 2,054 partitions, all of which live in schemas of their own), table
 inheritance (ledgersmb attaches 21 children with INHERITS, the only sample that
 does), four unique indexes declared `NULLS NOT DISTINCT` and one index with an
-`INCLUDE` column (discourse), columns typed by an extension that is not contrib
-(discourse's three `halfvec` columns, which need pgvector, and osm's one
-`geometry(Polygon,4326)` column, which needs PostGIS and is the only type
-modifier any sample reports in mixed case), and
+`INCLUDE` column (discourse), views at scale (chado's 1,864 are more than
+twenty times every other sample put together, and 1,832 of them are the
+Sequence Ontology views in its `so` schema, each selecting from tables in
+`chado`), gist indexes over a function the schema defines itself (chado's three
+name `boxrange`, one of them partial and declared from another schema), columns
+typed by an extension that is not contrib (discourse's three `halfvec` columns,
+which need pgvector, and osm's one `geometry(Polygon,4326)` column, which needs
+PostGIS and is the only type modifier any sample reports in mixed case), and
 foreign keys that cross a schema boundary: 20 of adventureworks' 90 span its
 five schemas, 12 of mimiciv's 51 point from `mimiciv_icu` into `mimiciv_hosp`,
-and every one of gitlab's partitions is attached across one; and triggers
+4 of chado's 472 point from `frange` into `chado`, and every one of gitlab's
+partitions is attached across one; and triggers
 (gitlab's 388, more than any other sample, one of them held in `ENABLE ALWAYS`
 state; kea's 81 outnumber its 64 tables; ledgersmb's 11 and dotcms's 10 come
 next).
@@ -248,6 +257,19 @@ strip only what is irrelevant to a schema round trip:
   them create a schema, so `camunda` is created up front and the files are
   concatenated in dependency order (process engine, history, identity, then the
   case and decision engines with their history).
+- **chado**: the file names no schema for the objects it creates, but four
+  times partway through it sets `search_path` itself with `public` in it, which
+  overrides anything `PGOPTIONS` passes in. The `public` in those four lines is
+  rewritten to `chado`, the way hive's one line is. The lines that name
+  `genetic_code`, `so`, and `frange` keep them: the file creates those three
+  schemas itself, so the sample is checked with all four. Its tables are all
+  `bigserial`, so `client_min_messages` is raised to `warning` to quiet the
+  implicit-sequence NOTICEs. Nine of its SQL functions are dropped, the six
+  written against the `@` box operator that PostgreSQL 14 removed and the three
+  that call one of those six; they error out on every version in the CI matrix,
+  and pistachio does not manage functions in any case. Every table, index,
+  constraint, and view still loads, the three gist indexes over `boxrange`
+  among them.
 - **clubdata**: the dump creates its own database and reconnects to it, which
   cannot be done mid-pipe. Those two lines are dropped; the rest creates the
   `cd` schema itself.

--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -267,8 +267,13 @@ strip only what is irrelevant to a schema round trip:
   implicit-sequence NOTICEs. Nine of its SQL functions are dropped, the six
   written against the `@` box operator that PostgreSQL 14 removed and the three
   that call one of those six; they error out on every version in the CI matrix,
-  and pistachio does not manage functions in any case. Every table, index,
-  constraint, and view still loads, the three gist indexes over `boxrange`
+  and pistachio does not manage functions in any case. The `create_point` calls
+  in the bodies of `boxrange` and `boxquery` are qualified with `chado.`,
+  because PostgreSQL 17 runs `CREATE INDEX` with `search_path` set to
+  `pg_catalog, pg_temp`: the three gist indexes over `boxrange` inline it,
+  which re-resolves an unqualified `create_point` under that `search_path` and
+  does not find it. With the calls qualified, every table, index, constraint,
+  and view loads on all four versions of the CI matrix, the three gist indexes
   among them.
 - **clubdata**: the dump creates its own database and reconnects to it, which
   cannot be done mid-pipe. Those two lines are dropped; the rest creates the

--- a/sample-db-test.md
+++ b/sample-db-test.md
@@ -42,7 +42,13 @@ each sample, it:
    sit in, and a dump that says `CREATE EXTENSION IF NOT EXISTS` does nothing
    when an earlier sample already installed that extension somewhere else,
    leaving its types and operator classes unresolvable.
-2. Runs the sample's loader target to download and load the schema.
+2. Runs the sample's loader target to download and load the schema. Every
+   loader pipes into `psql -v ON_ERROR_STOP=1`, so a statement that fails
+   stops the load and the sample reports `FAIL (load)`. Without it psql
+   prints the error, carries on, and exits 0, and the check then runs on a
+   schema quietly missing whatever the failed statement was going to create;
+   `dump` and `plan` agree about what is there, so the sample passes and the
+   loss goes unnoticed.
 3. Runs `pista dump -n <schemas>` to capture pistachio's model of the loaded
    schema as SQL.
 4. Runs `pista plan -n <schemas> <dump>` and requires the output to be
@@ -291,6 +297,9 @@ strip only what is irrelevant to a schema round trip:
   search path. The tail of the file is Rails' own `SET search_path` followed by
   the migration versions it inserts into `schema_migrations`, which is data, so
   everything from that line on is dropped.
+- **dvdrental**: the dump was taken by a `pg_dump` new enough to set
+  `transaction_timeout` in its preamble, which 15 and 16 do not have, so that
+  one line is dropped. It sets nothing the schema depends on.
 - **hive**: the dump belongs in a schema of its own like the group below, but
   it is `pg_dump` output that sets `search_path` to `public` itself, which
   overrides anything `PGOPTIONS` passes in. That one line is rewritten to name

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -148,6 +148,14 @@ sample-db-hive:
 # them, so the sample is checked with all four. `so` is where its 1,832
 # Sequence Ontology views land, more views than every other sample together.
 #
+# The same sed qualifies the create_point calls in the bodies of boxrange and
+# boxquery. PostgreSQL 17 runs CREATE INDEX with search_path set to
+# pg_catalog, pg_temp, and the three gist indexes over boxrange inline it,
+# which re-resolves the unqualified create_point under that search_path and
+# does not find it. Qualifying the calls keeps all three indexes on 17 and 18
+# and changes nothing on 15 and 16. The CREATE line for create_point itself is
+# left alone, so search_path still decides where the function lands.
+#
 # Nine of the file's SQL functions are written against the `@` box operator,
 # which PostgreSQL 14 removed, so they error out on every version in the CI
 # matrix. The awk drops them: it buffers each CREATE OR REPLACE FUNCTION
@@ -159,7 +167,7 @@ sample-db-hive:
 sample-db-chado:
 	psql -c 'CREATE SCHEMA IF NOT EXISTS chado'
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
-	  | sed -E 's/^(SET search_path ?=[^;]*)public/\1chado/' \
+	  | sed -E 's/^(SET search_path ?=[^;]*)public/\1chado/; /^CREATE/! s/create_point\(/chado.create_point(/g' \
 	  | awk '/^CREATE OR REPLACE FUNCTION/ && !hold { buf = $$0; hold = 1; next } \
 	         hold { buf = buf ORS $$0; \
 	                if (tolower($$0) ~ /language/) { hold = 0; \

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -63,6 +63,7 @@ ejabberd|sample-db-url-schema|URL=https://raw.githubusercontent.com/processone/e
 guacamole|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/guacamole-client/5be18be1eeadc4cc544c737c54bd761261d2ad65/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql SCHEMA=guacamole|guacamole
 dotcms|sample-db-url-schema|URL=https://raw.githubusercontent.com/dotCMS/core/b0095c0c3920e236efcc16ceb136cd5dd88804b7/dotCMS/src/main/resources/postgres.sql SCHEMA=dotcms|dotcms
 osm|sample-db-pgdump-schema|URL=https://raw.githubusercontent.com/openstreetmap/openstreetmap-website/9da0fa5ecbff8adc5e6e91c7cf22546755a91f77/db/structure.sql SCHEMA=osm|osm
+chado|sample-db-chado|URL=https://raw.githubusercontent.com/GMOD/Chado/31c2407716e3d0fe4e837b6effad0a510af22238/chado/schemas/1.31/default_schema.sql|chado,genetic_code,so,frange
 endef
 
 # Print the sample manifest, one record per line, for shell consumers.
@@ -136,6 +137,36 @@ sample-db-hive:
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
 	  | awk '/^SET search_path = / { print "SET search_path = $(SCHEMA), pg_catalog;"; next } { print }' \
 	  | psql
+
+# GMOD Chado (GMOD/Chado), the schema behind FlyBase and the other model
+# organism databases. It names no schema for the objects it creates, so
+# search_path decides where they land, but four times partway through the file
+# it sets search_path itself with `public` in it, which overrides anything
+# PGOPTIONS passes in. So rewrite `public` in those four lines to `chado`, as
+# sample-db-hive rewrites its one line. The lines that name genetic_code, so,
+# and frange keep them: the file creates those three schemas itself and fills
+# them, so the sample is checked with all four. `so` is where its 1,832
+# Sequence Ontology views land, more views than every other sample together.
+#
+# Nine of the file's SQL functions are written against the `@` box operator,
+# which PostgreSQL 14 removed, so they error out on every version in the CI
+# matrix. The awk drops them: it buffers each CREATE OR REPLACE FUNCTION
+# through the LANGUAGE line that ends it, and skips the six whose body uses the
+# operator plus the three that call the three-argument groupoverlaps, which is
+# one of the six. Nothing else is dropped, and pistachio does not manage
+# functions in any case, so what the check sees is the same schema.
+.PHONY: sample-db-chado
+sample-db-chado:
+	psql -c 'CREATE SCHEMA IF NOT EXISTS chado'
+	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
+	  | sed -E 's/^(SET search_path ?=[^;]*)public/\1chado/' \
+	  | awk '/^CREATE OR REPLACE FUNCTION/ && !hold { buf = $$0; hold = 1; next } \
+	         hold { buf = buf ORS $$0; \
+	                if (tolower($$0) ~ /language/) { hold = 0; \
+	                  if (buf !~ /@ boxrange|FROM groupoverlaps\(\$$1,\$$2,\$$3\)/) print buf } \
+	                next } \
+	         { print }' \
+	  | PGOPTIONS='-c search_path=chado -c client_min_messages=warning' psql
 
 # Join Order Benchmark (gregrahn/join-order-benchmark), the IMDB schema used by
 # the JOB query set. The tables and their indexes ship as two separate files, so

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -66,6 +66,13 @@ osm|sample-db-pgdump-schema|URL=https://raw.githubusercontent.com/openstreetmap/
 chado|sample-db-chado|URL=https://raw.githubusercontent.com/GMOD/Chado/31c2407716e3d0fe4e837b6effad0a510af22238/chado/schemas/1.31/default_schema.sql|chado,genetic_code,so,frange
 endef
 
+# Every loader pipes its schema into this psql. ON_ERROR_STOP makes a failing
+# statement stop the load and fail the target, which the runner reports as
+# FAIL (load). Without it psql prints the error, carries on, and exits 0, and
+# the check runs against a schema quietly missing whatever the statement was
+# going to create -- which dump and plan then agree about, so the sample passes.
+PSQL = psql -v ON_ERROR_STOP=1
+
 # Print the sample manifest, one record per line, for shell consumers.
 .PHONY: print-samples
 print-samples:
@@ -79,17 +86,23 @@ schema: clean-schema
 	  $(MAKE) $$target $$args; \
 	done
 
+# The Neon sample collection. dvdrental was dumped by a pg_dump new enough to
+# set transaction_timeout in its preamble, a parameter 15 and 16 do not have,
+# so the line is dropped rather than let it stop the load on those versions. It
+# sets nothing the schema depends on.
 .PHONY: sample-db
 sample-db:
-	curl -sSf --retry 3 --retry-delay 2 https://raw.githubusercontent.com/neondatabase/postgres-sample-dbs/b54cb67534bf20775803b181b7a1c6f573422161/$(SQL_FILE) | psql
+	curl -sSf --retry 3 --retry-delay 2 https://raw.githubusercontent.com/neondatabase/postgres-sample-dbs/b54cb67534bf20775803b181b7a1c6f573422161/$(SQL_FILE) \
+	  | sed '/^SET transaction_timeout = /d' \
+	  | $(PSQL)
 
 .PHONY: sample-db-tar
 sample-db-tar:
-	curl -sSfL --retry 3 --retry-delay 2 $(TAR_URL) | tar xzO $(TAR_SQL_PATH) | psql
+	curl -sSfL --retry 3 --retry-delay 2 $(TAR_URL) | tar xzO $(TAR_SQL_PATH) | $(PSQL)
 
 .PHONY: sample-db-url
 sample-db-url:
-	curl -sSfL --retry 3 --retry-delay 2 $(URL) | psql
+	curl -sSfL --retry 3 --retry-delay 2 $(URL) | $(PSQL)
 
 # MIMIC-IV (MIT-LCP/mimic-code, MIT). The schema ships as three files, so
 # concatenate them in dependency order: create.sql (which creates the mimiciv_*
@@ -105,7 +118,7 @@ sample-db-mimiciv:
 	for f in $(MIMICIV_SQL_FILES); do \
 	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/MIT-LCP/mimic-code/3a914fce11e05888a4b659c7788e207bc34d1728/mimic-iv/buildmimic/postgres/$$f || exit 1; \
 	  echo; \
-	done | PGOPTIONS='-c client_min_messages=warning' psql
+	done | PGOPTIONS='-c client_min_messages=warning' $(PSQL)
 
 # A plain SQL URL loaded into a schema of its own. These dumps name no schema at
 # all, so search_path decides where they land, and upstream expects them in the
@@ -123,8 +136,8 @@ CLIENT_MIN_MESSAGES ?= notice
 
 .PHONY: sample-db-url-schema
 sample-db-url-schema:
-	psql -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'
-	curl -sSfL --retry 3 --retry-delay 2 $(URL) | PGOPTIONS='-c search_path=$(SCHEMA) -c client_min_messages=$(CLIENT_MIN_MESSAGES)' psql
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'
+	curl -sSfL --retry 3 --retry-delay 2 $(URL) | PGOPTIONS='-c search_path=$(SCHEMA) -c client_min_messages=$(CLIENT_MIN_MESSAGES)' $(PSQL)
 
 # Hive metastore (apache/hive, Apache-2.0). Like the sample-db-url-schema
 # dumps this one belongs in a schema of its own, but it is a pg_dump-style
@@ -133,10 +146,10 @@ sample-db-url-schema:
 # search_path from outside.
 .PHONY: sample-db-hive
 sample-db-hive:
-	psql -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
 	  | awk '/^SET search_path = / { print "SET search_path = $(SCHEMA), pg_catalog;"; next } { print }' \
-	  | psql
+	  | $(PSQL)
 
 # GMOD Chado (GMOD/Chado), the schema behind FlyBase and the other model
 # organism databases. It names no schema for the objects it creates, so
@@ -165,7 +178,7 @@ sample-db-hive:
 # functions in any case, so what the check sees is the same schema.
 .PHONY: sample-db-chado
 sample-db-chado:
-	psql -c 'CREATE SCHEMA IF NOT EXISTS chado'
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS chado'
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
 	  | sed -E 's/^(SET search_path ?=[^;]*)public/\1chado/; /^CREATE/! s/create_point\(/chado.create_point(/g' \
 	  | awk '/^CREATE OR REPLACE FUNCTION/ && !hold { buf = $$0; hold = 1; next } \
@@ -174,7 +187,7 @@ sample-db-chado:
 	                  if (buf !~ /@ boxrange|FROM groupoverlaps\(\$$1,\$$2,\$$3\)/) print buf } \
 	                next } \
 	         { print }' \
-	  | PGOPTIONS='-c search_path=chado -c client_min_messages=warning' psql
+	  | PGOPTIONS='-c search_path=chado -c client_min_messages=warning' $(PSQL)
 
 # Join Order Benchmark (gregrahn/join-order-benchmark), the IMDB schema used by
 # the JOB query set. The tables and their indexes ship as two separate files, so
@@ -184,7 +197,7 @@ sample-db-imdb:
 	for f in schema.sql fkindexes.sql; do \
 	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/gregrahn/join-order-benchmark/a39603662e023e449cb2121997a5034df9e02ebf/$$f || exit 1; \
 	  echo; \
-	done | psql
+	done | $(PSQL)
 
 # AdventureWorks (lorint/AdventureWorks-for-Postgres, MIT). Schema-only load:
 # strip \copy lines (data lives in CSVs we don't fetch) and the inline
@@ -193,7 +206,7 @@ sample-db-imdb:
 sample-db-adventureworks:
 	curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/lorint/AdventureWorks-for-Postgres/b474991f0df1c4bf55ca4735eb0254ca0709eed2/install.sql \
 	  | awk '/^\\copy/ { next } /^INSERT INTO Production.ProductReview/ { skip=1 } skip { if (/\);[[:space:]]*$$/) skip=0; next } { print }' \
-	  | psql
+	  | $(PSQL)
 
 # PostgreSQL Exercises club data (pgexercises.com). The dump creates its own
 # database and reconnects to it, which we cannot do mid-pipe; strip those two
@@ -203,7 +216,7 @@ sample-db-adventureworks:
 sample-db-clubdata:
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
 	  | awk '/^CREATE DATABASE exercises;/ { next } /^\\c exercises/ { next } { print }' \
-	  | psql
+	  | $(PSQL)
 
 # Postgres Pro demo database (postgrespro/demodb, PostgreSQL License). The repo
 # ships a schema-generation script, not a plain dump: tables.sql defines the
@@ -213,10 +226,10 @@ sample-db-clubdata:
 # bookings.routes exclusion constraint requires.
 .PHONY: sample-db-demodb
 sample-db-demodb:
-	psql -c 'CREATE EXTENSION IF NOT EXISTS btree_gist'
+	$(PSQL) -c 'CREATE EXTENSION IF NOT EXISTS btree_gist'
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
 	  | awk '/^[[:space:]]*\\copy/ { next } { print }' \
-	  | psql
+	  | $(PSQL)
 
 # MusicBrainz (metabrainz/musicbrainz-server, GPL-2.0). The schema ships as one
 # file per object kind and none of them create the schema, so create
@@ -240,11 +253,11 @@ MUSICBRAINZ_SQL_FILES = \
 
 .PHONY: sample-db-musicbrainz
 sample-db-musicbrainz:
-	psql -c 'CREATE SCHEMA IF NOT EXISTS musicbrainz'
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS musicbrainz'
 	for f in $(MUSICBRAINZ_SQL_FILES); do \
 	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/metabrainz/musicbrainz-server/424c5fad44da2b3ad55d08286fe8ad07c11ec471/admin/sql/$$f || exit 1; \
 	  echo; \
-	done | PGOPTIONS='-c search_path=musicbrainz,public -c client_min_messages=warning' psql
+	done | PGOPTIONS='-c search_path=musicbrainz,public -c client_min_messages=warning' $(PSQL)
 
 # Znuny (znuny/Znuny, GPL-3.0). The schema ships as two files, so concatenate
 # them: schema.postgresql.sql (tables and indexes) and then
@@ -257,11 +270,11 @@ ZNUNY_SQL_FILES = schema.postgresql.sql schema-post.postgresql.sql
 
 .PHONY: sample-db-znuny
 sample-db-znuny:
-	psql -c 'CREATE SCHEMA IF NOT EXISTS znuny'
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS znuny'
 	for f in $(ZNUNY_SQL_FILES); do \
 	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/znuny/Znuny/0b894348ebc458621545ccdab5f3d24d1b396a70/scripts/database/$$f || exit 1; \
 	  echo; \
-	done | PGOPTIONS='-c search_path=znuny' psql
+	done | PGOPTIONS='-c search_path=znuny' $(PSQL)
 
 # Camunda 7 (camunda/camunda-bpm-platform, Apache-2.0). The schema ships as one
 # file per engine component and none of them create a schema, so create
@@ -280,11 +293,11 @@ CAMUNDA_SQL_FILES = \
 
 .PHONY: sample-db-camunda
 sample-db-camunda:
-	psql -c 'CREATE SCHEMA IF NOT EXISTS camunda'
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS camunda'
 	for f in $(CAMUNDA_SQL_FILES); do \
 	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/camunda/camunda-bpm-platform/ee4826e5e76c2348a1510ef46a2f4ccd3b080e48/engine/src/main/resources/org/camunda/bpm/engine/db/create/$$f || exit 1; \
 	  echo; \
-	done | PGOPTIONS='-c search_path=camunda' psql
+	done | PGOPTIONS='-c search_path=camunda' $(PSQL)
 
 # A pg_dump-style dump loaded into a schema of its own. discourse and osm ship
 # their schema as Rails' db/structure.sql, which belongs in a schema of its own
@@ -307,10 +320,10 @@ sample-db-camunda:
 # sample-db-test.md.
 .PHONY: sample-db-pgdump-schema
 sample-db-pgdump-schema:
-	psql -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
 	  | sed -E "/^SELECT pg_catalog.set_config\('search_path', '', false\);\$$/d; /^SET search_path TO /,\$$d; s/^public\.//; s/([^A-Za-z0-9_])public\./\1/g" \
-	  | PGOPTIONS='-c search_path=$(SCHEMA),public' psql
+	  | PGOPTIONS='-c search_path=$(SCHEMA),public' $(PSQL)
 
 .PHONY: test-samples
 test-samples:


### PR DESCRIPTION
GMOD Chado, the schema behind FlyBase and the other model organism
databases: 213 tables, 1,017 columns, 837 indexes, 472 foreign keys, 399
constraints, and 1,864 views.

The views are why it is worth having. Every other sample together has 86,
while chado's `so` schema alone holds 1,832 Sequence Ontology views, each
selecting from a table in `chado`, so the sample exercises the view path at
a scale nothing else reaches. Its three gist indexes are over `boxrange()`,
a function the schema defines itself, one of them partial and declared from
another schema, and 4 of its foreign keys cross from `frange` into `chado`.

The file names no schema for what it creates, but four times partway
through it sets search_path itself with `public` in it, which overrides
anything PGOPTIONS passes in, so sample-db-chado rewrites `public` in those
four lines the way sample-db-hive rewrites its one line. genetic_code, so,
and frange the file creates itself, so the sample is checked with all four.

Nine of its SQL functions are written against the `@` box operator that
PostgreSQL 14 removed, six using it and three calling one of the six, so
the loader drops them with awk rather than have psql print an error for
each on every run. pistachio does not manage functions in any case, and
every table, index, constraint, and view still loads, the three gist
indexes over boxrange among them.

Checked on PostgreSQL 16.13: load, then dump and plan, reports No changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wm6drKnK1AHdA3XGuEtyhz