### PR TITLE
Cut the Windows CI job's PostgreSQL connection overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
       # The runner's PostgreSQL listens on the default port; the Makefile
       # otherwise defaults to the port compose.yaml publishes locally.
       PGPORT: "5432"
+      # Every plan, apply and dump opens its own connection, and the fixtures
+      # add up to more than a thousand of them. sslmode=disable takes the SSL
+      # negotiation round-trip out of each one; the server is on loopback and
+      # has SSL off anyway, so there is nothing to negotiate.
+      TEST_PISTA_CONN_STR: postgres://postgres@localhost:5432/postgres?sslmode=disable
     steps:
       # Keep LF line endings; test fixtures are compared byte for byte.
       - run: git config --global core.autocrlf false
@@ -71,6 +76,20 @@ jobs:
           go-version-file: go.mod
       - name: Install GNU Make
         run: choco install -y --no-progress make
+      # A PostgreSQL backend on Windows is a new process rather than a fork,
+      # and Defender scans every one of them. The tests open a connection per
+      # fixture, so that scan sits on the hot path more than a thousand times.
+      # Excluding the server's own files and executable takes it off. This only
+      # buys time, so warn and carry on if the image stops allowing it.
+      - name: Exclude PostgreSQL from Defender
+        shell: pwsh
+        run: |
+          try {
+            Add-MpPreference -ExclusionPath $env:PGBIN, $env:PGDATA -ErrorAction Stop
+            Add-MpPreference -ExclusionProcess postgres.exe -ErrorAction Stop
+          } catch {
+            Write-Warning "could not add Defender exclusions: $_"
+          }
       # PostgreSQL is preinstalled on the runner image but the service is
       # stopped and disabled by default. PGDATA / PGBIN are set by the image
       # and point at that install. Switch it to trust auth to match the Linux


### PR DESCRIPTION
The Windows job takes twice as long as the Linux ones. Timing the last run on main (33242445350's predecessor, 33242189990):

| | Windows | Linux (pg18) |
| --- | --- | --- |
| job | 6:00 | 3:06 |
| `make` step | 4:38 | 1:11 |
| root package | 230s | 44s |
| TestApply / TestPlan / TestDump | 101 / 78 / 17s | 20 / 15 / 4s |

Plan, apply and dump each open their own connection, so the fixtures open more than a thousand of them, and the gap tracks the connection count exactly: plan runs one per case and costs 122ms more than on Linux, apply runs three and costs 358ms.

Two changes, both confined to the Windows job:

- A backend on Windows is a new process rather than a fork, and Defender scans every one. Exclude the server's files and executable. This only buys time, so it warns and carries on if the image stops allowing it.
- Drop the SSL negotiation round-trip from each connection through `sslmode=disable`. The server is on loopback with SSL off, so there is nothing to negotiate. Against a local container that round-trip alone is worth 12-19% of TestPlan (prefer 11.1/12.3/13.1s, disable 9.0/10.8/11.7s).

If this does not bring the job under about 4 minutes, the next step is splitting it into a matrix over TestApply / TestPlan / the rest, which trades runners for wall clock.