### PR TITLE
Cover view triggers, empty enums and table extras in the diff suite

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/winebarrel/pistachio/catalog"
 	"github.com/winebarrel/pistachio/internal/testutil"
+	"github.com/winebarrel/pistachio/model"
 )
 
 func TestNewCatalog(t *testing.T) {
@@ -25,4 +26,48 @@ func TestNewCatalog(t *testing.T) {
 		_, err := catalog.NewCatalog(conn, []string{})
 		require.Error(t, err)
 	})
+}
+
+// A dropped connection surfaces as an error from every catalog reader rather
+// than a panic or an empty result.
+func TestCatalog_ClosedConnection(t *testing.T) {
+	conn := testutil.ConnectDB(t)
+	ctx := context.Background()
+
+	cat, err := catalog.NewCatalog(conn, []string{"public"})
+	require.NoError(t, err)
+	require.NoError(t, conn.Close(ctx))
+
+	tbl := &model.Table{Schema: "public", Name: "users"}
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"Tables", func() error { _, err := cat.Tables(ctx); return err }},
+		{"ListTables", func() error { _, err := cat.ListTables(ctx); return err }},
+		{"Views", func() error { _, err := cat.Views(ctx); return err }},
+		{"ListViews", func() error { _, err := cat.ListViews(ctx); return err }},
+		{"Enums", func() error { _, err := cat.Enums(ctx); return err }},
+		{"ListEnums", func() error { _, err := cat.ListEnums(ctx); return err }},
+		{"Domains", func() error { _, err := cat.Domains(ctx); return err }},
+		{"ListDomains", func() error { _, err := cat.ListDomains(ctx); return err }},
+		{"CompositeTypes", func() error { _, err := cat.CompositeTypes(ctx); return err }},
+		{"ListCompositeTypes", func() error { _, err := cat.ListCompositeTypes(ctx); return err }},
+		{"Sequences", func() error { _, err := cat.Sequences(ctx); return err }},
+		{"ListSequences", func() error { _, err := cat.ListSequences(ctx); return err }},
+		{"Routines", func() error { _, err := cat.Routines(ctx); return err }},
+		{"ListRoutines", func() error { _, err := cat.ListRoutines(ctx); return err }},
+		{"ListIndexes", func() error { _, err := cat.ListIndexes(ctx); return err }},
+		{"ListTriggers", func() error { _, err := cat.ListTriggers(ctx); return err }},
+		{"ListColumnsByTable", func() error { _, err := cat.ListColumnsByTable(ctx, tbl); return err }},
+		{"ListConstraintsByTable", func() error { _, _, err := cat.ListConstraintsByTable(ctx, tbl); return err }},
+		{"ListPoliciesByTable", func() error { _, err := cat.ListPoliciesByTable(ctx, tbl); return err }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, tt.call())
+		})
+	}
 }

--- a/diff/enums_test.go
+++ b/diff/enums_test.go
@@ -593,3 +593,23 @@ func TestDiffEnums_RenameSourceNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source")
 }
+
+func TestDiffEnums_AddValuesToEmptyEnum(t *testing.T) {
+	current := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+	})
+	desired := newEnumMap(&model.Enum{
+		Schema: "public",
+		Name:   "status",
+		Values: []string{"active", "inactive"},
+	})
+	result, err := diff.DiffEnums(current, desired, diff.AllowAllDrops{})
+	require.NoError(t, err)
+	// With no existing value to anchor on, the first ADD VALUE carries
+	// neither AFTER nor BEFORE; the second anchors on the first.
+	assert.Equal(t, []string{
+		"ALTER TYPE public.status ADD VALUE 'active';",
+		"ALTER TYPE public.status ADD VALUE 'inactive' AFTER 'active';",
+	}, result.Stmts)
+}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -3588,3 +3588,35 @@ func TestEqualIndexDef_storageParamAdded(t *testing.T) {
 		"CREATE INDEX idx ON public.users USING btree (id) WITH (fillfactor=80)",
 	))
 }
+
+func TestDiffTables_newTable_withStorageRLSAndTrigger(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	tbl := newTable("public", "docs")
+	tbl.Columns.Set("body", &model.Column{Name: "body", TypeName: "text", NotNull: true, StorageType: "external", TypeStorage: "extended", Compression: "pglz"})
+	tbl.RowSecurity = true
+	using := "true"
+	tbl.Policies.Set("p", &model.Policy{
+		Name: "p", Schema: "public", Table: "docs",
+		Permissive: true, Command: 'r', Using: &using,
+	})
+	tbl.Triggers.Set("stamp", &model.Trigger{
+		Schema:     "public",
+		Table:      "docs",
+		Name:       "stamp",
+		Definition: "CREATE TRIGGER stamp BEFORE INSERT ON public.docs FOR EACH ROW EXECUTE FUNCTION stamp()",
+	})
+	desired.Set("public.docs", tbl)
+
+	result, err := DiffTables(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.Stmts, 6)
+	assert.Contains(t, result.Stmts[0], "CREATE TABLE public.docs")
+	assert.Equal(t, "ALTER TABLE public.docs ALTER COLUMN body SET STORAGE EXTERNAL;", result.Stmts[1])
+	assert.Equal(t, "ALTER TABLE public.docs ALTER COLUMN body SET COMPRESSION pglz;", result.Stmts[2])
+	assert.Equal(t, "ALTER TABLE public.docs ENABLE ROW LEVEL SECURITY;", result.Stmts[3])
+	assert.Equal(t, "CREATE POLICY p ON public.docs FOR SELECT USING (true);", result.Stmts[4])
+	assert.Equal(t, "CREATE TRIGGER stamp BEFORE INSERT ON public.docs FOR EACH ROW EXECUTE FUNCTION stamp();", result.Stmts[5])
+	assert.False(t, result.HasConcurrently)
+}

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -20,6 +20,25 @@ func TestDiffViews_newView(t *testing.T) {
 	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v1")
 }
 
+func TestDiffViews_newView_withTrigger(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	desired := orderedmap.New[string, *model.View]()
+	triggers := orderedmap.New[string, *model.Trigger]()
+	triggers.Set("v1_ins", &model.Trigger{
+		Schema:     "public",
+		Table:      "v1",
+		Name:       "v1_ins",
+		Definition: "CREATE TRIGGER v1_ins INSTEAD OF INSERT ON public.v1 FOR EACH ROW EXECUTE FUNCTION stamp()",
+	})
+	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", Triggers: triggers})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	require.Len(t, result.CreateStmts, 2)
+	assert.Contains(t, result.CreateStmts[0], "CREATE OR REPLACE VIEW public.v1")
+	assert.Equal(t, "CREATE TRIGGER v1_ins INSTEAD OF INSERT ON public.v1 FOR EACH ROW EXECUTE FUNCTION stamp();", result.CreateStmts[1])
+}
+
 func TestDiffViews_dropView(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})

--- a/dump_test.go
+++ b/dump_test.go
@@ -939,3 +939,112 @@ CREATE TABLE public.users (id integer);`)
 	assert.Len(t, files, 1)
 	assert.Contains(t, files, "public.users.sql")
 }
+
+func TestDumpResult_SortByDeps_OmitSchemaCollisionFallsBackInString(t *testing.T) {
+	// Client.Dump rejects --omit-schema with several schemas, but String() has
+	// no error channel. In a directly built DumpResult, stripping the schema
+	// off two same-named objects collapses them onto one key, the adjusted
+	// collection comes up short against the dependency order, and String()
+	// degrades to the name order instead of panicking. One sub-case per
+	// collection so every appendDumpItems call sees its own short map.
+	newTable := func(schema string) *model.Table {
+		tbl := &model.Table{
+			Schema:      schema,
+			Name:        "x",
+			Columns:     orderedmap.New[string, *model.Column](),
+			Constraints: orderedmap.New[string, *model.Constraint](),
+			ForeignKeys: orderedmap.New[string, *model.ForeignKey](),
+			Indexes:     orderedmap.New[string, *model.Index](),
+		}
+		tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
+		return tbl
+	}
+
+	tests := []struct {
+		name   string
+		result *pistachio.DumpResult
+		want   string
+	}{
+		{
+			name: "enums",
+			result: func() *pistachio.DumpResult {
+				m := orderedmap.New[string, *model.Enum]()
+				m.Set("a.x", &model.Enum{Schema: "a", Name: "x", Values: []string{"v"}})
+				m.Set("b.x", &model.Enum{Schema: "b", Name: "x", Values: []string{"v"}})
+				return &pistachio.DumpResult{Enums: m}
+			}(),
+			want: "CREATE TYPE x AS ENUM",
+		},
+		{
+			name: "domains",
+			result: func() *pistachio.DumpResult {
+				m := orderedmap.New[string, *model.Domain]()
+				m.Set("a.x", &model.Domain{Schema: "a", Name: "x", BaseType: "text"})
+				m.Set("b.x", &model.Domain{Schema: "b", Name: "x", BaseType: "text"})
+				return &pistachio.DumpResult{Domains: m}
+			}(),
+			want: "CREATE DOMAIN x AS text",
+		},
+		{
+			name: "composite types",
+			result: func() *pistachio.DumpResult {
+				m := orderedmap.New[string, *model.CompositeType]()
+				m.Set("a.x", &model.CompositeType{Schema: "a", Name: "x", Attributes: []*model.CompositeAttribute{{Name: "n", TypeName: "text"}}})
+				m.Set("b.x", &model.CompositeType{Schema: "b", Name: "x", Attributes: []*model.CompositeAttribute{{Name: "n", TypeName: "text"}}})
+				return &pistachio.DumpResult{CompositeTypes: m}
+			}(),
+			want: "CREATE TYPE x AS (",
+		},
+		{
+			name: "sequences",
+			result: func() *pistachio.DumpResult {
+				m := orderedmap.New[string, *model.Sequence]()
+				m.Set("a.x", &model.Sequence{Schema: "a", Name: "x"})
+				m.Set("b.x", &model.Sequence{Schema: "b", Name: "x"})
+				return &pistachio.DumpResult{Sequences: m}
+			}(),
+			want: "CREATE SEQUENCE x",
+		},
+		{
+			name: "routines",
+			result: func() *pistachio.DumpResult {
+				m := orderedmap.New[string, *model.Routine]()
+				m.Set("a.x()", &model.Routine{Schema: "a", Name: "x", Language: "sql", ReturnType: "integer", Body: " SELECT 1 "})
+				m.Set("b.x()", &model.Routine{Schema: "b", Name: "x", Language: "sql", ReturnType: "integer", Body: " SELECT 1 "})
+				return &pistachio.DumpResult{Routines: m}
+			}(),
+			want: "CREATE OR REPLACE FUNCTION x()",
+		},
+		{
+			name: "tables",
+			result: func() *pistachio.DumpResult {
+				m := orderedmap.New[string, *model.Table]()
+				m.Set("a.x", newTable("a"))
+				m.Set("b.x", newTable("b"))
+				return &pistachio.DumpResult{Tables: m}
+			}(),
+			want: "CREATE TABLE x",
+		},
+		{
+			name: "views",
+			result: func() *pistachio.DumpResult {
+				m := orderedmap.New[string, *model.View]()
+				m.Set("a.x", &model.View{Schema: "a", Name: "x", Definition: "SELECT 1"})
+				m.Set("b.x", &model.View{Schema: "b", Name: "x", Definition: "SELECT 1"})
+				return &pistachio.DumpResult{Views: m}
+			}(),
+			want: "CREATE OR REPLACE VIEW x",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.result.SortByDeps = true
+			tt.result.OmitSchema = true
+			s := tt.result.String()
+			assert.Contains(t, s, tt.want)
+			// The two originals collapsed onto one unqualified object.
+			assert.Equal(t, 1, strings.Count(s, tt.want))
+		})
+	}
+}

--- a/internal/pgast/pgast_test.go
+++ b/internal/pgast/pgast_test.go
@@ -240,3 +240,21 @@ func TestParseExpr_TargetIsMutable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, sql, "quantity * 2")
 }
+
+func TestParseExpr_NoTarget(t *testing.T) {
+	// SELECT FROM t parses with an empty target list, so the trailing error
+	// is the one path that reports it.
+	_, _, err := pgast.ParseExpr("FROM t")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected parse result for expression")
+}
+
+func TestDeparseConstraintDef_NotAConstraintResult(t *testing.T) {
+	// A ParseResult that did not come from ParseConstraintDefStrict deparses
+	// without the wrapper prefix and is rejected.
+	result, err := pg_query.Parse("SELECT 1")
+	require.NoError(t, err)
+	_, err = pgast.DeparseConstraintDef(result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected deparsed form")
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3163,3 +3163,105 @@ func TestParseCommentStmt_InheritsChildColumnNotSynthesized(t *testing.T) {
 	// entry would look like a new column, so no entry is created.
 	assert.Equal(t, 0, child.Columns.Len())
 }
+
+func TestReadSQLFile_Stdin_ReadError(t *testing.T) {
+	// Reading from the write end of a pipe fails, so ReadSQLFile reports it.
+	_, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = w
+	defer func() {
+		os.Stdin = origStdin
+	}()
+
+	_, err = parser.ReadSQLFile("-")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read SQL from stdin")
+}
+
+func TestParseSQL_RenameDirective_InlineForeignKey(t *testing.T) {
+	sql := `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (id),
+    -- pista:renamed-from old_fk
+    CONSTRAINT new_fk FOREIGN KEY (user_id) REFERENCES public.users(id)
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.orders")
+	require.True(t, ok)
+	fk, ok := tbl.ForeignKeys.GetOk("new_fk")
+	require.True(t, ok)
+	require.NotNil(t, fk.RenameFrom)
+	assert.Equal(t, "old_fk", *fk.RenameFrom)
+}
+
+func TestParseSQL_RenameDirective_CompositeType(t *testing.T) {
+	sql := `-- pista:renamed-from public.old_addr
+CREATE TYPE public.addr AS (
+    street text,
+    -- pista:renamed-from town
+    city text
+);`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	ct, ok := result.CompositeTypes.GetOk("public.addr")
+	require.True(t, ok)
+	require.NotNil(t, ct.RenameFrom)
+	assert.Equal(t, "public.old_addr", *ct.RenameFrom)
+	require.Len(t, ct.Attributes, 2)
+	assert.Nil(t, ct.Attributes[0].RenameFrom)
+	require.NotNil(t, ct.Attributes[1].RenameFrom)
+	assert.Equal(t, "town", *ct.Attributes[1].RenameFrom)
+}
+
+func TestParseSQL_DuplicateCompositeType(t *testing.T) {
+	sql := `CREATE TYPE public.addr AS (street text);
+CREATE TYPE public.addr AS (street text);`
+
+	_, err := parseSQLWithPublicSchema(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate composite type")
+}
+
+func TestParseSQL_RenameDirective_Sequence(t *testing.T) {
+	sql := `-- pista:renamed-from old_seq
+CREATE SEQUENCE public.new_seq;`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	seq, ok := result.Sequences.GetOk("public.new_seq")
+	require.True(t, ok)
+	require.NotNil(t, seq.RenameFrom)
+	assert.Equal(t, "public.old_seq", *seq.RenameFrom)
+}
+
+func TestParseSQL_DuplicateSequence(t *testing.T) {
+	sql := `CREATE SEQUENCE public.s1;
+CREATE SEQUENCE public.s1;`
+
+	_, err := parseSQLWithPublicSchema(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate sequence")
+}
+
+func TestParseSQL_SequenceValueOverflow(t *testing.T) {
+	// A literal past int64 arrives as a Float node and fails ParseInt.
+	sql := `CREATE SEQUENCE public.s1 MAXVALUE 99999999999999999999;`
+
+	_, err := parseSQLWithPublicSchema(sql)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid value "99999999999999999999" for sequence option maxvalue`)
+}

--- a/parser/routine.go
+++ b/parser/routine.go
@@ -317,18 +317,14 @@ func parseRoutineConfig(arg *pg_query.Node) (*model.RoutineConfig, error) {
 	return cfg, nil
 }
 
+// The generated getters take a nil receiver, so a non-String (non-Boolean)
+// argument falls through to the proto zero value without a guard here.
 func defElemString(arg *pg_query.Node) string {
-	if s := arg.GetString_(); s != nil {
-		return s.GetSval()
-	}
-	return ""
+	return arg.GetString_().GetSval()
 }
 
 func defElemBool(arg *pg_query.Node) bool {
-	if b := arg.GetBoolean(); b != nil {
-		return b.GetBoolval()
-	}
-	return false
+	return arg.GetBoolean().GetBoolval()
 }
 
 func defElemFloat(arg *pg_query.Node) (float64, error) {

--- a/parser/routine_test.go
+++ b/parser/routine_test.go
@@ -485,3 +485,28 @@ func TestParseSQL_CommentOnRoutineWithQualifiedArgType(t *testing.T) {
 	require.NotNil(t, r.Comment)
 	assert.Equal(t, "v1", *r.Comment)
 }
+
+func TestParseSQL_FunctionSecurityDefinerAndLeakproof(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE FUNCTION public.f() RETURNS integer
+		    LANGUAGE sql SECURITY DEFINER LEAKPROOF AS $$ SELECT 1 $$;
+	`)
+	require.NoError(t, err)
+
+	r, ok := result.Routines.GetOk("public.f()")
+	require.True(t, ok)
+	assert.True(t, r.SecurityDefiner)
+	assert.True(t, r.Leakproof)
+}
+
+func TestParseRoutineDef(t *testing.T) {
+	r, err := parser.ParseRoutineDef(
+		"CREATE FUNCTION public.add(a integer, b integer) RETURNS integer LANGUAGE sql AS $$ SELECT a + b $$;",
+		"public",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "public", r.Schema)
+	assert.Equal(t, "add", r.Name)
+	assert.Equal(t, "integer", r.ReturnType)
+	assert.Equal(t, " SELECT a + b ", r.Body)
+}


### PR DESCRIPTION
The plan fixtures for these paths exist, but coverage is counted per
package, so DiffViews never ran viewTriggerStmts past the nil guard,
DiffEnums never added a value without an anchor, and newTableExtras
never rendered storage, RLS or triggers under its own tests.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NL16AW9aeMc51p16kr1aSV