### PR TITLE
Add Joomla and Harbor sample databases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.14"
       # Cairo and its friends are what the social plugin renders the card
       # images with. Pillow and CairoSVG bind to them but do not ship them.
-      - run: sudo apt-get install --no-install-recommends -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       - run: pip install -r requirements-docs.txt
       - run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/docs/contributing-samples.md
+++ b/docs/contributing-samples.md
@@ -139,6 +139,8 @@ the SHA in `sample-db.mk`, and re-run `make test-samples`.
 | danbooru | danbooru | [danbooru/danbooru](https://github.com/danbooru/danbooru) |
 | openolat | openolat | [OpenOLAT/OpenOLAT](https://github.com/OpenOLAT/OpenOLAT) |
 | inaturalist | inaturalist | [inaturalist/inaturalist](https://github.com/inaturalist/inaturalist) |
+| joomla | joomla | [joomla/joomla-cms](https://github.com/joomla/joomla-cms) |
+| harbor | harbor | [goharbor/harbor](https://github.com/goharbor/harbor) |
 
 ## Coverage
 
@@ -147,7 +149,8 @@ for icingadb, rt, znuny, gitlab, hive, ranger, ambari, ovirt, and chado, the
 last counted 2026-08-24; the Sequences column was counted on 15.18 throughout,
 Triggers, added 2026-08-24, and Routines, added 2026-08-25, on 15.18 for every
 sample; wso2is, nightingale, and danbooru were counted 2026-08-29 on 15.17;
-openolat and inaturalist 2026-08-30 on 16.13). "Constraints" excludes foreign
+openolat and inaturalist 2026-08-30 on 16.13; joomla and harbor 2026-09-01 on
+16.13). "Constraints" excludes foreign
 keys; "Types" counts enums and domains; "Sequences" counts standalone sequences
 only, since pistachio manages the sequence behind a serial or identity column as
 an attribute of that column rather than as an object of its own. Counting those
@@ -215,9 +218,11 @@ schema and pistachio does not read them either.
 | danbooru | 66 | 641 | 456 | 93 | 65 | 2 | 0 | 0 | 0 | 3 |
 | openolat | 382 | 4,378 | 1,239 | 632 | 423 | 8 | 0 | 0 | 0 | 0 |
 | inaturalist | 186 | 1,673 | 580 | 1 | 159 | 0 | 0 | 0 | 0 | 4 |
-| **Total** | **5,655** | **47,977** | **17,544** | **7,088** | **9,892** | **1,960** | **71** | **421** | **555** | **789** |
+| joomla | 76 | 830 | 287 | 0 | 84 | 0 | 0 | 0 | 0 | 1 |
+| harbor | 48 | 390 | 119 | 13 | 90 | 0 | 0 | 0 | 10 | 1 |
+| **Total** | **5,779** | **49,197** | **17,950** | **7,101** | **10,066** | **1,960** | **71** | **421** | **565** | **791** |
 
-The 52 dumps come to about 161,000 lines of SQL. chado is 43,700 of them, the
+The 54 dumps come to about 163,000 lines of SQL. chado is 43,700 of them, the
 longest dump of any sample, and gitlab 34,700. gitlab is still about 40 percent
 of the constraints, more than a third of the indexes, and roughly a third of the
 columns and foreign keys, over a quarter of the tables; musicbrainz, openolat,
@@ -280,15 +285,16 @@ partitions is attached across one; and triggers
 state; kea's 81 outnumber its 64 tables; ledgersmb's 11 and dotcms's 10 come
 next).
 
-Routines are concentrated the same way. Nineteen of the 52 samples declare one
-at all, and gitlab's 337, kea's and musicbrainz's 130 each, and chado's 94 are
-691 of the 789. Two thirds of them, 523, return `trigger`, though not every one
-of those has a trigger to call it: musicbrainz's 89 do not, since its loader
-concatenates a file list that leaves triggers out. 712 are written in plpgsql
-and 77 in sql. sourcegraph declares the only procedure any sample has, and
-inaturalist the only aggregate, which `--manage-routine` does not read and so is
-in neither count. Only chado and kea overload a name, 11 of them and 3, though
-danbooru's three, all sql, include a `lower(text[])` that shadows a built-in.
+Routines are concentrated the same way. Twenty-one of the 54 samples declare
+one at all, and gitlab's 337, kea's and musicbrainz's 130 each, and chado's 94
+are 691 of the 791. Two thirds of them, 524, return `trigger`, though not
+every one of those has a trigger to call it: musicbrainz's 89 do not, since its
+loader concatenates a file list that leaves triggers out. 714 are written in
+plpgsql and 77 in sql. sourcegraph declares the only procedure any sample has,
+and inaturalist the only aggregate, which `--manage-routine` does not read and
+so is in neither count. Only chado and kea overload a name, 11 of them and 3,
+though danbooru's three, all sql, include a `lower(text[])` that shadows a
+built-in.
 Only sourcegraph, ledgersmb, and gitlab comment a routine, seven between them.
 
 ## Load-time adjustments
@@ -345,12 +351,27 @@ strip only what is irrelevant to a schema round trip:
 - **dvdrental**: the dump was taken by a `pg_dump` new enough to set
   `transaction_timeout` in its preamble, which 15 and 16 do not have, so that
   one line is dropped. It sets nothing the schema depends on.
+- **harbor**: the schema ships as one file per release, each a delta meant to
+  be replayed by golang-migrate, which tracks what it has applied in a
+  `schema_migrations` table of its own. One delta `ALTER TABLE`s that table
+  directly, so a stand-in `schema_migrations` is created before the deltas run
+  and dropped once they have; it is golang-migrate's bookkeeping, not part of
+  Harbor's schema. A few deltas also omit their file's closing `;`, which
+  merges the next file's opening statement into it once concatenated, so
+  every file gets one appended regardless of whether it already ends in one.
 - **hive**: the dump belongs in a schema of its own like the group below, but
   it is `pg_dump` output that sets `search_path` to `public` itself, which
   overrides anything `PGOPTIONS` passes in. That one line is rewritten to name
   the `hive` schema.
 - **imdb**: the schema and its foreign key indexes ship as two files, so
   `schema.sql` and `fkindexes.sql` are concatenated.
+- **joomla**: the schema ships as three files that must load in order --
+  `base.sql`, `extensions.sql`, and `supports.sql`, the last of which
+  references content types `extensions.sql` creates -- so they are
+  concatenated. None of the three create a schema or set `search_path`
+  themselves, and every table name carries the literal `#__` prefix Joomla
+  substitutes at install time; quoted, it is just an ordinary identifier and
+  needs no rewriting.
 - **kea**, **dolphinscheduler**, **wso2apim**, **wso2is**: each dump drops what
   it is about to create with `IF EXISTS`, so `client_min_messages` is raised to
   `warning` for the load. wso2is is also where five index names run past the 63

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -69,6 +69,8 @@ nightingale|sample-db-url-schema|URL=https://raw.githubusercontent.com/ccfos/nig
 danbooru|sample-db-pgdump-schema|URL=https://raw.githubusercontent.com/danbooru/danbooru/f8de3ba286db1f9a1f3efbbf495bcbc1001e7b9b/db/structure.sql SCHEMA=danbooru|danbooru
 openolat|sample-db-url-schema|URL=https://raw.githubusercontent.com/OpenOLAT/OpenOLAT/8d07a02fe4dafb8c82179f3efa77e1cb985fdc7e/src/main/resources/database/postgresql/setupDatabase.sql SCHEMA=openolat|openolat
 inaturalist|sample-db-pgdump-schema|URL=https://raw.githubusercontent.com/inaturalist/inaturalist/e52c649d2f0e8e260c2dce6fcf6448d971100415/db/structure.sql SCHEMA=inaturalist|inaturalist
+joomla|sample-db-joomla||joomla
+harbor|sample-db-harbor||harbor
 endef
 
 # Every loader pipes its schema into this psql. ON_ERROR_STOP makes a failing
@@ -337,6 +339,59 @@ sample-db-pgdump-schema:
 	curl -sSfL --retry 3 --retry-delay 2 $(URL) \
 	  | sed -E "/^SELECT pg_catalog.set_config\('search_path', '', false\);\$$/d; /^SET search_path TO /,\$$d; s/^public\.//; s/([^A-Za-z0-9_])public\./\1/g" \
 	  | PGOPTIONS='-c search_path=$(SCHEMA),public' $(PSQL)
+
+# Joomla CMS (joomla/joomla-cms, GPL-2.0-or-later). The PostgreSQL installer
+# ships as three files that must load in that order -- base.sql (the core
+# tables), extensions.sql (the bundled extensions and plugins), and
+# supports.sql (the smart search tables, which reference extensions.sql's
+# content types) -- none of which create a schema or set search_path
+# themselves. Every table name carries the literal `#__` prefix Joomla
+# replaces at install time; left as `#__` and quoted, it is just an ordinary
+# identifier, so nothing needs rewriting.
+JOOMLA_SQL_FILES = base.sql extensions.sql supports.sql
+
+.PHONY: sample-db-joomla
+sample-db-joomla:
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS joomla'
+	for f in $(JOOMLA_SQL_FILES); do \
+	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/joomla/joomla-cms/b2648c39655a1dc9ceb2791cf9131acc4f98d22e/installation/sql/postgresql/$$f || exit 1; \
+	  echo; \
+	done | PGOPTIONS='-c search_path=joomla' $(PSQL)
+
+# Harbor (goharbor/harbor, Apache-2.0), the CNCF container registry. Its
+# schema ships as one file per release, each an incremental delta meant to be
+# replayed by golang-migrate, which tracks what it has already applied in a
+# schema_migrations table of its own. One delta ALTERs that table directly to
+# add a column a later delta drops again, so a stand-in schema_migrations
+# table is created before the deltas run and dropped once they have, since
+# golang-migrate's own bookkeeping is not part of Harbor's schema. A few
+# deltas also omit their file's closing semicolon, which merges the next
+# file's opening statement into it once concatenated, so every file gets one
+# appended regardless of whether it already ends in one.
+HARBOR_SQL_FILES = 0001_initial_schema.up.sql 0002_1.7.0_schema.up.sql \
+	0003_add_replication_op_uuid.up.sql 0004_1.8.0_schema.up.sql \
+	0005_1.8.2_schema.up.sql 0010_1.9.0_schema.up.sql 0011_1.9.1_schema.up.sql \
+	0012_1.9.4_schema.up.sql 0015_1.10.0_schema.up.sql 0030_2.0.0_schema.up.sql \
+	0031_2.0.3_schema.up.sql 0040_2.1.0_schema.up.sql 0041_2.1.4_schema.up.sql \
+	0050_2.2.0_schema.up.sql 0051_2.2.1_schema.up.sql 0052_2.2.2_schema.up.sql \
+	0053_2.2.3_schema.up.sql 0060_2.3.0_schema.up.sql 0061_2.3.4_schema.up.sql \
+	0070_2.4.0_schema.up.sql 0071_2.4.2_schema.up.sql 0080_2.5.0_schema.up.sql \
+	0081_2.5.2_schema.up.sql 0082_2.5.3_schema.up.sql 0090_2.6.0_schema.up.sql \
+	0091_2.6.2_schema.up.sql 0100_2.7.0_schema.up.sql 0110_2.8.0_schema.up.sql \
+	0111_2.8.1_schema.up.sql 0120_2.9.0_schema.up.sql 0130_2.10.0_schema.up.sql \
+	0140_2.11.0_schema.up.sql 0150_2.12.0_schema.up.sql 0160_2.13.0_schema.up.sql \
+	0170_2.14.0_schema.up.sql 0171_2.14.1_schema.up.sql 0180_2.15.0_schema.up.sql \
+	0181_2.15.3_schema.up.sql 0190_2.16.0_schema.up.sql
+
+.PHONY: sample-db-harbor
+sample-db-harbor:
+	$(PSQL) -c 'CREATE SCHEMA IF NOT EXISTS harbor'
+	$(PSQL) -c 'SET search_path = harbor; CREATE TABLE schema_migrations (version bigint NOT NULL PRIMARY KEY, dirty boolean NOT NULL DEFAULT false)'
+	for f in $(HARBOR_SQL_FILES); do \
+	  curl -sSfL --retry 3 --retry-delay 2 https://raw.githubusercontent.com/goharbor/harbor/fb4e2406747df0b01dec994bf593f49261f6a874/make/migrations/postgresql/$$f || exit 1; \
+	  echo ';'; \
+	done | PGOPTIONS='-c search_path=harbor -c client_min_messages=warning' $(PSQL)
+	$(PSQL) -c 'SET search_path = harbor; DROP TABLE schema_migrations'
 
 .PHONY: test-samples
 test-samples:


### PR DESCRIPTION
Both round-trip clean through pista dump/plan: Joomla's PostgreSQL
installer (76 tables) loads as three files concatenated in dependency
order, and Harbor's per-release migration deltas (48 tables) load
concatenated in order behind a stand-in schema_migrations table that
one delta ALTERs directly.