### PR TITLE
Emit policy renames in the desired schema's order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Emit the `ALTER POLICY ... RENAME TO` statements in the desired schema's order. The renames were read out of a Go map, whose iteration order is randomized, so a plan renaming two or more policies on one table printed them in a different order on every run. The statements are independent, so only the output moved, but a plan that is reviewed, or diffed against the previous run, has to be stable.
+
 ## [1.34.0] - 2026-08-28
 
 * Manage a partitioned table without its partitions, behind `--skip-partition-child` (`$PISTA_SKIP_PARTITION_CHILD`). Where another tool creates the partitions, pg_partman for example, a schema file that declares the parent alone planned a `DROP TABLE` for every partition, and `-E` only reached names that carry a pattern. With the flag `dump` writes the parent alone, and `plan` / `apply` skip a partition on both sides of the diff, including the indexes, policies and comments it owns. The parent stays managed, and PostgreSQL carries `ADD COLUMN` and an index created on it down to the partitions. A partition is skipped whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it. An `INHERITS` child carries no partition bound and stays managed.

--- a/diff/policies.go
+++ b/diff/policies.go
@@ -50,7 +50,7 @@ func diffPolicies(
 
 	// Detect renames first so subsequent diff steps see the renamed policy
 	// under its new name in the adjusted current map.
-	renameStmts, current, renamedFrom, err := detectPolicyRenames(fqtn, current, desired)
+	current, renamedFrom, err := detectPolicyRenames(fqtn, current, desired)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -71,18 +71,14 @@ func diffPolicies(
 			needsRecreateRenamed[newName] = true
 		}
 	}
-	for newName, oldName := range renamedFrom {
-		if needsRecreateRenamed[newName] {
+	// The renames follow the desired schema's order. renamedFrom is a Go map,
+	// so iterating it would put them in a different order on every run.
+	for newName := range desired.Keys() {
+		oldName, renamed := renamedFrom[newName]
+		if !renamed || needsRecreateRenamed[newName] {
 			continue
 		}
-		// Find the matching rename statement (ordering preserved from desired).
-		needle := "ALTER POLICY " + model.Ident(oldName) + " ON " + fqtn + " RENAME TO " + model.Ident(newName) + ";"
-		for _, stmt := range renameStmts {
-			if stmt == needle {
-				stmts = append(stmts, stmt)
-				break
-			}
-		}
+		stmts = append(stmts, renamePolicySQL(fqtn, oldName, newName))
 	}
 
 	policyAllowed := dc.IsDropAllowed("policy")
@@ -143,6 +139,10 @@ func needsRecreate(a, b *model.Policy) bool {
 
 func dropPolicySQL(fqtn, name string) string {
 	return "DROP POLICY " + model.Ident(name) + " ON " + fqtn + ";"
+}
+
+func renamePolicySQL(fqtn, oldName, newName string) string {
+	return "ALTER POLICY " + model.Ident(oldName) + " ON " + fqtn + " RENAME TO " + model.Ident(newName) + ";"
 }
 
 // alterPolicySQL returns a single ALTER POLICY statement covering the

--- a/diff/policies_test.go
+++ b/diff/policies_test.go
@@ -363,3 +363,68 @@ func TestDiffPolicies_Rename_QuotedIdentifierWithArrow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{`ALTER POLICY "a->b" ON public.documents RENAME TO c;`}, stmts)
 }
+
+// Several renames on one table are emitted in the desired schema's order. The
+// rename bookkeeping is a Go map, whose iteration order is randomized, so a
+// single run can line up by chance; the repeat catches an order that follows
+// the map rather than the desired schema.
+func TestDiffPolicies_RenameOrderFollowsDesired(t *testing.T) {
+	names := []string{"a", "b", "c", "d"}
+
+	want := make([]string, len(names))
+	for i, n := range names {
+		want[i] = "ALTER POLICY old_" + n + " ON public.documents RENAME TO new_" + n + ";"
+	}
+
+	for i := 0; i < 20; i++ {
+		cur := orderedmap.New[string, *model.Policy]()
+		des := orderedmap.New[string, *model.Policy]()
+		for _, n := range names {
+			cur.Set("old_"+n, newPolicy("old_"+n, 'r', withUsing("true")))
+			des.Set("new_"+n, newPolicy("new_"+n, 'r', withUsing("true"), renameFrom("old_"+n)))
+		}
+
+		stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
+		require.NoError(t, err)
+		assert.Equal(t, want, stmts)
+	}
+}
+
+// A directive naming the policy itself is not a rename.
+func TestDiffPolicies_RenameToSameName(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("p", newPolicy("p", 'r', withUsing("true")))
+	des.Set("p", newPolicy("p", 'r', withUsing("true"), renameFrom("p")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+// The run after the rename was applied still carries the directive: the source
+// is gone and the destination is there, so there is nothing left to do.
+func TestDiffPolicies_RenameAlreadyApplied(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("new", newPolicy("new", 'r', withUsing("true")))
+	des.Set("new", newPolicy("new", 'r', withUsing("true"), renameFrom("old")))
+
+	stmts, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, stmts)
+}
+
+// Renaming onto a policy the table already has would collide, so it fails
+// rather than emitting a statement PostgreSQL rejects.
+func TestDiffPolicies_RenameDestinationExists(t *testing.T) {
+	cur := orderedmap.New[string, *model.Policy]()
+	des := orderedmap.New[string, *model.Policy]()
+	cur.Set("old", newPolicy("old", 'r', withUsing("true")))
+	cur.Set("new", newPolicy("new", 'r', withUsing("true")))
+	des.Set("new", newPolicy("new", 'r', withUsing("true"), renameFrom("old")))
+
+	_, _, err := diffPolicies("public.documents", cur, des, allowAllDrops{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot rename policy old to new on public.documents: destination already exists")
+}

--- a/diff/rename.go
+++ b/diff/rename.go
@@ -448,11 +448,11 @@ func detectForeignKeyRenames(fqtn string, current, desired *orderedmap.Map[strin
 }
 
 // detectPolicyRenames finds desired policies with RenameFrom that match a
-// current policy on the same table. Returns the rename statements, the
-// adjusted current map keyed by new names, and a renamedFrom[newName] = oldName
-// map so the caller can suppress the RENAME when the policy needs DROP+CREATE.
-func detectPolicyRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Policy]) ([]string, *orderedmap.Map[string, *model.Policy], map[string]string, error) {
-	var stmts []string
+// current policy on the same table. Returns the adjusted current map keyed by
+// new names and a renamedFrom[newName] = oldName map. The caller renders the
+// ALTER POLICY ... RENAME statements, so it can both suppress the ones whose
+// policy needs DROP+CREATE and keep the rest in the desired schema's order.
+func detectPolicyRenames(fqtn string, current, desired *orderedmap.Map[string, *model.Policy]) (*orderedmap.Map[string, *model.Policy], map[string]string, error) {
 	adjusted := cloneMap(current)
 	renamedFrom := map[string]string{}
 
@@ -471,14 +471,13 @@ func detectPolicyRenames(fqtn string, current, desired *orderedmap.Map[string, *
 			if _, exists := adjusted.GetOk(newName); exists {
 				continue
 			}
-			return nil, nil, nil, fmt.Errorf("rename source policy %s not found on %s", model.Ident(oldName), fqtn)
+			return nil, nil, fmt.Errorf("rename source policy %s not found on %s", model.Ident(oldName), fqtn)
 		}
 
 		if _, exists := adjusted.GetOk(newName); exists {
-			return nil, nil, nil, fmt.Errorf("cannot rename policy %s to %s on %s: destination already exists", model.Ident(oldName), model.Ident(newName), fqtn)
+			return nil, nil, fmt.Errorf("cannot rename policy %s to %s on %s: destination already exists", model.Ident(oldName), model.Ident(newName), fqtn)
 		}
 
-		stmts = append(stmts, "ALTER POLICY "+model.Ident(oldName)+" ON "+fqtn+" RENAME TO "+model.Ident(newName)+";")
 		renamedFrom[newName] = oldName
 
 		adjusted.Delete(oldName)
@@ -487,7 +486,7 @@ func detectPolicyRenames(fqtn string, current, desired *orderedmap.Map[string, *
 		adjusted.Set(newName, &renamed)
 	}
 
-	return stmts, adjusted, renamedFrom, nil
+	return adjusted, renamedFrom, nil
 }
 
 // cloneMap creates a shallow copy of an orderedmap.

--- a/testdata/plan/rls_rename_policies.yml
+++ b/testdata/plan/rls_rename_policies.yml
@@ -1,0 +1,27 @@
+init: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY old_read ON public.documents FOR SELECT USING (owner = current_user);
+  CREATE POLICY old_write ON public.documents FOR INSERT WITH CHECK (owner = current_user);
+  CREATE POLICY old_purge ON public.documents FOR DELETE USING (owner = current_user);
+desired: |
+  CREATE TABLE public.documents (
+      id bigint NOT NULL,
+      owner text NOT NULL,
+      CONSTRAINT documents_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+  -- pista:renamed-from old_read
+  CREATE POLICY new_read ON public.documents FOR SELECT USING (owner = current_user);
+  -- pista:renamed-from old_write
+  CREATE POLICY new_write ON public.documents FOR INSERT WITH CHECK (owner = current_user);
+  -- pista:renamed-from old_purge
+  CREATE POLICY new_purge ON public.documents FOR DELETE USING (owner = current_user);
+plan: |
+  ALTER POLICY old_read ON public.documents RENAME TO new_read;
+  ALTER POLICY old_write ON public.documents RENAME TO new_write;
+  ALTER POLICY old_purge ON public.documents RENAME TO new_purge;


### PR DESCRIPTION
`diffPolicies` read the renames out of `renamedFrom`, a Go map keyed by the new name, so the `ALTER POLICY ... RENAME TO` statements came out in a random order. One rename on a table cannot show it; two or more, and the same desired schema produced a different plan on each run. The statements are independent, so nothing broke, but a plan that is reviewed, or diffed against the previous run, has to be stable.

The renames now follow `desired`, which is an ordered map, the way `DiffViews` and `diffTriggers` already do. Rendering the statement moved to the caller, so `detectPolicyRenames` returns the rename map alone, and `diffPolicies` both suppresses the ones whose policy needs DROP+CREATE and keeps the rest in order. That also drops the needle matching the old code used to pair a statement with its entry.

## Tests

`TestDiffPolicies_RenameOrderFollowsDesired` repeats the diff, since a single run can line up by chance, and `testdata/plan/rls_rename_policies.yml` covers the same case end to end. Both fail on `main`: the unit test on every run, the fixture on about five runs in six.

`detectPolicyRenames` was reached only through `diffPolicies`, so its remaining branches are covered too: a directive naming the policy itself, a rename already applied, and a destination that already exists. It goes from 90.3% to 100%.

Measured the way CI does on PostgreSQL 16, 94.677% -> 94.714%. `make lint`, `make deadcode` and `make test` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mm1HUGN1Khg8K8UVjJ6MGd)_