### PR TITLE
Retire the two unreachable branches in DiffViews

### DIFF
--- a/diff/views.go
+++ b/diff/views.go
@@ -233,13 +233,14 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 		if !dok || !cok {
 			continue
 		}
-		// TODO: dead code. detectViewRenames already rejects a rename that
-		// switches between VIEW and MATERIALIZED VIEW, so this condition is
-		// never true here. Consider removing.
-		if currentView.Materialized != desiredView.Materialized {
-			needsRecreateRenamed[newKey] = true
-			continue
-		}
+		// detectViewRenames rejects a rename that switches between VIEW and
+		// MATERIALIZED VIEW, so this cannot be reached. Kept for the day that
+		// rename is allowed, when a type switch has to take the recreate path
+		// rather than ALTER ... RENAME.
+		// if currentView.Materialized != desiredView.Materialized {
+		// 	needsRecreateRenamed[newKey] = true
+		// 	continue
+		// }
 		if !equalViewDef(currentView.Definition, desiredView.Definition) {
 			if desiredView.Materialized || !canCreateOrReplaceView(currentView.Definition, desiredView.Definition) {
 				needsRecreateRenamed[newKey] = true
@@ -393,15 +394,6 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 		// pre-recreation shape, so skip comment diff to keep the output
 		// consistent with "nothing executable was emitted for this view".
 		if recreateDenied[k] {
-			continue
-		}
-
-		// If the type changed (VIEW <-> MATERIALIZED VIEW) but drop was denied,
-		// the object type hasn't changed yet; skip comment diff.
-		// TODO: dead code. A denied type change always sets recreateDenied[k],
-		// so the check above already continues before reaching this. Consider
-		// removing.
-		if ok && currentView.Materialized != desiredView.Materialized && !dc.IsDropAllowed("view") {
 			continue
 		}
 


### PR DESCRIPTION
`9338584` marked two branches in `DiffViews` with a `TODO: dead code` comment. Both are confirmed unreachable, so one is removed and the other is kept as commented-out code with a comment that explains why.

## Deleted: the comment-diff check for a denied type change

```go
if ok && currentView.Materialized != desiredView.Materialized && !dc.IsDropAllowed("view") {
    continue
}
```

`f0b1fd8` added this when it was the only guard. `8b9d057` introduced `recreateDenied` the next day and placed the broader gate above it. That commit message already said the narrower check "is now subsumed by the new gate"; only the removal was missing.

A type change makes `needsDropCreate` true unconditionally, so a denied drop always sets `recreateDenied[k]`, and `if recreateDenied[k] { continue }` fires first. The surviving comment above that gate covers both the type change and the matview definition change, so nothing is lost.

## Commented out: the rename type-switch check

```go
if currentView.Materialized != desiredView.Materialized {
    needsRecreateRenamed[newKey] = true
    continue
}
```

`detectViewRenames` returns an error on a VIEW/MATERIALIZED VIEW mismatch, and on success stores a copy of the old view under the new key, so both sides of a `renamedFrom` entry always agree.

Unlike the first one this is not a duplicated guard. It rests on a precondition of another function, and it is the handling this loop would need if that rename is ever allowed, so it stays as a comment. The `TODO: dead code ... Consider removing` wording is replaced with one that says it is deliberate.

## Verified

Neither branch was reachable, so the plan output does not change.

- `go build` / `go vet` / `gofmt -l` clean, `golangci-lint run` reports 0 issues, `make deadcode` passes
- `make test` passes on every package, `make test-scenario` passes all 11 scenarios
- coverage measured with `-coverpkg=./...`: `DiffViews` 94.5% -> 96.8%, overall 95.4% -> 95.5%

The `-coverprofile` blocks for the two branch bodies were both hit 0 times across the 772 fixtures and the Go tests before this change, while the enclosing condition lines were evaluated.