### PR TITLE
Read a schema in a fixed number of queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.39.0] - 2026-09-02
+
+* Read a schema in a fixed number of queries. A table's columns, constraints and policies were read one table at a time, and a domain's constraints and a composite type's attributes one type at a time, so a run cost a round trip per object. The gitlab sample schema took 910 statements for its 1083 tables; it now takes 13. The cost was in the round trips, so the gain grows with the latency to the database. The catalog is unchanged, so no plan or dump differs.
+
 ## [1.38.1] - 2026-09-01
 
 * Make a table's storage parameters opt-in, behind `--manage-storage-param` (`$PISTA_MANAGE_STORAGE_PARAM`). Managing them by default reset the autovacuum settings a table was tuned with, which are set on the database more often than written in a schema file. Without the flag they are dropped from both sides of the diff: no `SET` or `RESET` is planned, the `WITH` clause a file writes is left off the `CREATE TABLE`, and `dump` does not write one. An index's parameters are part of its definition and are managed either way.

--- a/TODO.md
+++ b/TODO.md
@@ -211,7 +211,7 @@ syntax, which `pg_query_go` does not yet parse (libpg_query PR #317 is
 still in draft as of 2026-05). Once that lands, the parser can accept
 the standalone form and the diff can drop the no-op branches.
 
-A second limitation: `catalog.ListColumnsByTable` strips any constraint
+A second limitation: `catalog.ListColumnsByTables` strips any constraint
 name with the `_not_null` suffix to mask PG18's auto-naming (which does
 not follow column or table renames). An explicit user name that happens
 to end in `_not_null` is therefore lost on round-trip. A more precise
@@ -524,7 +524,7 @@ replans forever.
 
 Closing this means letting the catalog surface sequences that are merely
 owned, kept apart from the serial and identity ones that stay column
-attributes (the distinction `catalog.ListColumnsByTable` already draws by
+attributes (the distinction `catalog.ListColumnsByTables` already draws by
 checking that the column default draws from the sequence), and teaching the
 diff to emit `ALTER SEQUENCE ... OWNED BY` / `OWNED BY NONE` for the
 transitions. That widens the set of objects pistachio manages, so it is a

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -38,7 +38,9 @@ func TestCatalog_ClosedConnection(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, conn.Close(ctx))
 
-	tbl := &model.Table{Schema: "public", Name: "users"}
+	// A non-zero OID so the batched readers reach the connection instead of
+	// returning early on an empty table list.
+	tbls := []*model.Table{{OID: 1, Schema: "public", Name: "users"}}
 
 	tests := []struct {
 		name string
@@ -60,9 +62,9 @@ func TestCatalog_ClosedConnection(t *testing.T) {
 		{"ListRoutines", func() error { _, err := cat.ListRoutines(ctx); return err }},
 		{"ListIndexes", func() error { _, err := cat.ListIndexes(ctx); return err }},
 		{"ListTriggers", func() error { _, err := cat.ListTriggers(ctx); return err }},
-		{"ListColumnsByTable", func() error { _, err := cat.ListColumnsByTable(ctx, tbl); return err }},
-		{"ListConstraintsByTable", func() error { _, _, err := cat.ListConstraintsByTable(ctx, tbl); return err }},
-		{"ListPoliciesByTable", func() error { _, err := cat.ListPoliciesByTable(ctx, tbl); return err }},
+		{"ListColumnsByTables", func() error { _, err := cat.ListColumnsByTables(ctx, tbls); return err }},
+		{"ListConstraintsByTables", func() error { _, _, err := cat.ListConstraintsByTables(ctx, tbls); return err }},
+		{"ListPoliciesByTables", func() error { _, err := cat.ListPoliciesByTables(ctx, tbls); return err }},
 	}
 
 	for _, tt := range tests {

--- a/catalog/columns.go
+++ b/catalog/columns.go
@@ -9,10 +9,14 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([]*model.Column, error) {
+// ListColumnsByTables returns the columns of the given tables, keyed by table
+// OID and in attnum order. One query serves every table; reading them one at a
+// time cost a round trip per table.
+func (c *Catalog) ListColumnsByTables(ctx context.Context, tables []*model.Table) (map[uint32][]*model.Column, error) {
 	q := `
 		-- https://www.postgresql.org/docs/current/catalog-pg-attribute.html
 		SELECT
+			a.attrelid,
 			a.attname,
 			CASE
 				WHEN s.is_serial
@@ -91,15 +95,21 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 			AND nn.contype = 'n'
 			AND nn.conkey = ARRAY[a.attnum]
 		WHERE
-			a.attrelid = @table_oid
+			a.attrelid = ANY(@table_oids::oid[])
 			AND a.attnum >= 1
 			AND NOT a.attisdropped
 		ORDER BY
+			a.attrelid,
 			a.attnum
 	`
 
+	oids := tableOIDs(tables)
+	if len(oids) == 0 {
+		return map[uint32][]*model.Column{}, nil
+	}
+
 	args := pgx.NamedArgs{
-		"table_oid": table.OID,
+		"table_oids": oids,
 	}
 
 	rows, err := c.conn.Query(ctx, q, args)
@@ -108,10 +118,12 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 	}
 	defer rows.Close()
 
-	var cols []*model.Column
+	colsByTable := map[uint32][]*model.Column{}
 	for rows.Next() {
 		var col model.Column
+		var tableOID uint32
 		err := rows.Scan(
+			&tableOID,
 			&col.Name,
 			&col.TypeName,
 			&col.NotNull,
@@ -138,12 +150,12 @@ func (c *Catalog) ListColumnsByTable(ctx context.Context, table *model.Table) ([
 		if col.NotNullName != nil && strings.HasSuffix(*col.NotNullName, "_not_null") {
 			col.NotNullName = nil
 		}
-		cols = append(cols, &col)
+		colsByTable[tableOID] = append(colsByTable[tableOID], &col)
 	}
 
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("catalog: failed to scan column info rows: %w", err)
 	}
 
-	return cols, nil
+	return colsByTable, nil
 }

--- a/catalog/columns_test.go
+++ b/catalog/columns_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/winebarrel/pistachio/internal/testutil"
 )
 
-func TestListColumnsByTable(t *testing.T) {
+func TestListColumnsByTables(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)

--- a/catalog/composite_types.go
+++ b/catalog/composite_types.go
@@ -86,22 +86,32 @@ func (c *Catalog) ListCompositeTypes(ctx context.Context) ([]*model.CompositeTyp
 		return nil, fmt.Errorf("catalog: failed to scan composite type info rows: %w", err)
 	}
 
+	relids := make([]uint32, len(ctRows))
+	for i, r := range ctRows {
+		relids[i] = r.typrelid
+	}
+
+	attrsByRelid, err := c.listCompositeAttributes(ctx, relids)
+	if err != nil {
+		return nil, err
+	}
+
 	compositeTypes := make([]*model.CompositeType, 0, len(ctRows))
 	for _, r := range ctRows {
-		attrs, err := c.listCompositeAttributes(ctx, r.typrelid)
-		if err != nil {
-			return nil, err
-		}
-		r.ct.Attributes = attrs
+		r.ct.Attributes = attrsByRelid[r.typrelid]
 		compositeTypes = append(compositeTypes, r.ct)
 	}
 
 	return compositeTypes, nil
 }
 
-func (c *Catalog) listCompositeAttributes(ctx context.Context, relid uint32) ([]*model.CompositeAttribute, error) {
+// listCompositeAttributes returns the attributes of the given composite types'
+// relations, keyed by relation OID and in attnum order. One query serves every
+// composite type.
+func (c *Catalog) listCompositeAttributes(ctx context.Context, relids []uint32) (map[uint32][]*model.CompositeAttribute, error) {
 	q := `
 		SELECT
+			a.attrelid,
 			a.attname,
 			pg_catalog.format_type(a.atttypid, a.atttypmod) AS type,
 			(SELECT quote_ident(cn.nspname) || '.' || quote_ident(coll.collname) FROM pg_catalog.pg_collation coll JOIN pg_catalog.pg_namespace cn ON cn.oid = coll.collnamespace WHERE coll.oid = a.attcollation AND a.attcollation <> 0 AND coll.collname <> 'default') AS collation,
@@ -112,15 +122,21 @@ func (c *Catalog) listCompositeAttributes(ctx context.Context, relid uint32) ([]
 			AND d.classoid = 'pg_class'::regclass
 			AND d.objsubid = a.attnum
 		WHERE
-			a.attrelid = @relid
+			a.attrelid = ANY(@relids::oid[])
 			AND a.attnum > 0
 			AND NOT a.attisdropped
 		ORDER BY
+			a.attrelid,
 			a.attnum
 	`
 
+	attrs := map[uint32][]*model.CompositeAttribute{}
+	if len(relids) == 0 {
+		return attrs, nil
+	}
+
 	args := pgx.NamedArgs{
-		"relid": relid,
+		"relids": relids,
 	}
 
 	rows, err := c.conn.Query(ctx, q, args)
@@ -129,14 +145,14 @@ func (c *Catalog) listCompositeAttributes(ctx context.Context, relid uint32) ([]
 	}
 	defer rows.Close()
 
-	var attrs []*model.CompositeAttribute
 	for rows.Next() {
 		var a model.CompositeAttribute
-		err := rows.Scan(&a.Name, &a.TypeName, &a.Collation, &a.Comment)
+		var relid uint32
+		err := rows.Scan(&relid, &a.Name, &a.TypeName, &a.Collation, &a.Comment)
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan composite attribute: %w", err)
 		}
-		attrs = append(attrs, &a)
+		attrs[relid] = append(attrs[relid], &a)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/catalog/composite_types_test.go
+++ b/catalog/composite_types_test.go
@@ -75,4 +75,34 @@ func TestCompositeTypes(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 0, cts.Len())
 	})
+
+	// Attributes are read for every composite type at once. A type must get its
+	// own and only its own, in attnum order. A table's rowtype sits in the same
+	// catalog and must not leak in.
+	t.Run("multiple composite types", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TYPE public.address AS (street text, city text, zip text);
+			CREATE TYPE public.point3d AS (x double precision, y double precision);
+			CREATE TABLE public.users (id int, name text);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		cts, err := cat.CompositeTypes(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 2, cts.Len())
+
+		address := cts.Get("public.address")
+		require.NotNil(t, address)
+		require.Len(t, address.Attributes, 3)
+		assert.Equal(t, "street", address.Attributes[0].Name)
+		assert.Equal(t, "city", address.Attributes[1].Name)
+		assert.Equal(t, "zip", address.Attributes[2].Name)
+
+		point := cts.Get("public.point3d")
+		require.NotNil(t, point)
+		require.Len(t, point.Attributes, 2)
+		assert.Equal(t, "x", point.Attributes[0].Name)
+		assert.Equal(t, "double precision", point.Attributes[0].TypeName)
+		assert.Equal(t, "y", point.Attributes[1].Name)
+	})
 }

--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -9,7 +9,10 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table) ([]*model.Constraint, []*model.ForeignKey, error) {
+// ListConstraintsByTables returns the table constraints and the foreign keys of
+// the given tables, each keyed by table OID and in contype then name order. One
+// query serves every table.
+func (c *Catalog) ListConstraintsByTables(ctx context.Context, tables []*model.Table) (map[uint32][]*model.Constraint, map[uint32][]*model.ForeignKey, error) {
 	q := `
 		WITH
 			-- One row per pg_constraint row: the conkey columns in conkey
@@ -31,11 +34,12 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 					JOIN pg_catalog.pg_attribute a ON a.attrelid = con.conrelid
 					AND a.attnum = ANY(con.conkey)
 				WHERE
-					con.conrelid = @table_oid
+					con.conrelid = ANY(@table_oids::oid[])
 				GROUP BY
 					con.oid
 			)
 		SELECT
+			con.conrelid,
 			con.oid,
 			con.conname,
 			con.contype,
@@ -53,12 +57,12 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 			LEFT JOIN pg_catalog.pg_namespace rn ON rn.oid = rc.relnamespace
 			LEFT JOIN column_t col ON col.con_oid = con.oid
 		WHERE
-			con.conrelid = @table_oid
+			con.conrelid = ANY(@table_oids::oid[])
 			-- The table-level constraint types, listed the way the ORDER BY
 			-- below lists them. Two other types share the catalog and belong
 			-- elsewhere. PG18's per-column NOT NULL rows (contype='n') are
 			-- read into Column.NotNull / Column.NotNullName by
-			-- ListColumnsByTable. CREATE CONSTRAINT TRIGGER records the
+			-- ListColumnsByTables. CREATE CONSTRAINT TRIGGER records the
 			-- trigger here too (contype='t'), where pg_get_constraintdef
 			-- renders it as the bare word TRIGGER, followed by the deferral
 			-- clause when it has one; reading that as a table constraint made
@@ -68,11 +72,22 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 			-- the model has somewhere to put it.
 			AND con.contype = ANY ('{p,u,c,x,f}'::"char"[])
 		ORDER BY
+			con.conrelid,
 			array_position('{p,u,c,x,f}'::"char"[], con.contype),
 			con.conname
 	`
+
+	constraints := map[uint32][]*model.Constraint{}
+	foreignKeys := map[uint32][]*model.ForeignKey{}
+
+	oids := tableOIDs(tables)
+	if len(oids) == 0 {
+		return constraints, foreignKeys, nil
+	}
+
+	tableByOID := tablesByOID(tables)
 	args := pgx.NamedArgs{
-		"table_oid": table.OID,
+		"table_oids": oids,
 	}
 
 	rows, err := c.conn.Query(ctx, q, args)
@@ -81,13 +96,13 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 	}
 	defer rows.Close()
 
-	var constraints []*model.Constraint
-	var foreignKeys []*model.ForeignKey
 	for rows.Next() {
 		var con model.Constraint
+		var tableOID uint32
 		var refSchema, refTable *string
 
 		err := rows.Scan(
+			&tableOID,
 			&con.OID,
 			&con.Name,
 			&con.Type,
@@ -109,6 +124,7 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 		con.Definition = strings.TrimSuffix(con.Definition, " NOT VALID")
 
 		if con.Type.IsForeignKeyConstraint() {
+			table := tableByOID[tableOID]
 			fk := model.ForeignKey{
 				Constraint: con,
 				Schema:     table.Schema,
@@ -116,9 +132,9 @@ func (c *Catalog) ListConstraintsByTable(ctx context.Context, table *model.Table
 				RefSchema:  refSchema,
 				RefTable:   refTable,
 			}
-			foreignKeys = append(foreignKeys, &fk)
+			foreignKeys[tableOID] = append(foreignKeys[tableOID], &fk)
 		} else {
-			constraints = append(constraints, &con)
+			constraints[tableOID] = append(constraints[tableOID], &con)
 		}
 	}
 

--- a/catalog/constraints_test.go
+++ b/catalog/constraints_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/winebarrel/pistachio/internal/testutil"
 )
 
-func TestListConstraintsByTable(t *testing.T) {
+func TestListConstraintsByTables(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)

--- a/catalog/domains.go
+++ b/catalog/domains.go
@@ -93,35 +93,49 @@ func (c *Catalog) ListDomains(ctx context.Context) ([]*model.Domain, error) {
 		return nil, fmt.Errorf("catalog: failed to scan domain info rows: %w", err)
 	}
 
-	// Fetch constraints for each domain
+	oids := make([]uint32, len(domains))
+	for i, d := range domains {
+		oids[i] = d.OID
+	}
+
+	constraintsByDomain, err := c.listDomainConstraints(ctx, oids)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, d := range domains {
-		constraints, err := c.listDomainConstraints(ctx, d.OID)
-		if err != nil {
-			return nil, err
-		}
-		d.Constraints = constraints
+		d.Constraints = constraintsByDomain[d.OID]
 	}
 
 	return domains, nil
 }
 
-func (c *Catalog) listDomainConstraints(ctx context.Context, domainOID uint32) ([]*model.DomainConstraint, error) {
+// listDomainConstraints returns the check constraints of the given domains,
+// keyed by domain OID and in conname order. One query serves every domain.
+func (c *Catalog) listDomainConstraints(ctx context.Context, domainOIDs []uint32) (map[uint32][]*model.DomainConstraint, error) {
 	q := `
 		SELECT
+			con.contypid,
 			con.conname,
 			pg_catalog.pg_get_constraintdef(con.oid) AS definition,
 			con.convalidated
 		FROM
 			pg_catalog.pg_constraint con
 		WHERE
-			con.contypid = @oid
+			con.contypid = ANY(@domain_oids::oid[])
 			AND con.contype = 'c'
 		ORDER BY
+			con.contypid,
 			con.conname
 	`
 
+	constraints := map[uint32][]*model.DomainConstraint{}
+	if len(domainOIDs) == 0 {
+		return constraints, nil
+	}
+
 	args := pgx.NamedArgs{
-		"oid": domainOID,
+		"domain_oids": domainOIDs,
 	}
 
 	rows, err := c.conn.Query(ctx, q, args)
@@ -130,10 +144,10 @@ func (c *Catalog) listDomainConstraints(ctx context.Context, domainOID uint32) (
 	}
 	defer rows.Close()
 
-	var constraints []*model.DomainConstraint
 	for rows.Next() {
 		var dc model.DomainConstraint
-		err := rows.Scan(&dc.Name, &dc.Definition, &dc.Validated)
+		var domainOID uint32
+		err := rows.Scan(&domainOID, &dc.Name, &dc.Definition, &dc.Validated)
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan domain constraint: %w", err)
 		}
@@ -141,7 +155,7 @@ func (c *Catalog) listDomainConstraints(ctx context.Context, domainOID uint32) (
 		// constraints. Strip it so Definition only holds the constraint body;
 		// validation state is tracked via Validated.
 		dc.Definition = strings.TrimSuffix(dc.Definition, " NOT VALID")
-		constraints = append(constraints, &dc)
+		constraints[domainOID] = append(constraints[domainOID], &dc)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/catalog/domains_test.go
+++ b/catalog/domains_test.go
@@ -73,4 +73,39 @@ func TestDomains(t *testing.T) {
 		require.NotNil(t, d.Comment)
 		assert.Equal(t, "Positive integer", *d.Comment)
 	})
+
+	// Constraints are read for every domain at once. A domain must get its own
+	// and only its own, in conname order, and one without constraints must stay
+	// without them.
+	t.Run("multiple domains", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE DOMAIN public.pos_int AS integer
+				CONSTRAINT pos_int_max CHECK (VALUE < 100)
+				CONSTRAINT pos_int_min CHECK (VALUE > 0);
+			CREATE DOMAIN public.lower_text AS text
+				CONSTRAINT lower_text_case CHECK (VALUE = lower(VALUE));
+			CREATE DOMAIN public.plain AS text;
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		domains, err := cat.Domains(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 3, domains.Len())
+
+		posInt := domains.Get("public.pos_int")
+		require.NotNil(t, posInt)
+		require.Len(t, posInt.Constraints, 2)
+		assert.Equal(t, "pos_int_max", posInt.Constraints[0].Name)
+		assert.Equal(t, "pos_int_min", posInt.Constraints[1].Name)
+		assert.Contains(t, posInt.Constraints[1].Definition, "> 0")
+
+		lowerText := domains.Get("public.lower_text")
+		require.NotNil(t, lowerText)
+		require.Len(t, lowerText.Constraints, 1)
+		assert.Equal(t, "lower_text_case", lowerText.Constraints[0].Name)
+
+		plain := domains.Get("public.plain")
+		require.NotNil(t, plain)
+		assert.Empty(t, plain.Constraints)
+	})
 }

--- a/catalog/policies.go
+++ b/catalog/policies.go
@@ -8,9 +8,10 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-// ListPoliciesByTable returns row-level security policies attached to the
-// given table, in pg_policy.polname order.
-func (c *Catalog) ListPoliciesByTable(ctx context.Context, table *model.Table) ([]*model.Policy, error) {
+// ListPoliciesByTables returns the row-level security policies attached to the
+// given tables, keyed by table OID and in pg_policy.polname order. One query
+// serves every table.
+func (c *Catalog) ListPoliciesByTables(ctx context.Context, tables []*model.Table) (map[uint32][]*model.Policy, error) {
 	// pg_policy.polroles uses OID 0 to represent PUBLIC. pg_roles does not
 	// contain a row for OID 0, so a join would silently drop PUBLIC when it
 	// appears alongside named roles (e.g. TO PUBLIC, app_user). UNION the
@@ -18,6 +19,7 @@ func (c *Catalog) ListPoliciesByTable(ctx context.Context, table *model.Table) (
 	// preserved and sorted together.
 	q := `
 		SELECT
+			pol.polrelid,
 			pol.polname,
 			pol.polpermissive,
 			pol.polcmd,
@@ -41,11 +43,21 @@ func (c *Catalog) ListPoliciesByTable(ctx context.Context, table *model.Table) (
 			-- https://www.postgresql.org/docs/current/catalog-pg-policy.html
 			pg_catalog.pg_policy pol
 		WHERE
-			pol.polrelid = @table_oid
+			pol.polrelid = ANY(@table_oids::oid[])
 		ORDER BY
+			pol.polrelid,
 			pol.polname
 	`
-	args := pgx.NamedArgs{"table_oid": table.OID}
+
+	policies := map[uint32][]*model.Policy{}
+
+	oids := tableOIDs(tables)
+	if len(oids) == 0 {
+		return policies, nil
+	}
+
+	tableByOID := tablesByOID(tables)
+	args := pgx.NamedArgs{"table_oids": oids}
 
 	rows, err := c.conn.Query(ctx, q, args)
 	if err != nil {
@@ -53,13 +65,11 @@ func (c *Catalog) ListPoliciesByTable(ctx context.Context, table *model.Table) (
 	}
 	defer rows.Close()
 
-	var policies []*model.Policy
 	for rows.Next() {
-		p := &model.Policy{
-			Schema: table.Schema,
-			Table:  table.Name,
-		}
+		var tableOID uint32
+		p := &model.Policy{}
 		err := rows.Scan(
+			&tableOID,
 			&p.Name,
 			&p.Permissive,
 			&p.Command,
@@ -70,7 +80,10 @@ func (c *Catalog) ListPoliciesByTable(ctx context.Context, table *model.Table) (
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan policy info: %w", err)
 		}
-		policies = append(policies, p)
+		table := tableByOID[tableOID]
+		p.Schema = table.Schema
+		p.Table = table.Name
+		policies[tableOID] = append(policies[tableOID], p)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("catalog: failed to scan policy info rows: %w", err)

--- a/catalog/policies_test.go
+++ b/catalog/policies_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/winebarrel/pistachio/internal/testutil"
 )
 
-func TestListPoliciesByTable(t *testing.T) {
+func TestListPoliciesByTables(t *testing.T) {
 	ctx := context.Background()
 	conn := testutil.ConnectDB(t)
 	defer conn.Close(ctx)

--- a/catalog/query_count_test.go
+++ b/catalog/query_count_test.go
@@ -1,0 +1,120 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/catalog"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+// queryCounter counts the statements a connection sends.
+type queryCounter struct {
+	n int
+}
+
+func (c *queryCounter) TraceQueryStart(ctx context.Context, _ *pgx.Conn, _ pgx.TraceQueryStartData) context.Context {
+	c.n++
+	return ctx
+}
+
+func (c *queryCounter) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+func connectWithCounter(t *testing.T, ctx context.Context) (*pgx.Conn, *queryCounter) {
+	t.Helper()
+	cfg, err := pgx.ParseConfig(testutil.ConnString())
+	require.NoError(t, err)
+	counter := &queryCounter{}
+	cfg.Tracer = counter
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	require.NoError(t, err)
+	return conn, counter
+}
+
+// Reading tables costs a fixed number of statements: growing the schema must
+// not grow the statement count.
+func TestTables_QueryCountDoesNotGrowWithTables(t *testing.T) {
+	ctx := context.Background()
+	setupConn := testutil.ConnectDB(t)
+	defer setupConn.Close(ctx)
+
+	ddl := func(n int) string {
+		sql := ""
+		for i := range n {
+			name := "t" + string(rune('a'+i))
+			sql += `
+				CREATE TABLE public.` + name + ` (
+					id bigint NOT NULL,
+					owner text NOT NULL,
+					CONSTRAINT ` + name + `_pkey PRIMARY KEY (id),
+					CONSTRAINT ` + name + `_owner_check CHECK (owner <> '')
+				);
+				ALTER TABLE public.` + name + ` ENABLE ROW LEVEL SECURITY;
+				CREATE POLICY ` + name + `_sel ON public.` + name + ` FOR SELECT USING (owner = current_user);
+			`
+		}
+		return sql
+	}
+
+	count := func(t *testing.T, n int) int {
+		t.Helper()
+		testutil.SetupDB(t, ctx, setupConn, ddl(n))
+		conn, counter := connectWithCounter(t, ctx)
+		defer conn.Close(ctx)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+		require.Equal(t, n, tables.Len())
+		return counter.n
+	}
+
+	few := count(t, 2)
+	many := count(t, 20)
+	assert.Equal(t, few, many, "statement count grew with the number of tables")
+}
+
+// Domains and composite types are read the same way, so their statement count
+// is fixed too.
+func TestTypes_QueryCountDoesNotGrowWithTypes(t *testing.T) {
+	ctx := context.Background()
+	setupConn := testutil.ConnectDB(t)
+	defer setupConn.Close(ctx)
+
+	ddl := func(n int) string {
+		sql := ""
+		for i := range n {
+			name := "d" + string(rune('a'+i))
+			sql += `
+				CREATE DOMAIN public.` + name + ` AS text
+					CONSTRAINT ` + name + `_len CHECK (length(VALUE) > 0)
+					CONSTRAINT ` + name + `_low CHECK (VALUE = lower(VALUE));
+				CREATE TYPE public.c` + name + ` AS (a integer, b text, c timestamptz);
+			`
+		}
+		return sql
+	}
+
+	count := func(t *testing.T, n int) int {
+		t.Helper()
+		testutil.SetupDB(t, ctx, setupConn, ddl(n))
+		conn, counter := connectWithCounter(t, ctx)
+		defer conn.Close(ctx)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		domains, err := cat.Domains(ctx)
+		require.NoError(t, err)
+		require.Equal(t, n, domains.Len())
+		compositeTypes, err := cat.CompositeTypes(ctx)
+		require.NoError(t, err)
+		require.Equal(t, n, compositeTypes.Len())
+		return counter.n
+	}
+
+	few := count(t, 2)
+	many := count(t, 20)
+	assert.Equal(t, few, many, "statement count grew with the number of types")
+}

--- a/catalog/tables.go
+++ b/catalog/tables.go
@@ -168,36 +168,58 @@ func (c *Catalog) ListTables(ctx context.Context) ([]*model.Table, error) {
 		return nil, fmt.Errorf("catalog: failed to scan table info rows: %w", err)
 	}
 
+	// Each of these is one query for all the tables, keyed by table OID.
+	// Asking per table cost a round trip each.
+	colsByTable, err := c.ListColumnsByTables(ctx, tables)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get columns: %w", err)
+	}
+
+	consByTable, fksByTable, err := c.ListConstraintsByTables(ctx, tables)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get constraints: %w", err)
+	}
+
+	policiesByTable, err := c.ListPoliciesByTables(ctx, tables)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to get policies: %w", err)
+	}
+
 	for _, t := range tables {
-		cols, err := c.ListColumnsByTable(ctx, t)
-		if err != nil {
-			return nil, fmt.Errorf("catalog: failed to get columns for %s.%s: %w", t.Schema, t.Name, err)
-		}
-		for _, col := range cols {
+		for _, col := range colsByTable[t.OID] {
 			t.Columns.Set(col.Name, col)
 		}
-
-		cons, fks, err := c.ListConstraintsByTable(ctx, t)
-		if err != nil {
-			return nil, fmt.Errorf("catalog: failed to get constraints for %s.%s: %w", t.Schema, t.Name, err)
-		}
-		for _, con := range cons {
+		for _, con := range consByTable[t.OID] {
 			t.Constraints.Set(con.Name, con)
 		}
-		for _, fk := range fks {
+		for _, fk := range fksByTable[t.OID] {
 			t.ForeignKeys.Set(fk.Name, fk)
 		}
-
-		policies, err := c.ListPoliciesByTable(ctx, t)
-		if err != nil {
-			return nil, fmt.Errorf("catalog: failed to get policies for %s.%s: %w", t.Schema, t.Name, err)
-		}
-		for _, p := range policies {
+		for _, p := range policiesByTable[t.OID] {
 			t.Policies.Set(p.Name, p)
 		}
 	}
 
 	return tables, nil
+}
+
+// tableOIDs returns the pg_class OIDs the per-table readers filter on.
+func tableOIDs(tables []*model.Table) []uint32 {
+	oids := make([]uint32, len(tables))
+	for i, t := range tables {
+		oids[i] = t.OID
+	}
+	return oids
+}
+
+// tablesByOID indexes the tables by OID, for readers that need the schema and
+// name of the table a row belongs to.
+func tablesByOID(tables []*model.Table) map[uint32]*model.Table {
+	byOID := make(map[uint32]*model.Table, len(tables))
+	for _, t := range tables {
+		byOID[t.OID] = t
+	}
+	return byOID
 }
 
 // storageParams turns the two reloptions arrays a table is read with into one

--- a/catalog/tables_multi_test.go
+++ b/catalog/tables_multi_test.go
@@ -1,0 +1,133 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/catalog"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+// Columns, constraints and policies are read for every table at once. A table
+// must get its own rows and only those.
+func TestTables_MultipleTables(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+
+	testutil.SetupDB(t, ctx, conn, `
+		CREATE TABLE public.users (
+			id integer NOT NULL,
+			email text NOT NULL,
+			CONSTRAINT users_pkey PRIMARY KEY (id),
+			CONSTRAINT users_email_key UNIQUE (email)
+		);
+		ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+		CREATE POLICY users_sel ON public.users FOR SELECT USING (email = current_user);
+
+		CREATE TABLE public.posts (
+			id bigint NOT NULL,
+			user_id integer NOT NULL,
+			title text,
+			CONSTRAINT posts_pkey PRIMARY KEY (id),
+			CONSTRAINT posts_title_check CHECK (title <> ''),
+			CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users (id)
+		);
+		ALTER TABLE public.posts ENABLE ROW LEVEL SECURITY;
+		CREATE POLICY posts_ins ON public.posts FOR INSERT WITH CHECK (title <> '');
+		CREATE POLICY posts_sel ON public.posts FOR SELECT USING (true);
+
+		-- No constraints and no policies: this table must stay empty.
+		CREATE TABLE public.tags (
+			name text
+		);
+	`)
+
+	cat, err := catalog.NewCatalog(conn, []string{"public"})
+	require.NoError(t, err)
+	tables, err := cat.Tables(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 3, tables.Len())
+
+	users := tables.Get("public.users")
+	require.NotNil(t, users)
+	assert.Equal(t, []string{"id", "email"}, users.Columns.CollectKeys())
+	assert.Equal(t, []string{"users_pkey", "users_email_key"}, users.Constraints.CollectKeys())
+	assert.Equal(t, 0, users.ForeignKeys.Len())
+	assert.Equal(t, []string{"users_sel"}, users.Policies.CollectKeys())
+
+	posts := tables.Get("public.posts")
+	require.NotNil(t, posts)
+	assert.Equal(t, []string{"id", "user_id", "title"}, posts.Columns.CollectKeys())
+	assert.Equal(t, []string{"posts_pkey", "posts_title_check"}, posts.Constraints.CollectKeys())
+	assert.Equal(t, []string{"posts_ins", "posts_sel"}, posts.Policies.CollectKeys())
+
+	require.Equal(t, 1, posts.ForeignKeys.Len())
+	fk, ok := posts.ForeignKeys.GetOk("posts_user_id_fkey")
+	require.True(t, ok)
+	// The foreign key carries the table it is declared on.
+	assert.Equal(t, "public", fk.Schema)
+	assert.Equal(t, "posts", fk.Table)
+	assert.Equal(t, []string{"user_id"}, fk.Columns)
+
+	// A policy likewise names its own table.
+	sel, ok := posts.Policies.GetOk("posts_sel")
+	require.True(t, ok)
+	assert.Equal(t, "public", sel.Schema)
+	assert.Equal(t, "posts", sel.Table)
+
+	tags := tables.Get("public.tags")
+	require.NotNil(t, tags)
+	assert.Equal(t, []string{"name"}, tags.Columns.CollectKeys())
+	assert.Equal(t, 0, tags.Constraints.Len())
+	assert.Equal(t, 0, tags.ForeignKeys.Len())
+	assert.Equal(t, 0, tags.Policies.Len())
+}
+
+// Two schemas can hold tables of the same name. The readers key on OID, so the
+// two must not be mixed up.
+func TestTables_SameNameInTwoSchemas(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	defer func() {
+		_, err := conn.Exec(ctx, "DROP SCHEMA IF EXISTS app CASCADE")
+		require.NoError(t, err)
+	}()
+
+	testutil.SetupDB(t, ctx, conn, `
+		DROP SCHEMA IF EXISTS app CASCADE;
+		CREATE SCHEMA app;
+		CREATE TABLE public.items (
+			id integer NOT NULL,
+			CONSTRAINT items_pkey PRIMARY KEY (id)
+		);
+		CREATE TABLE app.items (
+			code text NOT NULL,
+			label text,
+			CONSTRAINT items_code_key UNIQUE (code)
+		);
+		ALTER TABLE app.items ENABLE ROW LEVEL SECURITY;
+		CREATE POLICY items_sel ON app.items FOR SELECT USING (true);
+	`)
+
+	cat, err := catalog.NewCatalog(conn, []string{"public", "app"})
+	require.NoError(t, err)
+	tables, err := cat.Tables(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, tables.Len())
+
+	pub := tables.Get("public.items")
+	require.NotNil(t, pub)
+	assert.Equal(t, []string{"id"}, pub.Columns.CollectKeys())
+	assert.Equal(t, []string{"items_pkey"}, pub.Constraints.CollectKeys())
+	assert.Equal(t, 0, pub.Policies.Len())
+
+	app := tables.Get("app.items")
+	require.NotNil(t, app)
+	assert.Equal(t, []string{"code", "label"}, app.Columns.CollectKeys())
+	assert.Equal(t, []string{"items_code_key"}, app.Constraints.CollectKeys())
+	assert.Equal(t, []string{"items_sel"}, app.Policies.CollectKeys())
+}

--- a/docs/about/performance.md
+++ b/docs/about/performance.md
@@ -35,6 +35,10 @@ The database runs on the same host, so client/server latency is negligible.
 Times over a network connection will be higher because reading the catalog adds
 round trips.
 
+These numbers predate 1.39.0, which made the catalog read a fixed number of
+queries. The noop plan and dump cases are faster than the table shows, and more
+so over a network.
+
 ## Schema shape
 
 Each table has 9 columns of mixed types (bigint identity primary key, text,

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -9,8 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ConnectDB(t *testing.T) *pgx.Conn {
-	t.Helper()
+// ConnString returns the connection string the tests use. A test that needs its
+// own connection builds it from here.
+func ConnString() string {
 	connString := os.Getenv("TEST_PISTA_CONN_STR")
 	if connString == "" {
 		// The port compose.yaml publishes PostgreSQL 15 on. `make test`
@@ -18,7 +19,12 @@ func ConnectDB(t *testing.T) *pgx.Conn {
 		// only applies to a bare `go test`.
 		connString = "postgres://postgres@localhost:5415/postgres"
 	}
-	conn, err := pgx.Connect(context.Background(), connString)
+	return connString
+}
+
+func ConnectDB(t *testing.T) *pgx.Conn {
+	t.Helper()
+	conn, err := pgx.Connect(context.Background(), ConnString())
 	require.NoError(t, err)
 	return conn
 }


### PR DESCRIPTION
A table's columns, constraints and policies were read one table at a
time, and a domain's constraints and a composite type's attributes one
type at a time, so a run cost a round trip per object. The gitlab sample
schema took 910 statements for its 1083 tables; it now takes 13.

Each reader now takes the objects it serves and filters on = ANY() over
their OIDs, returning the rows keyed by the OID they belong to. The
catalog is unchanged, and the sample schemas dump byte for byte as
before.

Every existing domain and composite type case declared a single object,
so nothing asserted that a row reaches the object it belongs to, and
handing each object the whole result set passed the suite. Both now
declare several objects, one of them without members.

The performance page notes that its numbers were measured before this,
since the catalog read is what they cover.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y1tQFZ6dtHaafK4vyXaYvA