### PR TITLE
Add NULLS NOT DISTINCT fixtures for unique constraints and indexes

### DIFF
--- a/testdata/apply/unique_nulls_not_distinct_shorthand.yml
+++ b/testdata/apply/unique_nulls_not_distinct_shorthand.yml
@@ -1,0 +1,27 @@
+# A column constraint, an unnamed table constraint and a separate ALTER TABLE
+# all reach the catalog as named table constraints, so the applied schema is the
+# form `pista dump` writes and the file plans clean afterwards.
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text UNIQUE NULLS NOT DISTINCT,
+      login text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      UNIQUE NULLS NOT DISTINCT (login)
+  );
+  ALTER TABLE public.users ADD CONSTRAINT users_tenant_key UNIQUE NULLS NOT DISTINCT (tenant_id);
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      login text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE NULLS NOT DISTINCT (email),
+      CONSTRAINT users_login_key UNIQUE NULLS NOT DISTINCT (login),
+      CONSTRAINT users_tenant_key UNIQUE NULLS NOT DISTINCT (tenant_id)
+  );
+verify_no_drift: true

--- a/testdata/dump/unique_nulls_not_distinct.yml
+++ b/testdata/dump/unique_nulls_not_distinct.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE NULLS NOT DISTINCT (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id) NULLS NOT DISTINCT;
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE NULLS NOT DISTINCT (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id) NULLS NOT DISTINCT;

--- a/testdata/plan/add_unique_nulls_not_distinct.yml
+++ b/testdata/plan/add_unique_nulls_not_distinct.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE NULLS NOT DISTINCT (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id) NULLS NOT DISTINCT;
+plan: |
+  ALTER TABLE public.users ADD CONSTRAINT users_email_key UNIQUE NULLS NOT DISTINCT (email);
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id) NULLS NOT DISTINCT;

--- a/testdata/plan/alter_unique_nulls_not_distinct.yml
+++ b/testdata/plan/alter_unique_nulls_not_distinct.yml
@@ -1,0 +1,25 @@
+# NULLS NOT DISTINCT is not something ALTER can turn on, so both the constraint
+# and the index have to be dropped and recreated.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE NULLS NOT DISTINCT (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id) NULLS NOT DISTINCT;
+plan: |
+  DROP INDEX public.users_tenant_idx;
+  ALTER TABLE public.users DROP CONSTRAINT users_email_key;
+  ALTER TABLE public.users ADD CONSTRAINT users_email_key UNIQUE NULLS NOT DISTINCT (email);
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id) NULLS NOT DISTINCT;

--- a/testdata/plan/drop_unique_nulls_not_distinct.yml
+++ b/testdata/plan/drop_unique_nulls_not_distinct.yml
@@ -1,0 +1,25 @@
+# The reverse of alter_unique_nulls_not_distinct.yml: dropping the option is a
+# recreate too.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE NULLS NOT DISTINCT (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id) NULLS NOT DISTINCT;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id);
+plan: |
+  DROP INDEX public.users_tenant_idx;
+  ALTER TABLE public.users DROP CONSTRAINT users_email_key;
+  ALTER TABLE public.users ADD CONSTRAINT users_email_key UNIQUE (email);
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id);

--- a/testdata/plan/no_diff_unique_nulls_distinct.yml
+++ b/testdata/plan/no_diff_unique_nulls_distinct.yml
@@ -1,0 +1,21 @@
+# NULLS DISTINCT is the default, and the catalog never prints it. A file that
+# spells it out still has to plan clean.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      tenant_id integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_email_key UNIQUE NULLS DISTINCT (email)
+  );
+  CREATE UNIQUE INDEX users_tenant_idx ON public.users USING btree (tenant_id) NULLS DISTINCT;
+plan: ""


### PR DESCRIPTION
The option was only exercised by the sample schema, and there only on
CREATE UNIQUE INDEX. Cover the table constraint too, along with the
shorthand forms the catalog rewrites and the explicit NULLS DISTINCT
spelling the catalog never prints.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ViiG3DUiyj7nHq7m151dzB