### PR TITLE
ci: upload test results to Codecov Test Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,19 @@ jobs:
         run: go build -o pista.exe ./cmd/pista
       - name: Smoke test
         run: ./pista.exe --help
-      - run: make TEST_OPTS='-coverprofile=coverage.txt'
+      - run: make TEST_OPTS='-coverprofile=coverage.txt' TEST_JUNIT=junit.xml
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: windows
+      # Uploaded even when the tests failed, since a failed test is what the
+      # report is there to describe.
+      - uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
+          disable_search: true
           flags: windows
 
   test:
@@ -147,7 +156,7 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       - run: make deadcode
-      - run: make TEST_OPTS='-coverprofile=coverage.txt'
+      - run: make TEST_OPTS='-coverprofile=coverage.txt' TEST_JUNIT=junit.xml
       - run: make test-scenario
       # test-fidelity reloads a dump and compares pg_dump output, and pg_dump
       # refuses a server newer than itself. The runner ships an older client
@@ -169,6 +178,15 @@ jobs:
           # Each matrix job uploads its own coverage; Codecov merges them so
           # PG-version-specific paths (e.g. PG18-only catalog reads) are
           # counted as covered when any matrix entry exercises them.
+      # Uploaded even when the tests failed, since a failed test is what the
+      # report is there to describe.
+      - uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
+          disable_search: true
+          flags: pg${{ matrix.postgres }}
 
   samples:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ install:
 vet:
 	go vet ./...
 
+# TEST_JUNIT names a file to write a JUnit XML report to, which is what
+# Codecov Test Analytics ingests. Leave it empty and the report is skipped;
+# `go test` then writes straight to the terminal. Set, the output goes through
+# go-junit-report instead and is copied to stderr so the log still shows it.
+ifneq ($(TEST_JUNIT),)
+TEST_REPORT = | tee /dev/stderr | go tool go-junit-report > $(TEST_JUNIT)
+endif
+
 # The Go tests reset `public` and nothing else, so whatever `make schema`
 # loaded into the other schemas is still there while they run. A test that
 # looks something up without naming its schema then finds a sample's object
@@ -47,7 +55,7 @@ vet:
 # another. Override PGPORT, or wipe the other server yourself.
 .PHONY: test
 test: clean-schema
-	go test -p 1 -v ./... $(TEST_OPTS)
+	go test -p 1 -v ./... $(TEST_OPTS) $(TEST_REPORT)
 
 .PHONY: lint
 lint:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jstemmer/go-junit-report/v2 v2.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/winebarrel/linkedlist v1.0.0 // indirect
@@ -27,4 +28,7 @@ require (
 	golang.org/x/tools v0.49.1-0.20260828025639-2e922938d07f // indirect
 )
 
-tool golang.org/x/tools/cmd/deadcode
+tool (
+	github.com/jstemmer/go-junit-report/v2
+	golang.org/x/tools/cmd/deadcode
+)

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -18,6 +19,8 @@ github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
 github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
+github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
The four PG-version test jobs and the windows job reported coverage but nothing about the tests themselves, so a flaky test showed up only as a red run someone had to open the log for.

## What changed

- `go.mod`: add `go-junit-report` as a tool, next to `deadcode`, so CI does not have to install it separately.
- `Makefile`: `make test` takes a `TEST_JUNIT` variable naming a JUnit XML report to write. Unset, the target runs `go test` unchanged; set, the output goes through the converter and is copied to stderr so the log still reads the same. `SHELL` carries `-o pipefail`, so a failing test still fails the target.
- `.github/workflows/ci.yml`: the five jobs that run `make test` set `TEST_JUNIT=junit.xml` and upload the report with `codecov/test-results-action` under the same flag as their coverage upload. The upload runs under `if: ${{ !cancelled() }}`, since a failed test is what the report is there to describe.

`codecov.yml` is unchanged: `after_n_builds` counts coverage uploads, and a test results upload is a separate report type.

## Scope

Go tests only. `test-scenario` and `test-fidelity` are bash and produce no JUnit output.

## Verified

- `make test TEST_JUNIT=... TEST_OPTS='-run TestQuoteIdent'` writes valid XML and keeps the console output.
- `pipefail` propagates a test failure through the pipe.
- `make vet`, `make lint`, `make deadcode`, the non-ASCII check and a YAML parse of `ci.yml` all pass.