### PR TITLE
Generate social cards so a link to the docs expands into a card

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,9 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
+      # Cairo and its friends are what the social plugin renders the card
+      # images with. Pillow and CairoSVG bind to them but do not ship them.
+      - run: sudo apt-get install --no-install-recommends -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       - run: pip install -r requirements-docs.txt
       - run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ site/
 
 # Byte-compiled hooks.py, written when the docs are built locally
 __pycache__/
+
+# Social card images and the fonts they are drawn with, cached by the social
+# plugin when the docs are built locally
+.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ make fix            # golangci-lint run --fix (auto-fix lint errors)
 - `testdata/` - YAML-based test fixtures for multiple test suites, including integration and unit tests
 - `test/scenario/` - CLI-level scenario tests (shell scripts that run `pista` CLI against sample schemas)
 - `test/fidelity/` - restore fidelity check: loads `pista dump` output into an empty database and diffs `pg_dump` against the original
-- `docs/` - the documentation site, built with MkDocs and published to GitHub Pages. The Markdown is the source; `mkdocs build --strict` fails on a broken internal link. `CHANGELOG.md` and `TODO.md` stay at the repository root and are symlinked into `docs/about/`.
+- `docs/` - the documentation site, built with MkDocs and published to GitHub Pages. The Markdown is the source; `mkdocs build --strict` fails on a broken internal link. The social plugin draws a preview card per page, so a local build needs Cairo and Pango installed as well as `requirements-docs.txt`. `CHANGELOG.md` and `TODO.md` stay at the repository root and are symlinked into `docs/about/`.
 
 ## Development workflow
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,11 @@
+---
+# The nav calls this page Home, which is the wrong headline for the social
+# card a link to the site expands into. Name the project there instead.
+social:
+  cards_layout_options:
+    title: pistachio
+---
+
 # ![pistachio](https://github.com/user-attachments/assets/d1e6ca05-778e-4329-af87-ce68d2abaebc)
 
 Declarative schema management tool for PostgreSQL with a Terraform-like

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,13 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 
+plugins:
+  # Listing plugins turns off the default set, so search has to be named again.
+  - search
+  # Generates a preview image per page and the og:/twitter: meta tags that point
+  # at it, so a link to the site expands into a card.
+  - social
+
 hooks:
   - hooks.py
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,1 @@
-mkdocs-material==9.7.7
+mkdocs-material[imaging]==9.7.7


### PR DESCRIPTION
## What

The published HTML carried no `og:` or `twitter:` meta, so pasting
https://winebarrel.github.io/pistachio/ into X or Slack showed a bare link with
no preview. Enable the Material social plugin, which renders a 1200x630 preview
image per page and emits the meta tags pointing at it.

## Changes

- `mkdocs.yml` - add the `social` plugin. Listing plugins turns the default set
  off, so `search` is named again.
- `requirements-docs.txt` - `mkdocs-material[imaging]`, which pulls in Pillow
  and CairoSVG.
- `.github/workflows/docs.yml` - install Cairo and friends before pip. Pillow
  and CairoSVG bind to them without shipping them.
- `docs/index.md` - the nav calls this page Home, which is the wrong headline
  for a card, so the front matter names the project instead.
- `.gitignore` - the plugin's local `.cache/` of fonts and rendered cards.
- `AGENTS.md` - note that a local docs build now needs Cairo and Pango.

## Verified

`mkdocs build --strict` from a cold cache, locally. Cards are generated for
every page, and the home page head gains:

```html
<meta property="og:image" content="https://winebarrel.github.io/pistachio/assets/images/social/index.png" />
<meta property="og:image:width" content="1200" />
<meta property="og:image:height" content="630" />
<meta property="twitter:card" content="summary_large_image" />
```

X caches previews, so the old no-card rendering may linger for a while after
this ships.