### PR TITLE
Leave partition children unmanaged behind --skip-partition-child

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ make fix            # golangci-lint run --fix (auto-fix lint errors)
 - Package-level tests generally use external test packages (e.g., `package catalog_test`, `package model_test`). Use same-package tests only when access to unexported identifiers is required (e.g., `package diff`).
 - Root-level integration tests use `package pistachio_test`.
 - Test fixtures are YAML files in `testdata/`. Required fields vary by test suite: `apply` uses `init`/`desired`/`applied`, `plan` uses `init`/`desired`/`plan`/`error`, `dump` uses `init`/`dump`, and `parser` uses `input`/`expected`. The plan/apply/dump harnesses also accept optional fields, but **the set differs per suite** (the lists below are not interchangeable):
-  - `dump`: `min_pg`, `omit_schema`, `sort_by_deps`, `manage_routine`, `include`/`exclude`/`enable`/`disable`, `dump_pg16`/`dump_pg17`/`dump_pg18`.
-  - `plan`: `min_pg`/`max_pg`, `count`, `drop_policy`, `disallowed_drops`, `ignored`, `disable_index_concurrently`, `force_index_concurrently`, `bulk_alter`, `assume_validated`, `manage_routine`, `include`/`exclude`/`enable`/`disable`, `pre_sql`/`pre_sql_file`/`concurrently_pre_sql`/`concurrently_pre_sql_file`.
+  - `dump`: `min_pg`, `omit_schema`, `sort_by_deps`, `manage_routine`, `skip_partition_child`, `include`/`exclude`/`enable`/`disable`, `dump_pg16`/`dump_pg17`/`dump_pg18`.
+  - `plan`: `min_pg`/`max_pg`, `count`, `drop_policy`, `disallowed_drops`, `ignored`, `disable_index_concurrently`, `force_index_concurrently`, `bulk_alter`, `assume_validated`, `manage_routine`, `skip_partition_child`, `include`/`exclude`/`enable`/`disable`, `pre_sql`/`pre_sql_file`/`concurrently_pre_sql`/`concurrently_pre_sql_file`.
   - `apply`: everything `plan` accepts other than `plan`/`error`, `max_pg` and `ignored`, plus `applied_sql`, `skip_drift_check` and `applied_pg16`/`applied_pg17`/`applied_pg18`.
     Every `apply` case re-plans after the apply and requires no drift;
     `skip_drift_check` turns that off for a case that leaves drift on purpose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Leave partition children unmanaged behind `--skip-partition-child` (`$PISTA_SKIP_PARTITION_CHILD`). Where another tool owns the partitions, pg_partman for example, a desired schema that declares the partitioned parent alone planned a `DROP TABLE` for every partition, and `-E` only reached the ones whose names carry a pattern. With the flag `dump` writes the parent without its partitions, and neither side of `plan` / `apply` produces DDL for one. The parent is still managed, and PostgreSQL carries `ADD COLUMN` and an index created on it down to the partitions. A partition is left out whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it; an `INHERITS` child, which declares its own columns and carries no bound, stays managed.
+* Manage a partitioned table without its partitions, behind `--skip-partition-child` (`$PISTA_SKIP_PARTITION_CHILD`). Where another tool creates the partitions, pg_partman for example, a schema file that declares the parent alone planned a `DROP TABLE` for every partition, and `-E` only reached names that carry a pattern. With the flag `dump` writes the parent alone, and `plan` / `apply` skip a partition on both sides of the diff, including the indexes, policies and comments it owns. The parent stays managed, and PostgreSQL carries `ADD COLUMN` and an index created on it down to the partitions. A partition is skipped whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it. An `INHERITS` child carries no partition bound and stays managed.
 
 ## [1.33.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Leave partition children unmanaged behind `--skip-partition-child` (`$PISTA_SKIP_PARTITION_CHILD`). Where another tool owns the partitions, pg_partman for example, a desired schema that declares the partitioned parent alone planned a `DROP TABLE` for every partition, and `-E` only reached the ones whose names carry a pattern. With the flag `dump` writes the parent without its partitions, and neither side of `plan` / `apply` produces DDL for one. The parent is still managed, and PostgreSQL carries `ADD COLUMN` and an index created on it down to the partitions. A partition is left out whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it; an `INHERITS` child, which declares its own columns and carries no bound, stays managed.
+
 ## [1.33.0] - 2026-08-28
 
 * Check the column references in a `DEFAULT` or `GENERATED` expression against the table's desired columns. The validator already read the index, constraint and foreign-key definitions on a table, so a stale name left in one of those failed the plan with a message naming it, while the same name in a column expression reached the database and failed there. A generated expression may reference only columns of its own table, so every name it carries is checked. A plain `DEFAULT` may reference no column at all, which PostgreSQL rejects on its own; the names it does carry are checked the same way rather than rejected outright. An expression pg_query cannot read is skipped, the way an unreadable index definition already was.

--- a/README.md
+++ b/README.md
@@ -175,78 +175,84 @@ Arguments:
   <files> ...    Path to the desired schema SQL file(s).
 
 Flags:
-  -h, --help                   Show context-sensitive help.
+  -h, --help                    Show context-sensitive help.
   -c, --conn-string="postgres://postgres@localhost/postgres"
-                               PostgreSQL connection string. See
-                               https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                               ($PISTA_CONN_STR)
-  -d, --dbname=STRING          PostgreSQL database name. Overrides the dbname in
-                               --conn-string ($PISTA_DBNAME).
-      --password=STRING        PostgreSQL password ($PISTA_PASSWORD).
-  -n, --schemas=public,...     Schemas to inspect and modify ($PISTA_SCHEMAS).
+                                PostgreSQL connection string. See
+                                https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+                                ($PISTA_CONN_STR)
+  -d, --dbname=STRING           PostgreSQL database name. Overrides the dbname
+                                in --conn-string ($PISTA_DBNAME).
+      --password=STRING         PostgreSQL password ($PISTA_PASSWORD).
+  -n, --schemas=public,...      Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
-                               Schema name mapping (e.g. -m old=new).
-      --search-path=public     search_path for the database connection.
-                               The catalog reports an object reachable through
-                               it without its schema, so this decides how
-                               dump writes that object. Pass an empty value to
-                               qualify everything ($PISTA_SEARCH_PATH).
-  -C, --config=FILE            Load options from a YAML file ($PISTA_CONFIG).
+                                Schema name mapping (e.g. -m old=new).
+      --search-path=public      search_path for the database connection.
+                                The catalog reports an object reachable through
+                                it without its schema, so this decides how
+                                dump writes that object. Pass an empty value to
+                                qualify everything ($PISTA_SEARCH_PATH).
+  -C, --config=FILE             Load options from a YAML file ($PISTA_CONFIG).
       --version
-      --[no-]pager             Force paging via $PISTA_PAGER even when stdout is
-                               not a TTY. PISTA_PAGER must be set.
+      --[no-]pager              Force paging via $PISTA_PAGER even when stdout
+                                is not a TTY. PISTA_PAGER must be set.
 
-  -I, --include=INCLUDE,...    Include only tables/views/enums/domains/composite
-                               types/sequences/routines matching the pattern
-                               (wildcard: *, ?; /re/ for a regular expression)
-                               ($PISTA_INCLUDE).
-  -E, --exclude=EXCLUDE,...    Exclude tables/views/enums/domains/composite
-                               types/sequences/routines matching the pattern
-                               (wildcard: *, ?; /re/ for a regular expression)
-                               ($PISTA_EXCLUDE).
-      --enable=ENABLE,...      Enable only specified object types (can be
-                               repeated) ($PISTA_ENABLE).
-      --disable=DISABLE,...    Disable specified object types (can be repeated)
-                               ($PISTA_DISABLE).
-      --manage-routine         Manage functions and procedures. Off by default;
-                               --allow-drop routine still gates dropping them
-                               ($PISTA_MANAGE_ROUTINE).
+  -I, --include=INCLUDE,...     Include only
+                                tables/views/enums/domains/composite
+                                types/sequences/routines matching the pattern
+                                (wildcard: *, ?; /re/ for a regular expression)
+                                ($PISTA_INCLUDE).
+  -E, --exclude=EXCLUDE,...     Exclude tables/views/enums/domains/composite
+                                types/sequences/routines matching the pattern
+                                (wildcard: *, ?; /re/ for a regular expression)
+                                ($PISTA_EXCLUDE).
+      --enable=ENABLE,...       Enable only specified object types (can be
+                                repeated) ($PISTA_ENABLE).
+      --disable=DISABLE,...     Disable specified object types (can be repeated)
+                                ($PISTA_DISABLE).
+      --manage-routine          Manage functions and procedures. Off by default;
+                                --allow-drop routine still gates dropping them
+                                ($PISTA_MANAGE_ROUTINE).
+      --skip-partition-child    Leave partition children unmanaged and
+                                manage the partitioned parent alone.
+                                For a schema whose partitions another tool
+                                creates. An INHERITS child is unaffected
+                                ($PISTA_SKIP_PARTITION_CHILD).
       --allow-drop=ALLOW-DROP,...
-                               Allow dropping these object types (repeatable;
-                               'all' allows everything) ($PISTA_ALLOW_DROP).
-      --pre-sql=STRING         SQL to prepend to the plan output
-                               ($PISTA_PRE_SQL).
-      --pre-sql-file=STRING    Path to a SQL file to prepend to the plan output
-                               ($PISTA_PRE_SQL_FILE).
+                                Allow dropping these object types (repeatable;
+                                'all' allows everything) ($PISTA_ALLOW_DROP).
+      --pre-sql=STRING          SQL to prepend to the plan output
+                                ($PISTA_PRE_SQL).
+      --pre-sql-file=STRING     Path to a SQL file to prepend to the plan output
+                                ($PISTA_PRE_SQL_FILE).
       --concurrently-pre-sql=STRING
-                               SQL to run before CONCURRENTLY index DDL (e.g.
-                               SET lock_timeout). Emitted only when
-                               the diff contains CONCURRENTLY index DDL
-                               ($PISTA_CONCURRENTLY_PRE_SQL).
+                                SQL to run before CONCURRENTLY index DDL (e.g.
+                                SET lock_timeout). Emitted only when
+                                the diff contains CONCURRENTLY index DDL
+                                ($PISTA_CONCURRENTLY_PRE_SQL).
       --concurrently-pre-sql-file=STRING
-                               Path to a SQL file to run before CONCURRENTLY
-                               index DDL ($PISTA_CONCURRENTLY_PRE_SQL_FILE).
+                                Path to a SQL file to run before CONCURRENTLY
+                                index DDL ($PISTA_CONCURRENTLY_PRE_SQL_FILE).
       --disable-index-concurrently
-                               Ignore CONCURRENTLY opt-ins (directive and
-                               inline) and emit plain CREATE/DROP INDEX
-                               ($PISTA_DISABLE_INDEX_CONCURRENTLY).
+                                Ignore CONCURRENTLY opt-ins (directive and
+                                inline) and emit plain CREATE/DROP INDEX
+                                ($PISTA_DISABLE_INDEX_CONCURRENTLY).
       --force-index-concurrently
-                               Force CONCURRENTLY on every
-                               CREATE/DROP INDEX, including pure drops
-                               ($PISTA_FORCE_INDEX_CONCURRENTLY).
-      --bulk-alter             Combine consecutive ALTER TABLE actions on the
-                               same table into a single statement. FK changes,
-                               RENAME, VALIDATE CONSTRAINT, RLS toggles, and
-                               skipped DROPs stay separate ($PISTA_BULK_ALTER).
-      --assume-validated       Treat every table constraint, domain constraint,
-                               and foreign key as validated: ignore NOT
-                               VALID and never emit VALIDATE CONSTRAINT
-                               ($PISTA_ASSUME_VALIDATED).
-      --no-read-only           Open the database connection read-write.
-                               By default plan uses a read-only connection
-                               ($PISTA_NO_READ_ONLY).
-      --check                  Exit with code 2 when the plan contains
-                               executable changes ($PISTA_CHECK).
+                                Force CONCURRENTLY on every
+                                CREATE/DROP INDEX, including pure drops
+                                ($PISTA_FORCE_INDEX_CONCURRENTLY).
+      --bulk-alter              Combine consecutive ALTER TABLE actions on the
+                                same table into a single statement. FK changes,
+                                RENAME, VALIDATE CONSTRAINT, RLS toggles, and
+                                skipped DROPs stay separate ($PISTA_BULK_ALTER).
+      --assume-validated        Treat every table constraint, domain constraint,
+                                and foreign key as validated: ignore NOT
+                                VALID and never emit VALIDATE CONSTRAINT
+                                ($PISTA_ASSUME_VALIDATED).
+      --no-read-only            Open the database connection read-write.
+                                By default plan uses a read-only connection
+                                ($PISTA_NO_READ_ONLY).
+      --check                   Exit with code 2 when the plan contains
+                                executable changes ($PISTA_CHECK).
 ```
 
 </details>
@@ -263,80 +269,87 @@ Arguments:
   <files> ...    Path to the desired schema SQL file(s).
 
 Flags:
-  -h, --help                   Show context-sensitive help.
+  -h, --help                    Show context-sensitive help.
   -c, --conn-string="postgres://postgres@localhost/postgres"
-                               PostgreSQL connection string. See
-                               https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                               ($PISTA_CONN_STR)
-  -d, --dbname=STRING          PostgreSQL database name. Overrides the dbname in
-                               --conn-string ($PISTA_DBNAME).
-      --password=STRING        PostgreSQL password ($PISTA_PASSWORD).
-  -n, --schemas=public,...     Schemas to inspect and modify ($PISTA_SCHEMAS).
+                                PostgreSQL connection string. See
+                                https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+                                ($PISTA_CONN_STR)
+  -d, --dbname=STRING           PostgreSQL database name. Overrides the dbname
+                                in --conn-string ($PISTA_DBNAME).
+      --password=STRING         PostgreSQL password ($PISTA_PASSWORD).
+  -n, --schemas=public,...      Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
-                               Schema name mapping (e.g. -m old=new).
-      --search-path=public     search_path for the database connection.
-                               The catalog reports an object reachable through
-                               it without its schema, so this decides how
-                               dump writes that object. Pass an empty value to
-                               qualify everything ($PISTA_SEARCH_PATH).
-  -C, --config=FILE            Load options from a YAML file ($PISTA_CONFIG).
+                                Schema name mapping (e.g. -m old=new).
+      --search-path=public      search_path for the database connection.
+                                The catalog reports an object reachable through
+                                it without its schema, so this decides how
+                                dump writes that object. Pass an empty value to
+                                qualify everything ($PISTA_SEARCH_PATH).
+  -C, --config=FILE             Load options from a YAML file ($PISTA_CONFIG).
       --version
-      --[no-]pager             Force paging via $PISTA_PAGER even when stdout is
-                               not a TTY. PISTA_PAGER must be set.
+      --[no-]pager              Force paging via $PISTA_PAGER even when stdout
+                                is not a TTY. PISTA_PAGER must be set.
 
-  -I, --include=INCLUDE,...    Include only tables/views/enums/domains/composite
-                               types/sequences/routines matching the pattern
-                               (wildcard: *, ?; /re/ for a regular expression)
-                               ($PISTA_INCLUDE).
-  -E, --exclude=EXCLUDE,...    Exclude tables/views/enums/domains/composite
-                               types/sequences/routines matching the pattern
-                               (wildcard: *, ?; /re/ for a regular expression)
-                               ($PISTA_EXCLUDE).
-      --enable=ENABLE,...      Enable only specified object types (can be
-                               repeated) ($PISTA_ENABLE).
-      --disable=DISABLE,...    Disable specified object types (can be repeated)
-                               ($PISTA_DISABLE).
-      --manage-routine         Manage functions and procedures. Off by default;
-                               --allow-drop routine still gates dropping them
-                               ($PISTA_MANAGE_ROUTINE).
+  -I, --include=INCLUDE,...     Include only
+                                tables/views/enums/domains/composite
+                                types/sequences/routines matching the pattern
+                                (wildcard: *, ?; /re/ for a regular expression)
+                                ($PISTA_INCLUDE).
+  -E, --exclude=EXCLUDE,...     Exclude tables/views/enums/domains/composite
+                                types/sequences/routines matching the pattern
+                                (wildcard: *, ?; /re/ for a regular expression)
+                                ($PISTA_EXCLUDE).
+      --enable=ENABLE,...       Enable only specified object types (can be
+                                repeated) ($PISTA_ENABLE).
+      --disable=DISABLE,...     Disable specified object types (can be repeated)
+                                ($PISTA_DISABLE).
+      --manage-routine          Manage functions and procedures. Off by default;
+                                --allow-drop routine still gates dropping them
+                                ($PISTA_MANAGE_ROUTINE).
+      --skip-partition-child    Leave partition children unmanaged and
+                                manage the partitioned parent alone.
+                                For a schema whose partitions another tool
+                                creates. An INHERITS child is unaffected
+                                ($PISTA_SKIP_PARTITION_CHILD).
       --allow-drop=ALLOW-DROP,...
-                               Allow dropping these object types (repeatable;
-                               'all' allows everything) ($PISTA_ALLOW_DROP).
-      --pre-sql=STRING         SQL to execute before applying changes
-                               ($PISTA_PRE_SQL).
-      --pre-sql-file=STRING    Path to a SQL file to execute before applying
-                               changes ($PISTA_PRE_SQL_FILE).
+                                Allow dropping these object types (repeatable;
+                                'all' allows everything) ($PISTA_ALLOW_DROP).
+      --pre-sql=STRING          SQL to execute before applying changes
+                                ($PISTA_PRE_SQL).
+      --pre-sql-file=STRING     Path to a SQL file to execute before applying
+                                changes ($PISTA_PRE_SQL_FILE).
       --concurrently-pre-sql=STRING
-                               SQL to execute before CONCURRENTLY
-                               index DDL (e.g. SET lock_timeout).
-                               Runs outside any transaction, only when
-                               the diff contains CONCURRENTLY index DDL
-                               ($PISTA_CONCURRENTLY_PRE_SQL).
+                                SQL to execute before CONCURRENTLY
+                                index DDL (e.g. SET lock_timeout).
+                                Runs outside any transaction, only when
+                                the diff contains CONCURRENTLY index DDL
+                                ($PISTA_CONCURRENTLY_PRE_SQL).
       --concurrently-pre-sql-file=STRING
-                               Path to a SQL file to execute before CONCURRENTLY
-                               index DDL ($PISTA_CONCURRENTLY_PRE_SQL_FILE).
-      --with-tx                Execute pre-SQL and schema changes in a
-                               transaction ($PISTA_WITH_TX).
-      --try-tx                 Execute pre-SQL and schema changes in a
-                               transaction when possible. A diff containing
-                               CONCURRENTLY index DDL runs without a transaction
-                               instead of failing ($PISTA_TRY_TX).
+                                Path to a SQL file to execute
+                                before CONCURRENTLY index DDL
+                                ($PISTA_CONCURRENTLY_PRE_SQL_FILE).
+      --with-tx                 Execute pre-SQL and schema changes in a
+                                transaction ($PISTA_WITH_TX).
+      --try-tx                  Execute pre-SQL and schema changes in a
+                                transaction when possible. A diff containing
+                                CONCURRENTLY index DDL runs without a
+                                transaction instead of failing ($PISTA_TRY_TX).
       --disable-index-concurrently
-                               Ignore CONCURRENTLY opt-ins (directive and
-                               inline) and emit plain CREATE/DROP INDEX
-                               ($PISTA_DISABLE_INDEX_CONCURRENTLY).
+                                Ignore CONCURRENTLY opt-ins (directive and
+                                inline) and emit plain CREATE/DROP INDEX
+                                ($PISTA_DISABLE_INDEX_CONCURRENTLY).
       --force-index-concurrently
-                               Force CONCURRENTLY on every CREATE/DROP INDEX,
-                               including pure drops. Cannot be combined with
-                               --with-tx ($PISTA_FORCE_INDEX_CONCURRENTLY).
-      --bulk-alter             Combine consecutive ALTER TABLE actions on the
-                               same table into a single statement. FK changes,
-                               RENAME, VALIDATE CONSTRAINT, RLS toggles, and
-                               skipped DROPs stay separate ($PISTA_BULK_ALTER).
-      --assume-validated       Treat every table constraint, domain constraint,
-                               and foreign key as validated: ignore NOT
-                               VALID and never emit VALIDATE CONSTRAINT
-                               ($PISTA_ASSUME_VALIDATED).
+                                Force CONCURRENTLY on every CREATE/DROP INDEX,
+                                including pure drops. Cannot be combined with
+                                --with-tx ($PISTA_FORCE_INDEX_CONCURRENTLY).
+      --bulk-alter              Combine consecutive ALTER TABLE actions on the
+                                same table into a single statement. FK changes,
+                                RENAME, VALIDATE CONSTRAINT, RLS toggles, and
+                                skipped DROPs stay separate ($PISTA_BULK_ALTER).
+      --assume-validated        Treat every table constraint, domain constraint,
+                                and foreign key as validated: ignore NOT
+                                VALID and never emit VALIDATE CONSTRAINT
+                                ($PISTA_ASSUME_VALIDATED).
 ```
 
 </details>
@@ -350,52 +363,58 @@ Usage: pista dump [flags]
 Dump the current database schema as SQL.
 
 Flags:
-  -h, --help                   Show context-sensitive help.
+  -h, --help                    Show context-sensitive help.
   -c, --conn-string="postgres://postgres@localhost/postgres"
-                               PostgreSQL connection string. See
-                               https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                               ($PISTA_CONN_STR)
-  -d, --dbname=STRING          PostgreSQL database name. Overrides the dbname in
-                               --conn-string ($PISTA_DBNAME).
-      --password=STRING        PostgreSQL password ($PISTA_PASSWORD).
-  -n, --schemas=public,...     Schemas to inspect and modify ($PISTA_SCHEMAS).
+                                PostgreSQL connection string. See
+                                https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+                                ($PISTA_CONN_STR)
+  -d, --dbname=STRING           PostgreSQL database name. Overrides the dbname
+                                in --conn-string ($PISTA_DBNAME).
+      --password=STRING         PostgreSQL password ($PISTA_PASSWORD).
+  -n, --schemas=public,...      Schemas to inspect and modify ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
-                               Schema name mapping (e.g. -m old=new).
-      --search-path=public     search_path for the database connection.
-                               The catalog reports an object reachable through
-                               it without its schema, so this decides how
-                               dump writes that object. Pass an empty value to
-                               qualify everything ($PISTA_SEARCH_PATH).
-  -C, --config=FILE            Load options from a YAML file ($PISTA_CONFIG).
+                                Schema name mapping (e.g. -m old=new).
+      --search-path=public      search_path for the database connection.
+                                The catalog reports an object reachable through
+                                it without its schema, so this decides how
+                                dump writes that object. Pass an empty value to
+                                qualify everything ($PISTA_SEARCH_PATH).
+  -C, --config=FILE             Load options from a YAML file ($PISTA_CONFIG).
       --version
-      --[no-]pager             Force paging via $PISTA_PAGER even when stdout is
-                               not a TTY. PISTA_PAGER must be set.
+      --[no-]pager              Force paging via $PISTA_PAGER even when stdout
+                                is not a TTY. PISTA_PAGER must be set.
 
-  -I, --include=INCLUDE,...    Include only tables/views/enums/domains/composite
-                               types/sequences/routines matching the pattern
-                               (wildcard: *, ?; /re/ for a regular expression)
-                               ($PISTA_INCLUDE).
-  -E, --exclude=EXCLUDE,...    Exclude tables/views/enums/domains/composite
-                               types/sequences/routines matching the pattern
-                               (wildcard: *, ?; /re/ for a regular expression)
-                               ($PISTA_EXCLUDE).
-      --enable=ENABLE,...      Enable only specified object types (can be
-                               repeated) ($PISTA_ENABLE).
-      --disable=DISABLE,...    Disable specified object types (can be repeated)
-                               ($PISTA_DISABLE).
-      --manage-routine         Manage functions and procedures. Off by default;
-                               --allow-drop routine still gates dropping them
-                               ($PISTA_MANAGE_ROUTINE).
-      --split=STRING           Output each table/view/enum/domain/composite
-                               type/sequence as a separate file in the specified
-                               directory.
-      --omit-schema            Omit schema name from the dump output.
-      --sort-by-deps           Order the dump output by object dependency
-                               instead of by name. Errors when the dependency
-                               graph has a cycle. Cannot be used with --split.
-      --no-read-only           Open the database connection read-write.
-                               By default dump uses a read-only connection
-                               ($PISTA_NO_READ_ONLY).
+  -I, --include=INCLUDE,...     Include only
+                                tables/views/enums/domains/composite
+                                types/sequences/routines matching the pattern
+                                (wildcard: *, ?; /re/ for a regular expression)
+                                ($PISTA_INCLUDE).
+  -E, --exclude=EXCLUDE,...     Exclude tables/views/enums/domains/composite
+                                types/sequences/routines matching the pattern
+                                (wildcard: *, ?; /re/ for a regular expression)
+                                ($PISTA_EXCLUDE).
+      --enable=ENABLE,...       Enable only specified object types (can be
+                                repeated) ($PISTA_ENABLE).
+      --disable=DISABLE,...     Disable specified object types (can be repeated)
+                                ($PISTA_DISABLE).
+      --manage-routine          Manage functions and procedures. Off by default;
+                                --allow-drop routine still gates dropping them
+                                ($PISTA_MANAGE_ROUTINE).
+      --skip-partition-child    Leave partition children unmanaged and
+                                manage the partitioned parent alone.
+                                For a schema whose partitions another tool
+                                creates. An INHERITS child is unaffected
+                                ($PISTA_SKIP_PARTITION_CHILD).
+      --split=STRING            Output each table/view/enum/domain/composite
+                                type/sequence as a separate file in the
+                                specified directory.
+      --omit-schema             Omit schema name from the dump output.
+      --sort-by-deps            Order the dump output by object dependency
+                                instead of by name. Errors when the dependency
+                                graph has a cycle. Cannot be used with --split.
+      --no-read-only            Open the database connection read-write.
+                                By default dump uses a read-only connection
+                                ($PISTA_NO_READ_ONLY).
 ```
 
 </details>
@@ -727,6 +746,22 @@ PISTA_EXCLUDE='tmp_*' pista plan schema.sql
 
 > [!NOTE]
 > When both a CLI flag and its corresponding environment variable are set, the CLI flag overrides the environment variable (values are not merged). For example, running `PISTA_EXCLUDE='tmp_*' pista plan -E 'foo_*' schema.sql` excludes only `foo_*`; `tmp_*` is ignored.
+
+### Skipping partition children
+
+Use `--skip-partition-child` to leave every partition of a partitioned table unmanaged and manage the parent alone. `dump` writes the parent without its partitions, and `plan` / `apply` neither create a partition the desired schema declares nor drop one the database holds. Also available as `$PISTA_SKIP_PARTITION_CHILD`. It works on the `dump`, `plan`, and `apply` subcommands.
+
+Use it where another tool owns the partitions, pg_partman for example. `-E '/^posts_\d+$/'` reaches a regularly numbered set, but nothing reaches one whose names carry no pattern, and a desired schema that declares the parent alone plans a `DROP TABLE` for every partition it does not know about.
+
+```bash
+# Manage the partitioned parent and leave its partitions alone
+pista plan --skip-partition-child schema.sql
+
+# Dump writes the parent without its partitions
+pista dump --skip-partition-child
+```
+
+A partition is left out whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it. The parent still carries a change down: PostgreSQL applies `ADD COLUMN` and an index created on a partitioned table to every partition. A table attached with `INHERITS` is not a partition and stays managed.
 
 ### Omit schema
 

--- a/README.md
+++ b/README.md
@@ -212,11 +212,10 @@ Flags:
       --manage-routine          Manage functions and procedures. Off by default;
                                 --allow-drop routine still gates dropping them
                                 ($PISTA_MANAGE_ROUTINE).
-      --skip-partition-child    Leave partition children unmanaged and
-                                manage the partitioned parent alone.
-                                For a schema whose partitions another tool
-                                creates. An INHERITS child is unaffected
-                                ($PISTA_SKIP_PARTITION_CHILD).
+      --skip-partition-child    Manage a partitioned table without its
+                                partitions. For a schema whose partitions
+                                another tool creates. An INHERITS child is
+                                unaffected ($PISTA_SKIP_PARTITION_CHILD).
       --allow-drop=ALLOW-DROP,...
                                 Allow dropping these object types (repeatable;
                                 'all' allows everything) ($PISTA_ALLOW_DROP).
@@ -306,11 +305,10 @@ Flags:
       --manage-routine          Manage functions and procedures. Off by default;
                                 --allow-drop routine still gates dropping them
                                 ($PISTA_MANAGE_ROUTINE).
-      --skip-partition-child    Leave partition children unmanaged and
-                                manage the partitioned parent alone.
-                                For a schema whose partitions another tool
-                                creates. An INHERITS child is unaffected
-                                ($PISTA_SKIP_PARTITION_CHILD).
+      --skip-partition-child    Manage a partitioned table without its
+                                partitions. For a schema whose partitions
+                                another tool creates. An INHERITS child is
+                                unaffected ($PISTA_SKIP_PARTITION_CHILD).
       --allow-drop=ALLOW-DROP,...
                                 Allow dropping these object types (repeatable;
                                 'all' allows everything) ($PISTA_ALLOW_DROP).
@@ -400,11 +398,10 @@ Flags:
       --manage-routine          Manage functions and procedures. Off by default;
                                 --allow-drop routine still gates dropping them
                                 ($PISTA_MANAGE_ROUTINE).
-      --skip-partition-child    Leave partition children unmanaged and
-                                manage the partitioned parent alone.
-                                For a schema whose partitions another tool
-                                creates. An INHERITS child is unaffected
-                                ($PISTA_SKIP_PARTITION_CHILD).
+      --skip-partition-child    Manage a partitioned table without its
+                                partitions. For a schema whose partitions
+                                another tool creates. An INHERITS child is
+                                unaffected ($PISTA_SKIP_PARTITION_CHILD).
       --split=STRING            Output each table/view/enum/domain/composite
                                 type/sequence as a separate file in the
                                 specified directory.
@@ -749,19 +746,16 @@ PISTA_EXCLUDE='tmp_*' pista plan schema.sql
 
 ### Skipping partition children
 
-Use `--skip-partition-child` to leave every partition of a partitioned table unmanaged and manage the parent alone. `dump` writes the parent without its partitions, and `plan` / `apply` neither create a partition the desired schema declares nor drop one the database holds. Also available as `$PISTA_SKIP_PARTITION_CHILD`. It works on the `dump`, `plan`, and `apply` subcommands.
+Use `--skip-partition-child` to manage a partitioned table without its partitions. `dump` writes the parent alone, and `plan` / `apply` neither create a partition the schema file declares nor drop one the database holds. Available on `dump`, `plan` and `apply`, and as `$PISTA_SKIP_PARTITION_CHILD`.
 
-Use it where another tool owns the partitions, pg_partman for example. `-E '/^posts_\d+$/'` reaches a regularly numbered set, but nothing reaches one whose names carry no pattern, and a desired schema that declares the parent alone plans a `DROP TABLE` for every partition it does not know about.
+Use it where another tool creates the partitions, pg_partman for example. Without it, a schema file that declares the parent alone plans a `DROP TABLE` for every partition, and `-E` only reaches names that carry a pattern.
 
 ```bash
-# Manage the partitioned parent and leave its partitions alone
 pista plan --skip-partition-child schema.sql
-
-# Dump writes the parent without its partitions
 pista dump --skip-partition-child
 ```
 
-A partition is left out whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it. The parent still carries a change down: PostgreSQL applies `ADD COLUMN` and an index created on a partitioned table to every partition. A table attached with `INHERITS` is not a partition and stays managed.
+A partition is skipped whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it. The parent still carries changes down: PostgreSQL applies `ADD COLUMN` and an index created on a partitioned table to every partition. An `INHERITS` child is not a partition and stays managed.
 
 ### Omit schema
 

--- a/apply_test.go
+++ b/apply_test.go
@@ -37,6 +37,7 @@ type applyTestCase struct {
 	Enable                   []string         `yaml:"enable,omitempty"`
 	Disable                  []string         `yaml:"disable,omitempty"`
 	ManageRoutine            bool             `yaml:"manage_routine,omitempty"`
+	SkipPartitionChild       bool             `yaml:"skip_partition_child,omitempty"`
 	PreSQL                   string           `yaml:"pre_sql,omitempty"`
 	// PreSQLFile holds SQL content; the runner writes it to a temp file and
 	// passes the path to ApplyOptions.PreSQLFile.
@@ -121,11 +122,12 @@ func TestApply(t *testing.T) {
 			result, err := client.Apply(ctx, &pistachio.ApplyOptions{
 				DropPolicy: dropPolicy,
 				FilterOptions: pistachio.FilterOptions{
-					Include:       tc.Include,
-					Exclude:       tc.Exclude,
-					Enable:        tc.Enable,
-					Disable:       tc.Disable,
-					ManageRoutine: tc.ManageRoutine,
+					Include:            tc.Include,
+					Exclude:            tc.Exclude,
+					Enable:             tc.Enable,
+					Disable:            tc.Disable,
+					ManageRoutine:      tc.ManageRoutine,
+					SkipPartitionChild: tc.SkipPartitionChild,
 				},
 				Files:                    []string{desiredFile},
 				DisableIndexConcurrently: tc.DisableIndexConcurrently,
@@ -155,11 +157,12 @@ func TestApply(t *testing.T) {
 				plan, err := client.Plan(ctx, &pistachio.PlanOptions{
 					DropPolicy: dropPolicy,
 					FilterOptions: pistachio.FilterOptions{
-						Include:       tc.Include,
-						Exclude:       tc.Exclude,
-						Enable:        tc.Enable,
-						Disable:       tc.Disable,
-						ManageRoutine: tc.ManageRoutine,
+						Include:            tc.Include,
+						Exclude:            tc.Exclude,
+						Enable:             tc.Enable,
+						Disable:            tc.Disable,
+						ManageRoutine:      tc.ManageRoutine,
+						SkipPartitionChild: tc.SkipPartitionChild,
 					},
 					Files:                    []string{desiredFile},
 					DisableIndexConcurrently: tc.DisableIndexConcurrently,

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -152,7 +152,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	// policies and comments are owned per-relation (children do not
 	// auto-inherit them), so they're still diffed here, mirroring how
 	// indexes and FKs work.
-	if desired.PartitionOf != nil && desired.PartitionBound != nil {
+	if desired.IsPartitionChild() {
 		idxResult, err := diffIndexes(current.Indexes, desired.Indexes, dc)
 		if err != nil {
 			return nil, err

--- a/dump_test.go
+++ b/dump_test.go
@@ -20,17 +20,18 @@ type dumpTestCase struct {
 	Dump string `yaml:"dump"`
 	// MinPG skips the fixture on a server older than this major version, for
 	// syntax the server does not accept yet.
-	MinPG         int      `yaml:"min_pg,omitempty"`
-	DumpPG16      string   `yaml:"dump_pg16,omitempty"`
-	DumpPG17      string   `yaml:"dump_pg17,omitempty"`
-	DumpPG18      string   `yaml:"dump_pg18,omitempty"`
-	OmitSchema    bool     `yaml:"omit_schema"`
-	SortByDeps    bool     `yaml:"sort_by_deps"`
-	Include       []string `yaml:"include,omitempty"`
-	Exclude       []string `yaml:"exclude,omitempty"`
-	Enable        []string `yaml:"enable,omitempty"`
-	Disable       []string `yaml:"disable,omitempty"`
-	ManageRoutine bool     `yaml:"manage_routine,omitempty"`
+	MinPG              int      `yaml:"min_pg,omitempty"`
+	DumpPG16           string   `yaml:"dump_pg16,omitempty"`
+	DumpPG17           string   `yaml:"dump_pg17,omitempty"`
+	DumpPG18           string   `yaml:"dump_pg18,omitempty"`
+	OmitSchema         bool     `yaml:"omit_schema"`
+	SortByDeps         bool     `yaml:"sort_by_deps"`
+	Include            []string `yaml:"include,omitempty"`
+	Exclude            []string `yaml:"exclude,omitempty"`
+	Enable             []string `yaml:"enable,omitempty"`
+	Disable            []string `yaml:"disable,omitempty"`
+	ManageRoutine      bool     `yaml:"manage_routine,omitempty"`
+	SkipPartitionChild bool     `yaml:"skip_partition_child,omitempty"`
 }
 
 func (tc *dumpTestCase) expectedDump(major int) string {
@@ -870,11 +871,12 @@ func TestDump(t *testing.T) {
 				OmitSchema: tc.OmitSchema,
 				SortByDeps: tc.SortByDeps,
 				FilterOptions: pistachio.FilterOptions{
-					Include:       tc.Include,
-					Exclude:       tc.Exclude,
-					Enable:        tc.Enable,
-					Disable:       tc.Disable,
-					ManageRoutine: tc.ManageRoutine,
+					Include:            tc.Include,
+					Exclude:            tc.Exclude,
+					Enable:             tc.Enable,
+					Disable:            tc.Disable,
+					ManageRoutine:      tc.ManageRoutine,
+					SkipPartitionChild: tc.SkipPartitionChild,
 				},
 			})
 			require.NoError(t, err)

--- a/export_test.go
+++ b/export_test.go
@@ -14,6 +14,10 @@ var (
 	BuildDefReplacer          = buildDefReplacer
 )
 
+func FilterTables(f *FilterOptions, tables *orderedmap.Map[string, *model.Table]) *orderedmap.Map[string, *model.Table] {
+	return f.filterTables(tables)
+}
+
 func DumpResultTables(r *DumpResult) *orderedmap.Map[string, *model.Table] {
 	return r.tables()
 }

--- a/filter.go
+++ b/filter.go
@@ -9,12 +9,15 @@ func (f *FilterOptions) filterTables(tables *orderedmap.Map[string, *model.Table
 	if !f.IsTypeEnabled("table") {
 		return orderedmap.New[string, *model.Table]()
 	}
-	if len(f.Include) == 0 && len(f.Exclude) == 0 {
+	if len(f.Include) == 0 && len(f.Exclude) == 0 && !f.SkipPartitionChild {
 		return tables
 	}
 
 	filtered := orderedmap.New[string, *model.Table]()
 	for k, t := range tables.All() {
+		if f.SkipPartitionChild && t.IsPartitionChild() {
+			continue
+		}
 		if f.MatchName(t.Name) {
 			filtered.Set(k, t)
 		}

--- a/filter_test.go
+++ b/filter_test.go
@@ -314,6 +314,13 @@ func TestFilterTables_SkipPartitionChild(t *testing.T) {
 		assert.Equal(t, []string{"public.events", "public.events_old"}, got.CollectKeys())
 	})
 
+	t.Run("with include", func(t *testing.T) {
+		// A partition matching --include is skipped all the same.
+		f := &pistachio.FilterOptions{SkipPartitionChild: true, Include: []string{"events*"}}
+		got := pistachio.FilterTables(f, tables)
+		assert.Equal(t, []string{"public.events", "public.events_old"}, got.CollectKeys())
+	})
+
 	t.Run("with disabled table type", func(t *testing.T) {
 		f := &pistachio.FilterOptions{SkipPartitionChild: true, Disable: []string{"table"}}
 		assert.Equal(t, 0, pistachio.FilterTables(f, tables).Len())

--- a/filter_test.go
+++ b/filter_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/orderedmap/v2"
 	"github.com/winebarrel/pistachio"
+	"github.com/winebarrel/pistachio/model"
 )
 
 func TestValidatePatterns(t *testing.T) {
@@ -274,5 +276,46 @@ func TestIsTypeEnabled_Enable(t *testing.T) {
 		assert.False(t, f.IsTypeEnabled("view"))
 		assert.True(t, f.IsTypeEnabled("enum"))
 		assert.False(t, f.IsTypeEnabled("domain"))
+	})
+}
+
+func partitionChildTable(name, parent, bound string) *model.Table {
+	return &model.Table{Schema: "public", Name: name, PartitionOf: &parent, PartitionBound: &bound}
+}
+
+func TestFilterTables_SkipPartitionChild(t *testing.T) {
+	tables := orderedmap.New[string, *model.Table]()
+	tables.Set("public.events", &model.Table{Schema: "public", Name: "events", Partitioned: true})
+	tables.Set("public.events_2024", partitionChildTable("events_2024", "public.events", "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')"))
+	// A middle level is both partitioned and a child, and goes with the rest.
+	sub := partitionChildTable("events_2025", "public.events", "FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')")
+	sub.Partitioned = true
+	tables.Set("public.events_2025", sub)
+	// An INHERITS child carries no bound, so it is not a partition child.
+	parent := "public.events"
+	tables.Set("public.events_old", &model.Table{Schema: "public", Name: "events_old", PartitionOf: &parent})
+	tables.Set("public.users", &model.Table{Schema: "public", Name: "users"})
+
+	t.Run("off", func(t *testing.T) {
+		f := &pistachio.FilterOptions{}
+		got := pistachio.FilterTables(f, tables)
+		assert.Equal(t, []string{"public.events", "public.events_2024", "public.events_2025", "public.events_old", "public.users"}, got.CollectKeys())
+	})
+
+	t.Run("on", func(t *testing.T) {
+		f := &pistachio.FilterOptions{SkipPartitionChild: true}
+		got := pistachio.FilterTables(f, tables)
+		assert.Equal(t, []string{"public.events", "public.events_old", "public.users"}, got.CollectKeys())
+	})
+
+	t.Run("with exclude", func(t *testing.T) {
+		f := &pistachio.FilterOptions{SkipPartitionChild: true, Exclude: []string{"users"}}
+		got := pistachio.FilterTables(f, tables)
+		assert.Equal(t, []string{"public.events", "public.events_old"}, got.CollectKeys())
+	})
+
+	t.Run("with disabled table type", func(t *testing.T) {
+		f := &pistachio.FilterOptions{SkipPartitionChild: true, Disable: []string{"table"}}
+		assert.Equal(t, 0, pistachio.FilterTables(f, tables).Len())
 	})
 }

--- a/model/table.go
+++ b/model/table.go
@@ -34,6 +34,13 @@ type Table struct {
 	Comment          *string
 }
 
+// IsPartitionChild reports whether the table is a partition of a declarative
+// partitioned table. An INHERITS child also carries PartitionOf, but no bound,
+// so the bound is what separates the two.
+func (t Table) IsPartitionChild() bool {
+	return t.PartitionOf != nil && t.PartitionBound != nil
+}
+
 func (t Table) FQTN() string {
 	return Ident(t.Schema, t.Name)
 }

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -178,6 +178,21 @@ func TestTable_SQL_partitioned(t *testing.T) {
 	assert.Contains(t, sql, "PARTITION BY RANGE (created_at)")
 }
 
+func TestTable_IsPartitionChild(t *testing.T) {
+	parent := "public.events"
+	bound := "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')"
+
+	tbl := newTable("public", "events_2024")
+	assert.False(t, tbl.IsPartitionChild())
+
+	tbl.PartitionOf = &parent
+	// An INHERITS child carries a parent but no bound.
+	assert.False(t, tbl.IsPartitionChild())
+
+	tbl.PartitionBound = &bound
+	assert.True(t, tbl.IsPartitionChild())
+}
+
 func TestTable_SQL_partitionOf_withBound(t *testing.T) {
 	tbl := newTable("public", "events_2024")
 	parent := "public.events"

--- a/options.go
+++ b/options.go
@@ -49,6 +49,12 @@ type FilterOptions struct {
 	// routines the desired schema does not declare, and reading pg_proc
 	// unasked would report every one of them as a drop.
 	ManageRoutine bool `env:"PISTA_MANAGE_ROUTINE" help:"Manage functions and procedures. Off by default; --allow-drop routine still gates dropping them."`
+	// SkipPartitionChild leaves every partition of a partitioned table
+	// unmanaged. Where a tool such as pg_partman creates the children on its
+	// own schedule, their names follow no pattern --exclude can state, and a
+	// desired schema that declares the parent alone would otherwise plan a
+	// DROP for each one.
+	SkipPartitionChild bool `env:"PISTA_SKIP_PARTITION_CHILD" help:"Leave partition children unmanaged and manage the partitioned parent alone. For a schema whose partitions another tool creates. An INHERITS child is unaffected."`
 }
 
 // IsTypeEnabled returns true if the given object type should be included.

--- a/options.go
+++ b/options.go
@@ -49,12 +49,11 @@ type FilterOptions struct {
 	// routines the desired schema does not declare, and reading pg_proc
 	// unasked would report every one of them as a drop.
 	ManageRoutine bool `env:"PISTA_MANAGE_ROUTINE" help:"Manage functions and procedures. Off by default; --allow-drop routine still gates dropping them."`
-	// SkipPartitionChild leaves every partition of a partitioned table
-	// unmanaged. Where a tool such as pg_partman creates the children on its
-	// own schedule, their names follow no pattern --exclude can state, and a
-	// desired schema that declares the parent alone would otherwise plan a
-	// DROP for each one.
-	SkipPartitionChild bool `env:"PISTA_SKIP_PARTITION_CHILD" help:"Leave partition children unmanaged and manage the partitioned parent alone. For a schema whose partitions another tool creates. An INHERITS child is unaffected."`
+	// SkipPartitionChild leaves the partitions of a partitioned table
+	// unmanaged. Where another tool creates them, their names follow no
+	// pattern --exclude can state, and a schema file that declares the parent
+	// alone would plan a DROP for each one.
+	SkipPartitionChild bool `env:"PISTA_SKIP_PARTITION_CHILD" help:"Manage a partitioned table without its partitions. For a schema whose partitions another tool creates. An INHERITS child is unaffected."`
 }
 
 // IsTypeEnabled returns true if the given object type should be included.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1777,7 +1777,7 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 			// Restricted to true partition children: an INHERITS-style child
 			// still goes through the regular column diff, where a bodyless
 			// entry would be mistaken for a new column.
-			if t.PartitionOf != nil && t.PartitionBound != nil {
+			if t.IsPartitionChild() {
 				t.Columns.Set(colName, &model.Column{Name: colName, Comment: comment})
 			}
 			return

--- a/plan_test.go
+++ b/plan_test.go
@@ -40,6 +40,7 @@ type planTestCase struct {
 	Enable                   []string        `yaml:"enable,omitempty"`
 	Disable                  []string        `yaml:"disable,omitempty"`
 	ManageRoutine            bool            `yaml:"manage_routine,omitempty"`
+	SkipPartitionChild       bool            `yaml:"skip_partition_child,omitempty"`
 	PreSQL                   string          `yaml:"pre_sql,omitempty"`
 	// PreSQLFile holds SQL content; the runner writes it to a temp file and
 	// passes the path to PlanOptions.PreSQLFile.
@@ -385,11 +386,12 @@ func TestPlan(t *testing.T) {
 			got, err := client.Plan(ctx, &pistachio.PlanOptions{
 				DropPolicy: dropPolicy,
 				FilterOptions: pistachio.FilterOptions{
-					Include:       tc.Include,
-					Exclude:       tc.Exclude,
-					Enable:        tc.Enable,
-					Disable:       tc.Disable,
-					ManageRoutine: tc.ManageRoutine,
+					Include:            tc.Include,
+					Exclude:            tc.Exclude,
+					Enable:             tc.Enable,
+					Disable:            tc.Disable,
+					ManageRoutine:      tc.ManageRoutine,
+					SkipPartitionChild: tc.SkipPartitionChild,
 				},
 				Files:                    []string{desiredFile},
 				DisableIndexConcurrently: tc.DisableIndexConcurrently,

--- a/test/scenario/skip_partition_child.test.sh
+++ b/test/scenario/skip_partition_child.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Scenario test: --skip-partition-child
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/helper.sh"
+
+DATA="$SCRIPT_DIR/testdata/skip_partition_child"
+
+setup_db "$DATA/init.sql"
+
+# --- Step 1: without the flag the partition the desired schema omits is dropped ---
+step "01 partition is dropped without the flag"
+plan_output=$(pista_plan "$DATA/steps/01_parent_only.sql") || { fail "plan failed: $plan_output"; true; }
+if echo "$plan_output" | grep -qF 'DROP TABLE public.events_p2024;'; then
+  pass
+else
+  fail "expected a DROP for the partition"
+  echo "    $plan_output" >&2
+fi
+
+# --- Step 2: the flag leaves it alone ---
+step "02 partition is left alone with the flag"
+plan_output=$("$PISTA" plan --allow-drop all --skip-partition-child "$DATA/steps/01_parent_only.sql" 2>&1) || { fail "plan failed: $plan_output"; true; }
+if echo "$plan_output" | grep -qF -e '-- No changes'; then
+  pass
+else
+  fail "expected no changes"
+  echo "    $plan_output" >&2
+fi
+
+# --- Step 3: a change to the parent still applies, drift-free ---
+step "03 parent change applies and reaches the partition"
+apply_output=$("$PISTA" apply --allow-drop all --skip-partition-child "$DATA/steps/02_parent_column.sql" 2>&1) || { fail "apply failed: $apply_output"; true; }
+child_col=$(psql -X "$PISTA_CONN_STR" -tAc "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='events_p2024' AND column_name='data')")
+if [ "$child_col" != "t" ]; then
+  fail "expected the added column to reach the partition"
+  echo "    $apply_output" >&2
+else
+  drift=$("$PISTA" plan --allow-drop all --skip-partition-child "$DATA/steps/02_parent_column.sql" 2>&1)
+  if echo "$drift" | grep -qF -e '-- No changes'; then
+    pass
+  else
+    fail "expected no drift after apply"
+    echo "    $drift" >&2
+  fi
+fi
+
+# --- Step 4: a partition created afterwards does not show up as a change ---
+step "04 new partition does not enter the plan"
+psql -X "$PISTA_CONN_STR" -q -v ON_ERROR_STOP=1 -c "CREATE TABLE public.events_p2025 PARTITION OF public.events FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')"
+plan_output=$("$PISTA" plan --allow-drop all --skip-partition-child "$DATA/steps/02_parent_column.sql" 2>&1) || { fail "plan failed: $plan_output"; true; }
+if echo "$plan_output" | grep -qF -e '-- No changes'; then
+  pass
+else
+  fail "expected no changes for the new partition"
+  echo "    $plan_output" >&2
+fi
+
+# --- Step 5: dump writes the parent alone ---
+step "05 dump omits the partitions"
+dump_output=$("$PISTA" dump --skip-partition-child 2>&1) || { fail "dump failed: $dump_output"; true; }
+if echo "$dump_output" | grep -qF 'PARTITION OF'; then
+  fail "expected no partition in the dump"
+  echo "    $dump_output" >&2
+elif ! echo "$dump_output" | grep -qF 'PARTITION BY RANGE (created_at)'; then
+  fail "expected the partitioned parent in the dump"
+  echo "    $dump_output" >&2
+elif ! echo "$dump_output" | grep -qF 'CREATE TABLE public.users'; then
+  fail "expected the other tables in the dump"
+  echo "    $dump_output" >&2
+else
+  pass
+fi
+
+# --- Step 6: the dump plans clean when fed back under the same flag ---
+step "06 dump output round-trips"
+tmp_sql=$(mktemp)
+trap 'rm -f "$tmp_sql"' EXIT
+"$PISTA" dump --skip-partition-child > "$tmp_sql"
+plan_output=$("$PISTA" plan --allow-drop all --skip-partition-child "$tmp_sql" 2>&1) || { fail "plan failed: $plan_output"; true; }
+if echo "$plan_output" | grep -qF -e '-- No changes'; then
+  pass
+else
+  fail "expected no changes when the dump is fed back"
+  echo "    $plan_output" >&2
+fi
+
+summary

--- a/test/scenario/skip_partition_child.test.sh
+++ b/test/scenario/skip_partition_child.test.sh
@@ -21,7 +21,7 @@ fi
 
 # --- Step 2: the flag leaves it alone ---
 step "02 partition is left alone with the flag"
-plan_output=$("$PISTA" plan --allow-drop all --skip-partition-child "$DATA/steps/01_parent_only.sql" 2>&1) || { fail "plan failed: $plan_output"; true; }
+plan_output=$(pista_plan --skip-partition-child "$DATA/steps/01_parent_only.sql") || { fail "plan failed: $plan_output"; true; }
 if echo "$plan_output" | grep -qF -e '-- No changes'; then
   pass
 else
@@ -31,13 +31,13 @@ fi
 
 # --- Step 3: a change to the parent still applies, drift-free ---
 step "03 parent change applies and reaches the partition"
-apply_output=$("$PISTA" apply --allow-drop all --skip-partition-child "$DATA/steps/02_parent_column.sql" 2>&1) || { fail "apply failed: $apply_output"; true; }
+apply_output=$(pista_apply --skip-partition-child "$DATA/steps/02_parent_column.sql") || { fail "apply failed: $apply_output"; true; }
 child_col=$(psql -X "$PISTA_CONN_STR" -tAc "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='events_p2024' AND column_name='data')")
 if [ "$child_col" != "t" ]; then
   fail "expected the added column to reach the partition"
   echo "    $apply_output" >&2
 else
-  drift=$("$PISTA" plan --allow-drop all --skip-partition-child "$DATA/steps/02_parent_column.sql" 2>&1)
+  drift=$(pista_plan --skip-partition-child "$DATA/steps/02_parent_column.sql")
   if echo "$drift" | grep -qF -e '-- No changes'; then
     pass
   else
@@ -49,7 +49,7 @@ fi
 # --- Step 4: a partition created afterwards does not show up as a change ---
 step "04 new partition does not enter the plan"
 psql -X "$PISTA_CONN_STR" -q -v ON_ERROR_STOP=1 -c "CREATE TABLE public.events_p2025 PARTITION OF public.events FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')"
-plan_output=$("$PISTA" plan --allow-drop all --skip-partition-child "$DATA/steps/02_parent_column.sql" 2>&1) || { fail "plan failed: $plan_output"; true; }
+plan_output=$(pista_plan --skip-partition-child "$DATA/steps/02_parent_column.sql") || { fail "plan failed: $plan_output"; true; }
 if echo "$plan_output" | grep -qF -e '-- No changes'; then
   pass
 else
@@ -78,7 +78,7 @@ step "06 dump output round-trips"
 tmp_sql=$(mktemp)
 trap 'rm -f "$tmp_sql"' EXIT
 "$PISTA" dump --skip-partition-child > "$tmp_sql"
-plan_output=$("$PISTA" plan --allow-drop all --skip-partition-child "$tmp_sql" 2>&1) || { fail "plan failed: $plan_output"; true; }
+plan_output=$(pista_plan --skip-partition-child "$tmp_sql") || { fail "plan failed: $plan_output"; true; }
 if echo "$plan_output" | grep -qF -e '-- No changes'; then
   pass
 else

--- a/test/scenario/testdata/skip_partition_child/init.sql
+++ b/test/scenario/testdata/skip_partition_child/init.sql
@@ -1,0 +1,15 @@
+CREATE TABLE public.events (
+    id integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+) PARTITION BY RANGE (created_at);
+
+-- Created out of band, the way pg_partman would.
+CREATE TABLE public.events_p2024 PARTITION OF public.events
+    FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/skip_partition_child/steps/01_parent_only.sql
+++ b/test/scenario/testdata/skip_partition_child/steps/01_parent_only.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public.events (
+    id integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+) PARTITION BY RANGE (created_at);
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/test/scenario/testdata/skip_partition_child/steps/02_parent_column.sql
+++ b/test/scenario/testdata/skip_partition_child/steps/02_parent_column.sql
@@ -1,0 +1,12 @@
+CREATE TABLE public.events (
+    id integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    data text,
+    CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+) PARTITION BY RANGE (created_at);
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);

--- a/testdata/apply/skip_partition_child.yml
+++ b/testdata/apply/skip_partition_child.yml
@@ -1,0 +1,30 @@
+# The desired schema declares the parent alone. The child pg_partman-style
+# tooling created stays in the database untouched, and the column added to the
+# parent reaches it through the parent.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+applied: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  )
+  PARTITION BY RANGE (created_at);
+
+  -- public.events_2024
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01 00:00:00+00') TO ('2025-01-01 00:00:00+00');

--- a/testdata/apply/skip_partition_child_drop_parent.yml
+++ b/testdata/apply/skip_partition_child_drop_parent.yml
@@ -1,0 +1,27 @@
+# Dropping the parent is still the parent's statement. PostgreSQL drops the
+# partitions with it, so an unmanaged partition does not survive its parent.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied_sql: |
+  DROP TABLE public.events;
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/dump/skip_partition_child.yml
+++ b/testdata/dump/skip_partition_child.yml
@@ -1,0 +1,21 @@
+# --skip-partition-child keeps the children out of the dump so its output can be
+# fed back as the desired schema under the same flag.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      level text NOT NULL,
+      message text,
+      CONSTRAINT logs_pkey PRIMARY KEY (level, id)
+  ) PARTITION BY LIST (level);
+  CREATE TABLE public.logs_info PARTITION OF public.logs FOR VALUES IN ('info', 'debug');
+  CREATE TABLE public.logs_error PARTITION OF public.logs FOR VALUES IN ('error', 'warning');
+dump: |
+  -- public.logs
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      level text NOT NULL,
+      message text,
+      CONSTRAINT logs_pkey PRIMARY KEY (level, id)
+  )
+  PARTITION BY LIST (level);

--- a/testdata/plan/skip_partition_child_add.yml
+++ b/testdata/plan/skip_partition_child_add.yml
@@ -1,0 +1,23 @@
+# --skip-partition-child leaves every declarative partition child unmanaged, so
+# a child the desired schema declares is not created and one the database holds
+# but the desired schema omits is not dropped. The parent is still managed.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2025 PARTITION OF public.events FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+plan: ""
+count:
+  tables: 1

--- a/testdata/plan/skip_partition_child_desired_objects.yml
+++ b/testdata/plan/skip_partition_child_desired_objects.yml
@@ -1,0 +1,23 @@
+# A partition left in the schema file is skipped along with the objects
+# declared on it, so nothing is created for a partition the database lacks.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  CREATE INDEX events_2024_data_idx ON public.events_2024 (data);
+  CREATE POLICY events_2024_all ON public.events_2024 USING (true);
+plan: ""
+count:
+  tables: 1

--- a/testdata/plan/skip_partition_child_objects.yml
+++ b/testdata/plan/skip_partition_child_objects.yml
@@ -1,0 +1,26 @@
+# Indexes, policies and comments are owned by the partition rather than
+# inherited, so they are the drift the flag has to cover: the desired schema
+# declares none of them and the plan stays empty.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  CREATE INDEX events_2024_data_idx ON public.events_2024 (data);
+  ALTER TABLE public.events_2024 ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY events_2024_all ON public.events_2024 USING (true);
+  COMMENT ON TABLE public.events_2024 IS 'created by another tool';
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+plan: ""
+count:
+  tables: 1

--- a/testdata/plan/skip_partition_child_parent_change.yml
+++ b/testdata/plan/skip_partition_child_parent_change.yml
@@ -1,0 +1,20 @@
+# A change to the parent is still planned while --skip-partition-child holds the
+# children out. The added column reaches every child through the parent, which
+# is why a child needs no statement of its own.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      data text,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, id)
+  ) PARTITION BY RANGE (created_at);
+plan: |
+  ALTER TABLE public.events ADD COLUMN data text;

--- a/testdata/plan/skip_partition_child_subpartition.yml
+++ b/testdata/plan/skip_partition_child_subpartition.yml
@@ -1,0 +1,22 @@
+# A middle level is a child of its own parent, so --skip-partition-child holds
+# it out along with the leaf under it. Only the top parent stays managed.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      region text NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, region, id)
+  ) PARTITION BY RANGE (created_at);
+  CREATE TABLE public.events_2024 PARTITION OF public.events FOR VALUES FROM ('2024-01-01') TO ('2025-01-01') PARTITION BY LIST (region);
+  CREATE TABLE public.events_2024_jp PARTITION OF public.events_2024 FOR VALUES IN ('jp');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      created_at timestamp with time zone NOT NULL,
+      region text NOT NULL,
+      CONSTRAINT events_pkey PRIMARY KEY (created_at, region, id)
+  ) PARTITION BY RANGE (created_at);
+plan: ""
+count:
+  tables: 1


### PR DESCRIPTION
Where another tool owns the partitions, pg_partman for example, the desired
schema declares the partitioned parent alone, and every partition in the
database read as a table nothing declares: the plan carried a DROP TABLE for
each one. -E reaches a regularly numbered set, but nothing reaches a set whose
names carry no pattern, so the escape hatch ran out exactly where the children
are created on someone else's schedule.

The flag sits in FilterOptions next to --manage-routine, so it is read by dump,
plan and apply, and filterTables applies it to both sides of the diff: a
partition the database holds is not dropped, and one the desired schema
declares is not created. dump writes the parent without its partitions, which
keeps its output plannable under the same flag.

A partition is left out whether or not it is partitioned itself, so a
sub-partitioned level goes with the leaves under it. The parent stays managed
and PostgreSQL carries ADD COLUMN and an index created on it down to the
partitions, so the children do not go stale for being unmanaged. An INHERITS
child declares its own columns and carries no bound, so IsPartitionChild
separates the two and leaves it managed; the same predicate replaces the pair
of nil checks the diff and the comment parser already spelled out.

Measured the way CI does, 94.6% -> 94.7%.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012GyB9Rhvc8MZSCoiAfFG9m