### PR TITLE
State that extensions, roles and grants are out of scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ Pistachio is a declarative schema management tool for PostgreSQL, written in Go.
 
 Drift that appears only with a desired schema written some other way is low priority, since matching what `dump` writes avoids it.
 
+`CREATE EXTENSION`, `CREATE ROLE` and `GRANT` are out of scope. They sit at a different privilege layer, so manage them where the rest of the infrastructure is managed, Terraform for example.
+
 Avoid normalization that makes the diff complex.
 
 Do not chase corner cases. A rare input is not worth an implementation that is hard to follow, and the schemas people actually write come first.


### PR DESCRIPTION
Adds one paragraph to the design policy in `AGENTS.md`. No code changes.

> `CREATE EXTENSION`, `CREATE ROLE` and `GRANT` are out of scope. They sit at a different privilege layer, so manage them where the rest of the infrastructure is managed, Terraform for example.

Until now the exclusion was only visible as behavior: the parser drops these statements and warns. Nothing said whether that was a gap to close or a boundary to keep. A schema that depends on one still works through `-- pista:execute-first`.

(This body briefly described a second paragraph about the cost of the emitted DDL. That was an error on my part: the paragraph was pushed to this branch after the merge, so it was never part of this PR. It is in #431 instead.)