### PR TITLE
Tighten the space around the logo on the home page

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,18 @@
+/* The home page heading holds the logo and no text, so the heading metrics
+   apply to nothing visible: an inline image sits on a text baseline, which
+   leaves the line box's leading above and below it, and the bottom margin is
+   sized for 2em text. */
+.md-typeset h1 > img {
+  display: block;
+}
+
+.md-typeset h1:has(> img) {
+  margin-bottom: 1rem;
+}
+
+/* The permalink is inline, so a block image pushes it onto a line of its own
+   and the heading gains an empty text line. The home page title needs no
+   anchor. */
+.md-typeset h1:has(> img) .headerlink {
+  display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,9 @@ theme:
 hooks:
   - hooks.py
 
+extra_css:
+  - stylesheets/extra.css
+
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
The logo is the home page's heading, so Material's heading metrics apply to an element with no text in it. Two things followed from that:

- The image sat on a text baseline, so the line box's leading stayed under it.
- The permalink is inline, so it took a line of its own once the image was there, and the heading gained an empty text line.

Below the logo that came to 55px, against 22px above it.

`docs/stylesheets/extra.css` makes the image a block and hides the permalink on a heading that holds one. The home page title has no use for an anchor.

Measured in the browser, deployed page against this build:

| | before | after |
|---|---:|---:|
| heading box | 273px | 262px |
| slack inside the heading | 11px | 0px |
| gap above | 22px | 22px |
| gap below | 44px | 22px |

The image is 262px tall, so the heading box is now exactly the image.

`:has()` scopes both rules to a heading that contains an image, which is only this one.