### PR TITLE
Compare a function call without its schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Stop a schema-qualified function call from drifting. `pg_get_constraintdef`, `pg_get_expr`, `pg_get_indexdef`, `pg_get_viewdef` and `pg_get_triggerdef` all print a call unqualified once the function's schema is on the search_path, while the desired side keeps what the file wrote, so `CHECK (public.lower_v(v) <> 'x')` and every other call written that way re-emitted its statement on every plan. A `CHECK` was dropped and re-added, which revalidates the whole table, an index was rebuilt, and a materialized view was dropped and recreated, discarding the data it held. A generated expression did not drift but failed the run outright, since it cannot be altered in place. The strip is symmetric and carries the tradeoff a view body's table reference already has: two same-named functions in different schemas compare equal. A schema inside a `nextval('public.counter'::regclass)` literal is not a call name and still drifts; TODO.md covers it.
+
 * Name the same pair every run when `-m` maps two schemas onto one destination. The check walked a Go map, so with three sources on one destination the rejection named a different pair each time the same command was run.
 
 * Stop one suppressed constraint rename from taking another with it. A renamed constraint whose definition also changes goes through `DROP` and `ADD` rather than `RENAME`, and the `RENAME` was suppressed by matching the rendered statement as a substring. With `a` renamed to `b` alongside `xa` renamed to `by` on one table, the needle for the first matched the statement for the second, so `xa` was left in the database under its old name and the same plan came back on the next run. Foreign keys were suppressed the same way and had the same hole.

--- a/TODO.md
+++ b/TODO.md
@@ -548,49 +548,34 @@ is the same prerequisite as the INHERITS plan / apply entry above.
 
 Origin: review of [#340](https://github.com/winebarrel/pistachio/pull/340).
 
-## Perpetual drift on a schema-qualified function call in a CHECK constraint
+## Perpetual drift on a schema-qualified sequence in a column DEFAULT
 
 Priority: low.
 
-A CHECK constraint that calls a function schema-qualified, written as
-`CHECK (public.lower_v(v) <> 'x')`, is re-emitted as `DROP CONSTRAINT` +
-`ADD CONSTRAINT` on every plan. Applying it succeeds and changes nothing, so
-`plan --check` stays at exit code 2 forever. `pg_get_constraintdef` returns
-the call unqualified when the function's schema is on the search_path, while
-the desired side keeps what the user wrote.
+A column `DEFAULT nextval('public.counter'::regclass)` is re-emitted as
+`ALTER COLUMN ... SET DEFAULT` on every plan. Applying it succeeds and changes
+nothing, so `plan --check` stays at exit code 2 forever. `pg_get_expr` returns
+the sequence unqualified when its schema is on the search_path, while the
+desired side keeps what the user wrote.
 
-`normalizeCheckExpr` (`diff/tables.go`) strips text-like casts and
-canonicalises `= ANY(ARRAY[...])` -> `IN (...)`, but never touches the
-`FuncCall` name, so the two forms deparse differently. Index expressions
-and index predicates run through `normalizeCheckExpr` as well
-(`normalizeIndexStmt`), so the same drift is expected there. A view body
-that calls a function qualified drifts the same way: `stripQualifications`
-(`diff/views.go`) clears `RangeVar.Schemaname` and never looks at the call.
+The call itself no longer drifts: `stripFuncSchema` (`diff/tables.go`) drops
+the schema from a `FuncCall` name symmetrically, which reaches every site
+`normalizeCheckExpr` covers. The sequence here is not in that name. It sits
+inside a string literal argument, so reaching it means reading the regclass
+literal, quoted identifiers included. `equalDefault` applies no schema
+normalization of any kind beyond the walk.
 
-A column `DEFAULT nextval('public.counter'::regclass)` drifts too, but not
-through the same node. The schema sits inside a string literal argument
-rather than in a `FuncCall` name, so stripping the name symmetrically leaves
-it; reaching it means reading the regclass literal. `equalDefault` applies no
-schema normalization of any kind.
+A function moved between two schemas is the cost of the symmetric strip:
+`a.f(v)` and `b.f(v)` compare equal, so the move produces no diff. This is the
+tradeoff a view body's table reference already carries. Telling them apart
+means the search_path-aware stripping described in the cross-schema user-type
+entry above, which the diff cannot do today because it does not thread the
+schema list.
 
-The codebase already normalizes schema qualification three different ways.
-`stripQualifications` (`diff/views.go`) clears `RangeVar.Schemaname` and a
-table-qualified `ColumnRef` unconditionally on both sides, without
-consulting the search_path. `normalizeFKSchema` (`diff/tables.go`) goes the
-other way and fills an empty schema in with the owning table's. And
-`stripTypeSchema` (`diff/tables.go`) removes only the container's own
-schema prefix.
+Workaround: write the sequence unqualified.
 
-The view approach is the cheapest fit here: strip the schema from a
-`FuncCall` name symmetrically in `normalizeCheckExpr`. It carries the same
-tradeoff views already accept, that two same-named functions in different
-schemas compare equal. The stricter alternative is the search_path-aware
-stripping described in the cross-schema user-type entry above, which the
-diff cannot do today because it does not thread the schema list.
-
-Workaround: write the call unqualified.
-
-Origin: found while adding `-- pista:execute-first`, 2026-07-31.
+Origin: found while adding `-- pista:execute-first`, 2026-07-31. The function
+call half was closed later; the literal half is what remains.
 
 ## Perpetual drift on a serial column written as an explicit default
 

--- a/TODO.md
+++ b/TODO.md
@@ -548,6 +548,33 @@ is the same prerequisite as the INHERITS plan / apply entry above.
 
 Origin: review of [#340](https://github.com/winebarrel/pistachio/pull/340).
 
+## An EXCLUDE constraint is not normalized at all
+
+Priority: low.
+
+`equalConstraintDef` normalizes `RawExpr`, which is where a `CHECK` body sits.
+An exclusion constraint puts its elements in `Constraint.Exclusions` and its
+predicate in `Constraint.WhereClause`, and neither goes through
+`normalizeCheckExpr`, so the two sides are compared as the parser left them.
+
+Every normalization the walk performs is therefore missing there. A
+schema-qualified call drifts, `EXCLUDE USING btree (public.lower_v(v) WITH =)`
+being re-emitted as `DROP CONSTRAINT` + `ADD CONSTRAINT` on every plan, and so
+does a cast the catalog adds and the file does not: `((v || 'x') WITH =)` is
+stored as `((v || 'x'::text) WITH =)`. This is wider than the schema question
+and predates the strip.
+
+Passing `Exclusions` and `WhereClause` through the same walk is the obvious
+shape, and the elements are `IndexElem` nodes, which `normalizeIndexStmt`
+already knows how to handle.
+
+`dump` writes the catalog form, so a dump fed back plans clean and only a
+hand-written exclusion reaches this.
+
+Workaround: write the exclusion the way `pg_get_constraintdef` prints it.
+
+Origin: review of [#455](https://github.com/winebarrel/pistachio/pull/455).
+
 ## Perpetual drift on a schema-qualified sequence in a column DEFAULT
 
 Priority: low.

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -596,6 +596,20 @@ func normalizeExprNode(ctx pgast.Ctx, node *pg_query.Node) *pg_query.Node {
 	return node
 }
 
+// lastNamePart drops everything before the final part of a qualified name, so
+// schema.f and catalog.schema.f both reduce to f. PostgreSQL accepts the
+// three-part form when the catalog names the current database, and pg_query
+// parses it, so matching on a two-part name alone would leave it drifting.
+//
+// parseTriggerDef applies it to an EXECUTE FUNCTION name, which is not an
+// expression node and so never reaches the walk below.
+func lastNamePart(name []*pg_query.Node) []*pg_query.Node {
+	if len(name) < 2 {
+		return name
+	}
+	return name[len(name)-1:]
+}
+
 // stripFuncSchema drops the schema qualifier from a function call name, so
 // public.f(v) and f(v) compare equal.
 //
@@ -611,14 +625,9 @@ func normalizeExprNode(ctx pgast.Ctx, node *pg_query.Node) *pg_query.Node {
 // functions in different schemas compare equal, so moving a call from one
 // schema to another produces no diff. Telling them apart means reading the
 // search_path, which the diff does not thread.
-//
-// Everything before the last part goes, so schema.f and catalog.schema.f both
-// reduce to f. PostgreSQL accepts the three-part form when the catalog names
-// the current database, and pg_query parses it, so matching on a two-part name
-// alone would leave it drifting.
 func stripFuncSchema(node *pg_query.Node) {
-	if fc := node.GetFuncCall(); fc != nil && len(fc.Funcname) > 1 {
-		fc.Funcname = fc.Funcname[len(fc.Funcname)-1:]
+	if fc := node.GetFuncCall(); fc != nil {
+		fc.Funcname = lastNamePart(fc.Funcname)
 	}
 }
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -612,11 +612,13 @@ func normalizeExprNode(ctx pgast.Ctx, node *pg_query.Node) *pg_query.Node {
 // schema to another produces no diff. Telling them apart means reading the
 // search_path, which the diff does not thread.
 //
-// Only a two-part name is touched. A bare name has nothing to strip, and a
-// longer one is not a function call the parser accepts.
+// Everything before the last part goes, so schema.f and catalog.schema.f both
+// reduce to f. PostgreSQL accepts the three-part form when the catalog names
+// the current database, and pg_query parses it, so matching on a two-part name
+// alone would leave it drifting.
 func stripFuncSchema(node *pg_query.Node) {
-	if fc := node.GetFuncCall(); fc != nil && len(fc.Funcname) == 2 {
-		fc.Funcname = fc.Funcname[1:]
+	if fc := node.GetFuncCall(); fc != nil && len(fc.Funcname) > 1 {
+		fc.Funcname = fc.Funcname[len(fc.Funcname)-1:]
 	}
 }
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -552,8 +552,10 @@ func isSerialType(typeName string) bool {
 //     expression.
 //   - Turns those operators against a bare NULL literal into the IS NULL test
 //     parse analysis rewrites them to, and inverts such a test under a NOT.
+//   - Drops the schema qualifier from a function call name, which the catalog
+//     omits whenever the function's schema is on the search_path.
 //
-// All four are symmetric: they apply to the catalog side and the written side
+// All five are symmetric: they apply to the catalog side and the written side
 // alike. The walk reaches every node kind, so a sub-query inside an RLS policy
 // or a view body, and an expression inside a SQL/JSON constructor, get the
 // same treatment as a top-level operand.
@@ -590,7 +592,32 @@ func normalizeExprNode(ctx pgast.Ctx, node *pg_query.Node) *pg_query.Node {
 	if folded := foldNotNullTest(node); folded != nil {
 		return folded
 	}
+	stripFuncSchema(node)
 	return node
+}
+
+// stripFuncSchema drops the schema qualifier from a function call name, so
+// public.f(v) and f(v) compare equal.
+//
+// pg_get_constraintdef, pg_get_expr, pg_get_indexdef, pg_get_viewdef and
+// pg_get_triggerdef print a call unqualified whenever the function's schema is
+// on the search_path, while the desired side keeps what the file wrote. Left
+// alone, a qualified call re-emits its constraint, index, policy, trigger,
+// default or view on every plan, and a generated expression, which cannot be
+// altered in place, fails the run outright.
+//
+// This is the treatment a view body's table reference already gets from
+// stripQualifications, and it carries the same tradeoff: two same-named
+// functions in different schemas compare equal, so moving a call from one
+// schema to another produces no diff. Telling them apart means reading the
+// search_path, which the diff does not thread.
+//
+// Only a two-part name is touched. A bare name has nothing to strip, and a
+// longer one is not a function call the parser accepts.
+func stripFuncSchema(node *pg_query.Node) {
+	if fc := node.GetFuncCall(); fc != nil && len(fc.Funcname) == 2 {
+		fc.Funcname = fc.Funcname[1:]
+	}
 }
 
 // foldNotDistinct turns NOT (a IS DISTINCT FROM b) into the equivalent

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -602,7 +602,7 @@ func normalizeExprNode(ctx pgast.Ctx, node *pg_query.Node) *pg_query.Node {
 // parses it, so matching on a two-part name alone would leave it drifting.
 //
 // parseTriggerDef applies it to an EXECUTE FUNCTION name, which is not an
-// expression node and so never reaches the walk below.
+// expression node and so never reaches the walk above.
 func lastNamePart(name []*pg_query.Node) []*pg_query.Node {
 	if len(name) < 2 {
 		return name

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -3509,3 +3509,52 @@ func TestDiffForeignKeys_RenameSuppressionKeepsOtherRenames(t *testing.T) {
 		"ALTER TABLE ONLY public.t ADD CONSTRAINT b FOREIGN KEY (pid) REFERENCES q(id);",
 	}, addStmts)
 }
+
+// A call written schema-qualified compares equal to the unqualified form the
+// catalog prints once the function's schema is on the search_path. One case
+// per comparison entry point, since each parses its own way in.
+func TestStripFuncSchema(t *testing.T) {
+	t.Run("constraint", func(t *testing.T) {
+		assert.True(t, equalConstraintDef(
+			"CHECK ((lower_v(v) <> 'x'::text))",
+			"CHECK (public.lower_v(v) <> 'x')"))
+	})
+
+	t.Run("index expression", func(t *testing.T) {
+		assert.True(t, equalIndexDef(
+			"CREATE INDEX i ON public.t USING btree (lower_v(v))",
+			"CREATE INDEX i ON public.t USING btree (public.lower_v(v))"))
+	})
+
+	t.Run("index predicate", func(t *testing.T) {
+		assert.True(t, equalIndexDef(
+			"CREATE INDEX i ON public.t USING btree (v) WHERE (lower_v(v) <> 'y'::text)",
+			"CREATE INDEX i ON public.t USING btree (v) WHERE public.lower_v(v) <> 'y'"))
+	})
+
+	t.Run("select expression", func(t *testing.T) {
+		assert.True(t, equalSelectExpr("lower_v(v)", "public.lower_v(v)"))
+	})
+
+	t.Run("default", func(t *testing.T) {
+		assert.True(t, equalDefault(new("lower_v('A'::text)"), new("public.lower_v('A')")))
+	})
+
+	t.Run("view body", func(t *testing.T) {
+		assert.True(t, equalViewDef(
+			"SELECT lower_v(t.v) AS lv FROM t",
+			"SELECT public.lower_v(t.v) AS lv FROM public.t"))
+	})
+
+	// PostgreSQL accepts catalog.schema.f when the catalog names the current
+	// database, so the strip cannot key on a two-part name alone.
+	t.Run("three-part name", func(t *testing.T) {
+		assert.True(t, equalSelectExpr("lower_v(v)", "postgres.public.lower_v(v)"))
+	})
+
+	// A bare name has nothing to strip and must survive untouched.
+	t.Run("unqualified is left alone", func(t *testing.T) {
+		assert.True(t, equalSelectExpr("lower_v(v)", "lower_v(v)"))
+		assert.False(t, equalSelectExpr("lower_v(v)", "upper_v(v)"))
+	})
+}

--- a/diff/triggers.go
+++ b/diff/triggers.go
@@ -219,10 +219,12 @@ func alterTriggerStateSQL(fqtn string, trg *model.Trigger) string {
 
 // parseTriggerDef parses a CREATE TRIGGER statement and takes out the wording
 // that says nothing about the trigger's state: an implicit relation schema is
-// filled in from the owning relation, OR REPLACE is cleared, and the WHEN
-// expression goes through the normalization constraint CHECK bodies use, since
-// pg_get_triggerdef adds casts there the way pg_get_constraintdef does. It
-// returns the whole result so the caller can deparse it back.
+// filled in from the owning relation, OR REPLACE is cleared, the schema of the
+// EXECUTE FUNCTION name is dropped, since pg_get_triggerdef omits it once the
+// function's schema is on the search_path, and the WHEN expression goes through
+// the normalization constraint CHECK bodies use, since pg_get_triggerdef adds
+// casts there the way pg_get_constraintdef does. It returns the whole result so
+// the caller can deparse it back.
 func parseTriggerDef(def, schema string) (*pg_query.ParseResult, *pg_query.CreateTrigStmt, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {
@@ -239,6 +241,9 @@ func parseTriggerDef(def, schema string) (*pg_query.ParseResult, *pg_query.Creat
 		ct.Relation.Schemaname = schema
 	}
 	ct.Replace = false
+	if len(ct.Funcname) == 2 {
+		ct.Funcname = ct.Funcname[1:]
+	}
 	if ct.WhenClause != nil {
 		ct.WhenClause = normalizeCheckExpr(ct.WhenClause)
 	}

--- a/diff/triggers.go
+++ b/diff/triggers.go
@@ -221,11 +221,10 @@ func alterTriggerStateSQL(fqtn string, trg *model.Trigger) string {
 // that says nothing about the trigger's state. An implicit relation schema is
 // filled in from the owning relation, and OR REPLACE is cleared.
 //
-// The EXECUTE FUNCTION name loses its schema, which pg_get_triggerdef omits
-// once the function's schema is on the search_path, the way stripFuncSchema
-// handles a call inside an expression. The WHEN expression goes through the
-// normalization constraint CHECK bodies use, since pg_get_triggerdef adds casts
-// there the way pg_get_constraintdef does.
+// The EXECUTE FUNCTION name goes through lastNamePart, since pg_get_triggerdef
+// omits the schema once the function's schema is on the search_path. The WHEN
+// expression goes through the normalization constraint CHECK bodies use, since
+// pg_get_triggerdef adds casts there the way pg_get_constraintdef does.
 //
 // It returns the whole result so the caller can deparse it back.
 func parseTriggerDef(def, schema string) (*pg_query.ParseResult, *pg_query.CreateTrigStmt, error) {
@@ -244,9 +243,7 @@ func parseTriggerDef(def, schema string) (*pg_query.ParseResult, *pg_query.Creat
 		ct.Relation.Schemaname = schema
 	}
 	ct.Replace = false
-	if len(ct.Funcname) > 1 {
-		ct.Funcname = ct.Funcname[len(ct.Funcname)-1:]
-	}
+	ct.Funcname = lastNamePart(ct.Funcname)
 	if ct.WhenClause != nil {
 		ct.WhenClause = normalizeCheckExpr(ct.WhenClause)
 	}

--- a/diff/triggers.go
+++ b/diff/triggers.go
@@ -218,13 +218,16 @@ func alterTriggerStateSQL(fqtn string, trg *model.Trigger) string {
 }
 
 // parseTriggerDef parses a CREATE TRIGGER statement and takes out the wording
-// that says nothing about the trigger's state: an implicit relation schema is
-// filled in from the owning relation, OR REPLACE is cleared, the schema of the
-// EXECUTE FUNCTION name is dropped, since pg_get_triggerdef omits it once the
-// function's schema is on the search_path, and the WHEN expression goes through
-// the normalization constraint CHECK bodies use, since pg_get_triggerdef adds
-// casts there the way pg_get_constraintdef does. It returns the whole result so
-// the caller can deparse it back.
+// that says nothing about the trigger's state. An implicit relation schema is
+// filled in from the owning relation, and OR REPLACE is cleared.
+//
+// The EXECUTE FUNCTION name loses its schema, which pg_get_triggerdef omits
+// once the function's schema is on the search_path, the way stripFuncSchema
+// handles a call inside an expression. The WHEN expression goes through the
+// normalization constraint CHECK bodies use, since pg_get_triggerdef adds casts
+// there the way pg_get_constraintdef does.
+//
+// It returns the whole result so the caller can deparse it back.
 func parseTriggerDef(def, schema string) (*pg_query.ParseResult, *pg_query.CreateTrigStmt, error) {
 	result, err := pg_query.Parse(def)
 	if err != nil {
@@ -241,8 +244,8 @@ func parseTriggerDef(def, schema string) (*pg_query.ParseResult, *pg_query.Creat
 		ct.Relation.Schemaname = schema
 	}
 	ct.Replace = false
-	if len(ct.Funcname) == 2 {
-		ct.Funcname = ct.Funcname[1:]
+	if len(ct.Funcname) > 1 {
+		ct.Funcname = ct.Funcname[len(ct.Funcname)-1:]
 	}
 	if ct.WhenClause != nil {
 		ct.WhenClause = normalizeCheckExpr(ct.WhenClause)

--- a/diff/triggers_test.go
+++ b/diff/triggers_test.go
@@ -388,3 +388,26 @@ func TestRenameTriggerDef_Unparseable(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected parse result")
 }
+
+// pg_get_triggerdef omits the schema of the EXECUTE FUNCTION name once the
+// function's schema is on the search_path, so the written qualified form has
+// to compare equal to it. A three-part name is stripped the same way.
+func TestEqualTriggerDef_QualifiedFunction(t *testing.T) {
+	current := "CREATE TRIGGER t_stamp BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION stamp()"
+
+	for name, desired := range map[string]string{
+		"two-part":   "CREATE TRIGGER t_stamp BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION public.stamp()",
+		"three-part": "CREATE TRIGGER t_stamp BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION postgres.public.stamp()",
+	} {
+		t.Run(name, func(t *testing.T) {
+			same, err := equalTriggerDef(current, desired, "public")
+			require.NoError(t, err)
+			assert.True(t, same)
+		})
+	}
+
+	// A different function is still a difference.
+	same, err := equalTriggerDef(current, "CREATE TRIGGER t_stamp BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION public.other()", "public")
+	require.NoError(t, err)
+	assert.False(t, same)
+}

--- a/testdata/plan/no_diff_check_calling_function.yml
+++ b/testdata/plan/no_diff_check_calling_function.yml
@@ -1,7 +1,7 @@
 # A CHECK that calls a function must not drift when the call is written
 # unqualified. pg_get_constraintdef returns it unqualified and adds a ::text
 # cast that normalizeCheckExpr strips, so both differences have to cancel out.
-# See TODO.md for the qualified form, which does drift.
+# The qualified form is covered by no_diff_qualified_function_call.yml.
 init: |
   CREATE FUNCTION public.lower_v(t text) RETURNS text AS $$ SELECT lower(t) $$ LANGUAGE sql IMMUTABLE;
   CREATE TABLE public.users (

--- a/testdata/plan/no_diff_qualified_function_call.yml
+++ b/testdata/plan/no_diff_qualified_function_call.yml
@@ -2,20 +2,22 @@
 # pg_get_constraintdef, pg_get_indexdef, pg_get_viewdef and pg_get_triggerdef
 # all print the call unqualified once the function's schema is on the
 # search_path, so every expression site below compared a qualified form against
-# an unqualified one and re-emitted its statement on every plan. The generated
-# column was worse than drift: a generated expression cannot be altered in
-# place, so the run failed outright.
+# an unqualified one and re-emitted its statement on every plan. The
+# materialized view was the worst of them: DROP plus CREATE discards the data
+# it holds, on every apply.
 #
-# One site per statement kind, so a failure names the one that drifted. The
+# One site per statement kind, so a failure names the ones that drifted. The
+# generated column sits in no_diff_qualified_function_call_generated.yml
+# instead: it fails the diff outright, which would mask everything here. The
 # functions live in init alone because routines are unmanaged by default.
 init: |
   CREATE FUNCTION public.lower_v(t text) RETURNS text AS $$ SELECT lower(t) $$ LANGUAGE sql IMMUTABLE;
   CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE DOMAIN public.lowered AS text CONSTRAINT lowered_check CHECK (public.lower_v(VALUE) = VALUE);
   CREATE TABLE public.t (
       id integer NOT NULL,
       v text,
       d text DEFAULT public.lower_v('A'),
-      g text GENERATED ALWAYS AS (public.lower_v(v)) STORED,
       CONSTRAINT t_pkey PRIMARY KEY (id),
       CONSTRAINT t_v_check CHECK (public.lower_v(v) <> 'x')
   );
@@ -23,14 +25,16 @@ init: |
   CREATE INDEX t_pred_idx ON public.t (v) WHERE public.lower_v(v) <> 'y';
   ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
   CREATE POLICY t_pol ON public.t USING (public.lower_v(v) <> 'z');
+  CREATE POLICY t_pol_w ON public.t FOR INSERT WITH CHECK (public.lower_v(v) <> 'w');
   CREATE TRIGGER t_stamp BEFORE INSERT ON public.t FOR EACH ROW WHEN (public.lower_v(NEW.v) <> 'q') EXECUTE FUNCTION public.stamp();
   CREATE VIEW public.v AS SELECT public.lower_v(t.v) AS lv FROM public.t;
+  CREATE MATERIALIZED VIEW public.mv AS SELECT public.lower_v(t.v) AS lv FROM public.t;
 desired: |
+  CREATE DOMAIN public.lowered AS text CONSTRAINT lowered_check CHECK (public.lower_v(VALUE) = VALUE);
   CREATE TABLE public.t (
       id integer NOT NULL,
       v text,
       d text DEFAULT public.lower_v('A'),
-      g text GENERATED ALWAYS AS (public.lower_v(v)) STORED,
       CONSTRAINT t_pkey PRIMARY KEY (id),
       CONSTRAINT t_v_check CHECK (public.lower_v(v) <> 'x')
   );
@@ -38,6 +42,8 @@ desired: |
   CREATE INDEX t_pred_idx ON public.t (v) WHERE public.lower_v(v) <> 'y';
   ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
   CREATE POLICY t_pol ON public.t USING (public.lower_v(v) <> 'z');
+  CREATE POLICY t_pol_w ON public.t FOR INSERT WITH CHECK (public.lower_v(v) <> 'w');
   CREATE TRIGGER t_stamp BEFORE INSERT ON public.t FOR EACH ROW WHEN (public.lower_v(NEW.v) <> 'q') EXECUTE FUNCTION public.stamp();
   CREATE VIEW public.v AS SELECT public.lower_v(t.v) AS lv FROM public.t;
+  CREATE MATERIALIZED VIEW public.mv AS SELECT public.lower_v(t.v) AS lv FROM public.t;
 plan: ""

--- a/testdata/plan/no_diff_qualified_function_call.yml
+++ b/testdata/plan/no_diff_qualified_function_call.yml
@@ -1,0 +1,43 @@
+# A function call written schema-qualified must not drift. pg_get_expr,
+# pg_get_constraintdef, pg_get_indexdef, pg_get_viewdef and pg_get_triggerdef
+# all print the call unqualified once the function's schema is on the
+# search_path, so every expression site below compared a qualified form against
+# an unqualified one and re-emitted its statement on every plan. The generated
+# column was worse than drift: a generated expression cannot be altered in
+# place, so the run failed outright.
+#
+# One site per statement kind, so a failure names the one that drifted. The
+# functions live in init alone because routines are unmanaged by default.
+init: |
+  CREATE FUNCTION public.lower_v(t text) RETURNS text AS $$ SELECT lower(t) $$ LANGUAGE sql IMMUTABLE;
+  CREATE FUNCTION public.stamp() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      v text,
+      d text DEFAULT public.lower_v('A'),
+      g text GENERATED ALWAYS AS (public.lower_v(v)) STORED,
+      CONSTRAINT t_pkey PRIMARY KEY (id),
+      CONSTRAINT t_v_check CHECK (public.lower_v(v) <> 'x')
+  );
+  CREATE INDEX t_expr_idx ON public.t (public.lower_v(v));
+  CREATE INDEX t_pred_idx ON public.t (v) WHERE public.lower_v(v) <> 'y';
+  ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY t_pol ON public.t USING (public.lower_v(v) <> 'z');
+  CREATE TRIGGER t_stamp BEFORE INSERT ON public.t FOR EACH ROW WHEN (public.lower_v(NEW.v) <> 'q') EXECUTE FUNCTION public.stamp();
+  CREATE VIEW public.v AS SELECT public.lower_v(t.v) AS lv FROM public.t;
+desired: |
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      v text,
+      d text DEFAULT public.lower_v('A'),
+      g text GENERATED ALWAYS AS (public.lower_v(v)) STORED,
+      CONSTRAINT t_pkey PRIMARY KEY (id),
+      CONSTRAINT t_v_check CHECK (public.lower_v(v) <> 'x')
+  );
+  CREATE INDEX t_expr_idx ON public.t (public.lower_v(v));
+  CREATE INDEX t_pred_idx ON public.t (v) WHERE public.lower_v(v) <> 'y';
+  ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY t_pol ON public.t USING (public.lower_v(v) <> 'z');
+  CREATE TRIGGER t_stamp BEFORE INSERT ON public.t FOR EACH ROW WHEN (public.lower_v(NEW.v) <> 'q') EXECUTE FUNCTION public.stamp();
+  CREATE VIEW public.v AS SELECT public.lower_v(t.v) AS lv FROM public.t;
+plan: ""

--- a/testdata/plan/no_diff_qualified_function_call_generated.yml
+++ b/testdata/plan/no_diff_qualified_function_call_generated.yml
@@ -1,0 +1,21 @@
+# A generated expression that calls a function schema-qualified. This is the
+# one site where the qualified form does not merely drift: a generated
+# expression cannot be altered in place, so the diff fails outright and takes
+# the whole run with it, including the objects that have nothing to do with it.
+# That is why it is not in no_diff_qualified_function_call.yml.
+init: |
+  CREATE FUNCTION public.lower_v(t text) RETURNS text AS $$ SELECT lower(t) $$ LANGUAGE sql IMMUTABLE;
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      v text,
+      g text GENERATED ALWAYS AS (public.lower_v(v)) STORED,
+      CONSTRAINT t_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.t (
+      id integer NOT NULL,
+      v text,
+      g text GENERATED ALWAYS AS (public.lower_v(v)) STORED,
+      CONSTRAINT t_pkey PRIMARY KEY (id)
+  );
+plan: ""


### PR DESCRIPTION
Picks up 362ba9d from the unmerged `claude/easy-fixes-fnjy5p`, plus a follow-up commit for what a review of it turned up.

## The fix

`pg_get_constraintdef`, `pg_get_expr`, `pg_get_indexdef`, `pg_get_viewdef` and `pg_get_triggerdef` print a call unqualified once the function's schema is on the search_path, while the desired side keeps what the file wrote. `stripFuncSchema` drops the schema from a `FuncCall` name inside `normalizeCheckExpr`, which reaches every site that walk covers, and `parseTriggerDef` does the same for the `EXECUTE FUNCTION` name.

Reproduced on `main` before applying anything: a CHECK, two indexes, a column default, a policy, a trigger and a view all re-emit on every plan, and a generated column fails the run with `cannot change GENERATED expression`.

## What the follow-up changes

**Coverage.** The cherry-pick alone measures 94.762% against main's 94.786%, a drop. `stripFuncSchema` reported 50% and `parseTriggerDef` 93.8%: the plan fixture reaches both, but it runs in the root package, where `diff` is a dependency rather than the package under test, so neither new line was counted. `TestStripFuncSchema` goes through each comparison entry point in turn, since a constraint, an index, a bare expression, a default and a view body each parse their own way in. Both functions reach 100%.

**A wrong claim.** The comment said a name longer than two parts is not one the parser accepts. It is: PostgreSQL takes `catalog.schema.f` when the catalog names the current database, and pg_query parses it to three parts, so the two-part test left it drifting. Keeping the last part alone handles both.

**A fixture that masked itself.** It claimed one site per statement kind so a failure names the one that drifted, but the generated column fails the diff outright and takes the run with it, so on an unfixed tree it was the only thing reported. It moves to its own fixture.

**Three sites that were missing.** A domain CHECK, a policy `WITH CHECK`, and a materialized view. All three drift without the fix. The materialized view is the worst case in the set: DROP plus CREATE discards the data it holds, on every apply.

**Prose.** `parseTriggerDef`'s comment had become one sentence of sixty words with two embedded `since` clauses; it is three sentences now. The change had no CHANGELOG entry; the one added names the matview and the generated column, since neither reads as ordinary drift.

## Known limitation, unchanged

The strip is symmetric, so two same-named functions in different schemas compare equal and moving a call between schemas produces no diff. This is the tradeoff a view body's table reference already carries. A schema inside a `nextval('public.counter'::regclass)` literal is not in a call name and still drifts; TODO.md is rewritten to cover that alone.

Measured the way CI does on PostgreSQL 16, 94.786% -> 94.789%. `make lint`, `make deadcode`, `make test` and `make test-scenario` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mm1HUGN1Khg8K8UVjJ6MGd)_