### PR TITLE
Make a table's storage parameters opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.38.1] - 2026-09-01
+
+* Make a table's storage parameters opt-in, behind `--manage-storage-param` (`$PISTA_MANAGE_STORAGE_PARAM`). Managing them by default reset the autovacuum settings a table was tuned with, which are set on the database more often than written in a schema file. Without the flag they are dropped from both sides of the diff: no `SET` or `RESET` is planned, the `WITH` clause a file writes is left off the `CREATE TABLE`, and `dump` does not write one. An index's parameters are part of its definition and are managed either way.
+
 ## [1.38.0] - 2026-08-31
 
 * Add `--exclusive` / `--exclusive-wait` to `apply`. Opted-in apply runs on one database become mutually exclusive: `--exclusive` fails at once while another exclusive apply is running, `--exclusive-wait` waits for it up to the given duration (`0` waits without limit). The exclusion is a session-level advisory lock scoped to the database, taken before the catalog read and released when the connection closes; `--with-tx` and CONCURRENTLY index DDL do not affect it, and DDL from any other source is not blocked.

--- a/TODO.md
+++ b/TODO.md
@@ -583,7 +583,8 @@ one that matters, since the view is a security boundary without it.
 `ALTER VIEW ... SET (...)` / `RESET (...)` and the `ALTER MATERIALIZED VIEW`
 forms are what a change goes out as. The table work put the reading and the
 rendering in `SortedStorageParams` and `Table.StorageParamsSQL`, which the view
-model can use as they are.
+model can use as they are, and `--manage-storage-param` is the gate they would
+sit behind.
 
 `dump` writes no clause and the parser reads none, so a dump fed back plans
 clean and only a hand-written view reaches this.

--- a/apply_test.go
+++ b/apply_test.go
@@ -37,6 +37,7 @@ type applyTestCase struct {
 	Enable                   []string         `yaml:"enable,omitempty"`
 	Disable                  []string         `yaml:"disable,omitempty"`
 	ManageRoutine            bool             `yaml:"manage_routine,omitempty"`
+	ManageStorageParam       bool             `yaml:"manage_storage_param,omitempty"`
 	SkipPartitionChild       bool             `yaml:"skip_partition_child,omitempty"`
 	PreSQL                   string           `yaml:"pre_sql,omitempty"`
 	// PreSQLFile holds SQL content; the runner writes it to a temp file and
@@ -127,6 +128,7 @@ func TestApply(t *testing.T) {
 					Enable:             tc.Enable,
 					Disable:            tc.Disable,
 					ManageRoutine:      tc.ManageRoutine,
+					ManageStorageParam: tc.ManageStorageParam,
 					SkipPartitionChild: tc.SkipPartitionChild,
 				},
 				Files:                    []string{desiredFile},
@@ -148,7 +150,10 @@ func TestApply(t *testing.T) {
 
 			// Verify
 			got, err := client.Dump(ctx, &pistachio.DumpOptions{
-				FilterOptions: pistachio.FilterOptions{ManageRoutine: tc.ManageRoutine},
+				FilterOptions: pistachio.FilterOptions{
+					ManageRoutine:      tc.ManageRoutine,
+					ManageStorageParam: tc.ManageStorageParam,
+				},
 			})
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.expectedApplied(pgMajor)), strings.TrimSpace(got.String()))
@@ -162,6 +167,7 @@ func TestApply(t *testing.T) {
 						Enable:             tc.Enable,
 						Disable:            tc.Disable,
 						ManageRoutine:      tc.ManageRoutine,
+						ManageStorageParam: tc.ManageStorageParam,
 						SkipPartitionChild: tc.SkipPartitionChild,
 					},
 					Files:                    []string{desiredFile},

--- a/diff/storage_params.go
+++ b/diff/storage_params.go
@@ -11,6 +11,10 @@ import (
 // names. Neither rewrites the table. Both sides are keyed in name order, so
 // the statements come out the same on every run.
 //
+// The caller clears the parameters on both sides unless --manage-storage-param
+// asked for them, so an unmanaged run reaches here with two empty maps and
+// plans nothing.
+//
 // A partitioned table needs no special case, since PostgreSQL rejects every
 // parameter on a relation that holds no storage. A partition holds its own,
 // which it does not take from the parent, and is diffed like any other table.

--- a/diff_all.go
+++ b/diff_all.go
@@ -147,6 +147,10 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		count.Routines = &n
 	}
 
+	if !options.ManageStorageParam {
+		clearStorageParams(filteredTables, desiredTables)
+	}
+
 	switch {
 	case options.DisableIndexConcurrently:
 		clearConcurrentlyDirectives(desiredTables, desiredViews)
@@ -291,6 +295,19 @@ func clearConcurrentlyDirectives(
 	for _, v := range views.CollectValues() {
 		for _, idx := range v.Indexes.CollectValues() {
 			idx.Concurrently = false
+		}
+	}
+}
+
+// clearStorageParams drops the storage parameters off every table in the
+// given maps, used when --manage-storage-param was not passed. Clearing both
+// sides is what leaves them unmanaged: no SET or RESET is planned, a WITH
+// clause a desired schema writes is not carried into the CREATE TABLE, and
+// dump does not write one.
+func clearStorageParams(tableMaps ...*orderedmap.Map[string, *model.Table]) {
+	for _, tables := range tableMaps {
+		for _, t := range tables.CollectValues() {
+			t.StorageParams = nil
 		}
 	}
 }

--- a/docs/contributing-samples.md
+++ b/docs/contributing-samples.md
@@ -16,10 +16,11 @@ check. It needs a running PostgreSQL instance (`PGHOST=localhost`,
 `PGUSER=postgres`, exported by the Makefile), plus `psql`, `curl`, and network
 access to the upstream hosts. The same target runs in CI as the `samples` job.
 
-The runner exports `PISTA_MANAGE_ROUTINE=1`, so functions and procedures are
-part of the round trip even though they are opt-in on the command line. It is an
-environment variable rather than a per-sample flag because it has to reach both
-the dump and the plan, and the manifest's flags column reaches only the plan.
+The runner exports `PISTA_MANAGE_ROUTINE=1` and `PISTA_MANAGE_STORAGE_PARAM=1`,
+so functions, procedures and a table's storage parameters are part of the round
+trip even though they are opt-in on the command line. They are environment
+variables rather than per-sample flags because they have to reach both the dump
+and the plan, and the manifest's flags column reaches only the plan.
 
 The server also needs pgvector for the discourse sample's `halfvec` columns and
 PostGIS for the osm and inaturalist samples' `geometry` columns. The official

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -92,6 +92,10 @@ Flags:
       --manage-routine          Manage functions and procedures. Off by default;
                                 --allow-drop routine still gates dropping them
                                 ($PISTA_MANAGE_ROUTINE).
+      --manage-storage-param    Manage a table's storage parameters, the WITH
+                                (...) clause. Off by default; without it the
+                                clause is ignored on both sides and dump does
+                                not write it ($PISTA_MANAGE_STORAGE_PARAM).
       --skip-partition-child    Manage a partitioned table without its
                                 partitions. For a schema whose partitions
                                 another tool creates. An INHERITS child is
@@ -187,6 +191,10 @@ Flags:
       --manage-routine             Manage functions and procedures. Off by
                                    default; --allow-drop routine still gates
                                    dropping them ($PISTA_MANAGE_ROUTINE).
+      --manage-storage-param       Manage a table's storage parameters, the WITH
+                                   (...) clause. Off by default; without it the
+                                   clause is ignored on both sides and dump does
+                                   not write it ($PISTA_MANAGE_STORAGE_PARAM).
       --skip-partition-child       Manage a partitioned table without its
                                    partitions. For a schema whose partitions
                                    another tool creates. An INHERITS child is
@@ -292,6 +300,10 @@ Flags:
       --manage-routine          Manage functions and procedures. Off by default;
                                 --allow-drop routine still gates dropping them
                                 ($PISTA_MANAGE_ROUTINE).
+      --manage-storage-param    Manage a table's storage parameters, the WITH
+                                (...) clause. Off by default; without it the
+                                clause is ignored on both sides and dump does
+                                not write it ($PISTA_MANAGE_STORAGE_PARAM).
       --skip-partition-child    Manage a partitioned table without its
                                 partitions. For a schema whose partitions
                                 another tool creates. An INHERITS child is

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -5,7 +5,7 @@
 - Composite types (`CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME ATTRIBUTE`). Attributes are matched by name, so reordering them produces no diff (PostgreSQL cannot reorder attributes). `ALTER ATTRIBUTE ... TYPE` fails at apply while a table column uses the type; PostgreSQL does not allow it and `CASCADE` does not help.
 - Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables)
-- Storage parameters, the `WITH (...)` clause on a table and on an index. A `toast.` parameter belongs to the TOAST relation. PostgreSQL creates that relation only for a table with a toastable column, and discards the setting when there is none, so such a table re-plans it on every run. A partitioned table holds no parameter, and a partition does not inherit the parent's.
+- Storage parameters, the `WITH (...)` clause. An index's parameters are always managed; a table's are opt-in with `--manage-storage-param`. See [Table storage parameters](#table-storage-parameters).
 - Views
 - Materialized views
 - Columns (serial/bigserial/smallserial, identity, generated, TOAST storage and compression)
@@ -21,6 +21,22 @@
 
 pistachio parses only the statements above. It drops any other statement in a schema file, such as `SET`, `GRANT`, or `CREATE EXTENSION`, and prints a `pistachio: ignored unsupported statement:` warning to standard error for each one. The same warning covers the parts it does not read of a statement it does parse, such as the `ALTER TABLE ... ADD COLUMN` and `ALTER COLUMN ... SET DEFAULT` a `pg_dump` file carries, or `COMMENT ON INDEX`. The `ALTER COLUMN ... SET STORAGE` and `SET COMPRESSION` such a file carries are read. To keep an unsupported statement in the file and run it during `apply`, mark it with `-- pista:execute`, which also silences the warning. A `BEGIN` or `COMMIT` warning points at `--with-tx` and `--try-tx`, which wrap the apply in a transaction.
 
+
+## Table storage parameters
+
+A table's storage parameters, the `WITH (...)` clause, are managed only when `--manage-storage-param` is passed (also `$PISTA_MANAGE_STORAGE_PARAM`). They are off by default because the autovacuum settings a table is tuned with are usually set on the database, not written in the schema file.
+
+```bash
+pista dump --manage-storage-param
+pista plan --manage-storage-param schema.sql
+pista apply --manage-storage-param schema.sql
+```
+
+Without the flag the parameters are dropped from both sides of the diff: no `SET` or `RESET` is planned, the clause a schema file writes is left off the `CREATE TABLE`, and `dump` does not write one.
+
+With it the schema file states every parameter the table is to have. A change goes out as `ALTER TABLE ... SET (...)`, with a `RESET` for the parameters the file no longer names; neither rewrites the table. A `toast.` parameter belongs to the TOAST relation. PostgreSQL creates that relation only for a table with a toastable column and discards the setting when there is none, so such a table re-plans it on every run. A partitioned table holds no parameter, and a partition does not inherit the parent's.
+
+An index's parameters are part of its definition and are managed either way.
 
 ## Routines
 

--- a/dump.go
+++ b/dump.go
@@ -539,6 +539,10 @@ func (client *Client) Dump(ctx context.Context, options *DumpOptions) (*DumpResu
 	filteredSequences := options.filterSequences(client.remapSequenceSchemas(sequences))
 	filteredRoutines := options.filterRoutines(client.remapRoutineSchemas(routines))
 
+	if !options.ManageStorageParam {
+		clearStorageParams(filteredTables)
+	}
+
 	// Validate the dependency order up front so a cycle is a hard error rather
 	// than a silent fall back to name order. String() renders in this order.
 	if options.SortByDeps {

--- a/dump_test.go
+++ b/dump_test.go
@@ -31,6 +31,7 @@ type dumpTestCase struct {
 	Enable             []string `yaml:"enable,omitempty"`
 	Disable            []string `yaml:"disable,omitempty"`
 	ManageRoutine      bool     `yaml:"manage_routine,omitempty"`
+	ManageStorageParam bool     `yaml:"manage_storage_param,omitempty"`
 	SkipPartitionChild bool     `yaml:"skip_partition_child,omitempty"`
 }
 
@@ -876,6 +877,7 @@ func TestDump(t *testing.T) {
 					Enable:             tc.Enable,
 					Disable:            tc.Disable,
 					ManageRoutine:      tc.ManageRoutine,
+					ManageStorageParam: tc.ManageStorageParam,
 					SkipPartitionChild: tc.SkipPartitionChild,
 				},
 			})

--- a/options.go
+++ b/options.go
@@ -50,6 +50,12 @@ type FilterOptions struct {
 	// routines the desired schema does not declare, and reading pg_proc
 	// unasked would report every one of them as a drop.
 	ManageRoutine bool `env:"PISTA_MANAGE_ROUTINE" help:"Manage functions and procedures. Off by default; --allow-drop routine still gates dropping them."`
+	// ManageStorageParam opts into a table's storage parameters, the WITH
+	// clause. They are unmanaged by default: the autovacuum settings a table
+	// is tuned with are usually set on the database, not written in the
+	// schema file, and reading them unasked would RESET every parameter the
+	// desired schema does not name.
+	ManageStorageParam bool `env:"PISTA_MANAGE_STORAGE_PARAM" help:"Manage a table's storage parameters, the WITH (...) clause. Off by default; without it the clause is ignored on both sides and dump does not write it."`
 	// SkipPartitionChild leaves the partitions of a partitioned table
 	// unmanaged. Where another tool creates them, their names follow no
 	// pattern --exclude can state, and a schema file that declares the parent

--- a/plan_test.go
+++ b/plan_test.go
@@ -40,6 +40,7 @@ type planTestCase struct {
 	Enable                   []string        `yaml:"enable,omitempty"`
 	Disable                  []string        `yaml:"disable,omitempty"`
 	ManageRoutine            bool            `yaml:"manage_routine,omitempty"`
+	ManageStorageParam       bool            `yaml:"manage_storage_param,omitempty"`
 	SkipPartitionChild       bool            `yaml:"skip_partition_child,omitempty"`
 	PreSQL                   string          `yaml:"pre_sql,omitempty"`
 	// PreSQLFile holds SQL content; the runner writes it to a temp file and
@@ -391,6 +392,7 @@ func TestPlan(t *testing.T) {
 					Enable:             tc.Enable,
 					Disable:            tc.Disable,
 					ManageRoutine:      tc.ManageRoutine,
+					ManageStorageParam: tc.ManageStorageParam,
 					SkipPartitionChild: tc.SkipPartitionChild,
 				},
 				Files:                    []string{desiredFile},

--- a/test/fidelity/run.sh
+++ b/test/fidelity/run.sh
@@ -32,6 +32,10 @@ export PGPORT="${PGPORT:-5415}"
 # else. Set as an environment variable so it reaches every pista call.
 export PISTA_MANAGE_ROUTINE=1
 
+# A table's storage parameters are opt-in as well, and pg_dump writes the WITH
+# clause, so the dump has to carry it for the two to compare equal.
+export PISTA_MANAGE_STORAGE_PARAM=1
+
 # Guarded because the script runs without -e: the checks below rely on a
 # failing command being a result rather than the end of the run. A build that
 # fails without stopping would leave an earlier binary in place and report on

--- a/test/samples/run.sh
+++ b/test/samples/run.sh
@@ -22,6 +22,10 @@ export PGPORT="${PGPORT:-5415}"
 # plan.
 export PISTA_MANAGE_ROUTINE=1
 
+# A table's storage parameters are opt-in as well, and the samples carry the
+# WITH clauses real schemas write, so the round trip has to hold up for them.
+export PISTA_MANAGE_STORAGE_PARAM=1
+
 : "${PISTA:=./pista}"
 
 _pass=0

--- a/testdata/apply/create_table_with_storage_params.yml
+++ b/testdata/apply/create_table_with_storage_params.yml
@@ -1,6 +1,7 @@
 # A new table carries the parameters in the CREATE, and the re-plan comes out
 # clean: what the parser read back out of the WITH clause has to match what
 # the catalog then reports.
+manage_storage_param: true
 init: ""
 desired: |
   CREATE TABLE public.docs (

--- a/testdata/apply/no_manage_table_storage_params.yml
+++ b/testdata/apply/no_manage_table_storage_params.yml
@@ -1,0 +1,37 @@
+# The parameters a database carries survive an apply that does not manage
+# them: nothing is reset, the new table is created without the clause its
+# file writes, and the re-plan is clean.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+applied: |
+  -- public.docs
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  );
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied_sql: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.users ADD COLUMN name text;

--- a/testdata/apply/table_storage_params.yml
+++ b/testdata/apply/table_storage_params.yml
@@ -2,6 +2,7 @@
 # text column so that it has a TOAST relation for the toast.* parameter to
 # land on: PostgreSQL accepts the statement either way and discards it when
 # there is no such relation.
+manage_storage_param: true
 init: |
   CREATE TABLE public.docs (
       id integer NOT NULL,

--- a/testdata/apply/table_storage_params_new_toast_column.yml
+++ b/testdata/apply/table_storage_params_new_toast_column.yml
@@ -2,6 +2,7 @@
 # discards a toast. parameter set on it. The ADD COLUMN in the same plan
 # creates the relation, so the parameter has somewhere to land as long as it
 # goes after the column statements. The re-plan is what checks it landed.
+manage_storage_param: true
 init: |
   CREATE TABLE public.docs (
       id integer NOT NULL,

--- a/testdata/dump/no_manage_table_storage_params.yml
+++ b/testdata/dump/no_manage_table_storage_params.yml
@@ -1,6 +1,5 @@
-# The table's parameters, a toast.* one, and an index's, all of which pg_dump
-# writes and none of which used to survive a dump.
-manage_storage_param: true
+# Without --manage-storage-param dump writes no WITH clause for a table. An
+# index's parameters are part of its definition and are written either way.
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,
@@ -14,6 +13,5 @@ dump: |
       id integer NOT NULL,
       name text,
       CONSTRAINT users_pkey PRIMARY KEY (id)
-  )
-  WITH (autovacuum_enabled='off', fillfactor='70', toast.autovacuum_enabled='off');
+  );
   CREATE INDEX users_name_idx ON public.users USING btree (name) WITH (fillfactor='80');

--- a/testdata/dump/no_manage_table_storage_params_partition.yml
+++ b/testdata/dump/no_manage_table_storage_params_partition.yml
@@ -1,7 +1,5 @@
-# A partition carries its own parameters, and the partitioned parent holds
-# none: PostgreSQL rejects every storage parameter on a relation with no
-# storage of its own.
-manage_storage_param: true
+# A partition renders through its own branch of the table SQL, so the clause
+# has to be left off there as well.
 init: |
   CREATE TABLE public.events (
       id integer NOT NULL,
@@ -18,5 +16,4 @@ dump: |
   PARTITION BY RANGE (at);
 
   -- public.events_2025
-  CREATE TABLE public.events_2025 PARTITION OF public.events FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')
-  WITH (fillfactor='60');
+  CREATE TABLE public.events_2025 PARTITION OF public.events FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');

--- a/testdata/plan/alter_table_storage_params.yml
+++ b/testdata/plan/alter_table_storage_params.yml
@@ -1,5 +1,6 @@
 # A parameter arriving and one changing value go out in one ALTER. Neither
 # rewrites the table; both decide how the table is filled and vacuumed later.
+manage_storage_param: true
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,

--- a/testdata/plan/bulk_alter_table_storage_params.yml
+++ b/testdata/plan/bulk_alter_table_storage_params.yml
@@ -5,6 +5,7 @@
 bulk_alter: true
 drop_policy:
   allow_drop: [column]
+manage_storage_param: true
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,

--- a/testdata/plan/create_table_with_storage_params.yml
+++ b/testdata/plan/create_table_with_storage_params.yml
@@ -1,5 +1,6 @@
 # A new table carries its storage parameters in the CREATE, so no ALTER
 # follows it.
+manage_storage_param: true
 init: ""
 desired: |
   CREATE TABLE public.users (

--- a/testdata/plan/no_diff_rename_table_storage_params.yml
+++ b/testdata/plan/no_diff_rename_table_storage_params.yml
@@ -1,5 +1,6 @@
 # The parameters carry through a rename untouched, so the plan is the RENAME
 # alone.
+manage_storage_param: true
 init: |
   CREATE TABLE public.old_users (
       id integer NOT NULL,

--- a/testdata/plan/no_diff_table_storage_params.yml
+++ b/testdata/plan/no_diff_table_storage_params.yml
@@ -1,6 +1,7 @@
 # The catalog reports a numeric value quoted and the file writes it bare, and
 # the order a file lists the parameters in is not the order the catalog keeps
 # them. Neither is a change.
+manage_storage_param: true
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,

--- a/testdata/plan/no_manage_create_table_storage_params.yml
+++ b/testdata/plan/no_manage_create_table_storage_params.yml
@@ -1,0 +1,16 @@
+# The WITH clause of a new table is dropped along with the rest: the CREATE
+# comes out without it, so a schema file that carries parameters plans the
+# same statement whether or not it does.
+init: ""
+desired: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70, toast.autovacuum_enabled = off);
+plan: |
+  CREATE TABLE public.docs (
+      id integer NOT NULL,
+      body text,
+      CONSTRAINT docs_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/no_manage_table_storage_params.yml
+++ b/testdata/plan/no_manage_table_storage_params.yml
@@ -1,0 +1,15 @@
+# Without --manage-storage-param the parameters are off both sides of the
+# diff: one the database carries and the desired schema drops is not reset,
+# one the desired schema writes and the database does not carry is not set,
+# and a value that differs is not altered.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70, autovacuum_enabled = off);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 90, toast.autovacuum_enabled = off);
+plan: ""

--- a/testdata/plan/rename_table_storage_params.yml
+++ b/testdata/plan/rename_table_storage_params.yml
@@ -1,5 +1,6 @@
 # A rename does not disturb the parameters, and a parameter that does change
 # is set under the new name, after the RENAME.
+manage_storage_param: true
 init: |
   CREATE TABLE public.old_users (
       id integer NOT NULL,

--- a/testdata/plan/reset_table_storage_params.yml
+++ b/testdata/plan/reset_table_storage_params.yml
@@ -1,6 +1,7 @@
 # Dropping a parameter from the desired schema asks for the default back.
 # RESET is the only way to say that: the catalog holds no entry for a
 # parameter that was never set, so there is no default value to name.
+manage_storage_param: true
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,

--- a/testdata/plan/skip_partition_child_storage_params.yml
+++ b/testdata/plan/skip_partition_child_storage_params.yml
@@ -1,6 +1,7 @@
 # --skip-partition-child drops the partitions from both sides, so a parameter
 # only a partition carries is neither set nor reset.
 skip_partition_child: true
+manage_storage_param: true
 init: |
   CREATE TABLE public.events (
       id integer NOT NULL,

--- a/testdata/plan/table_storage_params_bare_value.yml
+++ b/testdata/plan/table_storage_params_bare_value.yml
@@ -1,6 +1,7 @@
 # A parameter written without a value asks for true, which is what PostgreSQL
 # stores for it, so naming it in the desired schema against a table that
 # already has it is not a change.
+manage_storage_param: true
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,

--- a/testdata/plan/table_storage_params_oids.yml
+++ b/testdata/plan/table_storage_params_oids.yml
@@ -2,6 +2,7 @@
 # table. PostgreSQL accepts it in a CREATE TABLE and stores nothing for it, so
 # reading it as a parameter would plan an ALTER TABLE ... SET that PostgreSQL
 # rejects, on every table of such a dump and on every run.
+manage_storage_param: true
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,

--- a/testdata/plan/table_storage_params_partition_child.yml
+++ b/testdata/plan/table_storage_params_partition_child.yml
@@ -1,6 +1,7 @@
 # A partition holds its own storage parameters: PostgreSQL does not copy the
 # parent's as it creates one, so the child is diffed on its own. The parent is
 # partitioned and holds none, since it has no storage to apply them to.
+manage_storage_param: true
 init: |
   CREATE TABLE public.events (
       id integer NOT NULL,

--- a/testdata/plan/table_storage_params_toast.yml
+++ b/testdata/plan/table_storage_params_toast.yml
@@ -1,6 +1,7 @@
 # A toast.* parameter sits on the TOAST relation, not on the table, and is
 # what pg_dump writes into the same WITH clause. It is diffed alongside the
 # table's own parameters.
+manage_storage_param: true
 init: |
   CREATE TABLE public.docs (
       id integer NOT NULL,


### PR DESCRIPTION
A table's storage parameters, the `WITH (...)` clause, have been managed since 1.36.0. That turned out to be the wrong default: the autovacuum settings a table is tuned with are set on the database more often than they are written in a schema file, so a run against such a table planned a `RESET` for every parameter the file did not name.

They are now opt-in behind `--manage-storage-param` (`$PISTA_MANAGE_STORAGE_PARAM`), available on `plan`, `apply` and `dump`.

Without the flag the parameters are cleared on both sides of the diff, in `diffAll` and in `Dump`: no `SET` or `RESET` is planned, the clause a file writes is left off the `CREATE TABLE`, and `dump` does not write one. A dump fed back plans clean either way. The catalog reads `reloptions` in the same query as everything else, so skipping the read would save nothing and it still happens.

An index's parameters are part of its definition and are managed either way.

## Tests

The 17 existing storage-parameter fixtures carry `manage_storage_param: true`, so the managed path is still asserted. Five fixtures cover the default:

- `plan`: an existing table whose parameters are added, changed and dropped at once plans nothing
- `plan`: a new table's `CREATE` comes out without the clause
- `dump`: the table clause is dropped and an index's is kept
- `dump`: a partition renders through its own branch and drops the clause there too
- `apply`: the parameters the database carries survive, a new table is created without the clause, and the re-plan is clean

`test/samples/run.sh` and `test/fidelity/run.sh` export `PISTA_MANAGE_STORAGE_PARAM=1`, the way they already do for routines, so both keep checking the round trip.

Coverage is unchanged against main (root 97.7%, diff 97.1%, 94.9% overall), and the new code is fully covered. `make lint`, `make test`, `make test-scenario` and `test/fidelity/run.sh` all pass on PostgreSQL 16.