### PR TITLE
Put a database icon in the header instead of the default book

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  icon:
+    logo: material/database-sync
   features:
     - navigation.sections
     - navigation.top


### PR DESCRIPTION
The header carried Material's default book icon. `theme.icon.logo` takes an icon name and inlines the SVG, so this adds no image file to the repository.

```yaml
theme:
  icon:
    logo: material/database-sync
```

Worth recording, since the build does not catch it: `theme.logo` and `theme.icon.logo` are different keys. `theme.logo` takes a path to an image, so putting the icon name there renders `<img src="material/database-sync">` pointing at nothing, and `mkdocs build --strict` still passes. The first attempt did exactly that and only the built HTML showed it.

The favicon stays at Material's default. `theme.favicon` accepts a file path only, and the reason for using an icon here was to avoid committing an image.

Missed the merge of #460 by a few minutes, so this comes as its own branch.
