### PR TITLE
Manage a table's storage parameters, and stop an index's from drifting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.36.0] - 2026-08-29
+
+* Manage a table's storage parameters, the `WITH (...)` clause. Neither side read them, so `dump` dropped the clause and no plan proposed one: the per-table autovacuum settings a pg_dump file carries went unmanaged without a warning. A change goes out as `ALTER TABLE ... SET (...)` with a `RESET` for the parameters the desired schema no longer names. A `toast.` parameter is read from the TOAST relation and diffed alongside. `WITH (oids = false)`, which a pg_dump before 12 writes, is not a parameter and is skipped.
+
+* Stop an index's storage parameters from drifting. `pg_get_indexdef` quotes a value that does not read as an identifier, `fillfactor='80'`, while a file writes the number bare, so the two never matched and the index was dropped and recreated on every run. The order the catalog keeps them in is not compared either.
+
 ## [1.35.0] - 2026-08-29
 
 * Stop a schema-qualified function call from drifting. `pg_get_constraintdef`, `pg_get_expr`, `pg_get_indexdef`, `pg_get_viewdef` and `pg_get_triggerdef` all print a call unqualified once the function's schema is on the search_path, while the desired side keeps what the file wrote, so `CHECK (public.lower_v(v) <> 'x')` and every other call written that way re-emitted its statement on every plan. A `CHECK` was dropped and re-added, which revalidates the whole table, an index was rebuilt, and a materialized view was dropped and recreated, discarding the data it held. A generated expression did not drift but failed the run outright, since it cannot be altered in place. The strip is symmetric and carries the tradeoff a view body's table reference already has: two same-named functions in different schemas compare equal. A schema inside a `nextval('public.counter'::regclass)` literal is not a call name and still drifts; TODO.md covers it.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ pista apply ./schema/*.sql         # apply it
 - Composite types (`CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME ATTRIBUTE`). Attributes are matched by name, so reordering them produces no diff (PostgreSQL cannot reorder attributes). `ALTER ATTRIBUTE ... TYPE` fails at apply while a table column uses the type; PostgreSQL does not allow it and `CASCADE` does not help.
 - Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables)
+- Storage parameters, the `WITH (...)` clause on a table and on an index. A `toast.` parameter belongs to the TOAST relation. PostgreSQL creates that relation only for a table with a toastable column, and discards the setting when there is none, so such a table re-plans it on every run. A partitioned table holds no parameter, and a partition does not inherit the parent's.
 - Views
 - Materialized views
 - Columns (serial/bigserial/smallserial, identity, generated, TOAST storage and compression)

--- a/TODO.md
+++ b/TODO.md
@@ -548,6 +548,32 @@ is the same prerequisite as the INHERITS plan / apply entry above.
 
 Origin: review of [#340](https://github.com/winebarrel/pistachio/pull/340).
 
+## A constraint's index storage parameters are not read
+
+Priority: low.
+
+`ALTER TABLE t ADD CONSTRAINT t_v_key UNIQUE (v) WITH (fillfactor = 70)` puts
+the parameters on the index the constraint owns. `pg_get_constraintdef` does
+not print them, so the current side reads the constraint as `UNIQUE (v)` and
+the two never match: the plan is `DROP CONSTRAINT` + `ADD CONSTRAINT` on every
+run, which rebuilds the index under an ACCESS EXCLUSIVE lock. `dump` drops the
+clause for the same reason, so a table's parameters survive a dump and a
+constraint's do not.
+
+The parameters are on `pg_class` under `pg_constraint.conindid`, next to the
+ones `ListIndexes` already reads, and appending them to the definition is what
+would make both sides agree. `normalizeStorageParams` then folds the quoting
+the way it does for a plain index.
+
+`dump` writes the catalog form, so a dump fed back plans clean and only a
+hand-written constraint reaches this.
+
+Workaround: create the index separately, `CREATE UNIQUE INDEX ... WITH
+(fillfactor = 70)`, where the parameters are read.
+
+Origin: the storage parameter work; found while auditing what else carries a
+`WITH` clause.
+
 ## An EXCLUDE constraint is not normalized at all
 
 Priority: low.

--- a/TODO.md
+++ b/TODO.md
@@ -548,6 +548,27 @@ is the same prerequisite as the INHERITS plan / apply entry above.
 
 Origin: review of [#340](https://github.com/winebarrel/pistachio/pull/340).
 
+## View and materialized view storage parameters are not read
+
+Priority: low.
+
+A view carries `security_barrier` and `check_option`, a materialized view the
+autovacuum settings, and neither side reads them. `dump` drops the clause, and
+a desired schema that writes it plans nothing, the way a table's parameters
+behaved before they were read. Losing `security_barrier` from a dump is the
+one that matters, since the view is a security boundary without it.
+
+`pg_class.reloptions` holds them for both, next to the table's, and
+`ALTER VIEW ... SET (...)` / `RESET (...)` and the `ALTER MATERIALIZED VIEW`
+forms are what a change goes out as. The table work put the reading and the
+rendering in `SortedStorageParams` and `Table.StorageParamsSQL`, which the view
+model can use as they are.
+
+`dump` writes no clause and the parser reads none, so a dump fed back plans
+clean and only a hand-written view reaches this.
+
+Origin: review of [#458](https://github.com/winebarrel/pistachio/pull/458).
+
 ## A constraint's index storage parameters are not read
 
 Priority: low.
@@ -571,8 +592,7 @@ hand-written constraint reaches this.
 Workaround: create the index separately, `CREATE UNIQUE INDEX ... WITH
 (fillfactor = 70)`, where the parameters are read.
 
-Origin: the storage parameter work; found while auditing what else carries a
-`WITH` clause.
+Origin: [#458](https://github.com/winebarrel/pistachio/pull/458).
 
 ## An EXCLUDE constraint is not normalized at all
 

--- a/catalog/tables.go
+++ b/catalog/tables.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/winebarrel/orderedmap/v2"
@@ -84,12 +85,15 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 			pg_catalog.pg_get_expr(c.relpartbound, c.oid) AS partition_bound,
 			c.relrowsecurity,
 			c.relforcerowsecurity,
+			c.reloptions,
+			tc.reloptions AS toast_reloptions,
 			d.description
 		FROM
 			-- https://www.postgresql.org/docs/current/catalog-pg-class.html
 			pg_catalog.pg_class c
 			JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 			LEFT JOIN pg_catalog.pg_tablespace ts ON ts.oid = c.reltablespace
+			LEFT JOIN pg_catalog.pg_class tc ON tc.oid = c.reltoastrelid
 			LEFT JOIN partition p ON p.inhrelid = c.oid
 			LEFT JOIN dependency_extension de ON de.objid = c.oid
 			-- https://www.postgresql.org/docs/current/catalog-pg-description.html
@@ -118,6 +122,7 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 	for rows.Next() {
 		var t model.Table
 		var parentSchema, parentName *string
+		var reloptions, toastReloptions []string
 		err := rows.Scan(
 			&t.OID,
 			&t.Schema,
@@ -131,6 +136,8 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 			&t.PartitionBound,
 			&t.RowSecurity,
 			&t.ForceRowSecurity,
+			&reloptions,
+			&toastReloptions,
 			&t.Comment,
 		)
 		if err != nil {
@@ -148,6 +155,7 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 			parent := model.Ident(schema, *parentName)
 			t.PartitionOf = &parent
 		}
+		t.StorageParams = storageParams(reloptions, toastReloptions)
 		t.Columns = orderedmap.New[string, *model.Column]()
 		t.Indexes = orderedmap.New[string, *model.Index]()
 		t.Constraints = orderedmap.New[string, *model.Constraint]()
@@ -190,4 +198,22 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 	}
 
 	return tables, nil
+}
+
+// storageParams turns the two reloptions arrays a table is read with into one
+// map. reloptions holds the table's own parameters, toastReloptions the TOAST
+// relation's, which PostgreSQL sets and reads under a `toast.` prefix and
+// which pg_dump writes into the same WITH clause. Every entry is name=value,
+// including one written without a value, which PostgreSQL stores as true.
+func storageParams(reloptions, toastReloptions []string) *orderedmap.Map[string, string] {
+	params := make(map[string]string, len(reloptions)+len(toastReloptions))
+	collect := func(entries []string, prefix string) {
+		for _, e := range entries {
+			name, value, _ := strings.Cut(e, "=")
+			params[prefix+name] = value
+		}
+	}
+	collect(reloptions, "")
+	collect(toastReloptions, "toast.")
+	return model.SortedStorageParams(params)
 }

--- a/catalog/tables_test.go
+++ b/catalog/tables_test.go
@@ -170,3 +170,48 @@ func TestTables(t *testing.T) {
 		assert.Equal(t, `public."Odd Parent"`, *child.PartitionOf)
 	})
 }
+
+func TestTables_StorageParams(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	t.Run("none", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.users (
+				id integer NOT NULL,
+				CONSTRAINT users_pkey PRIMARY KEY (id)
+			);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+		tbl, ok := tables.GetOk("public.users")
+		require.True(t, ok)
+		assert.Equal(t, 0, tbl.StorageParams.Len())
+	})
+
+	// The TOAST relation's parameters are read under the toast. prefix
+	// PostgreSQL sets them with, and the table's own without one. The text
+	// column is what gives the table a TOAST relation to read.
+	t.Run("table and toast", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.docs (
+				id integer NOT NULL,
+				body text,
+				CONSTRAINT docs_pkey PRIMARY KEY (id)
+			) WITH (fillfactor = 70, autovacuum_enabled = off, toast.autovacuum_enabled = off);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+		tbl, ok := tables.GetOk("public.docs")
+		require.True(t, ok)
+		assert.Equal(t,
+			[]string{"autovacuum_enabled", "fillfactor", "toast.autovacuum_enabled"},
+			tbl.StorageParams.CollectKeys())
+		assert.Equal(t, []string{"off", "70", "off"}, tbl.StorageParams.CollectValues())
+	})
+}

--- a/diff/storage_params.go
+++ b/diff/storage_params.go
@@ -1,0 +1,54 @@
+package diff
+
+import (
+	"github.com/winebarrel/orderedmap/v2"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// diffStorageParams returns the statements that bring a table's storage
+// parameters in line with the desired schema: one SET for the parameters that
+// arrive or change value, one RESET for the ones the desired schema no longer
+// names. Neither rewrites the table. Both sides are keyed in name order, so
+// the statements come out the same on every run.
+//
+// A partitioned table needs no special case, since PostgreSQL rejects every
+// parameter on a relation that holds no storage. A partition holds its own,
+// which it does not take from the parent, and is diffed like any other table.
+func diffStorageParams(fqtn string, current, desired *model.Table) []string {
+	currentParams := storageParams(current)
+	desiredParams := storageParams(desired)
+
+	var stmts []string
+
+	var set []string
+	for name, value := range desiredParams.All() {
+		if cur, ok := currentParams.GetOk(name); !ok || cur != value {
+			set = append(set, name+"="+model.QuoteLiteral(value))
+		}
+	}
+	if len(set) > 0 {
+		stmts = append(stmts, model.SetStorageParamsSQL(fqtn, set))
+	}
+
+	var reset []string
+	for name := range currentParams.Keys() {
+		if _, ok := desiredParams.GetOk(name); !ok {
+			reset = append(reset, name)
+		}
+	}
+	if len(reset) > 0 {
+		stmts = append(stmts, model.ResetStorageParamsSQL(fqtn, reset))
+	}
+
+	return stmts
+}
+
+// storageParams reads a table's parameters, standing in an empty map for one
+// built without any. The catalog and the parser always set the map, other
+// callers may not.
+func storageParams(t *model.Table) *orderedmap.Map[string, string] {
+	if t.StorageParams == nil {
+		return orderedmap.New[string, string]()
+	}
+	return t.StorageParams
+}

--- a/diff/storage_params_test.go
+++ b/diff/storage_params_test.go
@@ -1,0 +1,62 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/pistachio/model"
+)
+
+func paramsTable(params map[string]string) *model.Table {
+	t := &model.Table{Schema: "public", Name: "users"}
+	if params != nil {
+		t.StorageParams = model.SortedStorageParams(params)
+	}
+	return t
+}
+
+func TestDiffStorageParams_noChange(t *testing.T) {
+	params := map[string]string{"fillfactor": "70"}
+	assert.Empty(t, diffStorageParams("public.users", paramsTable(params), paramsTable(params)))
+}
+
+func TestDiffStorageParams_neitherSideCarriesTheMap(t *testing.T) {
+	assert.Empty(t, diffStorageParams("public.users", paramsTable(nil), paramsTable(nil)))
+}
+
+func TestDiffStorageParams_add(t *testing.T) {
+	assert.Equal(t,
+		[]string{"ALTER TABLE public.users SET (autovacuum_enabled='off', fillfactor='70');"},
+		diffStorageParams("public.users",
+			paramsTable(nil),
+			paramsTable(map[string]string{"fillfactor": "70", "autovacuum_enabled": "off"})))
+}
+
+func TestDiffStorageParams_changeValue(t *testing.T) {
+	assert.Equal(t,
+		[]string{"ALTER TABLE public.users SET (fillfactor='90');"},
+		diffStorageParams("public.users",
+			paramsTable(map[string]string{"fillfactor": "70"}),
+			paramsTable(map[string]string{"fillfactor": "90"})))
+}
+
+func TestDiffStorageParams_reset(t *testing.T) {
+	assert.Equal(t,
+		[]string{"ALTER TABLE public.users RESET (autovacuum_enabled, fillfactor);"},
+		diffStorageParams("public.users",
+			paramsTable(map[string]string{"fillfactor": "70", "autovacuum_enabled": "off"}),
+			paramsTable(nil)))
+}
+
+// One parameter arriving next to another leaving is the shape a rewritten
+// WITH clause takes. SET comes first so a table never sits without either.
+func TestDiffStorageParams_setAndReset(t *testing.T) {
+	assert.Equal(t,
+		[]string{
+			"ALTER TABLE public.users SET (toast.autovacuum_enabled='off');",
+			"ALTER TABLE public.users RESET (autovacuum_enabled);",
+		},
+		diffStorageParams("public.users",
+			paramsTable(map[string]string{"autovacuum_enabled": "off"}),
+			paramsTable(map[string]string{"toast.autovacuum_enabled": "off"})))
+}

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -172,8 +172,6 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
 		result.DisallowedDropStmts = append(result.DisallowedDropStmts, fkDisallowed...)
 
-		result.Stmts = append(result.Stmts, diffStorageParams(fqtn, current, desired)...)
-
 		result.Stmts = append(result.Stmts, diffRLS(fqtn, current, desired)...)
 		polStmts, polDisallowed, err := diffPolicies(fqtn, current.Policies, desired.Policies, dc)
 		if err != nil {
@@ -190,6 +188,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		result.DisallowedDropStmts = append(result.DisallowedDropStmts, trgDisallowed...)
 
 		result.Stmts = append(result.Stmts, diffComments(current, withInheritedColumns(current, desired))...)
+		result.Stmts = append(result.Stmts, diffStorageParams(fqtn, current, desired)...)
 
 		return result, nil
 	}
@@ -242,8 +241,6 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
 	result.DisallowedDropStmts = append(result.DisallowedDropStmts, fkDisallowed...)
 
-	result.Stmts = append(result.Stmts, diffStorageParams(fqtn, current, desired)...)
-
 	// RLS toggles run before CREATE POLICY so a newly enabled table has its
 	// flag set when policies attach. Disabling RLS likewise comes before any
 	// policy DROP that the user may have stacked alongside.
@@ -272,6 +269,13 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	// CONSTRAINT/INDEX fail with "does not exist". Policies referencing a
 	// dropped column block the DROP COLUMN entirely.
 	result.Stmts = append(result.Stmts, colDropStmts...)
+
+	// Storage parameters go last. Nothing in SET / RESET depends on the
+	// column statements, and sitting among them would split a --bulk-alter
+	// group, which merges only consecutive statements. They also have to stay
+	// after ADD COLUMN: a toast. parameter needs the TOAST relation that a
+	// first toastable column creates, and PostgreSQL discards it otherwise.
+	result.Stmts = append(result.Stmts, diffStorageParams(fqtn, current, desired)...)
 
 	return result, nil
 }

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -1,9 +1,11 @@
 package diff
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -170,6 +172,8 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 		result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
 		result.DisallowedDropStmts = append(result.DisallowedDropStmts, fkDisallowed...)
 
+		result.Stmts = append(result.Stmts, diffStorageParams(fqtn, current, desired)...)
+
 		result.Stmts = append(result.Stmts, diffRLS(fqtn, current, desired)...)
 		polStmts, polDisallowed, err := diffPolicies(fqtn, current.Policies, desired.Policies, dc)
 		if err != nil {
@@ -237,6 +241,8 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	result.FKDropStmts = append(result.FKDropStmts, fkDrops...)
 	result.FKAddStmts = append(result.FKAddStmts, fkAdds...)
 	result.DisallowedDropStmts = append(result.DisallowedDropStmts, fkDisallowed...)
+
+	result.Stmts = append(result.Stmts, diffStorageParams(fqtn, current, desired)...)
 
 	// RLS toggles run before CREATE POLICY so a newly enabled table has its
 	// flag set when policies attach. Disabling RLS likewise comes before any
@@ -1460,6 +1466,33 @@ func normalizeIndexStmt(is *pg_query.IndexStmt) {
 	if is.WhereClause != nil {
 		is.WhereClause = normalizeCheckExpr(is.WhereClause)
 	}
+	normalizeStorageParams(is.Options)
+}
+
+// normalizeStorageParams canonicalises an index's WITH clause so the two
+// spellings of one parameter compare equal. pg_get_indexdef quotes a value
+// that does not read as an identifier, `fillfactor='80'`, while a file writes
+// the number bare, so the two arrive as a String and an Integer node. The
+// order is not part of the setting either, and the catalog keeps the one the
+// parameters were created in. Without this an index carrying a parameter was
+// dropped and recreated on every run.
+//
+// Only an integer is folded. No index storage parameter takes a fractional
+// value, and a value that reads as a bare word arrives as a String from both
+// sides already.
+func normalizeStorageParams(options []*pg_query.Node) {
+	for _, o := range options {
+		de := o.GetDefElem()
+		if i := de.GetArg().GetInteger(); i != nil {
+			sval := strconv.FormatInt(int64(i.Ival), 10)
+			de.Arg = &pg_query.Node{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: sval}}}
+		}
+	}
+	// No index storage parameter has a namespace, unlike a table's toast.
+	// ones, so the name alone orders them.
+	slices.SortStableFunc(options, func(a, b *pg_query.Node) int {
+		return cmp.Compare(a.GetDefElem().GetDefname(), b.GetDefElem().GetDefname())
+	})
 }
 
 // alignIndexCasts asymmetrically strips current-side TypeCast wrappers at

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -3558,3 +3558,33 @@ func TestStripFuncSchema(t *testing.T) {
 		assert.False(t, equalSelectExpr("lower_v(v)", "upper_v(v)"))
 	})
 }
+
+func TestEqualIndexDef_storageParamQuoting(t *testing.T) {
+	// pg_get_indexdef quotes the value, a file writes it bare.
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON public.users USING btree (id) WITH (fillfactor='80')",
+		"CREATE INDEX idx ON public.users USING btree (id) WITH (fillfactor=80)",
+	))
+}
+
+func TestEqualIndexDef_storageParamOrder(t *testing.T) {
+	// The catalog keeps the order the parameters were created in.
+	assert.True(t, equalIndexDef(
+		"CREATE INDEX idx ON public.users USING btree (id) WITH (fillfactor='80', deduplicate_items=off)",
+		"CREATE INDEX idx ON public.users USING btree (id) WITH (deduplicate_items=off, fillfactor=80)",
+	))
+}
+
+func TestEqualIndexDef_storageParamValueChange(t *testing.T) {
+	assert.False(t, equalIndexDef(
+		"CREATE INDEX idx ON public.users USING btree (id) WITH (fillfactor='80')",
+		"CREATE INDEX idx ON public.users USING btree (id) WITH (fillfactor=90)",
+	))
+}
+
+func TestEqualIndexDef_storageParamAdded(t *testing.T) {
+	assert.False(t, equalIndexDef(
+		"CREATE INDEX idx ON public.users USING btree (id)",
+		"CREATE INDEX idx ON public.users USING btree (id) WITH (fillfactor=80)",
+	))
+}

--- a/directives.md
+++ b/directives.md
@@ -132,7 +132,7 @@ ALTER TABLE public.users
   ALTER COLUMN name SET NOT NULL;
 ```
 
-Foreign keys, `RENAME`, `VALIDATE CONSTRAINT`, RLS toggles, and skipped DROPs stay separate statements. The `--bulk-alter` flag merges every table regardless of directives.
+Foreign keys, `RENAME`, `VALIDATE CONSTRAINT`, RLS toggles, storage parameter `SET` / `RESET`, and skipped DROPs stay separate statements. The `--bulk-alter` flag merges every table regardless of directives.
 
 ## -- pista:ignore
 

--- a/model/table.go
+++ b/model/table.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"maps"
 	"slices"
 	"strings"
 
@@ -16,8 +17,12 @@ type Table struct {
 	// Ignore marks the table as unmanaged (set by -- pista:ignore). Ignored
 	// objects are not created, altered, or dropped; always false on the
 	// catalog side.
-	Ignore           bool
-	TableSpace       *string
+	Ignore     bool
+	TableSpace *string
+	// StorageParams holds the table's storage parameters, pg_class.reloptions,
+	// keyed by parameter name and ordered by it. A `toast.` prefix names a
+	// parameter of the TOAST relation, which is where pg_dump writes it too.
+	StorageParams    *orderedmap.Map[string, string]
 	Unlogged         bool
 	Partitioned      bool
 	PartitionDef     *string
@@ -58,6 +63,9 @@ func (t Table) SQL() string {
 			if t.Partitioned && t.PartitionDef != nil {
 				sql += "\nPARTITION BY " + *t.PartitionDef
 			}
+			if w := t.StorageParamsSQL(); w != "" {
+				sql += "\n" + w
+			}
 			if t.TableSpace != nil {
 				sql += "\nTABLESPACE " + Ident(*t.TableSpace)
 			}
@@ -71,8 +79,11 @@ func (t Table) SQL() string {
 					",\n",
 				) +
 				")\n" +
-				"INHERITS (" + *t.PartitionOf + ");"
-			return sql
+				"INHERITS (" + *t.PartitionOf + ")"
+			if w := t.StorageParamsSQL(); w != "" {
+				sql += "\n" + w
+			}
+			return sql + ";"
 		}
 	}
 
@@ -113,6 +124,10 @@ func (t Table) SQL() string {
 
 	if t.Partitioned && t.PartitionDef != nil {
 		sql += "\nPARTITION BY " + *t.PartitionDef
+	}
+
+	if w := t.StorageParamsSQL(); w != "" {
+		sql += "\n" + w
 	}
 
 	if t.TableSpace != nil {
@@ -165,6 +180,47 @@ func (t Table) TrigSQL() string {
 		}
 	}
 	return strings.Join(stmts, "\n")
+}
+
+// SortedStorageParams turns a name -> value map of storage parameters into an
+// ordered map keyed in name order, so neither the comparison nor the dump
+// depends on the order a file or the catalog kept them in.
+func SortedStorageParams(params map[string]string) *orderedmap.Map[string, string] {
+	om := orderedmap.New[string, string]()
+	for _, name := range slices.Sorted(maps.Keys(params)) {
+		om.Set(name, params[name])
+	}
+	return om
+}
+
+// StorageParamsSQL renders the table's storage parameters as the WITH clause
+// of a CREATE TABLE, or "" when it holds none. Every value is quoted.
+// PostgreSQL accepts that for any parameter, so the renderer does not have to
+// decide which spellings pass as a bare identifier.
+func (t Table) StorageParamsSQL() string {
+	if t.StorageParams == nil || t.StorageParams.Len() == 0 {
+		return ""
+	}
+	return "WITH (" + strings.Join(
+		t.StorageParams.TransformSlice(func(name, value string) string {
+			return name + "=" + QuoteLiteral(value)
+		}),
+		", ",
+	) + ")"
+}
+
+// SetStorageParamsSQL returns the statement that sets the named storage
+// parameters. It does not rewrite the table.
+func SetStorageParamsSQL(fqtn string, params []string) string {
+	return "ALTER TABLE " + fqtn + " SET (" + strings.Join(params, ", ") + ");"
+}
+
+// ResetStorageParamsSQL returns the statement that hands the named storage
+// parameters back to their defaults. RESET is the only way to say that: the
+// catalog holds no entry for a parameter that was never set, so a SET has no
+// default value to name.
+func ResetStorageParamsSQL(fqtn string, names []string) string {
+	return "ALTER TABLE " + fqtn + " RESET (" + strings.Join(names, ", ") + ");"
 }
 
 // SetStorageSQL returns the statement that puts a column's TOAST strategy at

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -403,3 +403,85 @@ func TestTableToSQL_IncludesStorage(t *testing.T) {
 	assert.Contains(t, out, "CREATE TABLE public.docs")
 	assert.Contains(t, out, "ALTER TABLE public.docs ALTER COLUMN body SET STORAGE MAIN;")
 }
+
+func TestTable_StorageParamsSQL_empty(t *testing.T) {
+	tbl := newTable("public", "users")
+	assert.Empty(t, tbl.StorageParamsSQL())
+
+	tbl.StorageParams = model.SortedStorageParams(nil)
+	assert.Empty(t, tbl.StorageParamsSQL())
+}
+
+func TestTable_StorageParamsSQL_sortedAndQuoted(t *testing.T) {
+	tbl := newTable("public", "users")
+	tbl.StorageParams = model.SortedStorageParams(map[string]string{
+		"toast.autovacuum_enabled": "off",
+		"fillfactor":               "70",
+		"autovacuum_enabled":       "off",
+	})
+
+	assert.Equal(t,
+		"WITH (autovacuum_enabled='off', fillfactor='70', toast.autovacuum_enabled='off')",
+		tbl.StorageParamsSQL())
+}
+
+func TestTable_SQL_storageParams(t *testing.T) {
+	tbl := newTable("public", "users")
+	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+	tbl.StorageParams = model.SortedStorageParams(map[string]string{"fillfactor": "70"})
+
+	assert.Equal(t,
+		"CREATE TABLE public.users (\n    id integer NOT NULL\n)\nWITH (fillfactor='70');",
+		tbl.SQL())
+}
+
+func TestTable_SQL_storageParams_partitionOf(t *testing.T) {
+	tbl := newTable("public", "events_east")
+	parent := "public.events"
+	bound := "FOR VALUES FROM ('a') TO ('m')"
+	partDef := "LIST (kind)"
+	ts := "fast_ssd"
+	tbl.PartitionOf = &parent
+	tbl.PartitionBound = &bound
+	tbl.Partitioned = true
+	tbl.PartitionDef = &partDef
+	tbl.TableSpace = &ts
+	tbl.StorageParams = model.SortedStorageParams(map[string]string{"fillfactor": "60"})
+
+	// WITH sits between PARTITION BY and TABLESPACE, as the grammar has it.
+	assert.Equal(t,
+		"CREATE TABLE public.events_east PARTITION OF public.events FOR VALUES FROM ('a') TO ('m')\n"+
+			"PARTITION BY LIST (kind)\nWITH (fillfactor='60')\nTABLESPACE fast_ssd;",
+		tbl.SQL())
+}
+
+func TestTable_SQL_storageParams_inherits(t *testing.T) {
+	tbl := newTable("public", "child")
+	parent := "public.parent"
+	tbl.PartitionOf = &parent
+	tbl.Constraints.Set("child_pkey", &model.Constraint{Name: "child_pkey", Definition: "PRIMARY KEY (id)"})
+	tbl.StorageParams = model.SortedStorageParams(map[string]string{"fillfactor": "65"})
+
+	assert.Equal(t,
+		"CREATE TABLE public.child(\n    CONSTRAINT child_pkey PRIMARY KEY (id))\n"+
+			"INHERITS (public.parent)\nWITH (fillfactor='65');",
+		tbl.SQL())
+}
+
+func TestSetStorageParamsSQL(t *testing.T) {
+	assert.Equal(t,
+		"ALTER TABLE public.users SET (fillfactor='90', toast.autovacuum_enabled='off');",
+		model.SetStorageParamsSQL("public.users", []string{"fillfactor='90'", "toast.autovacuum_enabled='off'"}))
+}
+
+func TestResetStorageParamsSQL(t *testing.T) {
+	assert.Equal(t,
+		"ALTER TABLE public.users RESET (autovacuum_enabled, fillfactor);",
+		model.ResetStorageParamsSQL("public.users", []string{"autovacuum_enabled", "fillfactor"}))
+}
+
+func TestSortedStorageParams(t *testing.T) {
+	params := model.SortedStorageParams(map[string]string{"b": "2", "a": "1", "c": "3"})
+	assert.Equal(t, []string{"a", "b", "c"}, params.CollectKeys())
+	assert.Equal(t, []string{"1", "2", "3"}, params.CollectValues())
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2299,6 +2299,13 @@ func parseStorageParams(options []*pg_query.Node) *orderedmap.Map[string, string
 		if ns := de.GetDefnamespace(); ns != "" {
 			name = ns + "." + name
 		}
+		// WITH (oids = false) is what every pg_dump before 12 writes on every
+		// table. PostgreSQL still accepts it in a CREATE TABLE and stores
+		// nothing for it, while ALTER TABLE ... SET rejects the name, so it is
+		// not a parameter. oids = true is rejected by the CREATE itself.
+		if name == "oids" {
+			continue
+		}
 		params[name] = storageParamValue(de)
 	}
 	return model.SortedStorageParams(params)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -582,6 +582,8 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 		table.TableSpace = &ts
 	}
 
+	table.StorageParams = parseStorageParams(cs.Options)
+
 	if cs.Partspec != nil {
 		def, err := deparsePartitionSpec(cs)
 		if err != nil {
@@ -2284,4 +2286,44 @@ func deparsePartitionBound(cs *pg_query.CreateStmt) (string, error) {
 		return "", fmt.Errorf("could not extract partition bound from: %s", sql)
 	}
 	return strings.TrimSpace(sql[idx+len(prefix):]), nil
+}
+
+// parseStorageParams reads the WITH clause of a CREATE TABLE. A parameter of
+// the TOAST relation arrives with `toast` as its namespace and is keyed under
+// the same `toast.` prefix the catalog reports it with.
+func parseStorageParams(options []*pg_query.Node) *orderedmap.Map[string, string] {
+	params := make(map[string]string, len(options))
+	for _, o := range options {
+		de := o.GetDefElem()
+		name := de.GetDefname()
+		if ns := de.GetDefnamespace(); ns != "" {
+			name = ns + "." + name
+		}
+		params[name] = storageParamValue(de)
+	}
+	return model.SortedStorageParams(params)
+}
+
+// storageParamValue reads a storage parameter's value as text. A parameter
+// written without one asks for true, which is what PostgreSQL stores for it.
+func storageParamValue(de *pg_query.DefElem) string {
+	switch n := de.GetArg().GetNode().(type) {
+	case *pg_query.Node_String_:
+		return n.String_.Sval
+	case *pg_query.Node_Integer:
+		return strconv.FormatInt(int64(n.Integer.Ival), 10)
+	case *pg_query.Node_Float:
+		return n.Float.Fval
+	case *pg_query.Node_TypeName:
+		// A value that reads as a bare identifier, `autovacuum_enabled = off`,
+		// arrives as a type name: the grammar accepts a type there. Its parts
+		// carry the word PostgreSQL stores.
+		var parts []string
+		for _, name := range n.TypeName.Names {
+			parts = append(parts, name.GetString_().GetSval())
+		}
+		return strings.Join(parts, ".")
+	default:
+		return "true"
+	}
 }

--- a/testdata/apply/create_table_with_storage_params.yml
+++ b/testdata/apply/create_table_with_storage_params.yml
@@ -1,0 +1,25 @@
+# A new table carries the parameters in the CREATE, and the re-plan comes out
+# clean: what the parser read back out of the WITH clause has to match what
+# the catalog then reports.
+init: ""
+desired: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70, autovacuum_enabled = off, toast.autovacuum_enabled = off);
+applied: |
+  -- public.docs
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  )
+  WITH (autovacuum_enabled='off', fillfactor='70', toast.autovacuum_enabled='off');
+applied_sql: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  )
+  WITH (autovacuum_enabled='off', fillfactor='70', toast.autovacuum_enabled='off');

--- a/testdata/apply/index_storage_params.yml
+++ b/testdata/apply/index_storage_params.yml
@@ -1,0 +1,26 @@
+# A hand-written index parameter has to survive the apply and the re-plan.
+# Before the value was normalized the index was dropped and recreated on
+# every run that followed.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor = 80);
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor='80');
+applied_sql: |
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor=80);

--- a/testdata/apply/table_storage_params.yml
+++ b/testdata/apply/table_storage_params.yml
@@ -1,0 +1,27 @@
+# The parameters apply and the re-plan comes out clean. The table carries a
+# text column so that it has a TOAST relation for the toast.* parameter to
+# land on: PostgreSQL accepts the statement either way and discards it when
+# there is no such relation.
+init: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70, autovacuum_enabled = off);
+desired: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 90, toast.autovacuum_enabled = off);
+applied: |
+  -- public.docs
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  )
+  WITH (fillfactor='90', toast.autovacuum_enabled='off');
+applied_sql: |
+  ALTER TABLE public.docs SET (fillfactor='90', toast.autovacuum_enabled='off');
+  ALTER TABLE public.docs RESET (autovacuum_enabled);

--- a/testdata/apply/table_storage_params_new_toast_column.yml
+++ b/testdata/apply/table_storage_params_new_toast_column.yml
@@ -1,0 +1,26 @@
+# A table with no toastable column has no TOAST relation, and PostgreSQL
+# discards a toast. parameter set on it. The ADD COLUMN in the same plan
+# creates the relation, so the parameter has somewhere to land as long as it
+# goes after the column statements. The re-plan is what checks it landed.
+init: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  ) WITH (toast.autovacuum_enabled = off);
+applied: |
+  -- public.docs
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  )
+  WITH (toast.autovacuum_enabled='off');
+applied_sql: |
+  ALTER TABLE public.docs ADD COLUMN body text;
+  ALTER TABLE public.docs SET (toast.autovacuum_enabled='off');

--- a/testdata/dump/table_storage_params.yml
+++ b/testdata/dump/table_storage_params.yml
@@ -1,0 +1,18 @@
+# The table's parameters, a toast.* one, and an index's, all of which pg_dump
+# writes and none of which used to survive a dump.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70, autovacuum_enabled = off, toast.autovacuum_enabled = off);
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor = 80);
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  )
+  WITH (autovacuum_enabled='off', fillfactor='70', toast.autovacuum_enabled='off');
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor='80');

--- a/testdata/dump/table_storage_params_partition.yml
+++ b/testdata/dump/table_storage_params_partition.yml
@@ -1,0 +1,21 @@
+# A partition carries its own parameters, and the partitioned parent holds
+# none: PostgreSQL rejects every storage parameter on a relation with no
+# storage of its own.
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      at date NOT NULL
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.events_2025 PARTITION OF public.events
+      FOR VALUES FROM ('2025-01-01') TO ('2026-01-01') WITH (fillfactor = 60);
+dump: |
+  -- public.events
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      at date NOT NULL
+  )
+  PARTITION BY RANGE (at);
+
+  -- public.events_2025
+  CREATE TABLE public.events_2025 PARTITION OF public.events FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')
+  WITH (fillfactor='60');

--- a/testdata/parser/table_storage_params.yml
+++ b/testdata/parser/table_storage_params.yml
@@ -1,0 +1,10 @@
+input: |
+  CREATE TABLE public.users (
+      id integer NOT NULL
+  ) WITH (fillfactor = 70, autovacuum_enabled = off, autovacuum_vacuum_scale_factor = 0.05, toast.autovacuum_enabled = true, user_catalog_table);
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL
+  )
+  WITH (autovacuum_enabled='off', autovacuum_vacuum_scale_factor='0.05', fillfactor='70', toast.autovacuum_enabled='true', user_catalog_table='true');

--- a/testdata/parser/table_storage_params_oids.yml
+++ b/testdata/parser/table_storage_params_oids.yml
@@ -1,0 +1,10 @@
+input: |
+  CREATE TABLE public.users (
+      id integer NOT NULL
+  ) WITH (oids = false, fillfactor = 70);
+expected: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL
+  )
+  WITH (fillfactor='70');

--- a/testdata/plan/alter_index_storage_params.yml
+++ b/testdata/plan/alter_index_storage_params.yml
@@ -1,0 +1,20 @@
+# A parameter that actually changes still rebuilds the index. PostgreSQL can
+# ALTER INDEX ... SET, but it does not take effect until the index is rebuilt,
+# so the drop and create say what the change costs.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor = 80);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor = 90);
+plan: |
+  DROP INDEX public.users_name_idx;
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor=90);

--- a/testdata/plan/alter_table_storage_params.yml
+++ b/testdata/plan/alter_table_storage_params.yml
@@ -1,0 +1,14 @@
+# A parameter arriving and one changing value go out in one ALTER. Neither
+# rewrites the table; both decide how the table is filled and vacuumed later.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 90, autovacuum_vacuum_scale_factor = 0.05);
+plan: |
+  ALTER TABLE public.users SET (autovacuum_vacuum_scale_factor='0.05', fillfactor='90');

--- a/testdata/plan/bulk_alter_table_storage_params.yml
+++ b/testdata/plan/bulk_alter_table_storage_params.yml
@@ -1,0 +1,22 @@
+# --bulk-alter merges a table's column and constraint actions into one
+# statement. A storage parameter SET is not one of them and stays on its own,
+# so it does not pull an action PostgreSQL takes a different lock for into the
+# same statement.
+bulk_alter: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 90);
+plan: |
+  ALTER TABLE public.users
+    ADD COLUMN name text,
+    ADD COLUMN email text;
+  ALTER TABLE public.users SET (fillfactor='90');

--- a/testdata/plan/bulk_alter_table_storage_params.yml
+++ b/testdata/plan/bulk_alter_table_storage_params.yml
@@ -1,22 +1,24 @@
 # --bulk-alter merges a table's column and constraint actions into one
-# statement. A storage parameter SET is not one of them and stays on its own,
-# so it does not pull an action PostgreSQL takes a different lock for into the
-# same statement.
+# statement, and only while they are consecutive. A storage parameter SET is
+# not one of the actions it merges, so it goes after the column statements
+# rather than between them, where it would split the group in two.
 bulk_alter: true
+drop_policy:
+  allow_drop: [column]
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,
+      old_col text,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   ) WITH (fillfactor = 70);
 desired: |
   CREATE TABLE public.users (
       id integer NOT NULL,
       name text,
-      email text,
       CONSTRAINT users_pkey PRIMARY KEY (id)
   ) WITH (fillfactor = 90);
 plan: |
   ALTER TABLE public.users
     ADD COLUMN name text,
-    ADD COLUMN email text;
+    DROP COLUMN old_col;
   ALTER TABLE public.users SET (fillfactor='90');

--- a/testdata/plan/create_table_with_storage_params.yml
+++ b/testdata/plan/create_table_with_storage_params.yml
@@ -1,0 +1,14 @@
+# A new table carries its storage parameters in the CREATE, so no ALTER
+# follows it.
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70, autovacuum_enabled = off);
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  )
+  WITH (autovacuum_enabled='off', fillfactor='70');

--- a/testdata/plan/no_diff_index_storage_params.yml
+++ b/testdata/plan/no_diff_index_storage_params.yml
@@ -1,0 +1,18 @@
+# pg_get_indexdef quotes a numeric parameter value and a hand-written index
+# writes it bare, so the two spellings have to compare equal. They did not,
+# and the index was dropped and recreated on every run.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor = 80);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor = 80);
+plan: ""

--- a/testdata/plan/no_diff_index_storage_params_order.yml
+++ b/testdata/plan/no_diff_index_storage_params_order.yml
@@ -1,0 +1,18 @@
+# The catalog lists an index's parameters in the order they were created in,
+# which is not the order a file has to write them in. Only the settings are
+# compared.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor = 80, deduplicate_items = off);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (deduplicate_items = off, fillfactor = 80);
+plan: ""

--- a/testdata/plan/no_diff_rename_table_storage_params.yml
+++ b/testdata/plan/no_diff_rename_table_storage_params.yml
@@ -1,0 +1,15 @@
+# The parameters carry through a rename untouched, so the plan is the RENAME
+# alone.
+init: |
+  CREATE TABLE public.old_users (
+      id integer NOT NULL,
+      CONSTRAINT old_users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+desired: |
+  -- pista:renamed-from old_users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT old_users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+plan: |
+  ALTER TABLE public.old_users RENAME TO users;

--- a/testdata/plan/no_diff_table_storage_params.yml
+++ b/testdata/plan/no_diff_table_storage_params.yml
@@ -1,0 +1,14 @@
+# The catalog reports a numeric value quoted and the file writes it bare, and
+# the order a file lists the parameters in is not the order the catalog keeps
+# them. Neither is a change.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70, autovacuum_enabled = off);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (autovacuum_enabled = off, fillfactor = '70');
+plan: ""

--- a/testdata/plan/rename_table_storage_params.yml
+++ b/testdata/plan/rename_table_storage_params.yml
@@ -1,0 +1,16 @@
+# A rename does not disturb the parameters, and a parameter that does change
+# is set under the new name, after the RENAME.
+init: |
+  CREATE TABLE public.old_users (
+      id integer NOT NULL,
+      CONSTRAINT old_users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+desired: |
+  -- pista:renamed-from old_users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT old_users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 90);
+plan: |
+  ALTER TABLE public.old_users RENAME TO users;
+  ALTER TABLE public.users SET (fillfactor='90');

--- a/testdata/plan/reset_table_storage_params.yml
+++ b/testdata/plan/reset_table_storage_params.yml
@@ -1,0 +1,15 @@
+# Dropping a parameter from the desired schema asks for the default back.
+# RESET is the only way to say that: the catalog holds no entry for a
+# parameter that was never set, so there is no default value to name.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70, autovacuum_enabled = off);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+plan: |
+  ALTER TABLE public.users RESET (autovacuum_enabled);

--- a/testdata/plan/skip_partition_child_storage_params.yml
+++ b/testdata/plan/skip_partition_child_storage_params.yml
@@ -1,0 +1,16 @@
+# --skip-partition-child drops the partitions from both sides, so a parameter
+# only a partition carries is neither set nor reset.
+skip_partition_child: true
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      at date NOT NULL
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.events_2025 PARTITION OF public.events
+      FOR VALUES FROM ('2025-01-01') TO ('2026-01-01') WITH (fillfactor = 60);
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      at date NOT NULL
+  ) PARTITION BY RANGE (at);
+plan: ""

--- a/testdata/plan/table_storage_params_bare_value.yml
+++ b/testdata/plan/table_storage_params_bare_value.yml
@@ -1,0 +1,14 @@
+# A parameter written without a value asks for true, which is what PostgreSQL
+# stores for it, so naming it in the desired schema against a table that
+# already has it is not a change.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (autovacuum_enabled = true);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (autovacuum_enabled);
+plan: ""

--- a/testdata/plan/table_storage_params_oids.yml
+++ b/testdata/plan/table_storage_params_oids.yml
@@ -1,0 +1,15 @@
+# A pg_dump from before PostgreSQL 12 writes WITH (oids = false) on every
+# table. PostgreSQL accepts it in a CREATE TABLE and stores nothing for it, so
+# reading it as a parameter would plan an ALTER TABLE ... SET that PostgreSQL
+# rejects, on every table of such a dump and on every run.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (oids = false);
+plan: ""

--- a/testdata/plan/table_storage_params_partition_child.yml
+++ b/testdata/plan/table_storage_params_partition_child.yml
@@ -1,0 +1,19 @@
+# A partition holds its own storage parameters: PostgreSQL does not copy the
+# parent's as it creates one, so the child is diffed on its own. The parent is
+# partitioned and holds none, since it has no storage to apply them to.
+init: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      at date NOT NULL
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.events_2025 PARTITION OF public.events
+      FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+desired: |
+  CREATE TABLE public.events (
+      id integer NOT NULL,
+      at date NOT NULL
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.events_2025 PARTITION OF public.events
+      FOR VALUES FROM ('2025-01-01') TO ('2026-01-01') WITH (fillfactor = 60);
+plan: |
+  ALTER TABLE public.events_2025 SET (fillfactor='60');

--- a/testdata/plan/table_storage_params_toast.yml
+++ b/testdata/plan/table_storage_params_toast.yml
@@ -1,0 +1,17 @@
+# A toast.* parameter sits on the TOAST relation, not on the table, and is
+# what pg_dump writes into the same WITH clause. It is diffed alongside the
+# table's own parameters.
+init: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  ) WITH (toast.autovacuum_enabled = off);
+plan: |
+  ALTER TABLE public.docs SET (toast.autovacuum_enabled='off');


### PR DESCRIPTION
## A table's storage parameters were read by neither side

`WITH (fillfactor = 70, autovacuum_enabled = off)` was dropped from the desired schema without even the `ignored unsupported statement` warning an unsupported statement gets, `dump` did not write the clause, and no plan ever proposed one. pg_dump writes those parameters, and a pg_dump file is the natural starting point for a desired schema, so per-table autovacuum tuning went silently unmanaged the moment it was adopted.

Both sides read them now, from `pg_class.reloptions` and from the `CREATE TABLE`. A change goes out as `ALTER TABLE ... SET (...)`, with one `RESET` for the parameters the desired schema no longer names. Neither statement rewrites the table.

**TOAST.** A `toast.` parameter sits on the TOAST relation, which is where pg_dump writes it into the same clause. It is read from `reltoastrelid` and diffed alongside. PostgreSQL creates that relation only for a table with a toastable column and accepts the statement either way, discarding it when there is none, so such a table re-plans the parameter on every run. Documented in the README rather than special-cased.

**Partitioning.** A partitioned table takes no parameter at all, since it holds no storage, and a partition does not copy the parent's, so each is diffed on its own.

**Order.** Both sides are keyed in name order, so neither the order a file lists them in nor the order the catalog keeps them in reaches the comparison or the dump.

## An index's parameters were compared but not normalized

`pg_get_indexdef` quotes a value that does not read as an identifier, `fillfactor='80'`, while a file writes the number bare, so the two arrived as a String and an Integer node and never matched. An index carrying one was dropped and recreated on every plan, which is a full rebuild each run. Reproduced on `main`: apply the index, and the next two plans both emit `DROP INDEX` plus `CREATE INDEX` against a catalog that already holds `{fillfactor=80}`.

The catalog also keeps the parameters in creation order, which a file has no reason to follow, so the list is sorted before the comparison too.

Neither of these showed up in the dump round trip, since `dump` writes what `pg_get_indexdef` reports.

## Tests

14 plan fixtures, 3 apply, 2 dump, 1 parser, and unit tests in `model`, `diff` and `catalog`. The interactions are pinned as well: `--bulk-alter` leaves the `SET` on its own, `--skip-partition-child` drops a partition's parameters with the partition, and a rename carries them through and sets a changed one under the new name.

The `diff`, `parser` and `catalog` code needed package-local tests, not only fixtures. Measured the way CI does, the fixtures alone left the branch at 94.3% against main's 94.8%, because a fixture runs in the root package where those three are dependencies rather than the package under test.

## Left alone

Views and materialized views carry reloptions of their own, `security_barrier` and the autovacuum settings, and lose them the same way. A constraint's index takes them too, and `pg_get_constraintdef` does not print them, so a hand-written `UNIQUE (v) WITH (fillfactor = 70)` drops and re-adds the constraint on every run, rebuilding the index under an ACCESS EXCLUSIVE lock. Both are separate objects and separate statements. The constraint one is recorded in TODO.md with the shape of the fix.

`ALTER TABLE ... SET (...)` in a desired file is still warned about and dropped, like every other unsupported `ALTER TABLE` action. pg_dump writes the parameters inline in the `CREATE TABLE`, and so does `dump`, so nothing that round-trips depends on it.

Measured the way CI does on PostgreSQL 15, 94.8% -> 94.9%. `make lint`, `make deadcode`, `make test` and `make test-scenario` pass, and the 17 real-world sample schemas still round-trip.
