### PR TITLE
ci: add bug-oriented linters to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,18 @@
 version: "2"
 linters:
   enable:
+    - asasalint
+    - durationcheck
     - errorlint
+    - fatcontext
+    - makezero
+    - nilerr
+    - nilnesserr
+    - reassign
+    - testifylint
     - unconvert
+    - usestdlibvars
+    - wastedassign
   exclusions:
     rules:
       - linters:

--- a/catalog/columns_test.go
+++ b/catalog/columns_test.go
@@ -71,7 +71,7 @@ func TestListColumnsByTables(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "external", body.StorageType)
 		assert.Equal(t, "extended", body.TypeStorage)
-		assert.Equal(t, "", body.Compression)
+		assert.Empty(t, body.Compression)
 
 		note, ok := tbl.Columns.GetOk("note")
 		require.True(t, ok)
@@ -83,7 +83,7 @@ func TestListColumnsByTables(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "extended", title.StorageType)
 		assert.Equal(t, "extended", title.TypeStorage)
-		assert.Equal(t, "", title.Compression)
+		assert.Empty(t, title.Compression)
 
 		id, ok := tbl.Columns.GetOk("id")
 		require.True(t, ok)

--- a/connect_test.go
+++ b/connect_test.go
@@ -3,7 +3,6 @@ package pistachio
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -172,7 +171,7 @@ func TestBuildConnConfig_InvalidConnStringReturnsError(t *testing.T) {
 
 	_, err := client.buildConnConfig()
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "failed to parse connection string"))
+	assert.Contains(t, err.Error(), "failed to parse connection string")
 }
 
 func TestConnInfoComment(t *testing.T) {
@@ -275,5 +274,5 @@ func TestConnect_InvalidConnStringPropagatesBuildError(t *testing.T) {
 
 	_, err := client.connect(context.Background(), false)
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "failed to parse connection string"))
+	assert.Contains(t, err.Error(), "failed to parse connection string")
 }

--- a/diff/rename_test.go
+++ b/diff/rename_test.go
@@ -418,7 +418,7 @@ func TestRewriteColumnRefsInTriggers_FallbackOnEmptyDefinition(t *testing.T) {
 	out := rewriteColumnRefsInTriggers(in, one("qty", "quantity"))
 	got, ok := out.GetOk("t")
 	require.True(t, ok)
-	assert.Equal(t, "", got.Definition)
+	assert.Empty(t, got.Definition)
 }
 
 func TestRewriteColumnRefsInTriggers_FallbackOnOtherStatement(t *testing.T) {

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1270,7 +1270,7 @@ func TestSchemaOf(t *testing.T) {
 	// A quoted schema containing a dot: the dot inside quotes is not a separator.
 	assert.Equal(t, `"a.b"`, schemaOf(`"a.b".people`))
 	// No top-level dot yields "".
-	assert.Equal(t, "", schemaOf("people"))
+	assert.Empty(t, schemaOf("people"))
 }
 
 func TestEqualDefault(t *testing.T) {

--- a/model/composite_type_test.go
+++ b/model/composite_type_test.go
@@ -61,7 +61,7 @@ func TestCompositeType_CommentSQL(t *testing.T) {
 	assert.Equal(t, "COMMENT ON TYPE public.address IS 'an address';", ct.CommentSQL())
 
 	ct.Comment = nil
-	assert.Equal(t, "", ct.CommentSQL())
+	assert.Empty(t, ct.CommentSQL())
 }
 
 func TestCompositeType_AttributeCommentSQLs(t *testing.T) {

--- a/model/domain_test.go
+++ b/model/domain_test.go
@@ -56,7 +56,7 @@ func TestDomain_CommentSQL(t *testing.T) {
 
 func TestDomain_CommentSQL_NoComment(t *testing.T) {
 	d := &model.Domain{Schema: "public", Name: "pos_int", BaseType: "integer"}
-	assert.Equal(t, "", d.CommentSQL())
+	assert.Empty(t, d.CommentSQL())
 }
 
 func TestDomainToSQL(t *testing.T) {

--- a/model/enum_test.go
+++ b/model/enum_test.go
@@ -49,7 +49,7 @@ func TestEnum_CommentSQL_NoComment(t *testing.T) {
 		Name:   "status",
 		Values: []string{"active"},
 	}
-	assert.Equal(t, "", e.CommentSQL())
+	assert.Empty(t, e.CommentSQL())
 }
 
 func TestEnumToSQL(t *testing.T) {

--- a/model/policy_test.go
+++ b/model/policy_test.go
@@ -13,7 +13,7 @@ func TestPolicyCommand_String(t *testing.T) {
 	assert.Equal(t, "INSERT", model.PolicyCommand('a').String())
 	assert.Equal(t, "UPDATE", model.PolicyCommand('w').String())
 	assert.Equal(t, "DELETE", model.PolicyCommand('d').String())
-	assert.Equal(t, "", model.PolicyCommand(0).String())
+	assert.Empty(t, model.PolicyCommand(0).String())
 }
 
 func TestPolicyCommand_IsAll(t *testing.T) {

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -279,7 +279,7 @@ func TestTable_IdxSQL(t *testing.T) {
 
 func TestTable_IdxSQL_empty(t *testing.T) {
 	tbl := newTable("public", "users")
-	assert.Equal(t, "", tbl.IdxSQL())
+	assert.Empty(t, tbl.IdxSQL())
 }
 
 func TestTable_FkSQL(t *testing.T) {
@@ -307,7 +307,7 @@ func TestTable_CommentSQL(t *testing.T) {
 func TestTable_CommentSQL_noComments(t *testing.T) {
 	tbl := newTable("public", "users")
 	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
-	assert.Equal(t, "", tbl.CommentSQL())
+	assert.Empty(t, tbl.CommentSQL())
 }
 
 func TestTablesToSQL(t *testing.T) {

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -30,7 +30,7 @@ func TestIdent_uppercase(t *testing.T) {
 }
 
 func TestIdent_empty(t *testing.T) {
-	assert.Equal(t, "", Ident(""))
+	assert.Empty(t, Ident(""))
 }
 
 func TestIdent_emptySchema(t *testing.T) {

--- a/model/view_test.go
+++ b/model/view_test.go
@@ -32,7 +32,7 @@ func TestView_CommentSQL(t *testing.T) {
 
 func TestView_CommentSQL_nil(t *testing.T) {
 	v := model.View{Schema: "public", Name: "active_users"}
-	assert.Equal(t, "", v.CommentSQL())
+	assert.Empty(t, v.CommentSQL())
 }
 
 func TestViewsToSQL(t *testing.T) {

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -178,13 +178,13 @@ func TestExtractInlineDirectives_Mixed(t *testing.T) {
 func TestExtractConstraintName(t *testing.T) {
 	assert.Equal(t, "users_pkey", extractConstraintName("CONSTRAINT users_pkey PRIMARY KEY (id)"))
 	assert.Equal(t, "My Con", extractConstraintName(`CONSTRAINT "My Con" UNIQUE (code)`))
-	assert.Equal(t, "", extractConstraintName("id integer NOT NULL"))
-	assert.Equal(t, "", extractConstraintName(""))
+	assert.Empty(t, extractConstraintName("id integer NOT NULL"))
+	assert.Empty(t, extractConstraintName(""))
 	// Unquoted names are lowercased
 	assert.Equal(t, "users_pkey", extractConstraintName("CONSTRAINT Users_Pkey PRIMARY KEY (id)"))
 	// An unterminated quote yields no name rather than a truncated one
-	assert.Equal(t, "", extractConstraintName(`CONSTRAINT "unterminated UNIQUE (code)`))
-	assert.Equal(t, "", extractConstraintName("CONSTRAINT "))
+	assert.Empty(t, extractConstraintName(`CONSTRAINT "unterminated UNIQUE (code)`))
+	assert.Empty(t, extractConstraintName("CONSTRAINT "))
 }
 
 func TestNormalizeUnqualifiedDirective(t *testing.T) {
@@ -239,12 +239,12 @@ func TestExtractColumnName(t *testing.T) {
 	assert.Equal(t, "id", extractColumnName("id integer NOT NULL,"))
 	assert.Equal(t, "name", extractColumnName("name text NOT NULL"))
 	assert.Equal(t, "My Col", extractColumnName(`"My Col" text NOT NULL,`))
-	assert.Equal(t, "", extractColumnName("CONSTRAINT users_pkey PRIMARY KEY (id)"))
-	assert.Equal(t, "", extractColumnName(""))
+	assert.Empty(t, extractColumnName("CONSTRAINT users_pkey PRIMARY KEY (id)"))
+	assert.Empty(t, extractColumnName(""))
 	// Unquoted names are lowercased
 	assert.Equal(t, "displayname", extractColumnName("DisplayName text NOT NULL"))
 	// An unterminated quote yields no name rather than a truncated one
-	assert.Equal(t, "", extractColumnName(`"unterminated text NOT NULL`))
+	assert.Empty(t, extractColumnName(`"unterminated text NOT NULL`))
 }
 
 func TestExtractExecuteDirectives_WithCheckSQL(t *testing.T) {
@@ -287,7 +287,7 @@ GRANT SELECT ON public.users TO readonly_role;`
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	assert.Contains(t, stmts[0].SQL, "GRANT select")
-	assert.Equal(t, "", stmts[0].CheckSQL)
+	assert.Empty(t, stmts[0].CheckSQL)
 	assert.Len(t, skip, 1)
 }
 
@@ -320,7 +320,7 @@ CREATE OR REPLACE FUNCTION public.func2() RETURNS void AS $$ BEGIN END; $$ LANGU
 	stmts, skip, err := extractExecuteDirectives(sql, result.Stmts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 2)
-	assert.Equal(t, "", stmts[0].CheckSQL)
+	assert.Empty(t, stmts[0].CheckSQL)
 	assert.Equal(t, "SELECT true", stmts[1].CheckSQL)
 	assert.Len(t, skip, 2)
 }
@@ -349,7 +349,7 @@ CREATE OR REPLACE FUNCTION public.my_func() RETURNS void AS $$ BEGIN END; $$ LAN
 	require.Len(t, stmts, 1)
 	assert.True(t, stmts[0].First)
 	assert.Contains(t, stmts[0].SQL, "CREATE OR REPLACE FUNCTION")
-	assert.Equal(t, "", stmts[0].CheckSQL)
+	assert.Empty(t, stmts[0].CheckSQL)
 	assert.Len(t, skip, 1)
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -91,7 +91,7 @@ func TestReadSQLFile_Stdin_ReadAll(t *testing.T) {
 
 	got, err := parser.ReadSQLFile("-")
 	require.NoError(t, err)
-	assert.Equal(t, "", got)
+	assert.Empty(t, got)
 }
 
 func TestParseSQL_InvalidSQL(t *testing.T) {
@@ -536,8 +536,7 @@ func TestParseSQLFilesWithSchema(t *testing.T) {
 
 func TestParseSQLFilesWithSchema_MissingFile(t *testing.T) {
 	_, err := parser.ParseSQLFilesWithSchema([]string{filepath.Join(t.TempDir(), "missing.sql")}, "public")
-	require.Error(t, err)
-	assert.ErrorIs(t, err, fs.ErrNotExist)
+	require.ErrorIs(t, err, fs.ErrNotExist)
 	assert.Contains(t, err.Error(), "failed to read SQL file")
 }
 
@@ -1792,7 +1791,7 @@ GRANT SELECT ON public.users TO readonly_role;`
 	assert.Equal(t, 1, result.Tables.Len())
 	require.Len(t, result.ExecuteStmts, 1)
 	assert.Contains(t, result.ExecuteStmts[0].SQL, "GRANT select")
-	assert.Equal(t, "", result.ExecuteStmts[0].CheckSQL)
+	assert.Empty(t, result.ExecuteStmts[0].CheckSQL)
 }
 
 func TestParseSQL_IndexOnUnknownTableSkipped(t *testing.T) {


### PR DESCRIPTION
Enable ten more linters in the existing lint job. They all run inside the
current `golangci-lint-action` step, so CI time is unchanged (the full run
takes about 2.4s locally).

- asasalint
- durationcheck
- fatcontext
- makezero
- nilerr
- nilnesserr
- reassign
- testifylint
- usestdlibvars
- wastedassign

Only testifylint reported anything. The fixes are mechanical and were
produced by `golangci-lint run --fix`:

- `assert.Equal(t, "", x)` -> `assert.Empty(t, x)`
- `assert.True(t, strings.Contains(err.Error(), s))` -> `assert.Contains(t, err.Error(), s)`
- one `assert.ErrorIs` -> `require.ErrorIs`, dropping the now redundant
  `require.Error` next to it

## Linters tried and left out

- `exhaustive`: 20 hits, every one of them a switch over a pg_query
  protobuf enum. Handling a few kinds and ignoring the rest is the point of
  those switches, and `default-signifies-exhaustive` still leaves 10.
- `gocritic`: 4 hits, three `ifElseChain` and one `nilValReturn`
  (`if node == nil { return node }`). No bugs.
- `protogetter`: 50 hits. Routing proto field reads through getters does
  avoid a nil-message panic, but the diff is large enough to be its own
  change.
- `noctx` / `contextcheck`: 3 hits, in the pager's `exec.Command` and a test
  helper. Both are deliberate.

`golangci-lint run` reports 0 issues, and `go vet`, `go build` and the tests
for the touched packages pass.