### PR TITLE
Bring TODO.md back in line with the code

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -698,6 +698,8 @@ prints the name it chose, so a view whose body holds
 two `ResTarget` names disagree, and `CREATE OR REPLACE VIEW` is re-emitted on
 every plan. Reproducing the name means reimplementing `FigureColname`, which
 walks the expression to pick a function name, a column name or `?column?`.
+`figureIndexColname` (`parser/parser.go`) already walks an expression this way
+for an index element, so the shared half of the work is in the tree.
 
 Workaround: write the alias the way `pista dump` emits it.
 

--- a/TODO.md
+++ b/TODO.md
@@ -798,14 +798,6 @@ symmetric. `CREATE AGGREGATE` has a shape `model.Routine` does not cover.
 
 Origin: routine support.
 
-## Sample database coverage has no Routines column
-
-The table in `sample-db-test.md` counts tables, columns, indexes, FKs,
-constraints, views, types, sequences and triggers per sample. The counts predate
-`--manage-routine`, so routines have no column yet.
-
-Origin: routine support.
-
 ## `COMMENT ON INDEX` is not managed
 
 Priority: low.


### PR DESCRIPTION
Two entries had drifted from the code. Found by reading all 33 against the tree after the first one turned up.

**Sample database coverage has no Routines column** is gone. 62c7fed added the column on 2026-08-25; the table in `sample-db-test.md` has it, all 48 sample rows have a value, and the prose above records when the counts were taken and what `--manage-routine` reads.

**View drift on a target alias the catalog writes differently** put the work at reimplementing `FigureColname`. `figureIndexColname` (`parser/parser.go`) has since landed, following `FigureIndexColname` and `FigureColnameInternal` for an index element, so the half that walks an expression to pick a name exists. The two PostgreSQL functions differ, so the added line points at the shared half rather than claiming a drop-in.

The other 31 entries hold. Spot checks: `TableSpace` appears nowhere in `diff/`; `model.Sequence` has no `Unlogged` and `model.Index` no `Comment`; `catalog/routines.go` still filters `prokind IN ('f','p')` and `prosqlbody IS NULL`; pg_query_go v6.2.2 still rejects the standalone `ADD CONSTRAINT ... NOT NULL` form; `remapRoutines` still leaves the body alone; and `testdata/plan/alter_json_query_clauses.yml` still pins the deparser's stray spaces. The Aurora DSQL entry needs a live cluster, so it went unchecked.

Documentation only.