### PR TITLE
chore: Use TransformSlice method instead of TransformSlice func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5 // indirect
 	golang.org/x/text v0.39.0 // indirect
-	golang.org/x/tools v0.49.0 // indirect
+	golang.org/x/tools v0.49.1-0.20260828025639-2e922938d07f // indirect
 )
 
 tool golang.org/x/tools/cmd/deadcode

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/pganalyze/pg_query_go/v6 v6.2.2
 	github.com/stretchr/testify v1.12.1
-	github.com/winebarrel/orderedmap/v2 v2.0.0
+	github.com/winebarrel/orderedmap/v2 v2.1.0
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5 h1:ZUSxONxc981v7AW7QUg
 golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5/go.mod h1:LVehoXe41cL5SCVQilsV7Gg6BNG+Js6P9PhSbYTIUkQ=
 golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
 golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
-golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
-golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=
+golang.org/x/tools v0.49.1-0.20260828025639-2e922938d07f h1:b/WUcfDoUPy12ecQ1RH6gZfTY+1QhByQKIp58kensDg=
+golang.org/x/tools v0.49.1-0.20260828025639-2e922938d07f/go.mod h1:tIfhIAkQbak++ceknAzaDoYzagMAU9ia6SlRp+V3t8M=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
 google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/winebarrel/linkedlist v1.0.0 h1:O0xX3QprOQx7nzjybWiqzmAFslEAr5OlN4Erw0SGu7w=
 github.com/winebarrel/linkedlist v1.0.0/go.mod h1:q0tVx3lAnFjUE7qUzWo9sR3LVUQ3sLNZ4Ccm50AnxX4=
-github.com/winebarrel/orderedmap/v2 v2.0.0 h1:HARE+qAmkwMQ3Wl6bCwMxB+RKPPv6tNaTG4EYJQ/w/Q=
-github.com/winebarrel/orderedmap/v2 v2.0.0/go.mod h1:q3cXdPJW6JJ2+g3IVSkqRD+56aXF/rWYdi+IfMHm55U=
+github.com/winebarrel/orderedmap/v2 v2.1.0 h1:+yKnbB9Yu5v6cmIJThHZrgHm6sFEhd39R9Ps81g+e3o=
+github.com/winebarrel/orderedmap/v2 v2.1.0/go.mod h1:ljWUDX2Nj10EuOJYMtGvWhnvYojbWCWsqTLKhhdCZJk=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=

--- a/model/composite_type.go
+++ b/model/composite_type.go
@@ -90,7 +90,7 @@ func CompositeTypeToSQL(ct *CompositeType) string {
 
 func CompositeTypesToSQL(compositeTypes *orderedmap.Map[string, *CompositeType]) string {
 	return strings.Join(
-		orderedmap.TransformSlice(compositeTypes, func(_ string, ct *CompositeType) string {
+		compositeTypes.TransformSlice(func(_ string, ct *CompositeType) string {
 			return CompositeTypeToSQL(ct)
 		}),
 		"\n\n",

--- a/model/domain.go
+++ b/model/domain.go
@@ -74,7 +74,7 @@ func DomainToSQL(d *Domain) string {
 
 func DomainsToSQL(domains *orderedmap.Map[string, *Domain]) string {
 	return strings.Join(
-		orderedmap.TransformSlice(domains, func(_ string, d *Domain) string {
+		domains.TransformSlice(func(_ string, d *Domain) string {
 			return DomainToSQL(d)
 		}),
 		"\n\n",

--- a/model/enum.go
+++ b/model/enum.go
@@ -53,7 +53,7 @@ func EnumToSQL(e *Enum) string {
 
 func EnumsToSQL(enums *orderedmap.Map[string, *Enum]) string {
 	return strings.Join(
-		orderedmap.TransformSlice(enums, func(_ string, e *Enum) string {
+		enums.TransformSlice(func(_ string, e *Enum) string {
 			return EnumToSQL(e)
 		}),
 		"\n\n",

--- a/model/routine.go
+++ b/model/routine.go
@@ -308,7 +308,7 @@ func RoutineToSQL(r *Routine) string {
 
 func RoutinesToSQL(routines *orderedmap.Map[string, *Routine]) string {
 	return strings.Join(
-		orderedmap.TransformSlice(routines, func(_ string, r *Routine) string {
+		routines.TransformSlice(func(_ string, r *Routine) string {
 			return RoutineToSQL(r)
 		}),
 		"\n\n",

--- a/model/sequence.go
+++ b/model/sequence.go
@@ -84,7 +84,7 @@ func SequenceToSQL(seq *Sequence) string {
 
 func SequencesToSQL(sequences *orderedmap.Map[string, *Sequence]) string {
 	return strings.Join(
-		orderedmap.TransformSlice(sequences, func(_ string, seq *Sequence) string {
+		sequences.TransformSlice(func(_ string, seq *Sequence) string {
 			return SequenceToSQL(seq)
 		}),
 		"\n\n",

--- a/model/table.go
+++ b/model/table.go
@@ -58,7 +58,7 @@ func (t Table) SQL() string {
 		} else {
 			sql += "(\n" +
 				strings.Join(
-					orderedmap.TransformSlice(t.Constraints, func(_ string, con *Constraint) string {
+					t.Constraints.TransformSlice(func(_ string, con *Constraint) string {
 						return "    CONSTRAINT " + Ident(con.Name) + " " + con.Definition
 					}),
 					",\n",
@@ -72,7 +72,7 @@ func (t Table) SQL() string {
 	sql += " (\n" +
 		strings.Join(
 			slices.Concat(
-				orderedmap.TransformSlice(t.Columns, func(_ string, col *Column) string {
+				t.Columns.TransformSlice(func(_ string, col *Column) string {
 					q := "    " + Ident(col.Name) + " " + col.TypeName
 					if col.Collation != nil {
 						q += " COLLATE " + *col.Collation
@@ -96,7 +96,7 @@ func (t Table) SQL() string {
 					}
 					return q
 				}),
-				orderedmap.TransformSlice(t.Constraints, func(_ string, con *Constraint) string {
+				t.Constraints.TransformSlice(func(_ string, con *Constraint) string {
 					return "    CONSTRAINT " + Ident(con.Name) + " " + con.Definition
 				}),
 			),
@@ -117,14 +117,14 @@ func (t Table) SQL() string {
 
 func (t Table) IdxSQL() string {
 	return strings.Join(
-		orderedmap.TransformSlice(t.Indexes, func(_ string, idx *Index) string { return idx.SQL() }),
+		t.Indexes.TransformSlice(func(_ string, idx *Index) string { return idx.SQL() }),
 		"\n",
 	)
 }
 
 func (t Table) FkSQL() string {
 	return strings.Join(
-		orderedmap.TransformSlice(t.ForeignKeys, func(_ string, fk *ForeignKey) string { return fk.SQL() }),
+		t.ForeignKeys.TransformSlice(func(_ string, fk *ForeignKey) string { return fk.SQL() }),
 		"\n",
 	)
 }
@@ -195,7 +195,7 @@ func TableToSQL(t *Table) string {
 
 func TablesToSQL(tables *orderedmap.Map[string, *Table]) string {
 	return strings.Join(
-		orderedmap.TransformSlice(tables, func(_ string, t *Table) string {
+		tables.TransformSlice(func(_ string, t *Table) string {
 			return TableToSQL(t)
 		}),
 		"\n\n",

--- a/model/view.go
+++ b/model/view.go
@@ -76,7 +76,7 @@ func ViewToSQL(v *View) string {
 
 func ViewsToSQL(views *orderedmap.Map[string, *View]) string {
 	return strings.Join(
-		orderedmap.TransformSlice(views, func(_ string, v *View) string {
+		views.TransformSlice(func(_ string, v *View) string {
 			return ViewToSQL(v)
 		}),
 		"\n\n",


### PR DESCRIPTION
This pull request updates the `orderedmap` dependency to version 2.1.0 and refactors usage of its `TransformSlice` method across multiple model files. The refactor replaces calls to the global `orderedmap.TransformSlice` function with the new method form available on `orderedmap.Map` instances, simplifying the code and leveraging the updated API.

**Dependency update:**

* Updated `github.com/winebarrel/orderedmap/v2` from version 2.0.0 to 2.1.0 in `go.mod`, enabling use of new method-based APIs.

**Refactoring for new `orderedmap` API:**

* Replaced `orderedmap.TransformSlice(map, fn)` with `map.TransformSlice(fn)` in the following functions:
  - `CompositeTypesToSQL` in `model/composite_type.go`
  - `DomainsToSQL` in `model/domain.go`
  - `EnumsToSQL` in `model/enum.go`
  - `RoutinesToSQL` in `model/routine.go`
  - `SequencesToSQL` in `model/sequence.go`
  - `TablesToSQL` in `model/table.go`
  - `ViewsToSQL` in `model/view.go`
* Updated all relevant usages inside the `Table` struct methods in `model/table.go` to use the new method form for columns, constraints, indexes, and foreign keys. [[1]](diffhunk://#diff-8757c57420f27e52b5e1e4281c4cf6b7b4df3dfa483b37a82fc51174ee0c41e3L61-R61) [[2]](diffhunk://#diff-8757c57420f27e52b5e1e4281c4cf6b7b4df3dfa483b37a82fc51174ee0c41e3L75-R75) [[3]](diffhunk://#diff-8757c57420f27e52b5e1e4281c4cf6b7b4df3dfa483b37a82fc51174ee0c41e3L99-R99) [[4]](diffhunk://#diff-8757c57420f27e52b5e1e4281c4cf6b7b4df3dfa483b37a82fc51174ee0c41e3L120-R127)

These changes modernize the codebase to use the latest `orderedmap` interface, improving readability and maintainability.