### PR TITLE
Stop BETWEEN, LIKE and NOT IN from drifting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -628,8 +628,10 @@ Every normalization the walk performs is therefore missing there. A
 schema-qualified call drifts, `EXCLUDE USING btree (public.lower_v(v) WITH =)`
 being re-emitted as `DROP CONSTRAINT` + `ADD CONSTRAINT` on every plan, and so
 does a cast the catalog adds and the file does not: `((v || 'x') WITH =)` is
-stored as `((v || 'x'::text) WITH =)`. This is wider than the schema question
-and predates the strip.
+stored as `((v || 'x'::text) WITH =)`. The folds in `diff/desugar.go` are
+missing too, so the `BETWEEN` in
+`EXCLUDE USING gist (r WITH &&) WHERE (a BETWEEN 1 AND 10)` drifts here alone.
+This is wider than the schema question and predates the strip.
 
 Passing `Exclusions` and `WhereClause` through the same walk is the obvious
 shape, and the elements are `IndexElem` nodes, which `normalizeIndexStmt`
@@ -641,6 +643,36 @@ hand-written exclusion reaches this.
 Workaround: write the exclusion the way `pg_get_constraintdef` prints it.
 
 Origin: review of [#455](https://github.com/winebarrel/pistachio/pull/455).
+
+## Perpetual drift on a typed literal the catalog re-prints
+
+Priority: low.
+
+A constant written with a type name is stored as the value that type's input
+function produced, not as the text that produced it. `CHECK (a > timestamp
+'2000-01-01')` comes back from `pg_get_constraintdef` as
+`CHECK ((a > '2000-01-01 00:00:00'::timestamp without time zone))`, so the two
+sides never compare equal and the `CHECK` is dropped and re-added on every
+plan, revalidating the whole table. An index predicate, a view body, a policy,
+a trigger `WHEN` and a domain `CHECK` drift the same way, and a generated
+column fails the run, since it cannot be altered in place.
+
+`a AT TIME ZONE 'UTC' > '2000-01-01'` is the same case: the right operand
+resolves to `timestamp without time zone` and is re-printed in that type's
+output form.
+
+This is the one rewrite `diff/desugar.go` does not undo. The others are
+syntactic, so the fold is a tree rewrite the grammar already defines. Matching
+a literal means running the type's input and output functions over it, which
+would put a query to the server in the middle of the comparison.
+
+`dump` writes the catalog form, so a dump fed back plans clean and only a
+hand-written literal reaches this.
+
+Workaround: write the literal the way `pg_get_constraintdef` prints it, or
+leave the type off.
+
+Origin: expression normalization review, 2026-08-30.
 
 ## Perpetual drift on a schema-qualified sequence in a column DEFAULT
 

--- a/diff/desugar.go
+++ b/diff/desugar.go
@@ -1,0 +1,204 @@
+package diff
+
+import (
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"google.golang.org/protobuf/proto"
+)
+
+// The folds here undo the rewrites the PostgreSQL grammar and parse analysis
+// perform on the way into the catalog. pg_get_constraintdef, pg_get_expr,
+// pg_get_indexdef, pg_get_viewdef and pg_get_triggerdef print the stored form,
+// so a definition written with the keyword spelling never matches what comes
+// back and re-creates its object on every plan. A generated column fails the
+// run instead, since its expression cannot be altered in place.
+//
+// Each fold moves the written side onto the stored form, the direction
+// PostgreSQL itself defines. None changes what the expression means, and none
+// reaches the DDL: the diff emits the node it parsed.
+//
+// A typed literal is re-printed in its type's output form and still drifts.
+// TODO.md covers it.
+
+// desugarBetween expands BETWEEN into the comparisons parse analysis defines it
+// as, and returns nil for anything else. The four shapes follow
+// transformAExprBetween (src/backend/parser/parse_expr.c):
+//
+//	x BETWEEN a AND b               -> (x >= a) AND (x <= b)
+//	x NOT BETWEEN a AND b           -> (x < a) OR (x > b)
+//	x BETWEEN SYMMETRIC a AND b     -> ((x >= a) AND (x <= b)) OR ((x >= b) AND (x <= a))
+//	x NOT BETWEEN SYMMETRIC a AND b -> ((x < a) OR (x > b)) AND ((x < b) OR (x > a))
+//
+// The operand appears in each comparison, as a clone: a later walk must not
+// reach one copy through another.
+func desugarBetween(node *pg_query.Node) *pg_query.Node {
+	ae := node.GetAExpr()
+	if ae == nil {
+		return nil
+	}
+
+	var negated, symmetric bool
+	switch ae.Kind {
+	case pg_query.A_Expr_Kind_AEXPR_BETWEEN:
+	case pg_query.A_Expr_Kind_AEXPR_NOT_BETWEEN:
+		negated = true
+	case pg_query.A_Expr_Kind_AEXPR_BETWEEN_SYM:
+		symmetric = true
+	case pg_query.A_Expr_Kind_AEXPR_NOT_BETWEEN_SYM:
+		negated, symmetric = true, true
+	default:
+		return nil
+	}
+
+	list := ae.Rexpr.GetList()
+	if ae.Lexpr == nil || list == nil || len(list.Items) != 2 {
+		return nil
+	}
+	x, lo, hi := ae.Lexpr, list.Items[0], list.Items[1]
+
+	// The negated form is the plain one with both operators flipped and the
+	// two levels of AND/OR swapped, so one pair of names covers both.
+	loOp, hiOp := ">=", "<="
+	inner, outer := pg_query.BoolExprType_AND_EXPR, pg_query.BoolExprType_OR_EXPR
+	if negated {
+		loOp, hiOp = "<", ">"
+		inner, outer = outer, inner
+	}
+
+	bounded := makeBoolExpr(inner,
+		makeCmpExpr(loOp, cloneNode(x), lo),
+		makeCmpExpr(hiOp, cloneNode(x), hi),
+	)
+	if !symmetric {
+		return bounded
+	}
+
+	return makeBoolExpr(outer, bounded, makeBoolExpr(inner,
+		makeCmpExpr(loOp, cloneNode(x), cloneNode(hi)),
+		makeCmpExpr(hiOp, cloneNode(x), cloneNode(lo)),
+	))
+}
+
+// desugarPatternMatch drops the keyword spelling from LIKE, ILIKE and SIMILAR
+// TO. The grammar already puts the operator in the node's name (`~~`, `~~*`,
+// `!~~`, `!~~*`, `~`, `!~`) and an ESCAPE clause in the right operand as a
+// like_escape() or similar_to_escape() call, so all that is left is the kind
+// tag that makes the deparser print the keyword. The catalog prints the
+// operator, which parses as a plain one.
+//
+// The grammar writes the escape call pg_catalog-qualified and the catalog
+// prints it bare. stripFuncSchema settles that, and the walk has already
+// reached the call by the time it reaches this node.
+func desugarPatternMatch(node *pg_query.Node) {
+	ae := node.GetAExpr()
+	if ae == nil {
+		return
+	}
+	switch ae.Kind {
+	case pg_query.A_Expr_Kind_AEXPR_LIKE,
+		pg_query.A_Expr_Kind_AEXPR_ILIKE,
+		pg_query.A_Expr_Kind_AEXPR_SIMILAR:
+		ae.Kind = pg_query.A_Expr_Kind_AEXPR_OP
+	}
+}
+
+// normalizeRowFormat settles `(a, b)` against `ROW(a, b)`. Both build the same
+// row constructor and differ only in the field ruleutils reads to pick a
+// spelling. Both sides take the explicit form, which the catalog prints and
+// which a single-element row needs to stay a row.
+func normalizeRowFormat(node *pg_query.Node) {
+	if re := node.GetRowExpr(); re != nil {
+		re.RowFormat = pg_query.CoercionForm_COERCE_EXPLICIT_CALL
+	}
+}
+
+// foldArrayComparison turns the scalar-array comparison an IN list is stored as
+// back into the list: `= ANY (ARRAY[...])` for IN and `<> ALL (ARRAY[...])` for
+// NOT IN, the two shapes transformAExprIn produces.
+//
+// The operator is part of the match. Every other one reaches the catalog as
+// written, and folding it would make `x > ANY (...)` and `x > ALL (...)`
+// compare equal.
+func foldArrayComparison(node *pg_query.Node) {
+	ae := node.GetAExpr()
+	if ae == nil {
+		return
+	}
+	var op string
+	switch ae.Kind {
+	case pg_query.A_Expr_Kind_AEXPR_OP_ANY:
+		op = "="
+	case pg_query.A_Expr_Kind_AEXPR_OP_ALL:
+		op = "<>"
+	default:
+		return
+	}
+	if operatorName(ae.Name) != op {
+		return
+	}
+	arr := ae.Rexpr.GetAArrayExpr()
+	if arr == nil {
+		return
+	}
+	ae.Kind = pg_query.A_Expr_Kind_AEXPR_IN
+	ae.Rexpr = &pg_query.Node{
+		Node: &pg_query.Node_List{List: &pg_query.List{Items: arr.Elements}},
+	}
+}
+
+// flattenBoolExpr merges an AND argument of an AND, and an OR argument of an
+// OR, into the argument list holding it.
+//
+// makeAndExpr and makeOrExpr (src/backend/parser/gram.y) do this while parsing,
+// but only for a left operand that is a BoolExpr by then.
+// `(x BETWEEN 1 AND 10) AND y` is not one, so expanding the BETWEEN afterwards
+// leaves nesting the grammar would have removed, while re-parsing the catalog's
+// own output flattens it. The two sides would deparse differently over the same
+// expression.
+//
+// AND and OR are associative, so the flat list means what the nesting meant.
+// The walk reaches an argument before the node holding it, so one pass
+// collapses a chain of any depth.
+func flattenBoolExpr(node *pg_query.Node) {
+	be := node.GetBoolExpr()
+	if be == nil || be.Boolop == pg_query.BoolExprType_NOT_EXPR {
+		return
+	}
+	args := make([]*pg_query.Node, 0, len(be.Args))
+	for _, arg := range be.Args {
+		if nested := arg.GetBoolExpr(); nested != nil && nested.Boolop == be.Boolop {
+			args = append(args, nested.Args...)
+			continue
+		}
+		args = append(args, arg)
+	}
+	be.Args = args
+}
+
+// operatorName returns a bare operator name, and "" for a qualified one such as
+// OPERATOR(pg_catalog.=), which the folds above have no rule for.
+func operatorName(name []*pg_query.Node) string {
+	if len(name) != 1 {
+		return ""
+	}
+	return name[0].GetString_().GetSval()
+}
+
+func makeCmpExpr(op string, lexpr, rexpr *pg_query.Node) *pg_query.Node {
+	return &pg_query.Node{Node: &pg_query.Node_AExpr{AExpr: &pg_query.A_Expr{
+		Kind:  pg_query.A_Expr_Kind_AEXPR_OP,
+		Name:  []*pg_query.Node{pg_query.MakeStrNode(op)},
+		Lexpr: lexpr,
+		Rexpr: rexpr,
+	}}}
+}
+
+func makeBoolExpr(op pg_query.BoolExprType, args ...*pg_query.Node) *pg_query.Node {
+	return &pg_query.Node{Node: &pg_query.Node_BoolExpr{BoolExpr: &pg_query.BoolExpr{
+		Boolop: op,
+		Args:   args,
+	}}}
+}
+
+func cloneNode(node *pg_query.Node) *pg_query.Node {
+	return proto.Clone(node).(*pg_query.Node)
+}

--- a/diff/desugar_test.go
+++ b/diff/desugar_test.go
@@ -1,0 +1,200 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The catalog side of every case below is what pg_get_constraintdef returned
+// for the desired side loaded into PostgreSQL 16, so the pairs are the two
+// spellings of one stored constraint rather than two forms believed equal.
+
+func TestEqualConstraintDef_between(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK (((level >= 1) AND (level <= 10)))",
+		"CHECK (level BETWEEN 1 AND 10)",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK (((level < 1) OR (level > 10)))",
+		"CHECK (level NOT BETWEEN 1 AND 10)",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((((level >= 1) AND (level <= 10)) OR ((level >= 10) AND (level <= 1))))",
+		"CHECK (level BETWEEN SYMMETRIC 1 AND 10)",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((((level < 1) OR (level > 10)) AND ((level < 10) OR (level > 1))))",
+		"CHECK (level NOT BETWEEN SYMMETRIC 1 AND 10)",
+	))
+}
+
+func TestEqualConstraintDef_betweenOverExpression(t *testing.T) {
+	// The operand is copied into each comparison, so one that is a tree
+	// rather than a column reference has to survive being cloned. The
+	// function call also has its schema stripped before the copies are made.
+	assert.True(t, equalConstraintDef(
+		"CHECK (((char_length(code) >= 43) AND (char_length(code) <= 128)))",
+		"CHECK (pg_catalog.char_length(code) BETWEEN 43 AND 128)",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((((level + 1) >= 1) AND ((level + 1) <= 10)))",
+		"CHECK (level + 1 BETWEEN 1 AND 10)",
+	))
+}
+
+func TestEqualConstraintDef_betweenInConjunction(t *testing.T) {
+	// The grammar flattens `a AND b AND c` as it parses, so the catalog
+	// definition re-parses flat while the expansion leaves a nested BoolExpr
+	// behind. Both operand positions: the grammar flattens on the left alone.
+	assert.True(t, equalConstraintDef(
+		"CHECK ((((level >= 1) AND (level <= 10)) AND active))",
+		"CHECK ((level BETWEEN 1 AND 10) AND active)",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((active AND ((level >= 1) AND (level <= 10))))",
+		"CHECK (active AND (level BETWEEN 1 AND 10))",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((((level >= 1) AND (level <= 10)) AND ((other >= 1) AND (other <= 10)) AND active))",
+		"CHECK ((level BETWEEN 1 AND 10) AND (other BETWEEN 1 AND 10) AND active)",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((((level < 1) OR (level > 10)) OR active))",
+		"CHECK ((level NOT BETWEEN 1 AND 10) OR active)",
+	))
+}
+
+func TestEqualConstraintDef_betweenBoundsNotFolded(t *testing.T) {
+	// A different bound, and a negation, are different constraints.
+	assert.False(t, equalConstraintDef(
+		"CHECK (((level >= 1) AND (level <= 10)))",
+		"CHECK (level BETWEEN 1 AND 20)",
+	))
+	assert.False(t, equalConstraintDef(
+		"CHECK (((level >= 1) AND (level <= 10)))",
+		"CHECK (level NOT BETWEEN 1 AND 10)",
+	))
+	// SYMMETRIC widens the predicate rather than restating it.
+	assert.False(t, equalConstraintDef(
+		"CHECK (((level >= 1) AND (level <= 10)))",
+		"CHECK (level BETWEEN SYMMETRIC 1 AND 10)",
+	))
+}
+
+func TestEqualConstraintDef_patternMatch(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier ~~ 'own%'::text))",
+		"CHECK (carrier LIKE 'own%')",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier ~~* 'own%'::text))",
+		"CHECK (carrier ILIKE 'own%')",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier !~~ 'sub%'::text))",
+		"CHECK (carrier NOT LIKE 'sub%')",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier !~~* 'sub%'::text))",
+		"CHECK (carrier NOT ILIKE 'sub%')",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier ~ similar_to_escape('own%'::text)))",
+		"CHECK (carrier SIMILAR TO 'own%')",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier !~ similar_to_escape('own%'::text)))",
+		"CHECK (carrier NOT SIMILAR TO 'own%')",
+	))
+}
+
+func TestEqualConstraintDef_patternMatchEscape(t *testing.T) {
+	// An ESCAPE clause is already a call in the right operand; the catalog
+	// prints it unqualified because pg_catalog is on the search_path.
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier ~~ like_escape('own!%'::text, '!'::text)))",
+		"CHECK (carrier LIKE 'own!%' ESCAPE '!')",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier ~ similar_to_escape('own%'::text, '!'::text)))",
+		"CHECK (carrier SIMILAR TO 'own%' ESCAPE '!')",
+	))
+}
+
+func TestEqualConstraintDef_patternMatchOperatorsNotFolded(t *testing.T) {
+	// Case sensitivity and negation tell these operators apart.
+	assert.False(t, equalConstraintDef(
+		"CHECK ((carrier ~~ 'own%'::text))",
+		"CHECK (carrier ILIKE 'own%')",
+	))
+	assert.False(t, equalConstraintDef(
+		"CHECK ((carrier ~~ 'own%'::text))",
+		"CHECK (carrier NOT LIKE 'own%')",
+	))
+	assert.False(t, equalConstraintDef(
+		"CHECK ((carrier ~ similar_to_escape('own%'::text)))",
+		"CHECK (carrier LIKE 'own%')",
+	))
+}
+
+func TestEqualConstraintDef_notIn(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier <> ALL (ARRAY['a'::text, 'b'::text])))",
+		"CHECK (carrier NOT IN ('a', 'b'))",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((carrier = ANY (ARRAY['a'::text, 'b'::text])))",
+		"CHECK (carrier IN ('a', 'b'))",
+	))
+	// The two are each other's negation.
+	assert.False(t, equalConstraintDef(
+		"CHECK ((carrier <> ALL (ARRAY['a'::text, 'b'::text])))",
+		"CHECK (carrier IN ('a', 'b'))",
+	))
+}
+
+func TestEqualConstraintDef_scalarArrayOperatorMatters(t *testing.T) {
+	// Only `= ANY` and `<> ALL` are the shapes an IN list is stored as. Any
+	// other operator reaches the catalog as written, and folding one would
+	// make the two below compare equal.
+	assert.False(t, equalConstraintDef(
+		"CHECK ((level > ANY (ARRAY[1, 2])))",
+		"CHECK (level > ALL (ARRAY[1, 2]))",
+	))
+	assert.True(t, equalConstraintDef(
+		"CHECK ((level > ANY (ARRAY[1, 2])))",
+		"CHECK (level > ANY(ARRAY[1, 2]))",
+	))
+	// A qualified operator name has no rule, so it is left as written and
+	// only compares equal to itself.
+	assert.True(t, equalConstraintDef(
+		"CHECK ((level OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2])))",
+		"CHECK (level OPERATOR(pg_catalog.=) ANY(ARRAY[1, 2]))",
+	))
+}
+
+func TestEqualConstraintDef_rowConstructor(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"CHECK ((ROW(lo, hi) > ROW(0, 0)))",
+		"CHECK ((lo, hi) > (0, 0))",
+	))
+	assert.False(t, equalConstraintDef(
+		"CHECK ((ROW(lo, hi) > ROW(0, 0)))",
+		"CHECK ((lo, hi) >= (0, 0))",
+	))
+}
+
+func TestEqualConstraintDef_anyOverArrayColumn(t *testing.T) {
+	// The fold rewrites `= ANY (ARRAY[...])` into the IN list it stands for.
+	// `= ANY` over an array-valued expression is not an IN list and has
+	// nothing to fold to, so it is compared as written.
+	assert.True(t, equalConstraintDef(
+		"CHECK ((level = ANY (levels)))",
+		"CHECK (level = ANY(levels))",
+	))
+	assert.False(t, equalConstraintDef(
+		"CHECK ((level = ANY (levels)))",
+		"CHECK (level = ANY(others))",
+	))
+}

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -556,19 +556,24 @@ func isSerialType(typeName string) bool {
 //   - Strips casts to text-like types (text, varchar), which pg_get_constraintdef
 //     adds to anything string-typed and a written definition practically never
 //     carries.
-//   - Converts = ANY(ARRAY[...]) to IN (...) (PostgreSQL internal representation).
+//   - Converts = ANY(ARRAY[...]) to IN (...) and <> ALL(ARRAY[...]) to
+//     NOT IN (...) (PostgreSQL internal representation).
 //   - Folds NOT (a IS DISTINCT FROM b) into a IS NOT DISTINCT FROM b, the shape
 //     PostgreSQL rewrites the written operator into when it stores an
 //     expression.
 //   - Turns those operators against a bare NULL literal into the IS NULL test
 //     parse analysis rewrites them to, and inverts such a test under a NOT.
+//   - Expands BETWEEN, and drops the keyword spelling from LIKE, ILIKE and
+//     SIMILAR TO, as the grammar and parse analysis do before the expression
+//     reaches the catalog. desugar.go holds these, the row-constructor
+//     spelling, and the AND/OR flattening an expanded BETWEEN needs.
 //   - Drops the schema qualifier from a function call name, which the catalog
 //     omits whenever the function's schema is on the search_path.
 //
-// All five are symmetric: they apply to the catalog side and the written side
-// alike. The walk reaches every node kind, so a sub-query inside an RLS policy
-// or a view body, and an expression inside a SQL/JSON constructor, get the
-// same treatment as a top-level operand.
+// All of them are symmetric: they apply to the catalog side and the written
+// side alike. The walk reaches every node kind, so a sub-query inside an RLS
+// policy or a view body, and an expression inside a SQL/JSON constructor, get
+// the same treatment as a top-level operand.
 //
 // The one position left alone is a top-level cast on a SELECT target: the cast
 // type there decides the resulting view's output column type, so stripping it
@@ -583,16 +588,13 @@ func normalizeExprNode(ctx pgast.Ctx, node *pg_query.Node) *pg_query.Node {
 			return tc.Arg
 		}
 	}
-	if ae := node.GetAExpr(); ae != nil && ae.Kind == pg_query.A_Expr_Kind_AEXPR_OP_ANY {
-		if arr := ae.Rexpr.GetAArrayExpr(); arr != nil {
-			ae.Kind = pg_query.A_Expr_Kind_AEXPR_IN
-			ae.Rexpr = &pg_query.Node{
-				Node: &pg_query.Node_List{
-					List: &pg_query.List{Items: arr.Elements},
-				},
-			}
-		}
+	foldArrayComparison(node)
+	if expanded := desugarBetween(node); expanded != nil {
+		return expanded
 	}
+	desugarPatternMatch(node)
+	normalizeRowFormat(node)
+	flattenBoolExpr(node)
 	if folded := foldNotDistinct(node); folded != nil {
 		return folded
 	}

--- a/testdata/apply/add_check_between_and_pattern_match.yml
+++ b/testdata/apply/add_check_between_and_pattern_match.yml
@@ -1,0 +1,33 @@
+# A full round trip: the ADD CONSTRAINT the plan emits keeps the keyword
+# spelling, PostgreSQL stores the expansion, and the re-plan afterwards finds
+# no drift against it.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      carrier text,
+      CONSTRAINT readings_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      carrier text,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level BETWEEN 1 AND 10),
+      CONSTRAINT readings_carrier_check CHECK (carrier LIKE 'own%'),
+      CONSTRAINT readings_excl_check CHECK (carrier NOT IN ('a', 'b'))
+  );
+  CREATE INDEX readings_level_idx ON public.readings USING btree (id) WHERE (level BETWEEN 1 AND 10);
+applied: |
+  -- public.readings
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      carrier text,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_carrier_check CHECK (carrier ~~ 'own%'::text),
+      CONSTRAINT readings_excl_check CHECK (carrier <> ALL (ARRAY['a'::text, 'b'::text])),
+      CONSTRAINT readings_level_check CHECK (level >= 1 AND level <= 10)
+  );
+  CREATE INDEX readings_level_idx ON public.readings USING btree (id) WHERE ((level >= 1) AND (level <= 10));

--- a/testdata/plan/alter_check_any_to_all.yml
+++ b/testdata/plan/alter_check_any_to_all.yml
@@ -1,0 +1,20 @@
+# `= ANY (ARRAY[...])` folds to `IN` and `<> ALL (ARRAY[...])` to `NOT IN`,
+# because those are the two shapes PostgreSQL stores them as. Any other
+# operator has no such rewrite, so `> ANY` and `> ALL` have to stay apart.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level > ANY (ARRAY[1, 2]))
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level > ALL (ARRAY[1, 2]))
+  );
+plan: |
+  ALTER TABLE public.readings DROP CONSTRAINT readings_level_check;
+  ALTER TABLE public.readings ADD CONSTRAINT readings_level_check CHECK (level > ALL(ARRAY[1, 2]));

--- a/testdata/plan/alter_check_between_bounds.yml
+++ b/testdata/plan/alter_check_between_bounds.yml
@@ -1,0 +1,19 @@
+# The fold must not swallow a genuine change: a different upper bound is a
+# different constraint, so the CHECK is re-created.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level BETWEEN 1 AND 10)
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level BETWEEN 1 AND 20)
+  );
+plan: |
+  ALTER TABLE public.readings DROP CONSTRAINT readings_level_check;
+  ALTER TABLE public.readings ADD CONSTRAINT readings_level_check CHECK (level BETWEEN 1 AND 20);

--- a/testdata/plan/alter_check_between_to_not_between.yml
+++ b/testdata/plan/alter_check_between_to_not_between.yml
@@ -1,0 +1,18 @@
+# Negating a BETWEEN inverts the predicate, so the two must not fold together.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level BETWEEN 1 AND 10)
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level NOT BETWEEN 1 AND 10)
+  );
+plan: |
+  ALTER TABLE public.readings DROP CONSTRAINT readings_level_check;
+  ALTER TABLE public.readings ADD CONSTRAINT readings_level_check CHECK (level NOT BETWEEN 1 AND 10);

--- a/testdata/plan/alter_check_like_to_ilike.yml
+++ b/testdata/plan/alter_check_like_to_ilike.yml
@@ -1,0 +1,19 @@
+# LIKE and ILIKE are different operators, so folding the keyword away must not
+# make them compare equal.
+init: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_like_check CHECK (carrier LIKE 'own%')
+  );
+desired: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_like_check CHECK (carrier ILIKE 'own%')
+  );
+plan: |
+  ALTER TABLE public.parcels DROP CONSTRAINT parcels_like_check;
+  ALTER TABLE public.parcels ADD CONSTRAINT parcels_like_check CHECK (carrier ILIKE 'own%');

--- a/testdata/plan/no_diff_between.yml
+++ b/testdata/plan/no_diff_between.yml
@@ -1,0 +1,29 @@
+# PostgreSQL expands BETWEEN into the comparisons it is defined as before the
+# expression reaches the catalog, so pg_get_constraintdef, pg_get_indexdef and
+# pg_get_viewdef never hand BETWEEN back. Left unfolded, a written BETWEEN
+# re-creates its constraint, index and view on every plan.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level BETWEEN 1 AND 10),
+      CONSTRAINT readings_level_excl_check CHECK (level NOT BETWEEN 20 AND 30),
+      CONSTRAINT readings_level_sym_check CHECK (level BETWEEN SYMMETRIC 40 AND 50),
+      CONSTRAINT readings_level_notsym_check CHECK (level NOT BETWEEN SYMMETRIC 60 AND 70)
+  );
+  CREATE INDEX readings_level_idx ON public.readings USING btree (id) WHERE (level BETWEEN 1 AND 10);
+  CREATE VIEW public.readings_in_range AS SELECT id FROM public.readings WHERE level BETWEEN 1 AND 10;
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level BETWEEN 1 AND 10),
+      CONSTRAINT readings_level_excl_check CHECK (level NOT BETWEEN 20 AND 30),
+      CONSTRAINT readings_level_sym_check CHECK (level BETWEEN SYMMETRIC 40 AND 50),
+      CONSTRAINT readings_level_notsym_check CHECK (level NOT BETWEEN SYMMETRIC 60 AND 70)
+  );
+  CREATE INDEX readings_level_idx ON public.readings USING btree (id) WHERE (level BETWEEN 1 AND 10);
+  CREATE VIEW public.readings_in_range AS SELECT id FROM public.readings WHERE level BETWEEN 1 AND 10;
+plan: ""

--- a/testdata/plan/no_diff_between_generated_column.yml
+++ b/testdata/plan/no_diff_between_generated_column.yml
@@ -1,0 +1,18 @@
+# A generated column fails the run rather than drifting. PostgreSQL cannot
+# alter a generated expression in place, so the diff rejects the change and no
+# other table in the schema is planned.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      in_range boolean GENERATED ALWAYS AS (level BETWEEN 1 AND 10) STORED,
+      CONSTRAINT readings_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      in_range boolean GENERATED ALWAYS AS (level BETWEEN 1 AND 10) STORED,
+      CONSTRAINT readings_pkey PRIMARY KEY (id)
+  );
+plan: ""

--- a/testdata/plan/no_diff_between_in_conjunction.yml
+++ b/testdata/plan/no_diff_between_in_conjunction.yml
@@ -1,0 +1,25 @@
+# The grammar flattens `a AND b AND c` into one BoolExpr as it parses, so the
+# catalog definition re-parses flat while a BETWEEN expanded after parsing
+# keeps the nesting. They line up only once the fold flattens too. Both operand
+# positions are here, since the grammar flattens on the left alone.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      active boolean,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_left_check CHECK ((level BETWEEN 1 AND 10) AND active),
+      CONSTRAINT readings_right_check CHECK (active AND (level BETWEEN 1 AND 10)),
+      CONSTRAINT readings_or_check CHECK ((level NOT BETWEEN 1 AND 10) OR active)
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      active boolean,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_left_check CHECK ((level BETWEEN 1 AND 10) AND active),
+      CONSTRAINT readings_right_check CHECK (active AND (level BETWEEN 1 AND 10)),
+      CONSTRAINT readings_or_check CHECK ((level NOT BETWEEN 1 AND 10) OR active)
+  );
+plan: ""

--- a/testdata/plan/no_diff_between_index_expression_and_view_target.yml
+++ b/testdata/plan/no_diff_between_index_expression_and_view_target.yml
@@ -1,0 +1,20 @@
+# Two positions the WHERE-clause cases do not reach: an index key that is an
+# expression rather than a column, and a view's SELECT target, which the view
+# comparison walks separately so it can leave a top-level cast alone.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX readings_in_range_idx ON public.readings USING btree (((level BETWEEN 1 AND 10)));
+  CREATE VIEW public.readings_flagged AS SELECT id, (level BETWEEN 1 AND 10) AS in_range FROM public.readings;
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX readings_in_range_idx ON public.readings USING btree (((level BETWEEN 1 AND 10)));
+  CREATE VIEW public.readings_flagged AS SELECT id, (level BETWEEN 1 AND 10) AS in_range FROM public.readings;
+plan: ""

--- a/testdata/plan/no_diff_between_other_expression_sites.yml
+++ b/testdata/plan/no_diff_between_other_expression_sites.yml
@@ -1,0 +1,30 @@
+# normalizeCheckExpr is shared by every expression site, so the fold has to
+# hold outside a table CHECK too: a domain constraint, a column default, an RLS
+# policy predicate and a trigger WHEN clause each drifted on their own.
+init: |
+  CREATE FUNCTION public.noop() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+  CREATE DOMAIN public.small_level AS integer CONSTRAINT small_level_check CHECK (VALUE BETWEEN 1 AND 10);
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      owner text,
+      label text DEFAULT (CASE WHEN 1 BETWEEN 0 AND 2 THEN 'lo' ELSE 'hi' END),
+      CONSTRAINT readings_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.readings ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY readings_sel ON public.readings FOR SELECT USING (level BETWEEN 1 AND 10);
+  CREATE TRIGGER readings_stamp BEFORE UPDATE ON public.readings
+      FOR EACH ROW WHEN (NEW.level BETWEEN 1 AND 10) EXECUTE FUNCTION public.noop();
+desired: |
+  CREATE DOMAIN public.small_level AS integer CONSTRAINT small_level_check CHECK (VALUE BETWEEN 1 AND 10);
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      owner text,
+      label text DEFAULT (CASE WHEN 1 BETWEEN 0 AND 2 THEN 'lo' ELSE 'hi' END),
+      CONSTRAINT readings_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.readings ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY readings_sel ON public.readings FOR SELECT USING (level BETWEEN 1 AND 10);
+  CREATE TRIGGER readings_stamp BEFORE UPDATE ON public.readings FOR EACH ROW WHEN (new.level BETWEEN 1 AND 10) EXECUTE FUNCTION noop();
+plan: ""

--- a/testdata/plan/no_diff_between_over_function_call.yml
+++ b/testdata/plan/no_diff_between_over_function_call.yml
@@ -1,0 +1,18 @@
+# The operand is copied into each comparison, so one that is a call rather than
+# a column reference has to survive being cloned, with its schema already
+# stripped.
+init: |
+  CREATE TABLE public.onetime_codes (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT onetime_codes_pkey PRIMARY KEY (id),
+      CONSTRAINT onetime_codes_code_check CHECK (char_length(code) BETWEEN 43 AND 128)
+  );
+desired: |
+  CREATE TABLE public.onetime_codes (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT onetime_codes_pkey PRIMARY KEY (id),
+      CONSTRAINT onetime_codes_code_check CHECK (pg_catalog.char_length(code) BETWEEN 43 AND 128)
+  );
+plan: ""

--- a/testdata/plan/no_diff_between_stored_form.yml
+++ b/testdata/plan/no_diff_between_stored_form.yml
@@ -1,0 +1,18 @@
+# The other direction: `dump` writes the comparisons the catalog stores, so a
+# desired schema written that way has to keep planning clean once the desired
+# side folds BETWEEN too.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK (level BETWEEN 1 AND 10)
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      level integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_level_check CHECK ((level >= 1) AND (level <= 10))
+  );
+plan: ""

--- a/testdata/plan/no_diff_in_any_array.yml
+++ b/testdata/plan/no_diff_in_any_array.yml
@@ -1,0 +1,17 @@
+# The `IN` <-> `= ANY (ARRAY[...])` fold, in both spellings: what the file
+# writes and what `dump` writes have to plan clean against the same database.
+init: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_carrier_check CHECK (carrier IN ('own_a', 'own_b'))
+  );
+desired: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_carrier_check CHECK (carrier = ANY (ARRAY['own_a'::text, 'own_b'::text]))
+  );
+plan: ""

--- a/testdata/plan/no_diff_not_in.yml
+++ b/testdata/plan/no_diff_not_in.yml
@@ -1,0 +1,19 @@
+# `IN` already folded against the `= ANY (ARRAY[...])` the catalog stores.
+# `NOT IN` is stored as `<> ALL (ARRAY[...])` and did not.
+init: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_carrier_check CHECK (carrier NOT IN ('sub_a', 'sub_b'))
+  );
+  CREATE INDEX parcels_own_idx ON public.parcels USING btree (id) WHERE (carrier NOT IN ('sub_a', 'sub_b'));
+desired: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_carrier_check CHECK (carrier NOT IN ('sub_a', 'sub_b'))
+  );
+  CREATE INDEX parcels_own_idx ON public.parcels USING btree (id) WHERE (carrier NOT IN ('sub_a', 'sub_b'));
+plan: ""

--- a/testdata/plan/no_diff_not_in_stored_form.yml
+++ b/testdata/plan/no_diff_not_in_stored_form.yml
@@ -1,0 +1,17 @@
+# `dump` writes the scalar-array comparison the catalog stores, so that
+# spelling has to plan clean against a database loaded from `NOT IN`.
+init: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_carrier_check CHECK (carrier NOT IN ('sub_a', 'sub_b'))
+  );
+desired: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_carrier_check CHECK (carrier <> ALL (ARRAY['sub_a'::text, 'sub_b'::text]))
+  );
+plan: ""

--- a/testdata/plan/no_diff_pattern_match_operators.yml
+++ b/testdata/plan/no_diff_pattern_match_operators.yml
@@ -1,0 +1,37 @@
+# The grammar rewrites LIKE, ILIKE and SIMILAR TO into their operators
+# (`~~`, `~~*`, `~`) on the way in, so the catalog only ever hands the operator
+# back. An ESCAPE clause becomes a like_escape() / similar_to_escape() call,
+# which the catalog prints unqualified once pg_catalog is on the search_path.
+init: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_like_check CHECK (carrier LIKE 'own%'),
+      CONSTRAINT parcels_ilike_check CHECK (carrier ILIKE 'own%'),
+      CONSTRAINT parcels_not_like_check CHECK (carrier NOT LIKE 'sub%'),
+      CONSTRAINT parcels_not_ilike_check CHECK (carrier NOT ILIKE 'sub%'),
+      CONSTRAINT parcels_escape_check CHECK (carrier LIKE 'own!%' ESCAPE '!'),
+      CONSTRAINT parcels_similar_check CHECK (carrier SIMILAR TO 'own%'),
+      CONSTRAINT parcels_not_similar_check CHECK (carrier NOT SIMILAR TO 'sub%'),
+      CONSTRAINT parcels_similar_escape_check CHECK (carrier SIMILAR TO 'own%' ESCAPE '!')
+  );
+  CREATE INDEX parcels_own_idx ON public.parcels USING btree (id) WHERE (carrier LIKE 'own%');
+  CREATE VIEW public.parcels_own AS SELECT id FROM public.parcels WHERE carrier LIKE 'own%';
+desired: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_like_check CHECK (carrier LIKE 'own%'),
+      CONSTRAINT parcels_ilike_check CHECK (carrier ILIKE 'own%'),
+      CONSTRAINT parcels_not_like_check CHECK (carrier NOT LIKE 'sub%'),
+      CONSTRAINT parcels_not_ilike_check CHECK (carrier NOT ILIKE 'sub%'),
+      CONSTRAINT parcels_escape_check CHECK (carrier LIKE 'own!%' ESCAPE '!'),
+      CONSTRAINT parcels_similar_check CHECK (carrier SIMILAR TO 'own%'),
+      CONSTRAINT parcels_not_similar_check CHECK (carrier NOT SIMILAR TO 'sub%'),
+      CONSTRAINT parcels_similar_escape_check CHECK (carrier SIMILAR TO 'own%' ESCAPE '!')
+  );
+  CREATE INDEX parcels_own_idx ON public.parcels USING btree (id) WHERE (carrier LIKE 'own%');
+  CREATE VIEW public.parcels_own AS SELECT id FROM public.parcels WHERE carrier LIKE 'own%';
+plan: ""

--- a/testdata/plan/no_diff_pattern_match_stored_form.yml
+++ b/testdata/plan/no_diff_pattern_match_stored_form.yml
@@ -1,0 +1,17 @@
+# `dump` writes the operator the catalog stores, so the operator spelling has
+# to plan clean against a database loaded from the keyword spelling.
+init: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_like_check CHECK (carrier LIKE 'own%')
+  );
+desired: |
+  CREATE TABLE public.parcels (
+      id integer NOT NULL,
+      carrier text,
+      CONSTRAINT parcels_pkey PRIMARY KEY (id),
+      CONSTRAINT parcels_like_check CHECK (carrier ~~ 'own%'::text)
+  );
+plan: ""

--- a/testdata/plan/no_diff_row_comparison.yml
+++ b/testdata/plan/no_diff_row_comparison.yml
@@ -1,0 +1,20 @@
+# `(a, b)` and `ROW(a, b)` are the same row constructor, told apart in the
+# parse tree only by the row_format field ruleutils reads to pick a spelling.
+# The catalog always prints the explicit form.
+init: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      lo integer,
+      hi integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_bounds_check CHECK ((lo, hi) > (0, 0))
+  );
+desired: |
+  CREATE TABLE public.readings (
+      id integer NOT NULL,
+      lo integer,
+      hi integer,
+      CONSTRAINT readings_pkey PRIMARY KEY (id),
+      CONSTRAINT readings_bounds_check CHECK ((lo, hi) > (0, 0))
+  );
+plan: ""


### PR DESCRIPTION
PostgreSQL rewrites several written forms before the expression reaches the
catalog, so pg_get_constraintdef, pg_get_expr, pg_get_indexdef, pg_get_viewdef
and pg_get_triggerdef never hand them back the way the file wrote them:

  BETWEEN, NOT BETWEEN, BETWEEN SYMMETRIC   -> the comparisons they stand for
  LIKE, ILIKE, NOT LIKE, NOT ILIKE          -> ~~, ~~*, !~~, !~~*
  SIMILAR TO, NOT SIMILAR TO                -> ~ / !~ similar_to_escape(...)
  NOT IN (...)                              -> <> ALL (ARRAY[...])
  (a, b)                                    -> ROW(a, b)

None of them matched, so a CHECK was dropped and re-added on every run, which
revalidates the whole table, a partial index was rebuilt and a view recreated.
A generated column failed the run instead, since its expression cannot be
altered in place, and no other table in the schema was planned either.
IN (...) already folded against the = ANY (ARRAY[...]) it is stored as; NOT IN
did not.

The folds move the written side onto the stored form, the direction PostgreSQL
itself defines, and they sit in the shared expression normalization, so a
domain CHECK, a column DEFAULT, a policy USING / WITH CHECK and a trigger WHEN
clause get them along with the table CHECK, the index and the view. The emitted
DDL still carries what the file wrote: the normalization is only compared,
never printed.

An expanded BETWEEN needs the AND/OR flattening the grammar performs while
parsing, since `(x BETWEEN 1 AND 10) AND y` is a single A_Expr at the point
makeAndExpr would have flattened it while the catalog definition re-parses
flat. AND and OR are associative, so the flat list means what the nesting did.

The scalar-array fold now matches the operator too. `= ANY` and `<> ALL` are
the two shapes transformAExprIn produces; every other operator reaches the
catalog as written, and folding one would have made `x > ANY (...)` and
`x > ALL (...)` compare equal.

The fixtures cover each expression site: a table CHECK, a partial index
predicate, an index key that is an expression, a view body and a view SELECT
target, a domain CHECK, a column DEFAULT, a policy predicate, a trigger WHEN
clause and a generated column. desugar_test.go carries the unit half, since
`make test` writes one profile per package and the fixtures compile into the
root package. Every catalog-side string in it is what pg_get_constraintdef
returned for the desired side on PostgreSQL 16, and each positive case fails
with the folds disabled. The negative cases are there too: LIKE against ILIKE
and NOT LIKE, SIMILAR TO against LIKE, IN against NOT IN, `> ANY` against
`> ALL`, a changed bound, a negated BETWEEN, and SYMMETRIC against the plain
form.

The grammar's other rewrites already planned clean and were re-checked against
a live server: OVERLAPS, COLLATE, IS JSON, ISNULL / NOTNULL, NULLIF,
SUBSTRING / TRIM / POSITION / OVERLAY / EXTRACT, CAST, LIKE ANY (ARRAY[...])
and nested and negated BETWEEN combinations. A typed literal is still
re-printed in its type's output form, so `CHECK (a > timestamp '2000-01-01')`
drifts; TODO.md records it. An EXCLUDE constraint normalizes nothing at all, so
the folds miss it like every other one, and its existing TODO entry now names
the case.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ar29pa7DH2eRj8pfFcFMDN