### PR TITLE
Wipe the user schemas before the tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
           Set-Content -Path "$env:PGDATA\pg_hba.conf" -Value "host all all 127.0.0.1/32 trust`nhost all all ::1/128 trust"
           Get-Service -Name postgresql* | Set-Service -StartupType Manual -PassThru | Start-Service
           & "$env:PGBIN\pg_isready" -h localhost -t 30
+          # `make test` wipes the database through psql first, and the image
+          # leaves PGBIN off PATH, so put it on.
+          Add-Content -Path $env:GITHUB_PATH -Value $env:PGBIN
       - name: Build
         run: go build -o pista.exe ./cmd/pista
       - name: Smoke test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ make fix            # golangci-lint run --fix (auto-fix lint errors)
 
 - Tests require a running PostgreSQL instance. `compose.yaml` publishes each version of the CI matrix on its own port (15 -> 5415, 16 -> 5416, 17 -> 5417, 18 -> 5418), so several can run side by side; `PGPORT` (default 5415) selects which one every `psql`- and test-based target uses. The Makefile builds `TEST_PISTA_CONN_STR` from it; set that variable to point somewhere else entirely.
 - Tests run with `-p 1` (sequential packages) because integration tests share a single database.
+- `make test` and `make test-scenario` depend on `clean-schema`, so they wipe every user schema before running. The tests themselves reset only `public`, and a sample schema left over from `make schema` is otherwise still visible to them. `clean-schema` follows `PGHOST`/`PGUSER`/`PGPORT`, not `TEST_PISTA_CONN_STR`, so override `PGPORT` rather than the connection string.
 - `make schema` and other `psql`-based targets rely on `PGHOST=localhost` / `PGUSER=postgres` / `PGPORT` (exported from the Makefile).
 - The sample schema targets (`schema`, `sample-db-*`, `test-samples`, `clean-schema`, `reset-db`) live in `sample-db.mk`, which the Makefile includes. See `sample-db-test.md`.
 

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,17 @@ install:
 vet:
 	go vet ./...
 
+# The Go tests reset `public` and nothing else, so whatever `make schema`
+# loaded into the other schemas is still there while they run. A test that
+# looks something up without naming its schema then finds a sample's object
+# instead of its own. CI runs against an empty database and never sees it, so
+# wipe first and let a local run start from the same place.
+#
+# clean-schema goes through PGHOST/PGUSER/PGPORT, so overriding
+# TEST_PISTA_CONN_STR alone points the tests at one server and the wipe at
+# another. Override PGPORT, or wipe the other server yourself.
 .PHONY: test
-test:
+test: clean-schema
 	go test -p 1 -v ./... $(TEST_OPTS)
 
 .PHONY: lint
@@ -56,8 +65,10 @@ deadcode:
 keywords:
 	bash scripts/gen-keywords.sh
 
+# Cleaned for the same reason as `test`: run.sh resets `public` per scenario
+# and leaves every other schema alone.
 .PHONY: test-scenario
-test-scenario:
+test-scenario: clean-schema
 	bash test/scenario/run.sh
 
 .PHONY: demo

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -278,7 +278,8 @@ test-samples:
 	bash test/samples/run.sh
 
 # Wipe every user schema. Used by `schema` and `demo` to start from an empty
-# database, and by test-samples once before its first sample.
+# database, by test-samples once before its first sample, and by `test` and
+# `test-scenario`, which reset only `public` on their own.
 #
 # The tables go first, a batch at a time, and only then the schemas. A single
 # DROP SCHEMA ... CASCADE takes locks on every object it reaches, and the


### PR DESCRIPTION
## Problem

`make test` fails on a local database that has the sample schemas loaded:

```
--- FAIL: TestApply_ExecuteFirstCheckSQLError
    apply_test.go:676: expected: 0, actual: 1
```

`testutil.SetupDB` drops and recreates `public` and nothing else, and `test/scenario/helper.sh` does the same once per scenario. Everything `make schema` loaded into the other schemas is still there while the tests run. A test that looks an object up without naming its schema then finds a sample's object instead of its own. Here the test counts the `pg_class` rows named `users`, and the osm sample owns `osm.users`.

CI starts from an empty database, so it never sees this. Only a local run after `make schema` does.

## Change

`test` and `test-scenario` now depend on `clean-schema`, the target that already wipes every user schema for `schema`, `demo` and `test-samples`. It drops tables a batch at a time, so the large samples do not run the server out of lock table space.

`clean-schema` goes through `PGHOST`/`PGUSER`/`PGPORT` rather than `TEST_PISTA_CONN_STR`. Overriding the connection string on its own now points the tests at one server and the wipe at another, so override `PGPORT` instead. Noted next to the target and in `AGENTS.md`.

The Windows job runs the default goal (`all: vet test build`), so it reaches `clean-schema` too and needs `psql`. The runner image leaves `PGBIN` off `PATH`, which is why the existing step calls `pg_isready` by full path, so the step now adds it to `PATH`.

## Verified

- `make test` on the polluted database: user schemas 47 -> 1, all packages pass, `TestApply_ExecuteFirstCheckSQLError` included
- `make test-scenario`: 11 scenarios pass
- non-ASCII check clean, `ci.yml` parses

The Windows job is the one thing not exercised locally.