### PR TITLE
ci: stop the JUnit pipeline from swallowing a Windows test failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,14 @@ vet:
 # TEST_JUNIT names a file to write a JUnit XML report to, which is what
 # Codecov Test Analytics ingests. Leave it empty and the report is skipped;
 # `go test` then writes straight to the terminal. Set, the output goes through
-# go-junit-report instead and is copied to stderr so the log still shows it.
+# go-junit-report, which -iocopy passes on to the terminal unchanged.
+#
+# -set-exit-code is what carries a failure out of the pipeline: make on Windows
+# does not use the SHELL set above, so pipefail is not in effect there and the
+# pipeline would otherwise report go-junit-report's own status. It covers a
+# failed test, a package that fails as a whole, and a build failure.
 ifneq ($(TEST_JUNIT),)
-TEST_REPORT = | tee /dev/stderr | go tool go-junit-report > $(TEST_JUNIT)
+TEST_REPORT = | go tool go-junit-report -iocopy -set-exit-code -out $(TEST_JUNIT)
 endif
 
 # The Go tests reset `public` and nothing else, so whatever `make schema`


### PR DESCRIPTION
Follow-up to #486. The report was produced by piping `go test` through `tee` into `go-junit-report`, which broke two ways on the windows job.

## What went wrong

`tee /dev/stderr` failed there with `No such file or directory`. `tee` keeps writing to stdout when one output fails, so the report itself was complete, but the copy that made the test output visible in the log was gone: [the run](https://github.com/winebarrel/pistachio/actions/runs/33613827950) shows nothing between the psql wipe and the next target.

Worse, `tee`'s exit status was ignored. make on Windows does not use the `SHELL := /bin/bash -o pipefail` set at the top of the Makefile, so pipefail is not in effect and the pipeline reports the status of `go-junit-report`, which exits 0 whatever the tests did. **A failing test on Windows would have left the job green.**

## The fix

Drop `tee` and let `go-junit-report` do both jobs:

```make
TEST_REPORT = | go tool go-junit-report -iocopy -set-exit-code -out $(TEST_JUNIT)
```

- `-iocopy` passes the input through to the terminal, so the log reads the same and nothing depends on `/dev/stderr`.
- `-set-exit-code` makes it exit 1 when the report holds a failure, so the status survives the pipe with or without pipefail.

`-set-exit-code` covers a failed test, a package that fails as a whole (a `TestMain` or connection error), and a build failure.

## Verified

- A passing `make test TEST_JUNIT=... TEST_OPTS='-run TestQuoteIdent'` still prints its output and writes the test into the report.
- Running the pipeline under `/bin/sh` without pipefail, standing in for the Windows shell, exits 1 on a failing test and records it in the report.