### PR TITLE
Filter the desired sequences by schema too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Leave a sequence the desired schema declares outside the target schemas alone. The desired-side schema filter named every object type but the sequence, so a `CREATE SEQUENCE other.counter` sitting in a file planned with `-n public` was compared against a current side that never holds it, and the plan created it in a schema the run was not asked to manage. A table, view, enum, domain, composite type or routine in the same file was already dropped before the diff.
+
 ## [1.34.0] - 2026-08-28
 
 * Manage a partitioned table without its partitions, behind `--skip-partition-child` (`$PISTA_SKIP_PARTITION_CHILD`). Where another tool creates the partitions, pg_partman for example, a schema file that declares the parent alone planned a `DROP TABLE` for every partition, and `-E` only reached names that carry a pattern. With the flag `dump` writes the parent alone, and `plan` / `apply` skip a partition on both sides of the diff, including the indexes, policies and comments it owns. The parent stays managed, and PostgreSQL carries `ADD COLUMN` and an index created on it down to the partitions. A partition is skipped whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it. An `INHERITS` child carries no partition bound and stays managed.

--- a/schema_filter.go
+++ b/schema_filter.go
@@ -9,6 +9,12 @@ import (
 // filterDesiredBySchemas removes objects from the parse result whose schema
 // is not in the target schemas list. This prevents objects from unrelated
 // schemas in the SQL file from being treated as desired state.
+//
+// Every object map ParseResult carries is named below. One left out reaches the
+// diff with nothing to compare against, so the plan creates it in a schema the
+// run was not asked to manage. ExecuteStmts is not an object map: a
+// -- pista:execute statement is raw SQL the file asked to run, which carries no
+// schema to filter on.
 func filterDesiredBySchemas(result *parser.ParseResult, schemas []string, schemaMap map[string]string) {
 	schemaSet := make(map[string]bool, len(schemas))
 	for _, s := range schemas {
@@ -24,6 +30,7 @@ func filterDesiredBySchemas(result *parser.ParseResult, schemas []string, schema
 	result.Enums = filterMapBySchema(result.Enums, schemaSet, func(e *model.Enum) string { return e.Schema })
 	result.Domains = filterMapBySchema(result.Domains, schemaSet, func(d *model.Domain) string { return d.Schema })
 	result.CompositeTypes = filterMapBySchema(result.CompositeTypes, schemaSet, func(ct *model.CompositeType) string { return ct.Schema })
+	result.Sequences = filterMapBySchema(result.Sequences, schemaSet, func(s *model.Sequence) string { return s.Schema })
 	result.Routines = filterMapBySchema(result.Routines, schemaSet, func(r *model.Routine) string { return r.Schema })
 }
 

--- a/testdata/plan/desired_schema_filtered.yml
+++ b/testdata/plan/desired_schema_filtered.yml
@@ -1,5 +1,8 @@
+# Every object type the desired schema can declare outside the target schemas
+# is dropped before the diff, so none of them is created.
 count:
   tables: 1
+manage_routine: true
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,
@@ -13,4 +16,10 @@ desired: |
   CREATE TABLE other.stuff (
       id integer NOT NULL
   );
+  CREATE VIEW other.stuff_view AS SELECT id FROM other.stuff;
+  CREATE TYPE other.mood AS ENUM ('ok', 'bad');
+  CREATE DOMAIN other.positive AS integer CONSTRAINT positive_check CHECK (VALUE > 0);
+  CREATE TYPE other.point AS (x integer, y integer);
+  CREATE SEQUENCE other.counter;
+  CREATE FUNCTION other.answer() RETURNS integer LANGUAGE sql AS $$SELECT 42$$;
 plan: ""


### PR DESCRIPTION
`filterDesiredBySchemas` drops the objects a desired SQL file declares outside the schemas the run manages, so a file holding more than one schema can be planned one schema at a time. It named tables, views, enums, domains, composite types and routines, and left `ParseResult.Sequences` alone.

A sequence in another schema therefore reached the diff, where the current side is read from the target schemas alone and never holds it, so it read as new and the plan carried a `CREATE SEQUENCE` for a schema the run was not asked to touch. `apply` goes through the same `diffAll`, so it created it.

## Tests

`testdata/plan/desired_schema_filtered.yml` covered the case for a table alone. It now declares every object type outside the target schema. On `main` it fails with exactly one statement, the `CREATE SEQUENCE`, which is both the reproduction and the proof that the other six already worked.

`filterDesiredBySchemas` names each map explicitly, which is what let this one slip, so the doc comment now says what a missing name costs and why `ExecuteStmts` is not one.

Measured the way CI does on PostgreSQL 16, 94.677% -> 94.678%. `make lint`, `make deadcode` and `make test` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mm1HUGN1Khg8K8UVjJ6MGd)_