### PR TITLE
Add the CHANGELOG entry for 1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.37.0] - 2026-08-30
+
+* Stop `BETWEEN`, `LIKE` and `NOT IN` from drifting. The grammar rewrites `BETWEEN` into the comparisons it stands for, `LIKE` / `ILIKE` / `SIMILAR TO` into their operators, `NOT IN` into `<> ALL (ARRAY[...])` and `(a, b)` into `ROW(a, b)` before the expression reaches the catalog, so a desired schema that wrote the keyword never matched what came back: a `CHECK` was dropped and re-added on every run, which revalidates the whole table, a partial index was rebuilt and a view recreated. A generated column failed the run instead, since a generated expression cannot be altered in place. The folds sit in the shared expression normalization, so a domain `CHECK`, a column `DEFAULT`, a policy `USING` / `WITH CHECK` and a trigger `WHEN` clause get them too. `IN` already folded against the `= ANY (ARRAY[...])` it is stored as; that fold now matches the operator as well, so `x > ANY (...)` and `x > ALL (...)` stay apart. A typed literal is still re-printed in its type's output form and drifts; TODO.md covers it.
+
 ## [1.36.0] - 2026-08-29
 
 * Manage a table's storage parameters, the `WITH (...)` clause. Neither side read them, so `dump` dropped the clause and no plan proposed one: the per-table autovacuum settings a pg_dump file carries went unmanaged without a warning. A change goes out as `ALTER TABLE ... SET (...)` with a `RESET` for the parameters the desired schema no longer names. A `toast.` parameter is read from the TOAST relation and diffed alongside. `WITH (oids = false)`, which a pg_dump before 12 writes, is not a parameter and is skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.37.0] - 2026-08-30
+## [1.37.0] - 2026-08-31
 
 * Stop `BETWEEN`, `LIKE` and `NOT IN` from drifting. The grammar rewrites `BETWEEN` into the comparisons it stands for, `LIKE` / `ILIKE` / `SIMILAR TO` into their operators, `NOT IN` into `<> ALL (ARRAY[...])` and `(a, b)` into `ROW(a, b)` before the expression reaches the catalog, so a desired schema that wrote the keyword never matched what came back: a `CHECK` was dropped and re-added on every run, which revalidates the whole table, a partial index was rebuilt and a view recreated. A generated column failed the run instead, since a generated expression cannot be altered in place. The folds sit in the shared expression normalization, so a domain `CHECK`, a column `DEFAULT`, a policy `USING` / `WITH CHECK` and a trigger `WHEN` clause get them too. `IN` already folded against the `= ANY (ARRAY[...])` it is stored as; that fold now matches the operator as well, so `x > ANY (...)` and `x > ALL (...)` stay apart. A typed literal is still re-printed in its type's output form and drifts; TODO.md covers it.
 


### PR DESCRIPTION
One entry, for the folds that stopped BETWEEN, the pattern-match keywords and
NOT IN from drifting (#474).

Nothing else since 1.36.0 changes behavior: the rest is the documentation site,
the sample schemas and CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ar29pa7DH2eRj8pfFcFMDN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar29pa7DH2eRj8pfFcFMDN)_