### PR TITLE
Add --exclusive / --exclusive-wait to make apply runs mutually exclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.38.0] - 2026-08-31
+
+* Add `--exclusive` / `--exclusive-wait` to `apply`. Opted-in apply runs on one database become mutually exclusive: `--exclusive` fails at once while another exclusive apply is running, `--exclusive-wait` waits for it up to the given duration (`0` waits without limit). The exclusion is a session-level advisory lock scoped to the database, taken before the catalog read and released when the connection closes; `--with-tx` and CONCURRENTLY index DDL do not affect it, and DDL from any other source is not blocked.
+
 ## [1.37.0] - 2026-08-31
 
 * Stop `BETWEEN`, `LIKE` and `NOT IN` from drifting. The grammar rewrites `BETWEEN` into the comparisons it stands for, `LIKE` / `ILIKE` / `SIMILAR TO` into their operators, `NOT IN` into `<> ALL (ARRAY[...])` and `(a, b)` into `ROW(a, b)` before the expression reaches the catalog, so a desired schema that wrote the keyword never matched what came back: a `CHECK` was dropped and re-added on every run, which revalidates the whole table, a partial index was rebuilt and a view recreated. A generated column failed the run instead, since a generated expression cannot be altered in place. The folds sit in the shared expression normalization, so a domain `CHECK`, a column `DEFAULT`, a policy `USING` / `WITH CHECK` and a trigger `WHEN` clause get them too. `IN` already folded against the `= ANY (ARRAY[...])` it is stored as; that fold now matches the operator as well, so `x > ANY (...)` and `x > ALL (...)` stay apart. A typed literal is still re-printed in its type's output form and drifts; TODO.md covers it.

--- a/apply.go
+++ b/apply.go
@@ -28,7 +28,8 @@ type ApplyOptions struct {
 	// ExclusiveWait enables the same mutual exclusion as Exclusive and waits
 	// for the other apply instead of failing. A pointer because 0 is a valid
 	// value (wait without limit) and must be distinguishable from "not set".
-	ExclusiveWait *time.Duration `xor:"exclusive" env:"PISTA_EXCLUSIVE_WAIT" placeholder:"DURATION" help:"Like --exclusive, but wait up to the given duration (0 waits without limit) for the other apply to finish."`
+	// The type rejects a negative value at parse time.
+	ExclusiveWait *UnsignedDuration `xor:"exclusive" env:"PISTA_EXCLUSIVE_WAIT" placeholder:"DURATION" help:"Like --exclusive, but wait up to the given duration (0 waits without limit) for the other apply to finish."`
 }
 
 // ApplyResult holds the result of an Apply operation.

--- a/apply.go
+++ b/apply.go
@@ -24,6 +24,11 @@ type ApplyOptions struct {
 	ForceIndexConcurrently   bool     `xor:"index-concurrently,tx-mode" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops. Cannot be combined with --with-tx."`
 	BulkAlter                bool     `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
 	AssumeValidated          bool     `env:"PISTA_ASSUME_VALIDATED" help:"Treat every table constraint, domain constraint, and foreign key as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
+	Exclusive                bool     `xor:"exclusive" env:"PISTA_EXCLUSIVE" help:"Make apply runs on the same database mutually exclusive: fail immediately when another exclusive apply is running."`
+	// ExclusiveWait enables the same mutual exclusion as Exclusive and waits
+	// for the other apply instead of failing. A pointer because 0 is a valid
+	// value (wait without limit) and must be distinguishable from "not set".
+	ExclusiveWait *time.Duration `xor:"exclusive" env:"PISTA_EXCLUSIVE_WAIT" placeholder:"DURATION" help:"Like --exclusive, but wait up to the given duration (0 waits without limit) for the other apply to finish."`
 }
 
 // ApplyResult holds the result of an Apply operation.
@@ -54,6 +59,15 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 		return nil, err
 	}
 	defer conn.Close(ctx) //nolint:errcheck
+
+	// Acquire the exclusion before the catalog is read, so the diff below
+	// cannot be computed against a state another exclusive apply is still
+	// changing. Released when the connection closes.
+	if options.Exclusive || options.ExclusiveWait != nil {
+		if err := acquireExclusive(ctx, conn, options.ExclusiveWait, w); err != nil {
+			return nil, err
+		}
+	}
 
 	result, err := client.diffAll(ctx, conn, &diffAllOptions{
 		FilterOptions:            options.FilterOptions,

--- a/docs/guides/exclusive-apply.md
+++ b/docs/guides/exclusive-apply.md
@@ -1,0 +1,25 @@
+# Preventing concurrent applies
+
+Two `pista apply` runs against the same database can interleave: each computes its diff from a snapshot the other is still changing, then issues DDL based on it. `--exclusive` makes apply runs mutually exclusive. When another exclusive apply is running, the command fails immediately, before anything is read or applied:
+
+```bash
+pista apply schema.sql --exclusive
+```
+
+Use `--exclusive-wait` instead to wait for the other apply to finish, up to the given duration. `0` waits without limit. The two flags conflict.
+
+```bash
+pista apply schema.sql --exclusive-wait=5m
+```
+
+Also available as `$PISTA_EXCLUSIVE` / `$PISTA_EXCLUSIVE_WAIT`.
+
+## How it works
+
+The exclusion is a session-level [advisory lock](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS), taken right after connecting and before the current schema is read, so the diff is never computed against a state another exclusive apply is still changing. It is released when the connection closes, including on a crash, and it holds no table lock, so it does not block reads or writes to the schema.
+
+Because the lock is session-level, transaction boundaries do not affect it: it behaves the same with and without `--with-tx`, and across `CREATE INDEX CONCURRENTLY`, which runs outside a transaction. The lock key includes a hash of the database name, so applies to different databases on the same cluster do not exclude each other.
+
+## Limitations
+
+The exclusion only covers apply runs that opt in with `--exclusive` or `--exclusive-wait`. An apply without the flag, another tool, or a psql session issuing DDL is not blocked.

--- a/docs/guides/exclusive-apply.md
+++ b/docs/guides/exclusive-apply.md
@@ -1,12 +1,12 @@
 # Preventing concurrent applies
 
-Two `pista apply` runs against the same database can interleave: each computes its diff from a snapshot the other is still changing, then issues DDL based on it. `--exclusive` makes apply runs mutually exclusive. When another exclusive apply is running, the command fails immediately, before anything is read or applied:
+Two apply runs on one database can interleave: each computes its diff from a state the other is changing. `--exclusive` makes apply runs mutually exclusive. While another exclusive apply is running, the command fails at once, before anything is read or applied:
 
 ```bash
 pista apply schema.sql --exclusive
 ```
 
-Use `--exclusive-wait` instead to wait for the other apply to finish, up to the given duration. `0` waits without limit. The two flags conflict.
+`--exclusive-wait` waits for the other apply instead, up to the given duration. `0` waits without limit. The two flags conflict.
 
 ```bash
 pista apply schema.sql --exclusive-wait=5m
@@ -16,10 +16,8 @@ Also available as `$PISTA_EXCLUSIVE` / `$PISTA_EXCLUSIVE_WAIT`.
 
 ## How it works
 
-The exclusion is a session-level [advisory lock](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS), taken right after connecting and before the current schema is read, so the diff is never computed against a state another exclusive apply is still changing. It is released when the connection closes, including on a crash, and it holds no table lock, so it does not block reads or writes to the schema.
+The exclusion is a session-level [advisory lock](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS), taken right after connecting and before the current schema is read, so the diff never reflects a state another exclusive apply is changing. It holds no table lock and does not block reads or writes. It is released when the connection closes, including on a crash.
 
-Because the lock is session-level, transaction boundaries do not affect it: it behaves the same with and without `--with-tx`, and across `CREATE INDEX CONCURRENTLY`, which runs outside a transaction. The lock key includes a hash of the database name, so applies to different databases on the same cluster do not exclude each other.
+Transaction boundaries do not affect a session-level lock, so it works the same with and without `--with-tx` and across `CREATE INDEX CONCURRENTLY`. The lock key includes a hash of the database name; applies to different databases on one cluster do not exclude each other.
 
-## Limitations
-
-The exclusion only covers apply runs that opt in with `--exclusive` or `--exclusive-wait`. An apply without the flag, another tool, or a psql session issuing DDL is not blocked.
+Only apply runs that pass `--exclusive` or `--exclusive-wait` are excluded. DDL from any other source is not blocked.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -148,86 +148,100 @@ Arguments:
   <files> ...    Path to the desired schema SQL file(s).
 
 Flags:
-  -h, --help                    Show context-sensitive help.
+  -h, --help                       Show context-sensitive help.
   -c, --conn-string="postgres://postgres@localhost/postgres"
-                                PostgreSQL connection string. See
-                                https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                                ($PISTA_CONN_STR)
-  -d, --dbname=STRING           PostgreSQL database name. Overrides the dbname
-                                in --conn-string ($PISTA_DBNAME).
-      --password=STRING         PostgreSQL password ($PISTA_PASSWORD).
-  -n, --schemas=public,...      Schemas to inspect and modify ($PISTA_SCHEMAS).
+                                   PostgreSQL connection string. See
+                                   https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+                                   ($PISTA_CONN_STR)
+  -d, --dbname=STRING              PostgreSQL database name. Overrides the
+                                   dbname in --conn-string ($PISTA_DBNAME).
+      --password=STRING            PostgreSQL password ($PISTA_PASSWORD).
+  -n, --schemas=public,...         Schemas to inspect and modify
+                                   ($PISTA_SCHEMAS).
   -m, --schema-map=KEY=VALUE;...
-                                Schema name mapping (e.g. -m old=new).
-      --search-path=public      search_path for the database connection.
-                                The catalog reports an object reachable through
-                                it without its schema, so this decides how
-                                dump writes that object. Pass an empty value to
-                                qualify everything ($PISTA_SEARCH_PATH).
-  -C, --config=FILE             Load options from a YAML file ($PISTA_CONFIG).
+                                   Schema name mapping (e.g. -m old=new).
+      --search-path=public         search_path for the database connection. The
+                                   catalog reports an object reachable through
+                                   it without its schema, so this decides how
+                                   dump writes that object. Pass an empty value
+                                   to qualify everything ($PISTA_SEARCH_PATH).
+  -C, --config=FILE                Load options from a YAML file
+                                   ($PISTA_CONFIG).
       --version
-      --[no-]pager              Force paging via $PISTA_PAGER even when stdout
-                                is not a TTY. PISTA_PAGER must be set.
+      --[no-]pager                 Force paging via $PISTA_PAGER even when
+                                   stdout is not a TTY. PISTA_PAGER must be set.
 
-  -I, --include=INCLUDE,...     Include only
-                                tables/views/enums/domains/composite
-                                types/sequences/routines matching the pattern
-                                (wildcard: *, ?; /re/ for a regular expression)
-                                ($PISTA_INCLUDE).
-  -E, --exclude=EXCLUDE,...     Exclude tables/views/enums/domains/composite
-                                types/sequences/routines matching the pattern
-                                (wildcard: *, ?; /re/ for a regular expression)
-                                ($PISTA_EXCLUDE).
-      --enable=ENABLE,...       Enable only specified object types (can be
-                                repeated) ($PISTA_ENABLE).
-      --disable=DISABLE,...     Disable specified object types (can be repeated)
-                                ($PISTA_DISABLE).
-      --manage-routine          Manage functions and procedures. Off by default;
-                                --allow-drop routine still gates dropping them
-                                ($PISTA_MANAGE_ROUTINE).
-      --skip-partition-child    Manage a partitioned table without its
-                                partitions. For a schema whose partitions
-                                another tool creates. An INHERITS child is
-                                unaffected ($PISTA_SKIP_PARTITION_CHILD).
+  -I, --include=INCLUDE,...        Include only
+                                   tables/views/enums/domains/composite
+                                   types/sequences/routines matching the
+                                   pattern (wildcard: *, ?; /re/ for a regular
+                                   expression) ($PISTA_INCLUDE).
+  -E, --exclude=EXCLUDE,...        Exclude tables/views/enums/domains/composite
+                                   types/sequences/routines matching the
+                                   pattern (wildcard: *, ?; /re/ for a regular
+                                   expression) ($PISTA_EXCLUDE).
+      --enable=ENABLE,...          Enable only specified object types (can be
+                                   repeated) ($PISTA_ENABLE).
+      --disable=DISABLE,...        Disable specified object types (can be
+                                   repeated) ($PISTA_DISABLE).
+      --manage-routine             Manage functions and procedures. Off by
+                                   default; --allow-drop routine still gates
+                                   dropping them ($PISTA_MANAGE_ROUTINE).
+      --skip-partition-child       Manage a partitioned table without its
+                                   partitions. For a schema whose partitions
+                                   another tool creates. An INHERITS child is
+                                   unaffected ($PISTA_SKIP_PARTITION_CHILD).
       --allow-drop=ALLOW-DROP,...
-                                Allow dropping these object types (repeatable;
-                                'all' allows everything) ($PISTA_ALLOW_DROP).
-      --pre-sql=STRING          SQL to execute before applying changes
-                                ($PISTA_PRE_SQL).
-      --pre-sql-file=STRING     Path to a SQL file to execute before applying
-                                changes ($PISTA_PRE_SQL_FILE).
+                                   Allow dropping these object types
+                                   (repeatable; 'all' allows everything)
+                                   ($PISTA_ALLOW_DROP).
+      --pre-sql=STRING             SQL to execute before applying changes
+                                   ($PISTA_PRE_SQL).
+      --pre-sql-file=STRING        Path to a SQL file to execute before applying
+                                   changes ($PISTA_PRE_SQL_FILE).
       --concurrently-pre-sql=STRING
-                                SQL to execute before CONCURRENTLY
-                                index DDL (e.g. SET lock_timeout).
-                                Runs outside any transaction, only when
-                                the diff contains CONCURRENTLY index DDL
-                                ($PISTA_CONCURRENTLY_PRE_SQL).
+                                   SQL to execute before CONCURRENTLY
+                                   index DDL (e.g. SET lock_timeout).
+                                   Runs outside any transaction, only when
+                                   the diff contains CONCURRENTLY index DDL
+                                   ($PISTA_CONCURRENTLY_PRE_SQL).
       --concurrently-pre-sql-file=STRING
-                                Path to a SQL file to execute
-                                before CONCURRENTLY index DDL
-                                ($PISTA_CONCURRENTLY_PRE_SQL_FILE).
-      --with-tx                 Execute pre-SQL and schema changes in a
-                                transaction ($PISTA_WITH_TX).
-      --try-tx                  Execute pre-SQL and schema changes in a
-                                transaction when possible. A diff containing
-                                CONCURRENTLY index DDL runs without a
-                                transaction instead of failing ($PISTA_TRY_TX).
+                                   Path to a SQL file to execute
+                                   before CONCURRENTLY index DDL
+                                   ($PISTA_CONCURRENTLY_PRE_SQL_FILE).
+      --with-tx                    Execute pre-SQL and schema changes in a
+                                   transaction ($PISTA_WITH_TX).
+      --try-tx                     Execute pre-SQL and schema changes in
+                                   a transaction when possible. A diff
+                                   containing CONCURRENTLY index DDL runs
+                                   without a transaction instead of failing
+                                   ($PISTA_TRY_TX).
       --disable-index-concurrently
-                                Ignore CONCURRENTLY opt-ins (directive and
-                                inline) and emit plain CREATE/DROP INDEX
-                                ($PISTA_DISABLE_INDEX_CONCURRENTLY).
+                                   Ignore CONCURRENTLY opt-ins (directive and
+                                   inline) and emit plain CREATE/DROP INDEX
+                                   ($PISTA_DISABLE_INDEX_CONCURRENTLY).
       --force-index-concurrently
-                                Force CONCURRENTLY on every CREATE/DROP INDEX,
-                                including pure drops. Cannot be combined with
-                                --with-tx ($PISTA_FORCE_INDEX_CONCURRENTLY).
-      --bulk-alter              Combine consecutive ALTER TABLE actions on the
-                                same table into a single statement. FK changes,
-                                RENAME, VALIDATE CONSTRAINT, RLS toggles, and
-                                skipped DROPs stay separate ($PISTA_BULK_ALTER).
-      --assume-validated        Treat every table constraint, domain constraint,
-                                and foreign key as validated: ignore NOT
-                                VALID and never emit VALIDATE CONSTRAINT
-                                ($PISTA_ASSUME_VALIDATED).
+                                   Force CONCURRENTLY on every CREATE/DROP
+                                   INDEX, including pure drops.
+                                   Cannot be combined with --with-tx
+                                   ($PISTA_FORCE_INDEX_CONCURRENTLY).
+      --bulk-alter                 Combine consecutive ALTER TABLE actions on
+                                   the same table into a single statement.
+                                   FK changes, RENAME, VALIDATE CONSTRAINT,
+                                   RLS toggles, and skipped DROPs stay separate
+                                   ($PISTA_BULK_ALTER).
+      --assume-validated           Treat every table constraint, domain
+                                   constraint, and foreign key as validated:
+                                   ignore NOT VALID and never emit VALIDATE
+                                   CONSTRAINT ($PISTA_ASSUME_VALIDATED).
+      --exclusive                  Make apply runs on the same database
+                                   mutually exclusive: fail immediately
+                                   when another exclusive apply is running
+                                   ($PISTA_EXCLUSIVE).
+      --exclusive-wait=DURATION    Like --exclusive, but wait up to
+                                   the given duration (0 waits without
+                                   limit) for the other apply to finish
+                                   ($PISTA_EXCLUSIVE_WAIT).
 ```
 
 </details>
@@ -433,6 +447,13 @@ Use `--assume-validated` to treat every table constraint, domain constraint, and
 ```bash
 pista plan --assume-validated schema.sql
 pista apply --assume-validated schema.sql
+```
+
+Use `--exclusive` to make apply runs on the same database mutually exclusive. When another exclusive apply is running, the command fails immediately, before anything is read or applied. Use `--exclusive-wait` instead to wait for the other apply to finish, up to the given duration (`0` waits without limit). The two flags conflict. Also available as `$PISTA_EXCLUSIVE` / `$PISTA_EXCLUSIVE_WAIT`. See [Preventing concurrent applies](../guides/exclusive-apply.md).
+
+```bash
+pista apply schema.sql --exclusive
+pista apply schema.sql --exclusive-wait=5m
 ```
 
 By default, `plan` and `apply` do not drop tables, views, enums, domains, composite types, columns, constraints, foreign keys, or indexes. Use `--allow-drop` to enable dropping specific object types (`all`, `table`, `view`, `enum`, `domain`, `composite_type`, `sequence`, `routine`, `column`, `constraint`, `foreign_key`, `index`, `policy`, `trigger`). Also available as `$PISTA_ALLOW_DROP`. `constraint` covers CHECK / UNIQUE / PRIMARY KEY / EXCLUSION; foreign keys are governed by `foreign_key` separately. `composite_type` also gates `DROP ATTRIBUTE` on a composite type. `routine` covers functions and procedures, and also gates the drop half of a recreate.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -449,7 +449,7 @@ pista plan --assume-validated schema.sql
 pista apply --assume-validated schema.sql
 ```
 
-Use `--exclusive` to make apply runs on the same database mutually exclusive. When another exclusive apply is running, the command fails immediately, before anything is read or applied. Use `--exclusive-wait` instead to wait for the other apply to finish, up to the given duration (`0` waits without limit). The two flags conflict. Also available as `$PISTA_EXCLUSIVE` / `$PISTA_EXCLUSIVE_WAIT`. See [Preventing concurrent applies](../guides/exclusive-apply.md).
+Use `--exclusive` to make apply runs on the same database mutually exclusive: while another exclusive apply is running, the command fails at once. `--exclusive-wait` waits for the other apply instead, up to the given duration (`0` waits without limit). The two flags conflict. Also available as `$PISTA_EXCLUSIVE` / `$PISTA_EXCLUSIVE_WAIT`. See [Preventing concurrent applies](../guides/exclusive-apply.md).
 
 ```bash
 pista apply schema.sql --exclusive

--- a/exclusive.go
+++ b/exclusive.go
@@ -1,0 +1,66 @@
+package pistachio
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// exclusiveLockClassID is the first key of the two-key session-level advisory
+// lock that makes exclusive apply runs mutually exclusive ("Pist" in ASCII).
+// The second key is hashtext(current_database()): the advisory lock namespace
+// is cluster-wide, so hashing the database name scopes the exclusion to one
+// database.
+const exclusiveLockClassID = 0x50697374
+
+// acquireExclusive makes this apply run mutually exclusive with other
+// exclusive apply runs on the same database. It runs right after connecting,
+// before the catalog is read, so the diff cannot be computed against a state
+// another exclusive apply is still changing.
+//
+// The lock is session-level on purpose: it is unaffected by transaction
+// boundaries, so it behaves the same with --with-tx, without it, and across
+// CONCURRENTLY index DDL, and it is released when the connection closes,
+// including on a crash.
+//
+// With wait == nil a held lock is an immediate error. Otherwise a second,
+// blocking attempt waits for the holder, bounded by *wait through a context
+// deadline (0 waits without limit); a server-side setting like lock_timeout
+// is deliberately not used, so nothing leaks into the session the DDL then
+// runs on.
+func acquireExclusive(ctx context.Context, conn *pgx.Conn, wait *time.Duration, w io.Writer) error {
+	if wait != nil && *wait < 0 {
+		return fmt.Errorf("pistachio: negative exclusive wait duration: %s", *wait)
+	}
+
+	var acquired bool
+	if err := conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1, hashtext(current_database()))", exclusiveLockClassID).Scan(&acquired); err != nil {
+		return fmt.Errorf("pistachio: failed to acquire the apply exclusion: %w", err)
+	}
+	if acquired {
+		return nil
+	}
+	if wait == nil {
+		return errors.New("pistachio: another exclusive apply is running (--exclusive-wait waits for it)")
+	}
+
+	fmt.Fprintln(w, "-- Waiting for another exclusive apply to finish") //nolint:errcheck
+
+	waitCtx := ctx
+	if *wait > 0 {
+		var cancel context.CancelFunc
+		waitCtx, cancel = context.WithTimeout(ctx, *wait)
+		defer cancel()
+	}
+	if _, err := conn.Exec(waitCtx, "SELECT pg_advisory_lock($1, hashtext(current_database()))", exclusiveLockClassID); err != nil {
+		if waitCtx.Err() != nil && ctx.Err() == nil {
+			return fmt.Errorf("pistachio: another exclusive apply did not finish within %s", *wait)
+		}
+		return fmt.Errorf("pistachio: failed to acquire the apply exclusion: %w", err)
+	}
+	return nil
+}

--- a/exclusive.go
+++ b/exclusive.go
@@ -17,6 +17,23 @@ import (
 // database.
 const exclusiveLockClassID = 0x50697374
 
+// UnsignedDuration is a time.Duration that rejects a negative value at
+// parse time, so a flag, env var or config key using it cannot be set below
+// zero. kong decodes it through UnmarshalText like any other duration.
+type UnsignedDuration time.Duration
+
+func (d *UnsignedDuration) UnmarshalText(text []byte) error {
+	v, err := time.ParseDuration(string(text))
+	if err != nil {
+		return err
+	}
+	if v < 0 {
+		return fmt.Errorf("must not be negative: %s", v)
+	}
+	*d = UnsignedDuration(v)
+	return nil
+}
+
 // acquireExclusive makes this apply run mutually exclusive with other
 // exclusive apply runs on the same database. It runs right after connecting,
 // before the catalog is read, so the diff cannot be computed against a state
@@ -32,11 +49,7 @@ const exclusiveLockClassID = 0x50697374
 // deadline (0 waits without limit); a server-side setting like lock_timeout
 // is deliberately not used, so nothing leaks into the session the DDL then
 // runs on.
-func acquireExclusive(ctx context.Context, conn *pgx.Conn, wait *time.Duration, w io.Writer) error {
-	if wait != nil && *wait < 0 {
-		return fmt.Errorf("pistachio: negative exclusive wait duration: %s", *wait)
-	}
-
+func acquireExclusive(ctx context.Context, conn *pgx.Conn, wait *UnsignedDuration, w io.Writer) error {
 	var acquired bool
 	if err := conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1, hashtext(current_database()))", exclusiveLockClassID).Scan(&acquired); err != nil {
 		return fmt.Errorf("pistachio: failed to acquire the apply exclusion: %w", err)
@@ -53,12 +66,12 @@ func acquireExclusive(ctx context.Context, conn *pgx.Conn, wait *time.Duration, 
 	waitCtx := ctx
 	if *wait > 0 {
 		var cancel context.CancelFunc
-		waitCtx, cancel = context.WithTimeout(ctx, *wait)
+		waitCtx, cancel = context.WithTimeout(ctx, time.Duration(*wait))
 		defer cancel()
 	}
 	if _, err := conn.Exec(waitCtx, "SELECT pg_advisory_lock($1, hashtext(current_database()))", exclusiveLockClassID); err != nil {
 		if waitCtx.Err() != nil && ctx.Err() == nil {
-			return fmt.Errorf("pistachio: another exclusive apply did not finish within %s", *wait)
+			return fmt.Errorf("pistachio: another exclusive apply did not finish within %s", time.Duration(*wait))
 		}
 		return fmt.Errorf("pistachio: failed to acquire the apply exclusion: %w", err)
 	}

--- a/exclusive_test.go
+++ b/exclusive_test.go
@@ -164,6 +164,121 @@ func TestApplyExclusiveWait(t *testing.T) {
 	assert.Contains(t, buf.String(), "CREATE TABLE")
 }
 
+func TestApplyExclusiveWaitWithinDeadline(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	holder := testutil.ConnectDB(t)
+	defer holder.Close(ctx)
+	holdExclusive(t, ctx, holder)
+
+	release := make(chan error, 1)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		release <- releaseExclusive(ctx, holder)
+	}()
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	result, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
+		ExclusiveWait: durationPtr(10 * time.Second),
+	}, &buf)
+	require.NoError(t, err)
+	require.NoError(t, <-release)
+	assert.True(t, result.Applied)
+	assert.Contains(t, buf.String(), "-- Waiting for another exclusive apply to finish")
+}
+
+func TestApplyExclusiveWaitUncontended(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	result, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
+		ExclusiveWait: durationPtr(5 * time.Second),
+	}, &buf)
+	require.NoError(t, err)
+	assert.True(t, result.Applied)
+	assert.NotContains(t, buf.String(), "Waiting")
+}
+
+func TestApplyExclusiveWithTx(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// The exclusion is session-level: it must coexist with --with-tx and be
+	// released when the connection closes, not before.
+	var buf bytes.Buffer
+	result, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:     []string{writeDesiredFile(t, exclusiveDesired)},
+		Exclusive: true,
+		WithTx:    true,
+	}, &buf)
+	require.NoError(t, err)
+	assert.True(t, result.Applied)
+	assert.Contains(t, buf.String(), "-- Transaction committed")
+
+	var acquired bool
+	err = conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1, hashtext(current_database()))", pistachio.ExclusiveLockClassID).Scan(&acquired)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+	require.NoError(t, releaseExclusive(ctx, conn))
+}
+
+func TestApplyExclusiveWaitCanceled(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	holder := testutil.ConnectDB(t)
+	defer holder.Close(ctx)
+	holdExclusive(t, ctx, holder)
+	defer releaseExclusive(ctx, holder) //nolint:errcheck
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// Canceling the caller's context (e.g. Ctrl-C) must stop an unlimited
+	// wait, and must not be reported as a wait timeout.
+	applyCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := client.Apply(applyCtx, &pistachio.ApplyOptions{
+		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
+		ExclusiveWait: durationPtr(0),
+	}, io.Discard)
+	require.ErrorContains(t, err, "failed to acquire the apply exclusion")
+	assert.NotContains(t, err.Error(), "did not finish within")
+}
+
 func TestApplyExclusiveWaitNegative(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)

--- a/exclusive_test.go
+++ b/exclusive_test.go
@@ -1,0 +1,183 @@
+package pistachio_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+const exclusiveDesired = `CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+
+func writeDesiredFile(t *testing.T, sql string) string {
+	t.Helper()
+	file := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(file, []byte(sql), 0o644))
+	return file
+}
+
+func holdExclusive(t *testing.T, ctx context.Context, conn *pgx.Conn) {
+	t.Helper()
+	_, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1, hashtext(current_database()))", pistachio.ExclusiveLockClassID)
+	require.NoError(t, err)
+}
+
+func releaseExclusive(ctx context.Context, conn *pgx.Conn) error {
+	_, err := conn.Exec(ctx, "SELECT pg_advisory_unlock($1, hashtext(current_database()))", pistachio.ExclusiveLockClassID)
+	return err
+}
+
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
+}
+
+func TestApplyExclusive(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	result, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:     []string{writeDesiredFile(t, exclusiveDesired)},
+		Exclusive: true,
+	}, &buf)
+	require.NoError(t, err)
+	assert.True(t, result.Applied)
+	assert.Contains(t, buf.String(), "CREATE TABLE")
+
+	// Apply's connection is closed, so the exclusion must be free again.
+	var acquired bool
+	err = conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1, hashtext(current_database()))", pistachio.ExclusiveLockClassID).Scan(&acquired)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+	require.NoError(t, releaseExclusive(ctx, conn))
+}
+
+func TestApplyExclusiveConflict(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	holder := testutil.ConnectDB(t)
+	defer holder.Close(ctx)
+	holdExclusive(t, ctx, holder)
+	defer releaseExclusive(ctx, holder) //nolint:errcheck
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:     []string{writeDesiredFile(t, exclusiveDesired)},
+		Exclusive: true,
+	}, &buf)
+	require.ErrorContains(t, err, "another exclusive apply is running")
+	assert.Empty(t, buf.String())
+
+	// Nothing may have been applied.
+	var count int
+	err = conn.QueryRow(ctx, "SELECT count(*) FROM pg_tables WHERE schemaname = 'public'").Scan(&count)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+}
+
+func TestApplyExclusiveWaitTimeout(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	holder := testutil.ConnectDB(t)
+	defer holder.Close(ctx)
+	holdExclusive(t, ctx, holder)
+	defer releaseExclusive(ctx, holder) //nolint:errcheck
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	wait := 300 * time.Millisecond
+	start := time.Now()
+	var buf bytes.Buffer
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
+		ExclusiveWait: &wait,
+	}, &buf)
+	require.ErrorContains(t, err, "did not finish within")
+	assert.GreaterOrEqual(t, time.Since(start), wait)
+	assert.Contains(t, buf.String(), "-- Waiting for another exclusive apply to finish")
+}
+
+func TestApplyExclusiveWait(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	holder := testutil.ConnectDB(t)
+	defer holder.Close(ctx)
+	holdExclusive(t, ctx, holder)
+
+	release := make(chan error, 1)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		release <- releaseExclusive(ctx, holder)
+	}()
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	// 0 waits without limit.
+	var buf bytes.Buffer
+	result, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
+		ExclusiveWait: durationPtr(0),
+	}, &buf)
+	require.NoError(t, err)
+	require.NoError(t, <-release)
+	assert.True(t, result.Applied)
+	assert.Contains(t, buf.String(), "-- Waiting for another exclusive apply to finish")
+	assert.Contains(t, buf.String(), "CREATE TABLE")
+}
+
+func TestApplyExclusiveWaitNegative(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
+		ExclusiveWait: durationPtr(-time.Second),
+	}, io.Discard)
+	require.ErrorContains(t, err, "negative")
+}

--- a/exclusive_test.go
+++ b/exclusive_test.go
@@ -39,8 +39,9 @@ func releaseExclusive(ctx context.Context, conn *pgx.Conn) error {
 	return err
 }
 
-func durationPtr(d time.Duration) *time.Duration {
-	return &d
+func durationPtr(d time.Duration) *pistachio.UnsignedDuration {
+	w := pistachio.UnsignedDuration(d)
+	return &w
 }
 
 func TestApplyExclusive(t *testing.T) {
@@ -123,7 +124,7 @@ func TestApplyExclusiveWaitTimeout(t *testing.T) {
 	var buf bytes.Buffer
 	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
 		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
-		ExclusiveWait: &wait,
+		ExclusiveWait: durationPtr(wait),
 	}, &buf)
 	require.ErrorContains(t, err, "did not finish within")
 	assert.GreaterOrEqual(t, time.Since(start), wait)
@@ -279,20 +280,12 @@ func TestApplyExclusiveWaitCanceled(t *testing.T) {
 	assert.NotContains(t, err.Error(), "did not finish within")
 }
 
-func TestApplyExclusiveWaitNegative(t *testing.T) {
-	ctx := context.Background()
-	conn := testutil.ConnectDB(t)
-	defer conn.Close(ctx)
-	testutil.SetupDB(t, ctx, conn, "")
-
-	client := pistachio.NewClient(&pistachio.Options{
-		ConnString: conn.Config().ConnString(),
-		Schemas:    []string{"public"},
-	})
-
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
-		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
-		ExclusiveWait: durationPtr(-time.Second),
-	}, io.Discard)
-	require.ErrorContains(t, err, "negative")
+func TestUnsignedDuration(t *testing.T) {
+	var d pistachio.UnsignedDuration
+	require.NoError(t, d.UnmarshalText([]byte("5m")))
+	assert.Equal(t, pistachio.UnsignedDuration(5*time.Minute), d)
+	require.NoError(t, d.UnmarshalText([]byte("0")))
+	assert.Equal(t, pistachio.UnsignedDuration(0), d)
+	require.ErrorContains(t, d.UnmarshalText([]byte("-3s")), "negative")
+	require.Error(t, d.UnmarshalText([]byte("bad")))
 }

--- a/export_test.go
+++ b/export_test.go
@@ -5,6 +5,8 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
+const ExclusiveLockClassID = exclusiveLockClassID
+
 var (
 	ResolvePreSQL             = resolvePreSQL
 	ResolveConcurrentlyPreSQL = resolveConcurrentlyPreSQL

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - guides/filtering.md
       - guides/drops.md
       - guides/transactions.md
+      - guides/exclusive-apply.md
       - guides/executing-sql.md
       - guides/splitting.md
   - Reference:


### PR DESCRIPTION
Two apply runs on one database had nothing keeping them apart. apply reads
the catalog, computes the diff and issues the DDL on one connection with no
re-check in between, so a second apply, or a second CI pipeline passing
plan --check at the same time, could compute its diff from a state the other
was still changing and issue DDL based on it.

--exclusive makes apply runs mutually exclusive. The exclusion is a
session-level advisory lock, keyed on a fixed class ID and a hash of the
database name, taken right after connecting and before the catalog read, so
the whole diff-then-execute sequence is covered and applies to different
databases on one cluster stay independent. A held lock is an immediate
error. --exclusive-wait waits for the holder instead, up to the given
duration (0 waits without limit), enforced with a Go-side context deadline
so no server-side setting leaks into the session the DDL then runs on. The
two flags conflict.

Session level is what makes the lock uniform: transaction boundaries do not
affect it, so it behaves the same with and without --with-tx and across
CREATE INDEX CONCURRENTLY, and it disappears with the connection, including
on a crash. It holds no table lock and does not block other clients, and an
apply without the flag, or any other tool, is not excluded.

Documented as a standalone guide page, Preventing concurrent applies, since
the mechanism is orthogonal to the transaction flags.
