### PR TITLE
test: add fuzz targets for the parser and the diff

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,65 @@
+name: Fuzz
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Weekly, on a longer budget than a pull request gets.
+    - cron: '43 4 * * 1'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash -xeo pipefail {0}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    # The fuzz targets parse SQL and diff the result against itself, so no
+    # database is involved. `make test` already replays the seed corpus; this
+    # job is the part that goes looking for new inputs.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: ./parser/
+            target: FuzzParseSQLWithSchema
+          - package: ./diff/
+            target: FuzzDiffSelf
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      # go stores the corpus it grows under GOCACHE, so a run starts from
+      # whatever the last one found instead of from the seeds alone. The key
+      # rotates every run and falls back to the newest prefix match, which is
+      # how a cache entry gets replaced rather than frozen at its first write.
+      - id: gocache
+        run: echo "dir=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.gocache.outputs.dir }}/fuzz
+          key: fuzz-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: fuzz-${{ matrix.target }}-
+      - name: Fuzz ${{ matrix.target }}
+        run: |
+          go test ${{ matrix.package }} -run='^$' \
+            -fuzz='^${{ matrix.target }}$' \
+            -fuzztime=${{ github.event_name == 'schedule' && '15m' || '1m' }}
+      # A failing input is written into the package's testdata/fuzz/, where it
+      # becomes a seed the ordinary tests replay. Keep it so the crash can be
+      # committed and reproduced instead of having to be found again.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: '**/testdata/fuzz/**'
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ make vet            # go vet ./...
 make test           # go test -p 1 -v ./... $(TEST_OPTS)
 make test-scenario  # CLI scenario tests (bash, requires PostgreSQL)
 make test-fidelity  # restore fidelity check (bash, requires PostgreSQL and pg_dump)
+make fuzz           # fuzz targets (no database; FUZZTIME per target, default 1m)
 make lint           # golangci-lint run
 make fix            # golangci-lint run --fix (auto-fix lint errors)
 ```
@@ -49,6 +50,7 @@ make fix            # golangci-lint run --fix (auto-fix lint errors)
 - `model/` - Data model structs (Table, Column, Constraint, ForeignKey, Index, Policy, View, Enum, Domain)
 - `diff/` - Generates DDL diff between current and desired schemas
 - `internal/testutil/` - Test helpers (DB connection, setup)
+- `internal/testutil/fuzzseed/` - the SQL seed corpus the fuzz targets start from. The targets themselves are `parser/fuzz_test.go` (parse arbitrary text, then render the result) and `diff/fuzz_test.go` (a schema diffed against itself must need no DDL). Neither needs a database, and `make test` replays their seed corpus.
 - `testdata/` - YAML-based test fixtures for multiple test suites, including integration and unit tests
 - `test/scenario/` - CLI-level scenario tests (shell scripts that run `pista` CLI against sample schemas)
 - `test/fidelity/` - restore fidelity check: loads `pista dump` output into an empty database and diffs `pg_dump` against the original

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,18 @@ fix:
 deadcode:
 	bash scripts/check-deadcode.sh
 
+# Fuzzing. The targets need no database, so this is the one test target that
+# runs anywhere. FUZZTIME is per target, not for the run as a whole, and each
+# has to be started on its own because `go test -fuzz` takes one target at a
+# time. A crash is written under the package's testdata/fuzz/, where it turns
+# into a seed the ordinary `go test` replays from then on.
+FUZZTIME ?= 1m
+
+.PHONY: fuzz
+fuzz:
+	go test ./parser/ -run='^$$' -fuzz=FuzzParseSQLWithSchema -fuzztime=$(FUZZTIME)
+	go test ./diff/ -run='^$$' -fuzz=FuzzDiffSelf -fuzztime=$(FUZZTIME)
+
 .PHONY: keywords
 keywords:
 	bash scripts/gen-keywords.sh

--- a/diff/fuzz_test.go
+++ b/diff/fuzz_test.go
@@ -1,0 +1,117 @@
+package diff
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/winebarrel/pistachio/internal/testutil/fuzzseed"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+// FuzzDiffSelf checks the property the whole tool rests on: a schema diffed
+// against itself needs no DDL. Both sides come from the same input parsed
+// twice, so a statement here means a comparison reported two identical objects
+// as different, and a panic means the diff cannot walk a model the parser
+// accepts.
+//
+// It then diffs the same schema against an empty one, the path `pista plan`
+// takes against a fresh database, which reaches the create builders the
+// identity check skips.
+//
+// A Diff* error is not a failure. Some inputs are wrong rather than
+// unsupported (a -- pista:renamed-from naming an object that is not there,
+// say), and reporting them is the point.
+func FuzzDiffSelf(f *testing.F) {
+	seeds, err := fuzzseed.Schemas()
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, sql := range seeds {
+		f.Add(sql)
+	}
+
+	dir := f.TempDir()
+	path := filepath.Join(dir, "schema.sql")
+	emptyPath := filepath.Join(dir, "empty.sql")
+	if err := os.WriteFile(emptyPath, nil, 0o600); err != nil {
+		f.Fatal(err)
+	}
+	empty, err := parser.ParseSQLFilesWithSchema([]string{emptyPath}, "public")
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Fuzz(func(t *testing.T, sql string) {
+		if err := os.WriteFile(path, []byte(sql), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		// Parsed twice rather than shared: the diff functions may rewrite the
+		// models they are handed, and one pointer on both sides would hide it.
+		current, err := parser.ParseSQLFilesWithSchema([]string{path}, "public")
+		if err != nil {
+			return
+		}
+		desired, err := parser.ParseSQLFilesWithSchema([]string{path}, "public")
+		if err != nil {
+			t.Fatalf("the same input parsed twice gave different results: %v", err)
+		}
+
+		stmts, err := diffEverything(current, desired)
+		if err != nil {
+			return
+		}
+		if len(stmts) > 0 {
+			t.Fatalf("a schema diffed against itself wants %d statement(s): %v", len(stmts), stmts)
+		}
+
+		diffEverything(empty, desired)
+	})
+}
+
+// diffEverything runs every Diff* entry point over the two parse results and
+// returns the statements they produced. A nil DropChecker denies every drop,
+// so nothing here depends on a drop policy.
+func diffEverything(current, desired *parser.ParseResult) ([]string, error) {
+	enums, err := DiffEnums(current.Enums, desired.Enums, nil)
+	if err != nil {
+		return nil, err
+	}
+	sequences, err := DiffSequences(current.Sequences, desired.Sequences, nil)
+	if err != nil {
+		return nil, err
+	}
+	domains, err := DiffDomains(current.Domains, desired.Domains, nil)
+	if err != nil {
+		return nil, err
+	}
+	compositeTypes, err := DiffCompositeTypes(current.CompositeTypes, desired.CompositeTypes, nil)
+	if err != nil {
+		return nil, err
+	}
+	tables, err := DiffTables(current.Tables, desired.Tables, nil)
+	if err != nil {
+		return nil, err
+	}
+	views, err := DiffViews(current.Views, desired.Views, nil)
+	if err != nil {
+		return nil, err
+	}
+	routines, err := DiffRoutines(current.Routines, desired.Routines, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var stmts []string
+	stmts = append(stmts, enums.Stmts...)
+	stmts = append(stmts, sequences.Stmts...)
+	stmts = append(stmts, domains.Stmts...)
+	stmts = append(stmts, compositeTypes.Stmts...)
+	stmts = append(stmts, tables.Stmts...)
+	stmts = append(stmts, views.DropStmts...)
+	stmts = append(stmts, views.CreateStmts...)
+	stmts = append(stmts, routines.Stmts...)
+
+	return stmts, nil
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,3 +25,14 @@ checks that a `pista dump` reloaded into an empty database produces the schema
 it was taken from, comparing `pg_dump` output on both sides. The latter needs a
 `pg_dump` at least as new as the server.
 
+`make fuzz` runs the fuzz targets: one feeds arbitrary text to the parser and
+renders whatever comes back, the other diffs a parsed schema against itself and
+requires no DDL. Neither needs a database. `FUZZTIME` sets how long each target
+runs and defaults to one minute:
+
+```bash
+make FUZZTIME=10m fuzz
+```
+
+An input that fails is written under the package's `testdata/fuzz/`, and every
+ordinary `make test` replays it from then on, so commit it with the fix.

--- a/internal/testutil/fuzzseed/fuzzseed.go
+++ b/internal/testutil/fuzzseed/fuzzseed.go
@@ -1,0 +1,61 @@
+// Package fuzzseed loads the SQL corpus the fuzz targets start from.
+package fuzzseed
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+)
+
+// Schemas returns the schema files the restore fidelity check uses, plus a few
+// short inputs that exercise the directive scanner. The fidelity schemas are
+// the broadest SQL pistachio is known to handle, which makes them a better
+// starting corpus than anything written by hand for the fuzzer.
+//
+// The paths are resolved from this file's own location, so a target can call
+// this from any package without knowing where the test runs from.
+func Schemas() ([]string, error) {
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("cannot locate the fuzzseed source file")
+	}
+
+	root := filepath.Join(filepath.Dir(self), "..", "..", "..")
+	pattern := filepath.Join(root, "test", "fidelity", "schemas", "*.sql")
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no seed schemas matched %s; has the directory moved?", pattern)
+	}
+	sort.Strings(paths)
+
+	seeds := make([]string, 0, len(paths)+len(directives))
+	for _, path := range paths {
+		sql, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		seeds = append(seeds, string(sql))
+	}
+
+	return append(seeds, directives...), nil
+}
+
+// directives covers the hand-written comment scanner the fidelity schemas
+// never reach: pg_query drops comments, so a directive only becomes reachable
+// once the seed corpus puts one in front of the fuzzer.
+var directives = []string{
+	"",
+	"-- pista:ignore\nCREATE TABLE public.t (id int);",
+	"-- pista:renamed-from old_t\nCREATE TABLE public.t (id int);",
+	"CREATE TABLE public.t (\n  id int, -- pista:renamed-from old_id\n  v text\n);",
+	"CREATE TABLE public.t (id int);\n-- pista:concurrently\nCREATE INDEX i ON public.t (id);",
+	"-- pista:bulk-alter\nCREATE TABLE public.t (id int);",
+	"-- pista:execute SELECT 1\nGRANT SELECT ON public.t TO r;",
+	"-- pista:execute-first\nGRANT SELECT ON public.t TO r;",
+	"CREATE TYPE public.e AS ENUM ('a', 'b'); -- pista:renamed-from old_e",
+}

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -1,0 +1,48 @@
+package parser
+
+import (
+	"io"
+	"testing"
+
+	"github.com/winebarrel/pistachio/internal/testutil/fuzzseed"
+	"github.com/winebarrel/pistachio/model"
+)
+
+// FuzzParseSQLWithSchema feeds arbitrary text to the parser and renders
+// whatever comes back. Most inputs are rejected by pg_query and return an
+// error, so the value is in the ones the mutator builds out of the seeds:
+// those reach the AST walk and the SQL builders behind it, which is where an
+// unexpected node shape turns into a panic rather than an error.
+//
+// Rendering is part of the target because `pista dump` writes the model back
+// out, and a model the parser accepts but the builders cannot render is just
+// as broken as a parse that crashes.
+func FuzzParseSQLWithSchema(f *testing.F) {
+	f.Cleanup(SetWarnWriter(io.Discard))
+
+	seeds, err := fuzzseed.Schemas()
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, sql := range seeds {
+		f.Add(sql)
+	}
+
+	f.Fuzz(func(t *testing.T, sql string) {
+		result, err := parseSQLWithSchema(sql, "public")
+		if err != nil {
+			return
+		}
+
+		model.TablesToSQL(result.Tables)
+		model.EnumsToSQL(result.Enums)
+		model.DomainsToSQL(result.Domains)
+		model.CompositeTypesToSQL(result.CompositeTypes)
+		model.SequencesToSQL(result.Sequences)
+		model.RoutinesToSQL(result.Routines)
+		model.ViewsToSQL(result.Views)
+		for _, es := range result.ExecuteStmts {
+			FormatExecuteStmt(es)
+		}
+	})
+}


### PR DESCRIPTION
Two Go fuzz targets, neither of which needs a database.

## `parser.FuzzParseSQLWithSchema`

Feeds arbitrary text to the parser and renders whatever comes back through
the same builders `pista dump` uses. Most inputs are rejected by pg_query and
return an error; the value is in the ones the mutator builds out of the seeds,
which reach the AST walk and the builders behind it. A model the parser accepts
but the builders cannot render is as broken as a parse that crashes, so the
render is part of the target.

## `diff.FuzzDiffSelf`

Parses one input twice and diffs the result against itself, which must need no
DDL. That is stronger than checking for a panic: a statement here means a
comparison called two identical objects different. It then diffs the same
schema against an empty one, the path `pista plan` takes against a fresh
database, to reach the create builders the identity check skips.

A `Diff*` error is not a failure. Some inputs are wrong rather than unsupported
(a `-- pista:renamed-from` naming an object that is not there, say) and
reporting them is the point.

## Seed corpus

`internal/testutil/fuzzseed` loads the restore fidelity check's schemas, the
broadest SQL pistachio is known to handle, plus short inputs holding
directives. pg_query drops comments, so the directive scanner is only
reachable from a seed.

## Running it

`make fuzz` runs both targets. `FUZZTIME` is per target and defaults to 1m:

```sh
make FUZZTIME=10m fuzz
```

`.github/workflows/fuzz.yml` runs them for 1m per pull request and 15m weekly.
The corpus go grows under GOCACHE is carried between runs through
`actions/cache`, and a crasher is uploaded as an artifact. `make test` already
replays the seed corpus, so committing a crasher turns it into a permanent
regression test.

## Results

5 minutes per target locally found nothing: 41M execs for the parser (about
150k/sec), 3.8M for the diff (slower for the file write and the double parse).
`make lint`, `go vet`, `make deadcode`, the ASCII check, `make test` and
`actionlint` all pass.