### PR TITLE
docs: add opt-in policy for new features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Avoid normalization that makes the diff complex.
 
 Do not emit DDL a change does not need, and never emit it implicitly. Low load on the database comes before a simple interface: a directive the user writes beats an inference.
 
+New features are opt-in. Turning off a feature that is on by default is hard once users depend on it, so ship it behind a flag or a directive.
+
 Do not chase corner cases. A rare input is not worth an implementation that is hard to follow, and the schemas people actually write come first.
 
 Do not coddle the user. Assume they know PostgreSQL and their own schema.


### PR DESCRIPTION
Add a design policy line: new features are opt-in.

Once a feature is on by default, turning it off is hard because users depend on it. Ship it behind a flag or a directive instead.