### PR TITLE
Walk the whole parse tree for a view's dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Order a view after every relation its body names. The dependency scan walked a hand-written list of node kinds, so a reference under a cast, `GREATEST`, an array or row constructor, a subscript, `ORDER BY`, `GROUP BY`, `LIMIT`, an `OVER` clause or an aggregate `FILTER` went unseen. Two new views in one run, one reading the other from such a position, were created in the wrong order and the apply failed on the relation that did not exist yet. The scan now uses the same walk the view comparison does, which reaches every node kind.
+
 ## [1.34.0] - 2026-08-28
 
 * Manage a partitioned table without its partitions, behind `--skip-partition-child` (`$PISTA_SKIP_PARTITION_CHILD`). Where another tool creates the partitions, pg_partman for example, a schema file that declares the parent alone planned a `DROP TABLE` for every partition, and `-E` only reached names that carry a pattern. With the flag `dump` writes the parent alone, and `plan` / `apply` skip a partition on both sides of the diff, including the indexes, policies and comments it owns. The parent stays managed, and PostgreSQL carries `ADD COLUMN` and an index created on it down to the partitions. A partition is skipped whether or not it is partitioned itself, so a sub-partitioned level goes with the leaves under it. An `INHERITS` child carries no partition bound and stays managed.

--- a/toposort/schema.go
+++ b/toposort/schema.go
@@ -7,6 +7,7 @@ import (
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 	"github.com/winebarrel/orderedmap/v2"
+	"github.com/winebarrel/pistachio/internal/pgast"
 	"github.com/winebarrel/pistachio/model"
 )
 
@@ -243,6 +244,12 @@ func resolveUnqualified(name, defaultSchema string, defined map[string]bool) str
 
 // extractViewDeps parses a view definition SQL to find referenced tables/views.
 // Uses pg_query to parse the SELECT statement and extract RangeVar references.
+//
+// The walk reaches every node kind, which the older enumeration could not do: a
+// sub-query under a cast, GREATEST, an array or row constructor, a subscript,
+// ORDER BY, GROUP BY, LIMIT, an OVER clause or an aggregate FILTER named a
+// relation the view was then ordered without waiting for. Two new views in one
+// run, one reading the other from such a position, applied in the wrong order.
 func extractViewDeps(definition, defaultSchema string, defined map[string]bool) []string {
 	seen := make(map[string]bool)
 
@@ -256,9 +263,15 @@ func extractViewDeps(definition, defaultSchema string, defined map[string]bool) 
 		return extractViewDepsFallback(definition, defaultSchema, defined)
 	}
 
-	// Walk the AST to find RangeVar nodes
 	for _, stmt := range result.Stmts {
-		collectRangeVars(stmt.Stmt, defaultSchema, defined, seen)
+		pgast.Walk(stmt.Stmt, pgast.WalkOptions{}, func(_ pgast.Ctx, node *pg_query.Node) *pg_query.Node {
+			if rv := node.GetRangeVar(); rv != nil {
+				if name := qualifyRangeVar(rv, defaultSchema, defined); name != "" {
+					seen[name] = true
+				}
+			}
+			return node
+		})
 	}
 
 	deps := make([]string, 0, len(seen))
@@ -267,124 +280,6 @@ func extractViewDeps(definition, defaultSchema string, defined map[string]bool) 
 	}
 	sort.Strings(deps)
 	return deps
-}
-
-// collectRangeVars recursively walks a pg_query Node tree to find all
-// RangeVar references (table/view names in FROM clauses, JOINs, subqueries).
-func collectRangeVars(node *pg_query.Node, defaultSchema string, defined map[string]bool, seen map[string]bool) {
-	if node == nil {
-		return
-	}
-
-	// Check if this node is a RangeVar
-	if rv := node.GetRangeVar(); rv != nil {
-		if name := qualifyRangeVar(rv, defaultSchema, defined); name != "" {
-			seen[name] = true
-		}
-		return
-	}
-
-	// Check if this is a SelectStmt and walk its parts
-	if ss := node.GetSelectStmt(); ss != nil {
-		// CTEs (WITH clause)
-		if ss.WithClause != nil {
-			for _, cte := range ss.WithClause.Ctes {
-				if c := cte.GetCommonTableExpr(); c != nil {
-					collectRangeVars(c.Ctequery, defaultSchema, defined, seen)
-				}
-			}
-		}
-		// FROM clause
-		for _, from := range ss.FromClause {
-			collectRangeVars(from, defaultSchema, defined, seen)
-		}
-		// Target list (scalar subqueries in SELECT)
-		for _, target := range ss.TargetList {
-			if rt := target.GetResTarget(); rt != nil && rt.Val != nil {
-				collectRangeVars(rt.Val, defaultSchema, defined, seen)
-			}
-		}
-		if ss.WhereClause != nil {
-			collectRangeVars(ss.WhereClause, defaultSchema, defined, seen)
-		}
-		if ss.HavingClause != nil {
-			collectRangeVars(ss.HavingClause, defaultSchema, defined, seen)
-		}
-		// Set operations (UNION, INTERSECT, EXCEPT)
-		if ss.Larg != nil {
-			collectRangeVars(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Larg}}, defaultSchema, defined, seen)
-		}
-		if ss.Rarg != nil {
-			collectRangeVars(&pg_query.Node{Node: &pg_query.Node_SelectStmt{SelectStmt: ss.Rarg}}, defaultSchema, defined, seen)
-		}
-		return
-	}
-
-	// Walk JoinExpr (including join qualifiers that may contain subqueries)
-	if join := node.GetJoinExpr(); join != nil {
-		collectRangeVars(join.Larg, defaultSchema, defined, seen)
-		collectRangeVars(join.Rarg, defaultSchema, defined, seen)
-		if join.Quals != nil {
-			collectRangeVars(join.Quals, defaultSchema, defined, seen)
-		}
-		return
-	}
-
-	// Walk subselect
-	if sub := node.GetRangeSubselect(); sub != nil {
-		collectRangeVars(sub.Subquery, defaultSchema, defined, seen)
-		return
-	}
-
-	// Walk sublink (subquery in WHERE/HAVING clause, e.g., EXISTS, IN)
-	if sl := node.GetSubLink(); sl != nil {
-		collectRangeVars(sl.Subselect, defaultSchema, defined, seen)
-		return
-	}
-
-	// Walk expression nodes that may contain subqueries
-	if expr := node.GetAExpr(); expr != nil {
-		collectRangeVars(expr.Lexpr, defaultSchema, defined, seen)
-		collectRangeVars(expr.Rexpr, defaultSchema, defined, seen)
-		return
-	}
-
-	if boolExpr := node.GetBoolExpr(); boolExpr != nil {
-		for _, arg := range boolExpr.Args {
-			collectRangeVars(arg, defaultSchema, defined, seen)
-		}
-		return
-	}
-
-	if fc := node.GetFuncCall(); fc != nil {
-		for _, arg := range fc.Args {
-			collectRangeVars(arg, defaultSchema, defined, seen)
-		}
-		return
-	}
-
-	if ce := node.GetCoalesceExpr(); ce != nil {
-		for _, arg := range ce.Args {
-			collectRangeVars(arg, defaultSchema, defined, seen)
-		}
-		return
-	}
-
-	if cs := node.GetCaseExpr(); cs != nil {
-		if cs.Arg != nil {
-			collectRangeVars(cs.Arg, defaultSchema, defined, seen)
-		}
-		for _, when := range cs.Args {
-			if w := when.GetCaseWhen(); w != nil {
-				collectRangeVars(w.Expr, defaultSchema, defined, seen)
-				collectRangeVars(w.Result, defaultSchema, defined, seen)
-			}
-		}
-		if cs.Defresult != nil {
-			collectRangeVars(cs.Defresult, defaultSchema, defined, seen)
-		}
-		return
-	}
 }
 
 // qualifyRangeVar returns the schema-qualified FQDN of a RangeVar that exists

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -1252,3 +1252,85 @@ func TestOrderFromSchema_ViewWithFromSubquery(t *testing.T) {
 
 	assert.Less(t, idx["public.orders"], idx["public.order_totals"], "orders referenced in FROM subquery")
 }
+
+// A table reference sits wherever an expression can, and the walk has to reach
+// all of them. Each case names z_defaults from a position of its own. That name
+// sorts after the view, so only the dependency edge can place it first.
+func TestOrderFromSchema_ViewWithNestedSubquery(t *testing.T) {
+	definitions := map[string]string{
+		"cast":       "SELECT id, (SELECT val FROM z_defaults LIMIT 1)::text FROM users",
+		"greatest":   "SELECT id, GREATEST((SELECT val FROM z_defaults LIMIT 1), 0) FROM users",
+		"order by":   "SELECT id FROM users ORDER BY (SELECT val FROM z_defaults LIMIT 1)",
+		"group by":   "SELECT id FROM users GROUP BY id, (SELECT val FROM z_defaults LIMIT 1)",
+		"array":      "SELECT id, ARRAY[(SELECT val FROM z_defaults LIMIT 1)] FROM users",
+		"row":        "SELECT id, ROW((SELECT val FROM z_defaults LIMIT 1)) FROM users",
+		"is null":    "SELECT id FROM users WHERE (SELECT val FROM z_defaults LIMIT 1) IS NULL",
+		"window":     "SELECT id, count(*) OVER (PARTITION BY (SELECT val FROM z_defaults LIMIT 1)) FROM users",
+		"limit":      "SELECT id FROM users LIMIT (SELECT val FROM z_defaults LIMIT 1)",
+		"lateral":    "SELECT u.id FROM users u, LATERAL (SELECT val FROM z_defaults) d",
+		"filter":     "SELECT count(*) FILTER (WHERE id > (SELECT val FROM z_defaults LIMIT 1)) FROM users",
+		"values":     "SELECT id FROM users UNION ALL SELECT * FROM (VALUES ((SELECT val FROM z_defaults LIMIT 1))) v(id)",
+		"subscript":  "SELECT id, (ARRAY[1, 2])[(SELECT val FROM z_defaults LIMIT 1)] FROM users",
+		"not exists": "SELECT id FROM users WHERE NOT EXISTS (SELECT 1 FROM z_defaults)",
+	}
+
+	for name, definition := range definitions {
+		t.Run(name, func(t *testing.T) {
+			tables := orderedmap.New[string, *model.Table]()
+			tables.Set("public.users", newTable("public", "users"))
+			tables.Set("public.z_defaults", newTable("public", "z_defaults"))
+
+			views := orderedmap.New[string, *model.View]()
+			views.Set("public.a_view", &model.View{Schema: "public", Name: "a_view", Definition: definition})
+
+			order, err := orderFromSchema(
+				orderedmap.New[string, *model.Enum](),
+				orderedmap.New[string, *model.Domain](),
+				tables, views)
+			require.NoError(t, err)
+
+			idx := make(map[string]int)
+			for i, n := range order {
+				idx[n] = i
+			}
+			assert.Less(t, idx["public.users"], idx["public.a_view"])
+			assert.Less(t, idx["public.z_defaults"], idx["public.a_view"])
+		})
+	}
+}
+
+// A composite type is created after the types its attributes name. Both names
+// sort after the composite type, so only the dependency edges place them first.
+func TestOrderFromSchema_CompositeTypeAttributeTypes(t *testing.T) {
+	enums := orderedmap.New[string, *model.Enum]()
+	enums.Set("public.z_status", &model.Enum{Schema: "public", Name: "z_status", Values: []string{"ok"}})
+
+	domains := orderedmap.New[string, *model.Domain]()
+	domains.Set("public.z_positive", &model.Domain{Schema: "public", Name: "z_positive", BaseType: "integer"})
+
+	compositeTypes := orderedmap.New[string, *model.CompositeType]()
+	compositeTypes.Set("public.a_row", &model.CompositeType{
+		Schema: "public",
+		Name:   "a_row",
+		Attributes: []*model.CompositeAttribute{
+			{Name: "state", TypeName: "z_status"},
+			{Name: "qty", TypeName: "public.z_positive"},
+		},
+	})
+
+	order, err := toposort.OrderFromSchema(
+		enums, domains, compositeTypes,
+		orderedmap.New[string, *model.Table](),
+		orderedmap.New[string, *model.View](),
+		orderedmap.New[string, *model.Sequence](),
+		orderedmap.New[string, *model.Routine]())
+	require.NoError(t, err)
+
+	idx := make(map[string]int)
+	for i, name := range order {
+		idx[name] = i
+	}
+
+	assert.Less(t, idx["public.z_status"], idx["public.a_row"], "enum before composite type")
+	assert.Less(t, idx["public.z_positive"], idx["public.a_row"], "domain before composite type")
+}


### PR DESCRIPTION
`collectRangeVars` was five levels of hand-written recursion over about a dozen node kinds. A relation named from a position none of them descended into was not seen, so the view got no edge and the topological order placed it wherever the name sort put it. Two new views in one run, one reading the other from such a position, were created in the wrong order and the apply failed on the relation that did not exist yet. A new view over an existing table was fine, since tables are created in an earlier phase.

The positions that went unseen are ordinary: a scalar sub-query under a cast, which `pg_get_viewdef` adds on its own, and one under `GREATEST`, an array or row constructor, a subscript, `ORDER BY`, `GROUP BY`, `LIMIT`, an `OVER` clause or an aggregate `FILTER`.

`pgast.Walk` already reaches every node kind through protoreflect, and its own comment names this failure mode, so the scan uses it and the recursion goes away. The visitor keeps the `RangeVar` rule the old one ended at, so a CTE name still resolves the way it did.

## Tests

`TestOrderFromSchema_ViewWithNestedSubquery` names one relation from each position that was missed. 12 of its 14 cases fail on `main`; the two that pass, `LATERAL` and `NOT EXISTS`, went through `RangeSubselect` and `BoolExpr`, which the old recursion did handle.

Deleting 59 well-covered statements would have dropped the percentage on its own, so the composite-type attribute edges, which had no test at all, get one. That leaves it above where it started.

Measured the way CI does on PostgreSQL 16, 94.677% -> 94.730%. `make lint`, `make deadcode`, `make test` and `make test-scenario` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mm1HUGN1Khg8K8UVjJ6MGd)_