### PR TITLE
docs: re-measure the performance page

### DIFF
--- a/docs/about/performance.md
+++ b/docs/about/performance.md
@@ -29,7 +29,7 @@ Four cases are measured:
 
 - Apple M4 Pro (14 cores), 64 GB RAM
 - PostgreSQL 15.18 (Docker, connected over `localhost`)
-- pistachio built from `fafe754` (after v1.38.1, with the 1.39.0 catalog read)
+- pistachio built from `fafe754` (after v1.38.1)
 
 The database runs on the same host, so client/server latency is negligible.
 Times over a network connection will be higher because reading the catalog adds
@@ -62,26 +62,23 @@ grows the same way, from 160 to 16,000 lines.
 
 ## Analysis
 
-Runtime scales close to linearly with the table count. At small sizes a fixed
-overhead of about 30 ms (process startup and connecting to PostgreSQL)
-dominates, which is why the smallest schemas do not get proportionally faster.
-Subtract that overhead and going from 100 to 1,000 tables multiplies the
-remaining time by 8 to 10 in every case.
+Runtime scales close to linearly with the table count. A fixed overhead of about
+30 ms (process startup and connecting to PostgreSQL) sets the floor, which is
+why the smallest schemas do not get proportionally faster. Above it, 10 times
+the tables costs 8 to 10 times the time.
 
-No single stage dominates any more. The create plan parses the SQL file and
-generates the diff without reading the catalog; dump reads the catalog and
-serializes it without parsing. At 1,000 tables the two cost about the same
-(0.27s and 0.22s), and the noop plan, which does both, costs roughly their sum.
-The catalog read used to take a round trip per object and was the largest cost
-by a wide margin. 1.39.0 made it a fixed number of queries, and the noop plan
-and dump cases are now around 40% and 65% faster than the previous measurement
-of this page, which was taken after v1.19.0.
+No single stage dominates. The create plan parses the SQL file and diffs it
+without reading the catalog; dump reads the catalog and serializes it without
+parsing. At 1,000 tables the two cost about the same, 0.27s and 0.22s, and the
+noop plan, which does both, costs roughly their sum. The catalog read used to
+cost a round trip per object and outweighed the rest; 1.39.0, which this build
+includes, made it a fixed number of queries.
 
-The modify plan is only 8 ms slower than the noop plan at 1,000 tables. Reading
-the catalog and parsing the desired schema is the bulk of the work, so emitting
-3,000 DDL statements on top of that is cheap. Every case stays under half a
-second at 1,000 tables, so pistachio is not a bottleneck for schemas of typical
-size. Larger schemas were not measured.
+The modify plan is 8 ms slower than the noop plan at 1,000 tables. Reading the
+catalog and parsing the desired schema are the bulk of the work, so emitting
+3,000 DDL statements on top costs little. Every case stays under half a second
+at that size, so pistachio is not a bottleneck for schemas of typical size.
+Larger schemas were not measured.
 
 ## Reproducing
 
@@ -122,11 +119,10 @@ sed -e 's/qty integer/qty bigint/' \
 time pista plan modified.sql # modify plan (diff on every table)
 ```
 
-The foreign key has to be declared on the column. pistachio does not read a
-standalone `ALTER TABLE ... ADD COLUMN ... REFERENCES`, so writing it that way
-leaves the foreign keys out of the desired schema and the noop plan proposes
-dropping them.
+The foreign key has to sit on the column. pistachio does not read a standalone
+`ALTER TABLE ... ADD COLUMN ... REFERENCES`. Written that way the foreign keys
+never reach the desired schema, and the noop plan proposes dropping them.
 
-Dropping a schema of 1,000 tables in one statement needs more locks than the
-default allows. Raise `max_locks_per_transaction` (4096 is enough here) before
-resetting between runs.
+Dropping 1,000 tables in one statement needs more locks than the default allows,
+so raise `max_locks_per_transaction` before resetting between runs. 4096 is
+enough.

--- a/docs/about/performance.md
+++ b/docs/about/performance.md
@@ -29,22 +29,19 @@ Four cases are measured:
 
 - Apple M4 Pro (14 cores), 64 GB RAM
 - PostgreSQL 15.18 (Docker, connected over `localhost`)
-- pistachio built from `b1de372` (after v1.19.0)
+- pistachio built from `fafe754` (after v1.38.1, with the 1.39.0 catalog read)
 
 The database runs on the same host, so client/server latency is negligible.
 Times over a network connection will be higher because reading the catalog adds
 round trips.
 
-These numbers predate 1.39.0, which made the catalog read a fixed number of
-queries. The noop plan and dump cases are faster than the table shows, and more
-so over a network.
-
 ## Schema shape
 
 Each table has 9 columns of mixed types (bigint identity primary key, text,
-varchar, numeric, integer, boolean, and two timestamps), two secondary indexes,
-and a foreign key to the previous table. A schema of N tables therefore has N
-tables, N primary keys, 2N secondary indexes, and N-1 foreign keys.
+varchar, numeric, integer, boolean, and two timestamps) and two secondary
+indexes. Every table but the first also has a `parent_id` column with a foreign
+key to the previous table. A schema of N tables therefore has N tables, N
+primary keys, 2N secondary indexes, and N-1 foreign keys.
 
 ## Results
 
@@ -52,36 +49,39 @@ Each value is the median of three runs, in seconds.
 
 | Tables | create plan | noop plan | modify plan | dump  |
 |-------:|------------:|----------:|------------:|------:|
-|     10 |       0.035 |     0.044 |       0.047 | 0.040 |
-|     50 |       0.039 |     0.082 |       0.081 | 0.083 |
-|    100 |       0.052 |     0.135 |       0.136 | 0.121 |
-|    250 |       0.079 |     0.280 |       0.294 | 0.248 |
-|    500 |       0.132 |     0.533 |       0.559 | 0.467 |
-|  1,000 |       0.248 |     0.829 |       1.074 | 0.646 |
+|     10 |       0.033 |     0.036 |       0.037 | 0.034 |
+|     50 |       0.041 |     0.055 |       0.057 | 0.041 |
+|    100 |       0.053 |     0.078 |       0.083 | 0.052 |
+|    250 |       0.090 |     0.142 |       0.150 | 0.076 |
+|    500 |       0.148 |     0.263 |       0.273 | 0.122 |
+|  1,000 |       0.269 |     0.489 |       0.497 | 0.218 |
 
 The modify plan emits three DDL statements per table, so its output grows from
 30 lines at 10 tables to 3,000 lines at 1,000 tables. The create plan output
-grows the same way, from 142 to 14,002 lines.
+grows the same way, from 160 to 16,000 lines.
 
 ## Analysis
 
-Runtime scales close to linearly with the table count. In the 100 to 1,000
-table range, doubling the number of tables roughly doubles the time, with a
-slight sublinear trend at the top end. At small sizes a fixed overhead of about
-30 ms (process startup and connecting to PostgreSQL) dominates, which is why the
-smallest schemas do not get proportionally faster.
+Runtime scales close to linearly with the table count. At small sizes a fixed
+overhead of about 30 ms (process startup and connecting to PostgreSQL)
+dominates, which is why the smallest schemas do not get proportionally faster.
+Subtract that overhead and going from 100 to 1,000 tables multiplies the
+remaining time by 8 to 10 in every case.
 
-The create plan is much cheaper than the noop plan and dump because it never
-reads the catalog. Reading the current schema from `pg_catalog` is the largest
-cost, so runtime tracks the size of the existing database more than the size of
-the desired SQL file.
+No single stage dominates any more. The create plan parses the SQL file and
+generates the diff without reading the catalog; dump reads the catalog and
+serializes it without parsing. At 1,000 tables the two cost about the same
+(0.27s and 0.22s), and the noop plan, which does both, costs roughly their sum.
+The catalog read used to take a round trip per object and was the largest cost
+by a wide margin. 1.39.0 made it a fixed number of queries, and the noop plan
+and dump cases are now around 40% and 65% faster than the previous measurement
+of this page, which was taken after v1.19.0.
 
-The modify plan is the heaviest case. It reads the catalog like the noop plan,
-then generates and deparses the diff SQL, which adds cost proportional to the
-number of changes. At 1,000 tables it is the only case that exceeds one second
-(1.07s) because it emits 3,000 DDL statements. The read-only commands all stay
-under one second at that size, so pistachio is not a bottleneck for schemas of
-typical size. Larger schemas were not measured.
+The modify plan is only 8 ms slower than the noop plan at 1,000 tables. Reading
+the catalog and parsing the desired schema is the bulk of the work, so emitting
+3,000 DDL statements on top of that is cheap. Every case stays under half a
+second at 1,000 tables, so pistachio is not a bottleneck for schemas of typical
+size. Larger schemas were not measured.
 
 ## Reproducing
 
@@ -97,10 +97,11 @@ gen() {
     printf '  amount numeric(12,2) NOT NULL DEFAULT 0,\n  qty integer NOT NULL DEFAULT 0,\n'
     printf '  is_active boolean NOT NULL DEFAULT true,\n  note text,\n'
     printf '  created_at timestamptz NOT NULL DEFAULT now(),\n'
-    printf '  updated_at timestamptz NOT NULL DEFAULT now()\n);\n'
+    printf '  updated_at timestamptz NOT NULL DEFAULT now()'
+    [ "$i" -gt 1 ] && printf ',\n  parent_id bigint REFERENCES t_%d (id)' "$((i-1))"
+    printf '\n);\n'
     printf 'CREATE INDEX idx_t_%d_code ON t_%d (code);\n' "$i" "$i"
     printf 'CREATE INDEX idx_t_%d_created_at ON t_%d (created_at);\n' "$i" "$i"
-    [ "$i" -gt 1 ] && printf 'ALTER TABLE t_%d ADD COLUMN parent_id bigint REFERENCES t_%d (id);\n' "$i" "$((i-1))"
   done
 }
 
@@ -120,3 +121,12 @@ sed -e 's/qty integer/qty bigint/' \
     schema.sql > modified.sql
 time pista plan modified.sql # modify plan (diff on every table)
 ```
+
+The foreign key has to be declared on the column. pistachio does not read a
+standalone `ALTER TABLE ... ADD COLUMN ... REFERENCES`, so writing it that way
+leaves the foreign keys out of the desired schema and the noop plan proposes
+dropping them.
+
+Dropping a schema of 1,000 tables in one statement needs more locks than the
+default allows. Raise `max_locks_per_transaction` (4096 is enough here) before
+resetting between runs.


### PR DESCRIPTION
Re-measure `docs/about/performance.md`. The numbers were taken after v1.19.0 and carried a note saying they predate 1.39.0; both are now gone, replaced by a measurement on `fafe754`.

## A bug in the documented generator

The `gen()` in the Reproducing section declared the foreign key as a standalone statement:

```sql
ALTER TABLE t_N ADD COLUMN parent_id bigint REFERENCES t_M (id);
```

pistachio does not read that form. It warns `ignored unsupported statement`, so the `parent_id` columns and the foreign keys never entered the desired schema. The "noop plan" case was therefore not a noop: at 1,000 tables it emitted 2,000 `-- skipped: DROP COLUMN / DROP CONSTRAINT` lines. The numbers previously on the page were measured that way.

Moving the column into the `CREATE TABLE` gives `-- No changes`, so that is what the page now documents, with a note explaining why the FK has to sit on the column. The create plan output grows from 14,002 to 16,000 lines because the FK columns are really there now, and the modify plan is 3,002 lines, matching what the text already claimed.

## Results

Median of three runs, seconds. The full sweep was run twice and the passes agreed within a few ms at every size.

| Tables | create plan | noop plan | modify plan | dump |
|---:|---:|---:|---:|---:|
| 10 | 0.033 | 0.036 | 0.037 | 0.034 |
| 50 | 0.041 | 0.055 | 0.057 | 0.041 |
| 100 | 0.053 | 0.078 | 0.083 | 0.052 |
| 250 | 0.090 | 0.142 | 0.150 | 0.076 |
| 500 | 0.148 | 0.263 | 0.273 | 0.122 |
| 1,000 | 0.269 | 0.489 | 0.497 | 0.218 |

At 1,000 tables dump goes 0.646s to 0.218s. That one is directly comparable, since dump does not touch the desired schema. The noop plan is not comparable against the 0.829s on the page, because that run was not a noop; running the old generator against this build gives 0.460s, so the same-script comparison is 0.829s to 0.460s.

The page itself no longer carries either comparison. It just notes that 1.39.0 made the catalog read a fixed number of queries.

## Analysis rewritten

Two claims no longer hold and are replaced:

- The catalog read is no longer the dominant cost. Parse plus diff (create plan, 0.27s) and catalog read plus serialize (dump, 0.22s) now cost about the same at 1,000 tables, and the noop plan is roughly their sum.
- The modify plan is not the heaviest case and does not exceed one second. It is 8 ms off the noop plan, because emitting 3,000 statements is cheap next to reading the catalog and parsing the desired schema.

Also noted: dropping a 1,000-table schema in one statement exceeds the default `max_locks_per_transaction`, so resetting between runs needs it raised.

## Notes

- Docs only, no behavior change, so no CHANGELOG entry.
- `mkdocs build --strict` was not run (mkdocs is not installed locally). No links were added or changed.

