### PR TITLE
Make IS NOT DISTINCT FROM idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Stop `IS NOT DISTINCT FROM` from drifting. PostgreSQL stores the operator as the negation of `IS DISTINCT FROM`, so a desired schema that wrote it never matched the catalog: a `CHECK` was dropped and re-added on every run, which revalidates the whole table, and an index using it was rebuilt. The fold sits in the shared expression normalization, so a view body, a policy `USING` / `WITH CHECK`, a trigger `WHEN` clause and a domain `CHECK` get it too. A generated column did not drift but failed the run, since a generated expression cannot be altered in place.
+
 ## [1.31.0] - 2026-08-25
 
 * Accept a regular expression in `--include` / `--exclude`. A pattern wrapped in slashes is one, so `-E '/^posts_\d+$/'` reaches a numbered partition set that a wildcard cannot; anything else stays a wildcard, and the two forms mix in one invocation. A regular expression matches anywhere in the name unless it is anchored; a wildcard still has to match the whole name. An invalid expression is rejected before the database is read. The flags did not change, so `$PISTA_INCLUDE` / `$PISTA_EXCLUDE` and the config file carry both forms.

--- a/TODO.md
+++ b/TODO.md
@@ -583,6 +583,38 @@ Workaround: write the call unqualified.
 
 Origin: found while adding `-- pista:execute-first`, 2026-07-31.
 
+## Perpetual drift on the DISTINCT operators against NULL
+
+Priority: low.
+
+A comparison written against a NULL literal, as
+`CHECK (a IS NOT DISTINCT FROM NULL)`, is re-emitted on every plan. Applying
+it succeeds and changes nothing, so `plan --check` stays at exit code 2
+forever. Parse analysis rewrites the comparison to `a IS NULL` before it is
+stored, so `pg_get_constraintdef` and `pg_get_expr` hand back a `NullTest`
+while the desired side keeps what the user wrote. `IS DISTINCT FROM NULL`
+against `IS NOT NULL` goes the same way.
+
+The rewrite happens in parse analysis, so it lands on every expression the
+catalog stores rather than on one node kind: a CHECK, an index predicate and
+a view body written that way all come back as `IS NULL`. A column DEFAULT
+does too, though a DEFAULT cannot reference a column, so both operands there
+are constants.
+
+`foldNotDistinct` (`diff/tables.go`) folds
+`NOT (a IS DISTINCT FROM b)` into `a IS NOT DISTINCT FROM b`, which is the
+shape the catalog stores for every other operand, but a `NullTest` carries no
+negation to fold and is a different node. pg_query_go stops at the raw
+parser, so the desired side never reaches the rewrite on its own. Matching it
+means rewriting an `A_Expr` of kind `AEXPR_NOT_DISTINCT` whose operand is a
+NULL `A_Const` into a `NullTest` on the desired side, and `AEXPR_DISTINCT`
+into its negation.
+
+`dump` writes `IS NULL`, so a schema kept through `pista dump` never hits
+this.
+
+Workaround: write `IS NULL` / `IS NOT NULL`.
+
 ## Perpetual drift on a serial column written as an explicit default
 
 Priority: low.

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -480,8 +480,11 @@ func isSerialType(typeName string) bool {
 //     adds to anything string-typed and a written definition practically never
 //     carries.
 //   - Converts = ANY(ARRAY[...]) to IN (...) (PostgreSQL internal representation).
+//   - Folds NOT (a IS DISTINCT FROM b) into a IS NOT DISTINCT FROM b, the shape
+//     PostgreSQL rewrites the written operator into when it stores an
+//     expression.
 //
-// Both are symmetric: they apply to the catalog side and the written side
+// All three are symmetric: they apply to the catalog side and the written side
 // alike. The walk reaches every node kind, so a sub-query inside an RLS policy
 // or a view body, and an expression inside a SQL/JSON constructor, get the
 // same treatment as a top-level operand.
@@ -509,7 +512,35 @@ func normalizeExprNode(ctx pgast.Ctx, node *pg_query.Node) *pg_query.Node {
 			}
 		}
 	}
+	if folded := foldNotDistinct(node); folded != nil {
+		return folded
+	}
 	return node
+}
+
+// foldNotDistinct turns NOT (a IS DISTINCT FROM b) into the equivalent
+// a IS NOT DISTINCT FROM b, and returns nil for anything else.
+//
+// PostgreSQL stores the written IS NOT DISTINCT FROM as that negation, so
+// pg_get_constraintdef and pg_get_expr hand back the NOT form either way.
+// Folding towards the operator keeps the generated DDL in the spelling the
+// author used.
+//
+// PostgreSQL does not collapse the double negation a written NOT (a IS NOT
+// DISTINCT FROM b) leaves behind, and neither does this: the walk visits
+// children first, so only the inner negation folds, which is what the written
+// form parses to anyway.
+func foldNotDistinct(node *pg_query.Node) *pg_query.Node {
+	be := node.GetBoolExpr()
+	if be == nil || be.Boolop != pg_query.BoolExprType_NOT_EXPR || len(be.Args) != 1 {
+		return nil
+	}
+	inner := be.Args[0].GetAExpr()
+	if inner == nil || inner.Kind != pg_query.A_Expr_Kind_AEXPR_DISTINCT {
+		return nil
+	}
+	inner.Kind = pg_query.A_Expr_Kind_AEXPR_NOT_DISTINCT
+	return be.Args[0]
 }
 
 // isTextLikeTypeName returns true if the TypeName refers to a text-like type

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1926,6 +1926,58 @@ func TestEqualConstraintDef_castFormattingDiff(t *testing.T) {
 	))
 }
 
+func TestEqualConstraintDef_notDistinctFrom(t *testing.T) {
+	// pg_get_constraintdef returns the operator as the negation of
+	// IS DISTINCT FROM, whichever way the definition was written.
+	assert.True(t, equalConstraintDef(
+		"CHECK ((NOT (a IS DISTINCT FROM b)))",
+		"CHECK (a IS NOT DISTINCT FROM b)",
+	))
+}
+
+func TestEqualConstraintDef_notDistinctFromDoubleNegation(t *testing.T) {
+	// The negation PostgreSQL leaves in place stays on both sides, so only
+	// the inner one folds.
+	assert.True(t, equalConstraintDef(
+		"CHECK ((NOT (NOT (a IS DISTINCT FROM b))))",
+		"CHECK (NOT (a IS NOT DISTINCT FROM b))",
+	))
+}
+
+func TestEqualConstraintDef_distinctFromNotFolded(t *testing.T) {
+	// The fold is one-way: IS DISTINCT FROM is stored as written and must
+	// not compare equal to its negation.
+	assert.False(t, equalConstraintDef(
+		"CHECK ((a IS DISTINCT FROM b))",
+		"CHECK (a IS NOT DISTINCT FROM b)",
+	))
+}
+
+func TestEqualConstraintDef_notOverOtherOperatorKept(t *testing.T) {
+	// Only IS DISTINCT FROM folds; NOT over anything else is left alone.
+	assert.True(t, equalConstraintDef(
+		"CHECK ((NOT (a = b)))",
+		"CHECK (NOT (a = b))",
+	))
+	assert.False(t, equalConstraintDef(
+		"CHECK ((NOT (a = b)))",
+		"CHECK (a = b)",
+	))
+}
+
+func TestEqualConstraintDef_notOverBoolOperatorKept(t *testing.T) {
+	// NOT binds tighter than AND, so a fold that dropped the negation's
+	// parentheses would turn this into the different `NOT a AND b`.
+	assert.True(t, equalConstraintDef(
+		"CHECK ((NOT (a AND b)))",
+		"CHECK (NOT (a AND b))",
+	))
+	assert.False(t, equalConstraintDef(
+		"CHECK ((NOT (a AND b)))",
+		"CHECK ((NOT a) AND b)",
+	))
+}
+
 func TestEqualConstraintDef_different(t *testing.T) {
 	assert.False(t, equalConstraintDef(
 		"CHECK (age > 0)",

--- a/testdata/apply/check_is_not_distinct_from_idempotent.yml
+++ b/testdata/apply/check_is_not_distinct_from_idempotent.yml
@@ -1,0 +1,29 @@
+# A CHECK and a partial index written with `IS NOT DISTINCT FROM` are stored as
+# `NOT (... IS DISTINCT FROM ...)`, so without the fold every run re-adds the
+# constraint (revalidating the whole table) and rebuilds the index.
+init: |
+  CREATE TABLE public.shipments (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT shipments_pkey PRIMARY KEY (id),
+      CONSTRAINT shipments_carrier_check CHECK (carrier IS NOT DISTINCT FROM 'own_fleet')
+  );
+  CREATE INDEX shipments_in_house_idx ON public.shipments USING btree (id) WHERE (carrier IS NOT DISTINCT FROM 'own_fleet');
+desired: |
+  CREATE TABLE public.shipments (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT shipments_pkey PRIMARY KEY (id),
+      CONSTRAINT shipments_carrier_check CHECK (carrier IS NOT DISTINCT FROM 'own_fleet')
+  );
+  CREATE INDEX shipments_in_house_idx ON public.shipments USING btree (id) WHERE (carrier IS NOT DISTINCT FROM 'own_fleet');
+applied: |
+  -- public.shipments
+  CREATE TABLE public.shipments (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT shipments_pkey PRIMARY KEY (id),
+      CONSTRAINT shipments_carrier_check CHECK (NOT carrier IS DISTINCT FROM 'own_fleet'::text)
+  );
+  CREATE INDEX shipments_in_house_idx ON public.shipments USING btree (id) WHERE (NOT (carrier IS DISTINCT FROM 'own_fleet'::text));
+applied_sql: ""

--- a/testdata/plan/alter_check_to_is_not_distinct_from.yml
+++ b/testdata/plan/alter_check_to_is_not_distinct_from.yml
@@ -1,0 +1,21 @@
+# The fold must not swallow a genuine change: turning `IS DISTINCT FROM` into
+# `IS NOT DISTINCT FROM` inverts the predicate, so the CHECK is re-created.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      prev_value integer,
+      curr_value integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_changed_check CHECK (prev_value IS DISTINCT FROM curr_value)
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      prev_value integer,
+      curr_value integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_changed_check CHECK (prev_value IS NOT DISTINCT FROM curr_value)
+  );
+plan: |
+  ALTER TABLE public.readings DROP CONSTRAINT readings_changed_check;
+  ALTER TABLE public.readings ADD CONSTRAINT readings_changed_check CHECK (prev_value IS NOT DISTINCT FROM curr_value);

--- a/testdata/plan/no_diff_is_not_distinct_from.yml
+++ b/testdata/plan/no_diff_is_not_distinct_from.yml
@@ -1,0 +1,29 @@
+# PostgreSQL stores `a IS NOT DISTINCT FROM b` as `NOT (a IS DISTINCT FROM b)`,
+# so a desired schema that writes the operator has to fold into the same shape
+# as the catalog side. Without the fold the table and domain CHECKs are dropped
+# and re-added on every run, which revalidates every row, and both indexes are
+# rebuilt. An index carries an expression in its elements and in its WHERE
+# clause, so there is one of each here.
+init: |
+  CREATE DOMAIN public.grade AS integer CHECK (VALUE IS NOT DISTINCT FROM 3);
+  CREATE TABLE public.shipments (
+      id integer NOT NULL,
+      carrier text,
+      handed_over_at timestamp,
+      CONSTRAINT shipments_pkey PRIMARY KEY (id),
+      CONSTRAINT shipments_carrier_check CHECK (carrier IS NOT DISTINCT FROM 'own_fleet')
+  );
+  CREATE INDEX shipments_in_house_idx ON public.shipments USING btree (id) WHERE (carrier IS NOT DISTINCT FROM 'own_fleet');
+  CREATE INDEX shipments_carrier_expr_idx ON public.shipments USING btree (((carrier IS NOT DISTINCT FROM 'own_fleet')));
+desired: |
+  CREATE DOMAIN public.grade AS integer CHECK (VALUE IS NOT DISTINCT FROM 3);
+  CREATE TABLE public.shipments (
+      id integer NOT NULL,
+      carrier text,
+      handed_over_at timestamp,
+      CONSTRAINT shipments_pkey PRIMARY KEY (id),
+      CONSTRAINT shipments_carrier_check CHECK (carrier IS NOT DISTINCT FROM 'own_fleet')
+  );
+  CREATE INDEX shipments_in_house_idx ON public.shipments USING btree (id) WHERE (carrier IS NOT DISTINCT FROM 'own_fleet');
+  CREATE INDEX shipments_carrier_expr_idx ON public.shipments USING btree (((carrier IS NOT DISTINCT FROM 'own_fleet')));
+plan: ""

--- a/testdata/plan/no_diff_is_not_distinct_from_double_negation.yml
+++ b/testdata/plan/no_diff_is_not_distinct_from_double_negation.yml
@@ -1,0 +1,22 @@
+# PostgreSQL rewrites the operator but does not collapse the resulting double
+# negation: `NOT (a IS NOT DISTINCT FROM b)` is stored as
+# `NOT (NOT (a IS DISTINCT FROM b))`. Folding only the inner
+# `NOT (... IS DISTINCT FROM ...)` therefore lands both sides on the same
+# shape, with no double-negation elimination.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      prev_value integer,
+      curr_value integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_changed_check CHECK (NOT (prev_value IS NOT DISTINCT FROM curr_value))
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      prev_value integer,
+      curr_value integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_changed_check CHECK (NOT (prev_value IS NOT DISTINCT FROM curr_value))
+  );
+plan: ""

--- a/testdata/plan/no_diff_is_not_distinct_from_expressions.yml
+++ b/testdata/plan/no_diff_is_not_distinct_from_expressions.yml
@@ -1,0 +1,36 @@
+# The fold that makes `a IS NOT DISTINCT FROM b` compare equal to the stored
+# `NOT (a IS DISTINCT FROM b)` sits in the shared expression normalization, so
+# a view body, a policy USING and WITH CHECK, and a trigger WHEN clause get it
+# too.
+init: |
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.tickets (
+      id bigint NOT NULL,
+      assignee text,
+      closer text,
+      CONSTRAINT tickets_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.self_closed AS
+      SELECT id FROM public.tickets WHERE assignee IS NOT DISTINCT FROM closer;
+  ALTER TABLE public.tickets ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY own_tickets ON public.tickets USING (assignee IS NOT DISTINCT FROM current_user);
+  CREATE POLICY own_inserts ON public.tickets FOR INSERT WITH CHECK (assignee IS NOT DISTINCT FROM current_user);
+  CREATE TRIGGER tickets_audit AFTER UPDATE OF assignee ON public.tickets
+      FOR EACH ROW WHEN (old.assignee IS NOT DISTINCT FROM new.assignee) EXECUTE FUNCTION public.stamp();
+desired: |
+  CREATE TABLE public.tickets (
+      id bigint NOT NULL,
+      assignee text,
+      closer text,
+      CONSTRAINT tickets_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.self_closed AS
+      SELECT id FROM public.tickets WHERE assignee IS NOT DISTINCT FROM closer;
+  ALTER TABLE public.tickets ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY own_tickets ON public.tickets USING (assignee IS NOT DISTINCT FROM current_user);
+  CREATE POLICY own_inserts ON public.tickets FOR INSERT WITH CHECK (assignee IS NOT DISTINCT FROM current_user);
+  -- The catalog reports the trigger with the function unqualified, since
+  -- search_path reaches public, so the desired side writes it that way.
+  CREATE TRIGGER tickets_audit AFTER UPDATE OF assignee ON public.tickets
+      FOR EACH ROW WHEN (old.assignee IS NOT DISTINCT FROM new.assignee) EXECUTE FUNCTION stamp();
+plan: ""

--- a/testdata/plan/no_diff_is_not_distinct_from_generated_column.yml
+++ b/testdata/plan/no_diff_is_not_distinct_from_generated_column.yml
@@ -1,0 +1,18 @@
+# A generated column is the one place the unfolded operator did not drift but
+# failed the run: PostgreSQL has no way to alter a generated expression in
+# place, so the diff rejects the change it thought it saw.
+init: |
+  CREATE TABLE public.shipments (
+      id integer NOT NULL,
+      carrier text,
+      in_house boolean GENERATED ALWAYS AS (carrier IS NOT DISTINCT FROM 'own_fleet') STORED,
+      CONSTRAINT shipments_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.shipments (
+      id integer NOT NULL,
+      carrier text,
+      in_house boolean GENERATED ALWAYS AS (carrier IS NOT DISTINCT FROM 'own_fleet') STORED,
+      CONSTRAINT shipments_pkey PRIMARY KEY (id)
+  );
+plan: ""

--- a/testdata/plan/no_diff_is_not_distinct_from_stored_form.yml
+++ b/testdata/plan/no_diff_is_not_distinct_from_stored_form.yml
@@ -1,0 +1,20 @@
+# The other direction: `dump` writes what the catalog stores, so a desired
+# schema written that way must keep planning clean now that the fold runs on
+# the desired side too.
+init: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_carrier_check CHECK (carrier IS NOT DISTINCT FROM 'own_fleet')
+  );
+  CREATE INDEX parcels_in_house_idx ON public.parcels USING btree (id) WHERE (carrier IS NOT DISTINCT FROM 'own_fleet');
+desired: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_carrier_check CHECK (NOT carrier IS DISTINCT FROM 'own_fleet'::text)
+  );
+  CREATE INDEX parcels_in_house_idx ON public.parcels USING btree (id) WHERE (NOT (carrier IS DISTINCT FROM 'own_fleet'::text));
+plan: ""


### PR DESCRIPTION
PostgreSQL stores a written IS NOT DISTINCT FROM as the negation of
IS DISTINCT FROM, and the expression normalization did not fold the two
together, so a desired schema that wrote the operator never converged: a
CHECK was dropped and re-added on every run, which revalidates every row,
and an index using it was rebuilt.

The fold sits in normalizeExprNode, which every expression comparison goes
through, so a view body, a policy USING and WITH CHECK, a trigger WHEN clause
and a domain CHECK are covered too. A generated column did not drift but
failed the run outright, since PostgreSQL cannot alter a generated expression
in place.

PostgreSQL rewrites the operator but leaves the resulting double negation
alone, and so does the fold: the walk visits children first, so a stored
NOT (NOT (a IS DISTINCT FROM b)) folds at the inner negation only and lands on
the tree the written form parses to. No reverse fold and no double-negation
elimination is needed. Folding towards the operator keeps the generated DDL in
the spelling the author used.

The fixtures cover each expression the normalization reaches, the double
negation, the dump-form desired schema that has to keep planning clean now
that the fold runs on the desired side too, and a real IS DISTINCT FROM to
IS NOT DISTINCT FROM change that must not be swallowed. Every fixture that
pins the fix was run against a build with the fold removed and fails there.
A column DEFAULT carries the operator into the catalog verbatim and is
covered by the same fold, but gets no fixture: a DEFAULT cannot reference a
column, so both operands are constants and nobody writes this.

What stays out of scope is the operator against NULL, wherever it is written.
Parse analysis rewrites `a IS NOT DISTINCT FROM NULL` to `a IS NULL`, so every
expression the catalog stores comes back as a NullTest rather than the
negation, and no fold over the negation reaches it. `dump` writes `IS NULL`,
so the round trip that matters plans clean.


