### PR TITLE
Add the openolat and inaturalist samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,10 +198,11 @@ jobs:
         with:
           go-version-file: go.mod
       # The discourse sample declares `CREATE EXTENSION vector` and the osm
-      # sample `CREATE EXTENSION postgis`, neither of which the official image
-      # ships. Install both from PGDG into the running service container;
-      # CREATE EXTENSION reads the control file when it is called, so the server
-      # does not need a restart. compose.yaml does the same for local runs.
+      # and inaturalist samples `CREATE EXTENSION postgis`, neither of which the
+      # official image ships. Install both from PGDG into the running service
+      # container; CREATE EXTENSION reads the control file when it is called, so
+      # the server does not need a restart. compose.yaml does the same for local
+      # runs.
       - name: Install pgvector and PostGIS
         run: |
           cid=$(docker ps --filter ancestor=postgres:18 --format '{{.ID}}')

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,11 +7,11 @@
 #   docker compose up -d pg17         # 17 only
 #   docker compose --profile all up -d
 #
-# The discourse sample declares `CREATE EXTENSION vector` and the osm sample
-# `CREATE EXTENSION postgis`, neither of which the official image ships, so
-# install pgvector and PostGIS from PGDG before starting the server. The image's
-# entrypoint runs as root and drops to postgres itself, so apt runs first and
-# hands over with exec. Starting a container therefore needs network access; the
+# The discourse sample declares `CREATE EXTENSION vector` and the osm and
+# inaturalist samples `CREATE EXTENSION postgis`, neither of which the official
+# image ships, so install pgvector and PostGIS from PGDG before starting the
+# server. The image's entrypoint runs as root and drops to postgres itself, so
+# apt runs first and hands over with exec. Starting a container therefore needs network access; the
 # samples CI job installs the same packages into its service container.
 x-postgres: &postgres
   environment:

--- a/docs/contributing-samples.md
+++ b/docs/contributing-samples.md
@@ -22,13 +22,13 @@ environment variable rather than a per-sample flag because it has to reach both
 the dump and the plan, and the manifest's flags column reaches only the plan.
 
 The server also needs pgvector for the discourse sample's `halfvec` columns and
-PostGIS for the osm sample's `geometry` column. The official postgres image
-ships neither. compose.yaml installs `postgresql-<major>-pgvector` and
-`postgresql-<major>-postgis-3` from PGDG when a container starts, and the
-samples CI job installs the same packages into its service container, so both
-keep the official image and add the extensions to it. The runner checks for them
-up front and says so if one is missing; recreate the container with
-`docker compose down && docker compose up -d`.
+PostGIS for the osm and inaturalist samples' `geometry` columns. The official
+postgres image ships neither. compose.yaml installs
+`postgresql-<major>-pgvector` and `postgresql-<major>-postgis-3` from PGDG when
+a container starts, and the samples CI job installs the same packages into its
+service container, so both keep the official image and add the extensions to it.
+The runner checks for them up front and says so if one is missing; recreate the
+container with `docker compose down && docker compose up -d`.
 
 To load every sample into one database for manual inspection instead of
 checking them one at a time, use `make schema`.
@@ -136,18 +136,20 @@ the SHA in `sample-db.mk`, and re-run `make test-samples`.
 | wso2is | wso2is | [wso2/carbon-identity-framework](https://github.com/wso2/carbon-identity-framework) |
 | nightingale | nightingale | [ccfos/nightingale](https://github.com/ccfos/nightingale) |
 | danbooru | danbooru | [danbooru/danbooru](https://github.com/danbooru/danbooru) |
+| openolat | openolat | [OpenOLAT/OpenOLAT](https://github.com/OpenOLAT/OpenOLAT) |
+| inaturalist | inaturalist | [inaturalist/inaturalist](https://github.com/inaturalist/inaturalist) |
 
 ## Coverage
 
-Object counts of the loaded schemas, as of 2026-08-08 on PostgreSQL 15.18
-(16.13 for icingadb, rt, znuny, gitlab, hive, ranger, ambari, ovirt, and chado,
-the last counted 2026-08-24; the Sequences column was counted on 15.18
-throughout, Triggers, added 2026-08-24, and Routines, added 2026-08-25, on
-15.18 for every sample; wso2is, nightingale, and danbooru were counted
-2026-08-29 on 15.17). "Constraints" excludes foreign keys; "Types" counts
-enums and domains; "Sequences" counts standalone sequences only, since
-pistachio manages the sequence behind a serial or identity column as an
-attribute of that column rather than as an object of its own. Counting those
+Object counts of the loaded schemas, as of 2026-08-08 on PostgreSQL 15.18 (16.13
+for icingadb, rt, znuny, gitlab, hive, ranger, ambari, ovirt, and chado, the
+last counted 2026-08-24; the Sequences column was counted on 15.18 throughout,
+Triggers, added 2026-08-24, and Routines, added 2026-08-25, on 15.18 for every
+sample; wso2is, nightingale, and danbooru were counted 2026-08-29 on 15.17;
+openolat and inaturalist 2026-08-30 on 16.13). "Constraints" excludes foreign
+keys; "Types" counts enums and domains; "Sequences" counts standalone sequences
+only, since pistachio manages the sequence behind a serial or identity column as
+an attribute of that column rather than as an object of its own. Counting those
 too would add 2,206 more, 886 of them gitlab's and 210 chado's. "Triggers"
 excludes the internal triggers a foreign key installs and the clones PostgreSQL
 puts on each partition of a partitioned table's trigger, the same as what
@@ -210,18 +212,20 @@ schema and pistachio does not read them either.
 | wso2is | 172 | 1,108 | 362 | 128 | 271 | 0 | 0 | 92 | 0 | 0 |
 | nightingale | 47 | 514 | 116 | 0 | 59 | 0 | 0 | 0 | 0 | 0 |
 | danbooru | 66 | 641 | 456 | 93 | 65 | 2 | 0 | 0 | 0 | 3 |
-| **Total** | **5,087** | **41,926** | **15,725** | **6,455** | **9,310** | **1,952** | **69** | **421** | **555** | **785** |
+| openolat | 382 | 4,378 | 1,239 | 632 | 423 | 8 | 0 | 0 | 0 | 0 |
+| inaturalist | 186 | 1,673 | 580 | 1 | 159 | 0 | 0 | 0 | 0 | 4 |
+| **Total** | **5,655** | **47,977** | **17,544** | **7,088** | **9,892** | **1,960** | **71** | **421** | **555** | **789** |
 
-The 50 dumps come to about 150,000 lines of SQL. chado is 43,700 of them, the
+The 52 dumps come to about 161,000 lines of SQL. chado is 43,700 of them, the
 longest dump of any sample, and gitlab 34,700. gitlab is still about 40 percent
-of the indexes and constraints, a third of the columns and foreign keys, and
-more than a quarter of the tables; musicbrainz, discourse, and wso2apim are the
-largest of what remains, and chado is nearly all of the views. gitlab is also
-why `clean-schema` drops tables a batch at a time rather than cascading through
-`DROP SCHEMA`: a single statement takes locks on every object it reaches, and
-gitlab's 1,422 tables and their indexes run the server out of lock table space
-at the default `max_locks_per_transaction`. It is why `reset-db` resets only
-`public` between samples, too.
+of the constraints, more than a third of the indexes, and roughly a third of the
+columns and foreign keys, over a quarter of the tables; musicbrainz, openolat,
+discourse, and wso2apim are the largest of what remains, and chado is nearly all
+of the views. gitlab is also why `clean-schema` drops tables a batch at a time
+rather than cascading through `DROP SCHEMA`: a single statement takes locks on
+every object it reaches, and gitlab's 1,422 tables and their indexes run the
+server out of lock table space at the default `max_locks_per_transaction`. It is
+why `reset-db` resets only `public` between samples, too.
 
 Beyond size, the samples bring in shapes the hand-written fixtures do not
 always reach: partial and expression indexes and gin, gist, hash, and brin
@@ -249,7 +253,10 @@ case-sensitive (hive's 84 tables, where chinook has 11), index-heavy schemas
 (danbooru's 456 indexes over 66 tables are seven to a table, denser than any
 other sample, 55 of them gin, 29 of those over an expression and 17 naming
 `gin_trgm_ops`, and 49 partial; mediawiki's 192 over 64, only one of them
-partial and none over an expression), partitioned tables at scale (gitlab
+partial and none over an expression), a schema whose size is all width and no
+variety, every one of its 1,239 indexes btree and every one of its 632 foreign
+keys left at NO ACTION (openolat, whose 382 tables are more than any sample but
+gitlab), partitioned tables at scale (gitlab
 declares 100 of them and attaches 2,054 partitions, all of which live in
 schemas of their own), table
 inheritance (ledgersmb attaches 21 children with INHERITS, the only sample that
@@ -260,8 +267,10 @@ Sequence Ontology views in its `so` schema, each selecting from tables in
 `chado`), gist indexes over a function the schema defines itself (chado's three
 name `boxrange`, one of them partial and declared from another schema), columns
 typed by an extension that is not contrib (discourse's three `halfvec` columns,
-which need pgvector, and osm's one `geometry(Polygon,4326)` column, which needs
-PostGIS and is the only type modifier any sample reports in mixed case), and
+which need pgvector, and the `geometry` columns that need PostGIS: osm's one
+`geometry(Polygon,4326)` and inaturalist's 26, 8 of them carrying a modifier of
+their own and 8 gist indexes over them, and those modifiers are the only ones
+any sample reports in mixed case), and
 foreign keys that cross a schema boundary: 20 of adventureworks' 90 span its
 five schemas, 12 of mimiciv's 51 point from `mimiciv_icu` into `mimiciv_hosp`,
 4 of chado's 472 point from `frange` into `chado`, and every one of gitlab's
@@ -270,15 +279,16 @@ partitions is attached across one; and triggers
 state; kea's 81 outnumber its 64 tables; ledgersmb's 11 and dotcms's 10 come
 next).
 
-Routines are concentrated the same way. Eighteen of the 50 samples declare one
+Routines are concentrated the same way. Nineteen of the 52 samples declare one
 at all, and gitlab's 337, kea's and musicbrainz's 130 each, and chado's 94 are
-691 of the 785. Two thirds of them, 523, return `trigger`, though not every one
+691 of the 789. Two thirds of them, 523, return `trigger`, though not every one
 of those has a trigger to call it: musicbrainz's 89 do not, since its loader
-concatenates a file list that leaves triggers out. 710 are written in plpgsql
-and 75 in sql. sourcegraph declares the only procedure any sample has. Only
-chado and kea overload a name, 11 of them and 3, though danbooru's three, all
-sql, include a `lower(text[])` that shadows a built-in. Only sourcegraph,
-ledgersmb, and gitlab comment a routine, seven between them.
+concatenates a file list that leaves triggers out. 712 are written in plpgsql
+and 77 in sql. sourcegraph declares the only procedure any sample has, and
+inaturalist the only aggregate, which `--manage-routine` does not read and so is
+in neither count. Only chado and kea overload a name, 11 of them and 3, though
+danbooru's three, all sql, include a `lower(text[])` that shadows a built-in.
+Only sourcegraph, ledgersmb, and gitlab comment a routine, seven between them.
 
 ## Load-time adjustments
 
@@ -315,21 +325,22 @@ strip only what is irrelevant to a schema round trip:
   `cd` schema itself.
 - **demodb**: `btree_gist` is created first for the `bookings.routes` exclusion
   constraint, and the `\copy` lines are dropped.
-- **discourse**, **osm**, **danbooru**: all three ship their schema as Rails'
-  `db/structure.sql`, which belongs in a schema of its own like the group below
-  but is `pg_dump` output that empties `search_path` and qualifies every object
-  with `public`, so neither `PGOPTIONS` nor hive's one-line rewrite reaches it.
-  The line that empties `search_path` is dropped and the `public.` qualifier is
-  stripped, which leaves every name unqualified for `search_path` to place. The
-  `CREATE EXTENSION` lines say `WITH SCHEMA public` without a dot, so they are
-  untouched and the types they own still resolve from `public`, which stays
-  second in the search path. The tail of the file is Rails' own
-  `SET search_path` followed by the migration versions it inserts into
-  `schema_migrations`, which is data, so everything from that line on is
-  dropped. danbooru installs five extensions of its own, `btree_gin`,
+- **discourse**, **osm**, **danbooru**, **inaturalist**: all four ship their
+  schema as Rails' `db/structure.sql`, which belongs in a schema of its own like
+  the group below but is `pg_dump` output that empties `search_path` and
+  qualifies every object with `public`, so neither `PGOPTIONS` nor hive's
+  one-line rewrite reaches it. The line that empties `search_path` is dropped
+  and the `public.` qualifier is stripped, which leaves every name unqualified
+  for `search_path` to place. The `CREATE EXTENSION` lines say `WITH SCHEMA
+  public` without a dot, so they are untouched and the types they own still
+  resolve from `public`, which stays second in the search path. The tail of the
+  file is Rails' own `SET search_path` followed by the migration versions it
+  inserts into `schema_migrations`, which is data, so everything from that line
+  on is dropped. danbooru installs five extensions of its own, `btree_gin`,
   `fuzzystrmatch`, `pg_trgm`, `pgcrypto`, and `pgstattuple`, but all five are
-  contrib and the official image already has them, so it needs nothing
-  installed the way discourse and osm do.
+  contrib and the official image already has them, so it needs nothing installed
+  the way discourse and osm do. inaturalist needs PostGIS, as osm does, and
+  `uuid-ossp`, which is contrib and which 16 of its columns default through.
 - **dvdrental**: the dump was taken by a `pg_dump` new enough to set
   `transaction_timeout` in its preamble, which 15 and 16 do not have, so that
   one line is dropped. It sets nothing the schema depends on.
@@ -347,11 +358,11 @@ strip only what is irrelevant to a schema round trip:
   **ranger**, **ambari**, **ovirt**, **gitlab**, **ledgersmb**, **koji**,
   **kea**, **dolphinscheduler**, **wso2apim**, **icinga_director**,
   **flowable**, **ejabberd**, **guacamole**, **dotcms**, **wso2is**,
-  **nightingale**: these dumps name no schema at all, so whichever schema comes
-  first in `search_path` gets them. Each is loaded into a schema of its own
-  instead of `public`, so that `make schema`, which puts every sample in one
-  database, does not stack them on top of the other public samples (mediawiki
-  and pagila both define `actor` and `category`). gitlab creates
+  **nightingale**, **openolat**: these dumps name no schema at all, so whichever
+  schema comes first in `search_path` gets them. Each is loaded into a schema of
+  its own instead of `public`, so that `make schema`, which puts every sample in
+  one database, does not stack them on top of the other public samples
+  (mediawiki and pagila both define `actor` and `category`). gitlab creates
   `gitlab_partitions_static` and `gitlab_partitions_dynamic` itself and never
   qualifies anything with `public`, so its 1,083 top-level tables follow
   `search_path` into `gitlab` while its partitions stay in the two schemas it

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -67,6 +67,8 @@ chado|sample-db-chado|URL=https://raw.githubusercontent.com/GMOD/Chado/31c240771
 wso2is|sample-db-url-schema|URL=https://raw.githubusercontent.com/wso2/carbon-identity-framework/a956a69ffdd1bcf916132682b12b5f319102f69e/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/postgresql.sql SCHEMA=wso2is CLIENT_MIN_MESSAGES=warning|wso2is
 nightingale|sample-db-url-schema|URL=https://raw.githubusercontent.com/ccfos/nightingale/8362cbe18f98b3c06af176d71b13994673912c46/docker/compose-postgres/initsql_for_postgres/a-n9e-for-Postgres.sql SCHEMA=nightingale|nightingale
 danbooru|sample-db-pgdump-schema|URL=https://raw.githubusercontent.com/danbooru/danbooru/f8de3ba286db1f9a1f3efbbf495bcbc1001e7b9b/db/structure.sql SCHEMA=danbooru|danbooru
+openolat|sample-db-url-schema|URL=https://raw.githubusercontent.com/OpenOLAT/OpenOLAT/8d07a02fe4dafb8c82179f3efa77e1cb985fdc7e/src/main/resources/database/postgresql/setupDatabase.sql SCHEMA=openolat|openolat
+inaturalist|sample-db-pgdump-schema|URL=https://raw.githubusercontent.com/inaturalist/inaturalist/e52c649d2f0e8e260c2dce6fcf6448d971100415/db/structure.sql SCHEMA=inaturalist|inaturalist
 endef
 
 # Every loader pipes its schema into this psql. ON_ERROR_STOP makes a failing
@@ -304,28 +306,31 @@ sample-db-camunda:
 	  echo; \
 	done | PGOPTIONS='-c search_path=camunda' $(PSQL)
 
-# A pg_dump-style dump loaded into a schema of its own. discourse, osm, and
-# danbooru ship their schema as Rails' db/structure.sql, which belongs in a
-# schema of its own like the sample-db-url-schema dumps but is pg_dump output:
-# it empties search_path and qualifies every object it creates with `public`,
-# so neither PGOPTIONS nor the hive-style search_path rewrite reaches it. Drop
-# the line that empties search_path and strip the `public.` qualifier instead,
-# which leaves every name unqualified and lets search_path place it. The CREATE
+# A pg_dump-style dump loaded into a schema of its own. discourse, osm,
+# danbooru, and inaturalist ship their schema as Rails' db/structure.sql, which
+# belongs in a schema of its own like the sample-db-url-schema dumps but is
+# pg_dump output: it empties search_path and qualifies every object it creates
+# with `public`, so neither PGOPTIONS nor the hive-style search_path rewrite
+# reaches it. Drop the line that empties search_path and strip the `public.`
+# qualifier instead, which leaves every name unqualified and lets search_path
+# place it. The CREATE
 # EXTENSION lines say `WITH SCHEMA public` without a dot, so they are untouched
 # and the types and operator classes they own (discourse's halfvec, hstore, and
-# trgm operator classes, osm's geometry, danbooru's trgm and btree_gin operator
-# classes) still resolve from `public`, which stays second in the search path.
+# trgm operator classes, osm's and inaturalist's geometry, danbooru's trgm and
+# btree_gin operator classes) still resolve from `public`, which stays second in
+# the search path.
 # Column names that merely start with "public" (`public`, `public_version`) are
 # not qualifiers and are left alone. The tail of the file is Rails' own
 # `SET search_path TO "$user", public` followed by the migration versions it
 # inserts into schema_migrations, which is data and would land in the wrong
 # schema anyway, so everything from that line on is dropped.
 #
-# discourse needs pgvector and osm needs PostGIS, neither of which the official
-# postgres image ships; compose.yaml and the samples CI job install both. See
-# docs/contributing-samples.md. danbooru installs five extensions of its own,
-# btree_gin, fuzzystrmatch, pg_trgm, pgcrypto, and pgstattuple, but all five are
-# contrib and the official image already has them.
+# discourse needs pgvector and osm and inaturalist need PostGIS, neither of
+# which the official postgres image ships; compose.yaml and the samples CI job
+# install both. See docs/contributing-samples.md. danbooru installs five
+# extensions of its own, btree_gin, fuzzystrmatch, pg_trgm, pgcrypto, and
+# pgstattuple, and inaturalist one, uuid-ossp, which 16 of its columns default
+# through; those are all contrib and the official image already has them.
 .PHONY: sample-db-pgdump-schema
 sample-db-pgdump-schema:
 	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS $(SCHEMA)'

--- a/test/samples/run.sh
+++ b/test/samples/run.sh
@@ -72,22 +72,23 @@ check() {
   fi
 }
 
-# require_extension <extension> <package> <sample>
-# The discourse sample needs pgvector and the osm sample needs PostGIS, neither
-# of which the official postgres image ships. Say so up front: without them the
-# sample fails at load time and the reason is buried in psql's output.
+# require_extension <extension> <package> <samples>
+# The discourse sample needs pgvector and the osm and inaturalist samples need
+# PostGIS, neither of which the official postgres image ships. Say so up front:
+# without them the sample fails at load time and the reason is buried in psql's
+# output.
 require_extension() {
   local ext="$1" pkg="$2" sample="$3"
   if [ -z "$(psql -X -q -At -c "SELECT 1 FROM pg_available_extensions WHERE name = '$ext'")" ]; then
-    echo "$pkg is not installed on this server, and the $sample sample needs it." >&2
+    echo "$pkg is not installed on this server. It is needed by $sample." >&2
     echo "compose.yaml installs it at container start; recreate the container with" >&2
     echo "  docker compose down && docker compose up -d" >&2
     exit 1
   fi
 }
 
-require_extension vector pgvector discourse
-require_extension postgis PostGIS osm
+require_extension vector pgvector "the discourse sample"
+require_extension postgis PostGIS "the osm and inaturalist samples"
 
 echo "Building pista..."
 go build -o pista ./cmd/pista


### PR DESCRIPTION
Two more real-world schemas, neither of which needed a new loader target.

**openolat** is OpenOLAT's `src/main/resources/database/postgresql/setupDatabase.sql`, one Hibernate-generated file that names no schema, so `sample-db-url-schema` loads it the way it loads mediawiki and the rest of that group: 382 tables, 4,378 columns, 1,239 indexes, 632 foreign keys, 423 constraints, and 8 views. Only gitlab brings more tables. Its size is all width and no variety: every index is btree, every foreign key is left at NO ACTION, and it declares no type, standalone sequence, trigger, or routine at all.

**inaturalist** is Rails' `db/structure.sql`, so `sample-db-pgdump-schema` loads it the way it loads discourse, osm, and danbooru: 186 tables, 1,673 columns, 580 indexes, 159 constraints, and 4 routines, 2 plpgsql and 2 sql. It brings 26 PostGIS `geometry` columns, 8 of them carrying a type modifier and 8 gist indexes over them, 16 columns that default through uuid-ossp's `uuid_generate_v4()`, and the only aggregate any sample declares, which `--manage-routine` does not read. It needs PostGIS as osm does and uuid-ossp, which is contrib, so the samples CI job and compose.yaml install nothing new.

The coverage table's Types total read 69 while its rows summed to 71, a slip that goes back to the documentation split; it is corrected here along with the other totals.

| Sample | Tables | Columns | Indexes | FKs | Constraints | Views | Types | Sequences | Triggers | Routines |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| openolat | 382 | 4,378 | 1,239 | 632 | 423 | 8 | 0 | 0 | 0 | 0 |
| inaturalist | 186 | 1,673 | 580 | 1 | 159 | 0 | 0 | 0 | 0 | 4 |

## Verification

Both samples round-trip clean: `pista dump` planned back to "No changes" on PostgreSQL 16.13.

The sandbox this was written in cannot reach ftp.postgresql.org or pgexercises.com and has a pgvector too old for discourse's `halfvec` columns, so `make test-samples` there reports 45 passed and 7 failed to load - the two new samples among the passes, and none of the failures related to this change. The samples CI job, which runs on postgres:18 with pgvector and PostGIS from PGDG, is what confirms the full set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UosFqhQd5tgTYHvLbU4unq)_