### PR TITLE
Warn about ignored ALTER TABLE actions and COMMENT targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Warn about an `ALTER TABLE` action or a `COMMENT ON` target the parser drops. Both statements are supported as a whole, so neither reached the `ignored unsupported statement` warning, and the parts pistachio does not read were dropped in silence: `ALTER TABLE ... ADD COLUMN` left the column out of the desired schema, so the plan proposed dropping it from the database, and `ALTER COLUMN ... SET DEFAULT` / `SET NOT NULL` / `TYPE` went the same way. The actions the parser reads (`ADD CONSTRAINT`, the row-level security toggles, the trigger states) and the comment targets it models (table, column, view, materialized view, sequence, type, domain, function, procedure) are now listed explicitly, so an action or target added later warns instead of vanishing. A statement that mixes a read action with a dropped one reports only the dropped one. An `ALTER TABLE` naming a relation the file does not declare is still skipped in silence, the same as a `CREATE INDEX` on such a relation.
+* Warn about an `ALTER TABLE` action or a `COMMENT ON` target the parser drops. Both have a parser case of their own, so neither reached the `ignored unsupported statement` warning: a column added by `ALTER TABLE ... ADD COLUMN` was absent from the desired schema and the plan proposed dropping it from the database, and `ALTER COLUMN ... SET DEFAULT` / `SET NOT NULL` / `TYPE` went the same way. The warning follows what the parser reads, so an action or target added later warns instead of vanishing. An `ALTER TABLE` naming a relation the file does not declare is still skipped without one.
 
 ## [1.30.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Warn about an `ALTER TABLE` action or a `COMMENT ON` target the parser drops. Both statements are supported as a whole, so neither reached the `ignored unsupported statement` warning, and the parts pistachio does not read were dropped in silence: `ALTER TABLE ... ADD COLUMN` left the column out of the desired schema, so the plan proposed dropping it from the database, and `ALTER COLUMN ... SET DEFAULT` / `SET NOT NULL` / `TYPE` went the same way. The actions the parser reads (`ADD CONSTRAINT`, the row-level security toggles, the trigger states) and the comment targets it models (table, column, view, materialized view, sequence, type, domain, function, procedure) are now listed explicitly, so an action or target added later warns instead of vanishing. A statement that mixes a read action with a dropped one reports only the dropped one. An `ALTER TABLE` naming a relation the file does not declare is still skipped in silence, the same as a `CREATE INDEX` on such a relation.
+
 ## [1.30.0] - 2026-08-25
 
 * Manage functions and procedures, behind `--manage-routine` (`$PISTA_MANAGE_ROUTINE`). Routines are off by default, so a schema maintained with `-- pista:execute` keeps working and plan output is unchanged. With the flag, `pg_proc` is read, `dump` writes each routine, and the diff compares the body, the language and the attributes (volatility, `STRICT`, `SECURITY DEFINER`, `LEAKPROOF`, `PARALLEL`, `COST`, `ROWS`, `SET`). A routine is identified by its name and its argument types, so an overload set is several objects. Changes apply with `CREATE OR REPLACE`; the ones PostgreSQL refuses in place run as `DROP` and `CREATE`, gated by `--allow-drop routine`. `routine` also joins the `--enable` / `--disable` type list, and `-- pista:ignore` works on a `CREATE FUNCTION` or `CREATE PROCEDURE`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Warn about an `ALTER TABLE` action or a `COMMENT ON` target the parser drops. Both have a parser case of their own, so neither reached the `ignored unsupported statement` warning: a column added by `ALTER TABLE ... ADD COLUMN` was absent from the desired schema and the plan proposed dropping it from the database, and `ALTER COLUMN ... SET DEFAULT` / `SET NOT NULL` / `TYPE` went the same way. The warning follows what the parser reads, so an action or target added later warns instead of vanishing. An `ALTER TABLE` naming a relation the file does not declare is still skipped without one.
+* Warn about an `ALTER TABLE` action or a `COMMENT ON` target the parser drops. Both have a parser case of their own, so neither reached the `ignored unsupported statement` warning: a column added by `ALTER TABLE ... ADD COLUMN` was absent from the desired schema and the plan proposed dropping it from the database, and `ALTER COLUMN ... SET DEFAULT` / `SET NOT NULL` / `TYPE` went the same way. The warning follows what the parser reads, so an action or target added later warns instead of vanishing. An `ALTER TABLE` naming a relation the file does not declare, or one marked `-- pista:ignore`, is still skipped without one.
 
 ## [1.30.0] - 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pista apply ./schema/*.sql         # apply it
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 
-pistachio parses only the statements above. It drops any other statement in a schema file, such as `SET`, `GRANT`, or `CREATE EXTENSION`, and prints a `pistachio: ignored unsupported statement:` warning to standard error for each one. To keep an unsupported statement in the file and run it during `apply`, mark it with `-- pista:execute`, which also silences the warning. A `BEGIN` or `COMMIT` warning points at `--with-tx` and `--try-tx`, which wrap the apply in a transaction.
+pistachio parses only the statements above. It drops any other statement in a schema file, such as `SET`, `GRANT`, or `CREATE EXTENSION`, and prints a `pistachio: ignored unsupported statement:` warning to standard error for each one. The same warning covers the parts it does not read of a statement it does parse, such as the `ALTER TABLE ... ADD COLUMN` and `ALTER COLUMN ... SET DEFAULT` a `pg_dump` file carries, or `COMMENT ON INDEX`. To keep an unsupported statement in the file and run it during `apply`, mark it with `-- pista:execute`, which also silences the warning. A `BEGIN` or `COMMIT` warning points at `--with-tx` and `--try-tx`, which wrap the apply in a transaction.
 
 ## Usage
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -423,7 +423,11 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				continue
 			}
 
-			warnIgnoredAlterTableCmds(sql, rawStmt, as)
+			// A table marked -- pista:ignore is out of the diff, so an
+			// action dropped from it cannot mislead the plan.
+			if !t.Ignore {
+				warnIgnoredAlterTableCmds(sql, rawStmt, as)
+			}
 
 			// RLS toggles, trigger states and constraint subcommands can
 			// coexist in one ALTER TABLE statement. Each helper picks up only

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -85,6 +85,79 @@ func warnIgnoredStmt(sql string, rawStmt *pg_query.RawStmt) {
 	fmt.Fprintf(warnWriter, "pistachio: ignored unsupported statement: %s%s\n", snippet, txHint(rawStmt)) //nolint:errcheck
 }
 
+// alterTableSupportedCmds lists the ALTER TABLE actions the parser reads into
+// the model: constraints (parseAlterTableConstraints), the row-level security
+// toggles (applyAlterTableRLS) and the trigger states
+// (applyAlterTableTriggerState). Anything else is dropped, so warning is
+// driven off this list rather than off a list of the actions to reject: an
+// action PostgreSQL adds later warns instead of vanishing.
+var alterTableSupportedCmds = map[pg_query.AlterTableType]bool{
+	pg_query.AlterTableType_AT_AddConstraint:      true,
+	pg_query.AlterTableType_AT_EnableRowSecurity:  true,
+	pg_query.AlterTableType_AT_DisableRowSecurity: true,
+	pg_query.AlterTableType_AT_ForceRowSecurity:   true,
+	pg_query.AlterTableType_AT_NoForceRowSecurity: true,
+	pg_query.AlterTableType_AT_EnableTrig:         true,
+	pg_query.AlterTableType_AT_DisableTrig:        true,
+	pg_query.AlterTableType_AT_EnableAlwaysTrig:   true,
+	pg_query.AlterTableType_AT_EnableReplicaTrig:  true,
+}
+
+// commentTargetSupported lists the COMMENT ON targets parseCommentStmt reads
+// into the model. A comment on any other object is dropped, and warns.
+var commentTargetSupported = map[pg_query.ObjectType]bool{
+	pg_query.ObjectType_OBJECT_TABLE:     true,
+	pg_query.ObjectType_OBJECT_VIEW:      true,
+	pg_query.ObjectType_OBJECT_MATVIEW:   true,
+	pg_query.ObjectType_OBJECT_COLUMN:    true,
+	pg_query.ObjectType_OBJECT_SEQUENCE:  true,
+	pg_query.ObjectType_OBJECT_TYPE:      true,
+	pg_query.ObjectType_OBJECT_DOMAIN:    true,
+	pg_query.ObjectType_OBJECT_FUNCTION:  true,
+	pg_query.ObjectType_OBJECT_PROCEDURE: true,
+}
+
+// warnIgnoredAlterTableCmds warns about the ALTER TABLE actions no handler
+// reads. ALTER TABLE as a statement is supported, so such an action never
+// reaches the unsupported-statement warning; dropping it in silence would let
+// a column added this way read as absent from the desired schema and plan as
+// a DROP COLUMN.
+//
+// The warning carries a statement rebuilt from the ignored actions alone, so
+// one that mixes a supported action with an unsupported one reports only the
+// latter. The rebuilt statement keeps the original location, which is what
+// the snippet falls back to when deparse fails.
+func warnIgnoredAlterTableCmds(sql string, rawStmt *pg_query.RawStmt, as *pg_query.AlterTableStmt) {
+	var ignored []*pg_query.Node
+
+	for _, cmdNode := range as.Cmds {
+		cmd := cmdNode.GetAlterTableCmd()
+		if cmd == nil || alterTableSupportedCmds[cmd.Subtype] {
+			continue
+		}
+		ignored = append(ignored, cmdNode)
+	}
+
+	if len(ignored) == 0 {
+		return
+	}
+
+	warnIgnoredStmt(sql, &pg_query.RawStmt{
+		Stmt: &pg_query.Node{
+			Node: &pg_query.Node_AlterTableStmt{
+				AlterTableStmt: &pg_query.AlterTableStmt{
+					Relation:  as.Relation,
+					Objtype:   as.Objtype,
+					MissingOk: as.MissingOk,
+					Cmds:      ignored,
+				},
+			},
+		},
+		StmtLocation: rawStmt.StmtLocation,
+		StmtLen:      rawStmt.StmtLen,
+	})
+}
+
 func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error {
 	if _, ok := m.GetOk(key); ok {
 		return fmt.Errorf("duplicate %s: %s", kind, key)
@@ -350,6 +423,8 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				continue
 			}
 
+			warnIgnoredAlterTableCmds(sql, rawStmt, as)
+
 			// RLS toggles, trigger states and constraint subcommands can
 			// coexist in one ALTER TABLE statement. Each helper picks up only
 			// its own subtypes and walks the cmd list independently, so run
@@ -449,6 +524,10 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 
 		case node.GetCommentStmt() != nil:
 			cs := node.GetCommentStmt()
+			if !commentTargetSupported[cs.Objtype] {
+				warnIgnoredStmt(sql, rawStmt)
+				break
+			}
 			parseCommentStmt(cs, defaultSchema, tables, views, enums, domains, compositeTypes, sequences, routines)
 
 		default:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -234,6 +234,24 @@ func TestParseSQL_WarnsIgnoredAlterTableAction_KeepsSupportedAction(t *testing.T
 	assert.NotContains(t, out, "t_id_check", "the parsed action must not be reported as ignored")
 }
 
+// Several dropped actions in one statement are reported together, on one line.
+func TestParseSQL_WarnsIgnoredAlterTableAction_MultipleActions(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	_, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (id integer);
+		ALTER TABLE public.t ADD COLUMN x text, ALTER COLUMN id TYPE bigint;
+	`)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ADD COLUMN x text")
+	assert.Contains(t, out, "ALTER COLUMN id TYPE bigint")
+	assert.Equal(t, 1, strings.Count(out, "\n"), "the warning must be a single line")
+}
+
 // The actions the parser does read must stay silent.
 func TestParseSQL_NoWarnForSupportedAlterTableActions(t *testing.T) {
 	var buf bytes.Buffer
@@ -250,6 +268,37 @@ func TestParseSQL_NoWarnForSupportedAlterTableActions(t *testing.T) {
 		ALTER TABLE public.t DISABLE TRIGGER trg;
 	`)
 	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+// IF EXISTS is part of the statement, so it survives into the warning.
+func TestParseSQL_WarnsIgnoredAlterTableAction_IfExists(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	_, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (id integer);
+		ALTER TABLE IF EXISTS public.t ADD COLUMN x text;
+	`)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "ALTER TABLE IF EXISTS public.t ADD COLUMN x text")
+}
+
+// A statement marked -- pista:execute is run as written instead of being
+// diffed, so it must not warn.
+func TestParseSQL_ExecuteDirectiveSilencesAlterTableWarning(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (id integer);
+		-- pista:execute
+		ALTER TABLE public.t ADD COLUMN x text;
+	`)
+	require.NoError(t, err)
+	assert.Len(t, result.ExecuteStmts, 1)
 	assert.Empty(t, buf.String())
 }
 
@@ -299,15 +348,52 @@ func TestParseSQL_NoWarnForSupportedCommentTargets(t *testing.T) {
 		CREATE SEQUENCE public.s;
 		CREATE TABLE public.t (id integer);
 		CREATE VIEW public.v AS SELECT id FROM public.t;
+		CREATE MATERIALIZED VIEW public.mv AS SELECT id FROM public.t;
+		CREATE FUNCTION public.f() RETURNS integer LANGUAGE sql AS $$ SELECT 1 $$;
+		CREATE PROCEDURE public.p() LANGUAGE sql AS $$ SELECT 1 $$;
 		COMMENT ON TABLE public.t IS 't';
 		COMMENT ON COLUMN public.t.id IS 'c';
 		COMMENT ON VIEW public.v IS 'v';
+		COMMENT ON MATERIALIZED VIEW public.mv IS 'mv';
 		COMMENT ON SEQUENCE public.s IS 's';
 		COMMENT ON TYPE public.e IS 'e';
 		COMMENT ON DOMAIN public.d IS 'd';
+		COMMENT ON FUNCTION public.f() IS 'f';
+		COMMENT ON PROCEDURE public.p() IS 'p';
 	`)
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
+}
+
+// COMMENT ON COLUMN names a composite type attribute as well as a table
+// column, and the type is found by the same schema-qualified name.
+func TestParseSQL_CommentOnCompositeAttribute(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TYPE public.addr AS (street text, city text);
+		COMMENT ON COLUMN public.addr.city IS 'city name';
+	`)
+	require.NoError(t, err)
+
+	ct, ok := result.CompositeTypes.GetOk("public.addr")
+	require.True(t, ok)
+	require.Len(t, ct.Attributes, 2)
+	assert.Nil(t, ct.Attributes[0].Comment)
+	require.NotNil(t, ct.Attributes[1].Comment)
+	assert.Equal(t, "city name", *ct.Attributes[1].Comment)
+}
+
+// An explicit NULL comment clears one the same file set earlier.
+func TestParseSQL_CommentIsNullClearsComment(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE SEQUENCE public.s;
+		COMMENT ON SEQUENCE public.s IS 's';
+		COMMENT ON SEQUENCE public.s IS NULL;
+	`)
+	require.NoError(t, err)
+
+	seq, ok := result.Sequences.GetOk("public.s")
+	require.True(t, ok)
+	assert.Nil(t, seq.Comment)
 }
 
 func TestParseSQL_NoWarnForSupportedStmt(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -315,6 +315,22 @@ func TestParseSQL_NoWarnForAlterTableOnUndeclaredRelation(t *testing.T) {
 	assert.Empty(t, buf.String())
 }
 
+// A table marked -- pista:ignore is out of the diff, so an action dropped
+// from it cannot mislead the plan and the warning would be noise.
+func TestParseSQL_NoWarnForAlterTableOnIgnoredTable(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	_, err := parseSQLWithPublicSchema(`
+		-- pista:ignore
+		CREATE TABLE public.t (id integer);
+		ALTER TABLE public.t ADD COLUMN x text;
+	`)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
 // COMMENT ON is dispatched by target. A target the parser does not model is
 // dropped, so it warns like any other unsupported statement.
 func TestParseSQL_WarnsUnsupportedCommentTarget(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -183,6 +183,133 @@ func TestParseSQL_WarnsUnsupportedStmt_CollapsesMultiline(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(out, "\n"), "the warning must be a single line")
 }
 
+// An ALTER TABLE action the parser does not read is dropped from the desired
+// schema. The statement type itself is supported, so it never reaches the
+// unsupported-statement warning; without a warning of its own the column would
+// silently read as absent and the plan would propose dropping it.
+func TestParseSQL_WarnsIgnoredAlterTableAction(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (id integer);
+		ALTER TABLE public.t ADD COLUMN x text;
+	`)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.t")
+	require.True(t, ok)
+	_, hasCol := tbl.Columns.GetOk("x")
+	assert.False(t, hasCol, "the action is still dropped; only the warning is new")
+
+	out := buf.String()
+	assert.Contains(t, out, "ignored unsupported statement")
+	assert.Contains(t, out, "ADD COLUMN x text")
+}
+
+// A statement may mix an action the parser reads with one it does not. The
+// supported action still lands in the model, and the warning names only the
+// dropped one.
+func TestParseSQL_WarnsIgnoredAlterTableAction_KeepsSupportedAction(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (id integer);
+		ALTER TABLE public.t
+		    ADD CONSTRAINT t_id_check CHECK (id > 0),
+		    ADD COLUMN x text;
+	`)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.t")
+	require.True(t, ok)
+	_, hasCon := tbl.Constraints.GetOk("t_id_check")
+	assert.True(t, hasCon, "the supported action must still be parsed")
+
+	out := buf.String()
+	assert.Contains(t, out, "ADD COLUMN x text")
+	assert.NotContains(t, out, "t_id_check", "the parsed action must not be reported as ignored")
+}
+
+// The actions the parser does read must stay silent.
+func TestParseSQL_NoWarnForSupportedAlterTableActions(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	_, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (id integer);
+		ALTER TABLE public.t ADD CONSTRAINT t_id_check CHECK (id > 0);
+		ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE public.t FORCE ROW LEVEL SECURITY;
+		CREATE TRIGGER trg BEFORE INSERT ON public.t
+		    FOR EACH ROW EXECUTE FUNCTION public.f();
+		ALTER TABLE public.t DISABLE TRIGGER trg;
+	`)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+// An ALTER TABLE naming a relation the file does not declare is skipped whole,
+// the same as a CREATE INDEX on such a relation. That is deliberate, so it
+// stays silent.
+func TestParseSQL_NoWarnForAlterTableOnUndeclaredRelation(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	_, err := parseSQLWithPublicSchema(`ALTER TABLE public.nosuch ADD COLUMN x text;`)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+// COMMENT ON is dispatched by target. A target the parser does not model is
+// dropped, so it warns like any other unsupported statement.
+func TestParseSQL_WarnsUnsupportedCommentTarget(t *testing.T) {
+	for _, stmt := range []string{
+		`COMMENT ON INDEX public.t_idx IS 'i';`,
+		`COMMENT ON CONSTRAINT t_id_check ON public.t IS 'c';`,
+		`COMMENT ON SCHEMA public IS 's';`,
+		`COMMENT ON TRIGGER trg ON public.t IS 'g';`,
+	} {
+		t.Run(stmt, func(t *testing.T) {
+			var buf bytes.Buffer
+			restore := parser.SetWarnWriter(&buf)
+			defer restore()
+
+			_, err := parseSQLWithPublicSchema("CREATE TABLE public.t (id integer);\n" + stmt)
+			require.NoError(t, err)
+			assert.Contains(t, buf.String(), "ignored unsupported statement")
+		})
+	}
+}
+
+// The comment targets the parser does model must stay silent.
+func TestParseSQL_NoWarnForSupportedCommentTargets(t *testing.T) {
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	_, err := parseSQLWithPublicSchema(`
+		CREATE TYPE public.e AS ENUM ('a');
+		CREATE DOMAIN public.d AS text;
+		CREATE SEQUENCE public.s;
+		CREATE TABLE public.t (id integer);
+		CREATE VIEW public.v AS SELECT id FROM public.t;
+		COMMENT ON TABLE public.t IS 't';
+		COMMENT ON COLUMN public.t.id IS 'c';
+		COMMENT ON VIEW public.v IS 'v';
+		COMMENT ON SEQUENCE public.s IS 's';
+		COMMENT ON TYPE public.e IS 'e';
+		COMMENT ON DOMAIN public.d IS 'd';
+	`)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
 func TestParseSQL_NoWarnForSupportedStmt(t *testing.T) {
 	var buf bytes.Buffer
 	restore := parser.SetWarnWriter(&buf)
@@ -1734,7 +1861,11 @@ CREATE INDEX idx_users_name ON public.users USING btree (name) TABLESPACE fast_s
 }
 
 func TestParseSQL_AlterTableNonAddConstraint(t *testing.T) {
-	// ALTER TABLE with non-ADD CONSTRAINT commands should be silently skipped
+	var buf bytes.Buffer
+	restore := parser.SetWarnWriter(&buf)
+	defer restore()
+
+	// ALTER TABLE with non-ADD CONSTRAINT commands is skipped, with a warning
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,
     name text,
@@ -1750,6 +1881,7 @@ ALTER TABLE public.users DROP COLUMN name;`
 	// The parser does not apply DDL changes; the column should still be present
 	_, ok = tbl.Columns.GetOk("name")
 	assert.True(t, ok)
+	assert.Contains(t, buf.String(), "ignored unsupported statement")
 }
 
 func TestParseSQL_TableLevelExclusionConstraint(t *testing.T) {


### PR DESCRIPTION
`ALTER TABLE` and `COMMENT ON` each have a parser case of their own, so neither reached the `ignored unsupported statement` warning that covers an unhandled statement type. The parser reads only some of what they carry and dropped the rest without a word, which turned into a plan proposing the opposite of what the file asked for: a column added by `ALTER TABLE ... ADD COLUMN` was absent from the desired schema, so the plan proposed dropping it from the database. `ALTER COLUMN ... SET DEFAULT` / `SET NOT NULL` / `TYPE`, `DROP COLUMN`, `OWNER TO`, `SET UNLOGGED` and `COMMENT ON INDEX` / `CONSTRAINT` / `SCHEMA` / `TRIGGER` went the same way.

The warning now follows a list of what the parser reads rather than a list of what to reject, so an action or comment target added later warns instead of vanishing. `alterTableSupportedCmds` names `AT_AddConstraint`, the four row-level security toggles and the four trigger states; `commentTargetSupported` names table, view, materialized view, column, sequence, type, domain, function and procedure.

`warnIgnoredAlterTableCmds` rebuilds a statement from the ignored actions alone, so one that mixes a read action with a dropped one reports only the dropped one, and keeps the original location for the snippet fallback a deparse failure uses. `COMMENT ON` is checked at the entry to the case rather than in the switch inside `parseCommentStmt`, because a target such as `SCHEMA` carries no object list and returned before reaching it.

```
pistachio: ignored unsupported statement: ALTER TABLE public.a ADD COLUMN x text
pistachio: ignored unsupported statement: ALTER TABLE public.a ALTER COLUMN id TYPE bigint
pistachio: ignored unsupported statement: ALTER TABLE public.a OWNER TO postgres
pistachio: ignored unsupported statement: COMMENT ON INDEX public.a_id_idx IS 'i'
pistachio: ignored unsupported statement: COMMENT ON SCHEMA public IS 's'
```

Nothing but the warning changes: the actions were dropped before and are dropped now. A statement marked `-- pista:execute` never reaches the case, so it stays silent.

An `ALTER TABLE` naming a relation the file does not declare is still skipped without a warning. `CREATE INDEX` and the trigger states treat such a relation the same way, deliberately, so changing it is a separate call. Clause-level omissions inside a supported statement, such as a table's `WITH (fillfactor = 70)`, are also untouched; catching those means enumerating every field the parser does not read.

## Testing

Ten tests in `parser/parser_test.go`, written before the change and confirmed failing first, and the existing `TestParseSQL_AlterTableNonAddConstraint` now asserts the warning. They cover a dropped action, a statement mixing a dropped action with a read one, several dropped actions in one statement, `IF EXISTS`, `-- pista:execute` silencing the warning, each unsupported comment target, and silence for every action and comment target the parser reads. Two paths in `parseCommentStmt` that had no test of their own are covered as well: a comment on a composite type attribute, and an explicit `NULL` comment clearing one set earlier in the file.

`go vet ./...` and `gofmt` are clean and `make test` is green against PostgreSQL 16. The parser package goes from 91.4% to 92.4% and the repository from 94.3% to 94.5%; `warnIgnoredAlterTableCmds` is fully covered. What is left uncovered in the code this touches is defensive: an empty snippet, an object list that a supported comment target cannot produce, and a `COMMENT ON COLUMN` with a single name, which is not valid SQL.

`pista dump` output fed back still parses without a warning. `ALTER TABLE ONLY ... ADD CONSTRAINT ... FOREIGN KEY`, `ENABLE ROW LEVEL SECURITY` and `DISABLE TRIGGER` are all in the read set, and a dump then plan round trip prints `-- No changes` with empty stderr.