### PR TITLE
Correct the serial-default TODO entry, which describes drift that stopped

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -604,32 +604,33 @@ Workaround: write the sequence unqualified.
 Origin: found while adding `-- pista:execute-first`, 2026-07-31. The function
 call half was closed later; the literal half is what remains.
 
-## Perpetual drift on a serial column written as an explicit default
+## A pg_dump serial column loses its default
 
 Priority: low.
 
-A serial column written the way `pg_dump` writes it plans
-`ALTER COLUMN id SET DEFAULT nextval(...)` on every run. Applying it succeeds
-and changes nothing, so `plan --check` stays at exit code 2 forever. `pg_dump`
-never writes `serial`; it splits the column into a plain `integer`, a
+`pg_dump` never writes `serial`. It splits the column into a plain `integer`, a
 `CREATE SEQUENCE`, an `ALTER SEQUENCE ... OWNED BY`, and a separate
-`SET DEFAULT`. The catalog reports such a column as `serial` with no default,
-which is what lets `id serial` round-trip, while the desired side keeps the
-explicit default. `equalTypeName` already treats `serial` and `integer` as
-equal; the defaults are what differ.
+`SET DEFAULT`. The parser reads the first three and drops the fourth, since
+`ALTER TABLE ... ALTER COLUMN ... SET DEFAULT` has no handler. It warns and
+moves on.
 
-`dump` does not produce this shape, so a schema kept through `pista dump`
-never hits it. It shows up when a `pg_dump` output is used as the starting
-desired file, which is a normal way to adopt the tool on an existing
-database.
+Against the database the file came from, this plans clean. The catalog reports
+such a column as `serial` with no default, the desired side holds `integer`
+with no default, and `equalTypeName` treats the two type names as equal.
 
-Comparing them needs the sequence the current column draws from, which the
-model does not carry, since the catalog nulls the default for serial columns.
-Suppressing the statement whenever the current column is serial and the
-desired default is any `nextval` would also swallow a genuine change to a
-different sequence.
+Against an empty database it does not reproduce the column. The plan is
+`CREATE TABLE public.t (id integer NOT NULL)` alone: the sequence is unmanaged
+because `OWNED BY` marks it so, and the default was dropped. What comes out is
+a plain integer column.
 
-Origin: bug audit, 2026-07-31.
+Reading `AT_ColumnDefault` onto the column is the fix, next to the
+`AT_SetStorage` and `AT_SetCompression` actions `applyAlterTableColumnStorage`
+already reads. The `nextval` argument names the sequence, so the serial shape
+is recoverable from it.
+
+Origin: bug audit, 2026-07-31. Rewritten once the drift it described stopped
+happening: the warn-and-drop of an unsupported `ALTER TABLE` action, added in
+1.31.0, is what makes the two sides agree.
 
 ## Perpetual drift on a view defined with `SELECT *`
 


### PR DESCRIPTION
A stocktake of TODO.md against the current tree. Eight claims were checked against a database; one no longer holds, and it is the only file this touches.

## What changed

"Perpetual drift on a serial column written as an explicit default" said such a column plans `ALTER COLUMN id SET DEFAULT nextval(...)` on every run, leaving `plan --check` at exit code 2 forever. It does not:

```
$ pista plan -c ... pgdump_shape.sql
pistachio: ignored unsupported statement: ALTER TABLE ONLY public.t ALTER COLUMN id SET DEFAULT nextval('public.t_id_seq'::regclass)
-- No changes
```

`ALTER TABLE ... ALTER COLUMN ... SET DEFAULT` has no handler in the parser, so it warns and drops the statement. The desired side then holds no default against a catalog that reports the column as `serial` with no default either, and `equalTypeName` already treats the two type names as equal. The warn-and-drop of an unsupported `ALTER TABLE` action landed in 1.31.0, after the entry was written, which is what settled it.

The same drop is a real gap in the other direction, so the entry is rewritten rather than removed. Against an empty database the file does not reproduce the column:

```
CREATE TABLE public.t (
    id integer NOT NULL
);
```

The sequence is unmanaged because `OWNED BY` marks it so, and the default was dropped, so what comes out is a plain integer column. The entry now points the fix at `AT_ColumnDefault`, next to the two `ALTER TABLE` actions `applyAlterTableColumnStorage` already reads.

## What was checked and left alone

Seven other claims still reproduce exactly as written:

| Entry | Checked |
|---|---|
| View defined with `SELECT *` | drifts |
| Schema-qualified sequence in a `nextval` literal | drifts |
| EXCLUDE constraint not normalized | drifts, both the schema and the cast halves |
| `COMMENT ON INDEX` not managed | `dump` writes none |
| Composite attribute reordering not diffed | reorder plans nothing |
| `OWNED BY NONE` | plans `CREATE SEQUENCE` for a sequence that exists |
| View type-only change | emits `CREATE OR REPLACE VIEW`, which PostgreSQL rejects |

I also swept every backticked identifier in TODO.md against the code. The only two that do not resolve are deliberate: `equalPolicyExpr` appears as "formerly `equalPolicyExpr`, renamed in #207", and `ValidateColumnRefs` names the pass rather than the function, which is `validateColumnRefs`.

Documentation only, no code change. `make test` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mm1HUGN1Khg8K8UVjJ6MGd)_