### PR TITLE
Manage routines in the demo schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ pista plan  desired.sql     # ...should now print "No changes"
 pista dump                  # dump the current schema
 ```
 
+The image sets `$PISTA_MANAGE_ROUTINE`, so the functions and procedures in the demo schema are managed too.
+
 The source for the image is under [`demo/`](demo/).
 
 ## Example

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -32,6 +32,7 @@ ENV PGHOST=/var/run/postgresql \
     PGUSER=postgres \
     PGDATABASE=demo \
     PISTA_CONN_STR=postgres://postgres@/demo \
+    PISTA_MANAGE_ROUTINE=1 \
     PISTA_PAGER="bat -l sql -p --paging=never --color=always"
 
 WORKDIR /demo

--- a/demo/current.sql
+++ b/demo/current.sql
@@ -19,11 +19,10 @@ CREATE DOMAIN email_address AS text
 -- Sequence: public-facing post reference numbers
 CREATE SEQUENCE post_ref_seq START 1000;
 
--- ---------- trigger functions ----------
---  Not managed by pistachio; created only when missing.
+-- ---------- functions and procedures ----------
+--  Managed declaratively; the demo has $PISTA_MANAGE_ROUTINE set.
 
--- pista:execute-first SELECT to_regprocedure('public.set_updated_at()') IS NULL
-CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger
+CREATE FUNCTION set_updated_at() RETURNS trigger
     LANGUAGE plpgsql AS $$
 BEGIN
     NEW.updated_at := now();
@@ -31,12 +30,28 @@ BEGIN
 END;
 $$;
 
--- pista:execute-first SELECT to_regprocedure('public.notify_comment()') IS NULL
-CREATE OR REPLACE FUNCTION notify_comment() RETURNS trigger
+CREATE FUNCTION notify_comment() RETURNS trigger
     LANGUAGE plpgsql AS $$
 BEGIN
     PERFORM pg_notify('comments', NEW.post_id::text);
     RETURN NULL;
+END;
+$$;
+
+CREATE FUNCTION slugify(t text) RETURNS text
+    LANGUAGE sql IMMUTABLE STRICT
+    AS $$ SELECT lower(replace(t, ' ', '-')) $$;
+
+COMMENT ON FUNCTION slugify(text) IS 'Tag name -> URL slug';
+
+CREATE FUNCTION post_excerpt(body text, len integer DEFAULT 100) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT left(body, len) $$;
+
+CREATE PROCEDURE refresh_tag_usage()
+    LANGUAGE plpgsql AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW tag_usage;
 END;
 $$;
 

--- a/demo/desired.sql
+++ b/demo/desired.sql
@@ -17,11 +17,11 @@ CREATE DOMAIN email_address AS text
 -- Sequence: post_ref_seq, increment bumped to 10
 CREATE SEQUENCE post_ref_seq START 1000 INCREMENT BY 10;
 
--- ---------- trigger functions ----------
---  Not managed by pistachio; created only when missing.
+-- ---------- functions and procedures ----------
+--  slugify reworked and marked PARALLEL SAFE, post_excerpt default 100 -> 140,
+--  +comment_count, refresh_tag_usage dropped (needs --allow-drop routine)
 
--- pista:execute-first SELECT to_regprocedure('public.set_updated_at()') IS NULL
-CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger
+CREATE FUNCTION set_updated_at() RETURNS trigger
     LANGUAGE plpgsql AS $$
 BEGIN
     NEW.updated_at := now();
@@ -29,12 +29,31 @@ BEGIN
 END;
 $$;
 
--- pista:execute-first SELECT to_regprocedure('public.notify_comment()') IS NULL
-CREATE OR REPLACE FUNCTION notify_comment() RETURNS trigger
+CREATE FUNCTION notify_comment() RETURNS trigger
     LANGUAGE plpgsql AS $$
 BEGIN
     PERFORM pg_notify('comments', NEW.post_id::text);
     RETURN NULL;
+END;
+$$;
+
+CREATE FUNCTION slugify(t text) RETURNS text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    AS $$ SELECT trim(both '-' from regexp_replace(lower(t), '[^a-z0-9]+', '-', 'g')) $$;
+
+COMMENT ON FUNCTION slugify(text) IS 'Tag name -> URL slug';
+
+CREATE FUNCTION post_excerpt(body text, len integer DEFAULT 140) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT left(body, len) $$;
+
+CREATE FUNCTION comment_count(post bigint) RETURNS bigint
+    LANGUAGE plpgsql STABLE AS $$
+DECLARE
+    n bigint;
+BEGIN
+    SELECT count(*) INTO n FROM comments WHERE post_id = post;
+    RETURN n;
 END;
 $$;
 

--- a/demo/manual.txt
+++ b/demo/manual.txt
@@ -5,6 +5,9 @@
 A local PostgreSQL is running and the schema from current.sql
 is already loaded into the 'demo' database.
 
+Functions and procedures are managed as well: this image sets
+$PISTA_MANAGE_ROUTINE, which is off in a plain pista install.
+
 Try the following:
 
   pista plan  desired.sql     # show the DDL diff
@@ -13,13 +16,14 @@ Try the following:
   pista dump                  # dump the current schema
   psql                        # poke around the DB
 
-Destructive changes (DROP COLUMN / DROP TABLE / etc.) are skipped
-by default and shown as '-- skipped:' comments. To allow them,
-pass --allow-drop with the object types you want to permit:
+Destructive changes (DROP COLUMN / DROP TABLE / DROP FUNCTION /
+etc.) are skipped by default and shown as '-- skipped:' comments.
+To allow them, pass --allow-drop with the object types you want
+to permit:
 
-  pista plan  --allow-drop=column        desired.sql
-  pista apply --allow-drop=column,table  desired.sql
-  pista apply --allow-drop=all           desired.sql
+  pista plan  --allow-drop=column          desired.sql
+  pista apply --allow-drop=column,routine  desired.sql
+  pista apply --allow-drop=all             desired.sql
 
 Files in this directory (/demo):
   current.sql   - already loaded into 'demo'


### PR DESCRIPTION
The demo image kept its trigger functions out of pistachio's hands with `-- pista:execute-first`. This sets `$PISTA_MANAGE_ROUTINE=1` in the image so the demo schema manages functions and procedures declaratively.

- `current.sql`: drops the directives from `set_updated_at()` and `notify_comment()`, and adds `slugify(text)` with a `COMMENT ON FUNCTION`, `post_excerpt(text, integer DEFAULT 100)`, and a `refresh_tag_usage()` procedure.
- `desired.sql`: reworks `slugify()` and marks it `PARALLEL SAFE`, bumps the `post_excerpt()` default to 140, adds `comment_count(bigint)`, and removes `refresh_tag_usage()` so the `DROP PROCEDURE` shows up under `-- skipped:` until `--allow-drop routine` is passed.
- `manual.txt` and the README demo section mention that routines are managed here.

Verified on PostgreSQL 18:

- load `current.sql`, then `pista plan current.sql` prints `-- No changes`
- `pista plan desired.sql` shows the routine statements plus the skipped `DROP PROCEDURE`
- `pista apply --allow-drop=all desired.sql`, then plan again prints `-- No changes`
- `pista dump` fed back as the desired schema also plans clean