### PR TITLE
Put low load on the database before a simple interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Drift that appears only with a desired schema written some other way is low prio
 
 Avoid normalization that makes the diff complex.
 
+Do not emit DDL a change does not need, and never emit it implicitly. Low load on the database comes before a simple interface: a directive the user writes beats an inference.
+
 Do not chase corner cases. A rare input is not worth an implementation that is hard to follow, and the schemas people actually write come first.
 
 Do not coddle the user. Assume they know PostgreSQL and their own schema.


### PR DESCRIPTION
Adds one paragraph to the design policy in `AGENTS.md`. No code changes.

> Do not emit DDL a change does not need, and never emit it implicitly. Low load on the database comes before a simple interface: a directive the user writes beats an inference.

Extra DDL is never worth a shortcut, and it is never emitted on a guess. `-- pista:renamed-from` is the shape that trade takes today: a rename is stated, not inferred. The rule keeps a later change from reversing it.

This paragraph was first pushed to the #429 branch after that PR had already merged, so it never reached `main`. This is the same change on a branch off current `main`.