### PR TITLE
Stop the home page from printing Home above the logo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-![pistachio](https://github.com/user-attachments/assets/d1e6ca05-778e-4329-af87-ce68d2abaebc)
+# ![pistachio](https://github.com/user-attachments/assets/d1e6ca05-778e-4329-af87-ce68d2abaebc)
 
 Declarative schema management tool for PostgreSQL with a Terraform-like
 plan/apply workflow, built on


### PR DESCRIPTION
The home page opened with the word `Home` above the logo.

Material inserts the page title as an `<h1>` when the content carries none, and 054e618 replaced the `# pistachio` heading with the logo image. With no heading left, the title came from the nav entry.

Wrapping the image in the heading gives the page an `<h1>` again:

```markdown
# ![pistachio](https://github.com/user-attachments/assets/d1e6ca05-778e-4329-af87-ce68d2abaebc)
```

The inserted title is gone, the browser tab reads `pistachio` instead of `Home`, and the sidebar still says `Home`, which comes from the nav and is unaffected.