### PR TITLE
Name the file, line and column in parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Name the file, line and column in parse errors. A syntax error or a bad `-- pista:` directive now prints the offending line with a caret under the column, in the style of a compiler, instead of the bare message. With several schema files the line number is local to the file the error is in.
+
 * Stop a self-referencing foreign key from disabling the dependency sort. A key pointing at its own table's primary key, the `parent_id` of a tree, was added to the graph as a self-edge and read back as a cycle. `plan` and `apply` fall back to category order when the sort fails, so one such table anywhere in the schema dropped the order for the whole run: two new views, one selecting from the other, went out in file order and the apply failed on the view that did not exist yet. `dump --sort-by-deps` treats a cycle as a hard error and wrote nothing at all. The composite type and view branches already skipped a self-reference; the foreign key branch now does the same.
 
 * Manage an identity column's sequence options, the `( ... )` after `AS IDENTITY`. `START WITH`, `INCREMENT BY`, `MINVALUE`, `MAXVALUE`, `CACHE` and `CYCLE` were read by neither side, so a file that wrote them was applied at the defaults and `dump` dropped them. A change goes out as `ALTER TABLE ... ALTER COLUMN ... SET`, and an option the desired schema no longer names is reset to its default. `dump` writes only the options that differ from the defaults.

--- a/diff_all.go
+++ b/diff_all.go
@@ -90,9 +90,10 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		}
 	}
 
+	// Not wrapped: the parser's message already names the file.
 	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse SQL file: %w", err)
+		return nil, err
 	}
 
 	filterDesiredBySchemas(desired, client.Schemas, client.SchemaMap)

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -42,27 +42,28 @@ var knownDirectives = map[string]bool{
 // validateDirectives checks for unknown -- pista: directives in the raw SQL
 // and returns an error if any are found.
 func validateDirectives(rawSQL string) error {
-	matches := anyDirectivePattern.FindAllStringSubmatch(rawSQL, -1)
+	matches := anyDirectivePattern.FindAllStringSubmatchIndex(rawSQL, -1)
 	for _, m := range matches {
-		name := strings.TrimSpace(m[1])
+		// m[0] is the match start, m[2]:m[3] the name group.
+		name := strings.TrimSpace(rawSQL[m[2]:m[3]])
 		if name == "" {
-			return fmt.Errorf("invalid directive: -- pista: (missing directive name)")
+			return &locatedError{msg: "invalid directive: -- pista: (missing directive name)", offset: m[0]}
 		}
 		if !knownDirectives[name] {
-			return fmt.Errorf("unknown directive: -- pista:%s", name)
+			return &locatedError{msg: fmt.Sprintf("unknown directive: -- pista:%s", name), offset: m[2]}
 		}
 	}
 
-	if concurrentlyWithArgsPattern.MatchString(rawSQL) {
-		return fmt.Errorf("-- pista:concurrently does not accept arguments")
+	if m := concurrentlyWithArgsPattern.FindStringIndex(rawSQL); m != nil {
+		return &locatedError{msg: "-- pista:concurrently does not accept arguments", offset: m[0]}
 	}
 
-	if bulkAlterWithArgsPattern.MatchString(rawSQL) {
-		return fmt.Errorf("-- pista:bulk-alter does not accept arguments")
+	if m := bulkAlterWithArgsPattern.FindStringIndex(rawSQL); m != nil {
+		return &locatedError{msg: "-- pista:bulk-alter does not accept arguments", offset: m[0]}
 	}
 
-	if ignoreWithArgsPattern.MatchString(rawSQL) {
-		return fmt.Errorf("-- pista:ignore does not accept arguments")
+	if m := ignoreWithArgsPattern.FindStringIndex(rawSQL); m != nil {
+		return &locatedError{msg: "-- pista:ignore does not accept arguments", offset: m[0]}
 	}
 
 	return nil

--- a/parser/export_test.go
+++ b/parser/export_test.go
@@ -9,7 +9,18 @@ var (
 	ParseSQLWithSchema = parseSQLWithSchema
 	ReadSQLFile        = readSQLFile
 	IgnoredStmtSnippet = ignoredStmtSnippet
+	AnnotateError      = annotateError
 )
+
+type FileSpan = fileSpan
+
+func NewFileSpan(path string, start int) fileSpan {
+	return fileSpan{path: path, start: start}
+}
+
+func NewLocatedError(msg string, offset int) error {
+	return &locatedError{msg: msg, offset: offset}
+}
 
 // SetWarnWriter swaps the destination for ignored-statement warnings and
 // returns a function that restores the previous writer.

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -31,6 +31,9 @@ func FuzzParseSQLWithSchema(f *testing.F) {
 	f.Fuzz(func(t *testing.T, sql string) {
 		result, err := parseSQLWithSchema(sql, "public")
 		if err != nil {
+			// The location renderer must survive whatever position an
+			// arbitrary input produces.
+			annotateError(err, sql, []fileSpan{{path: "fuzz.sql", start: 0}})
 			return
 		}
 

--- a/parser/location.go
+++ b/parser/location.go
@@ -1,0 +1,107 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	pgparser "github.com/pganalyze/pg_query_go/v6/parser"
+)
+
+// fileSpan records where a desired-schema file starts in the SQL handed to
+// the parser, which parses every file joined into one input.
+type fileSpan struct {
+	path  string
+	start int // byte offset in the joined SQL
+}
+
+// locatedError is an error that knows the byte offset in the parsed SQL it
+// refers to. Directive validation returns it; pg_query errors carry their own
+// cursor position instead.
+type locatedError struct {
+	msg    string
+	offset int
+}
+
+func (e *locatedError) Error() string {
+	return e.msg
+}
+
+// annotateError appends the file, line and column an error points at, along
+// with the line itself and a caret under the offending column:
+//
+//	failed to parse SQL: syntax error at or near "TABEL"
+//	 --> schema/items.sql:6:8
+//	  |
+//	6 | CREATE TABEL public.items (
+//	  |        ^
+//
+// The position comes from a pg_query error's cursor (a 1-based character
+// index) or a locatedError's byte offset. An error carrying neither is
+// returned as it is.
+func annotateError(err error, sql string, spans []fileSpan) error {
+	offset := -1
+
+	if pgErr, ok := errors.AsType[*pgparser.Error](err); ok && pgErr.Cursorpos > 0 {
+		offset = runeOffsetToByte(sql, pgErr.Cursorpos-1)
+	} else if locErr, ok := errors.AsType[*locatedError](err); ok {
+		offset = locErr.offset
+	}
+
+	if offset < 0 || len(spans) == 0 {
+		return err
+	}
+	offset = min(offset, len(sql))
+
+	span := spans[0]
+	for _, s := range spans[1:] {
+		if s.start > offset {
+			break
+		}
+		span = s
+	}
+
+	lineStart := strings.LastIndexByte(sql[:offset], '\n') + 1
+	lineEnd := len(sql)
+	if i := strings.IndexByte(sql[offset:], '\n'); i >= 0 {
+		lineEnd = offset + i
+	}
+	lineNo := 1 + strings.Count(sql[span.start:offset], "\n")
+	col := 1 + utf8.RuneCountInString(sql[lineStart:offset])
+
+	// The caret pad mirrors the runes before the column, keeping tabs so the
+	// caret lands under the column however the line is indented.
+	var pad strings.Builder
+	for _, r := range sql[lineStart:offset] {
+		if r == '\t' {
+			pad.WriteByte('\t')
+		} else {
+			pad.WriteByte(' ')
+		}
+	}
+
+	num := strconv.Itoa(lineNo)
+	gutter := strings.Repeat(" ", len(num))
+
+	return fmt.Errorf("%s\n%s--> %s:%d:%d\n%s |\n%s | %s\n%s | %s^",
+		err.Error(),
+		gutter, span.path, lineNo, col,
+		gutter,
+		num, sql[lineStart:lineEnd],
+		gutter, pad.String())
+}
+
+// runeOffsetToByte returns the byte offset of the n-th rune (0-based), or
+// len(sql) when the input has fewer runes.
+func runeOffsetToByte(sql string, n int) int {
+	runes := 0
+	for i := range sql {
+		if runes == n {
+			return i
+		}
+		runes++
+	}
+	return len(sql)
+}

--- a/parser/location_test.go
+++ b/parser/location_test.go
@@ -1,0 +1,195 @@
+package parser_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+func writeSQLFiles(t *testing.T, files map[string]string) []string {
+	t.Helper()
+	dir := t.TempDir()
+	var paths []string
+	for name, sql := range files {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(sql), 0o644))
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func TestParseSQLFiles_SyntaxErrorLocation(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"items.sql": `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text NOT NULL
+);
+
+CREATE TABEL public.items (
+    id integer
+);
+`,
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `failed to parse SQL: syntax error at or near "TABEL"
+ --> `+paths[0]+`:6:8
+  |
+6 | CREATE TABEL public.items (
+  |        ^`, err.Error())
+}
+
+func TestParseSQLFiles_SyntaxErrorInSecondFile(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "a.sql")
+	second := filepath.Join(dir, "b.sql")
+	require.NoError(t, os.WriteFile(first, []byte("CREATE TABLE public.users (\n    id integer NOT NULL\n);\n"), 0o644))
+	require.NoError(t, os.WriteFile(second, []byte("-- items\nCREATE TABLE public.items (\n    id integer x\n);\n"), 0o644))
+
+	_, err := parser.ParseSQLFilesWithSchema([]string{first, second}, "public")
+	require.Error(t, err)
+	assert.Equal(t, `failed to parse SQL: syntax error at or near "x"
+ --> `+second+`:3:16
+  |
+3 |     id integer x
+  |                ^`, err.Error())
+}
+
+func TestParseSQLFiles_SyntaxErrorAtFileStart(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "a.sql")
+	second := filepath.Join(dir, "b.sql")
+	require.NoError(t, os.WriteFile(first, []byte("CREATE TABLE public.a (id integer);\n"), 0o644))
+	require.NoError(t, os.WriteFile(second, []byte(");\n"), 0o644))
+
+	_, err := parser.ParseSQLFilesWithSchema([]string{first, second}, "public")
+	require.Error(t, err)
+	assert.Equal(t, `failed to parse SQL: syntax error at or near ")"
+ --> `+second+`:1:1
+  |
+1 | );
+  | ^`, err.Error())
+}
+
+func TestParseSQLFiles_SyntaxErrorInMiddleFile(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "a.sql")
+	second := filepath.Join(dir, "b.sql")
+	third := filepath.Join(dir, "c.sql")
+	require.NoError(t, os.WriteFile(first, []byte("CREATE TABLE public.a (id integer);\n"), 0o644))
+	require.NoError(t, os.WriteFile(second, []byte("CREATE TABLE public.b (id integer x);\n"), 0o644))
+	require.NoError(t, os.WriteFile(third, []byte("CREATE TABLE public.c (id integer);\n"), 0o644))
+
+	_, err := parser.ParseSQLFilesWithSchema([]string{first, second, third}, "public")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), second+":1:35")
+}
+
+func TestParseSQLFiles_SyntaxErrorTabIndent(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"tab.sql": "CREATE TABLE public.items (\n\tid integer x\n);\n",
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `failed to parse SQL: syntax error at or near "x"
+ --> `+paths[0]+`:2:13
+  |
+2 | `+"\tid integer x"+`
+  | `+"\t           ^", err.Error())
+}
+
+func TestParseSQLFiles_SyntaxErrorMultibyteColumn(t *testing.T) {
+	// Two 2-byte runes precede the bad token; the column counts runes.
+	paths := writeSQLFiles(t, map[string]string{
+		"mb.sql": "CREATE TABLE public.items (\n    note text DEFAULT '\u00e9\u00e9' x\n);\n",
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, "failed to parse SQL: syntax error at or near \"x\"\n"+
+		" --> "+paths[0]+":2:28\n"+
+		"  |\n"+
+		"2 |     note text DEFAULT '\u00e9\u00e9' x\n"+
+		"  |                            ^", err.Error())
+}
+
+func TestParseSQLFiles_SyntaxErrorAtEndOfInput(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"eof.sql": "CREATE TABLE public.items (",
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "syntax error at end of input")
+	assert.Contains(t, err.Error(), paths[0]+":1:28")
+}
+
+func TestParseSQLFiles_UnknownDirectiveLocation(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"dir.sql": `CREATE TABLE public.items (
+    id integer
+);
+
+-- pista:renmaed-from public.old_items
+CREATE TABLE public.new_items (
+    id integer
+);
+`,
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `unknown directive: -- pista:renmaed-from
+ --> `+paths[0]+`:5:10
+  |
+5 | -- pista:renmaed-from public.old_items
+  |          ^`, err.Error())
+}
+
+func TestParseSQLFiles_DirectiveWithArgsLocation(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"dir.sql": "-- pista:concurrently 123\nCREATE INDEX idx ON public.items (id);\n",
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `-- pista:concurrently does not accept arguments
+ --> `+paths[0]+`:1:1
+  |
+1 | -- pista:concurrently 123
+  | ^`, err.Error())
+}
+
+func TestAnnotateError_NoPosition(t *testing.T) {
+	err := assert.AnError
+	got := parser.AnnotateError(err, "CREATE TABLE t (id int);", []parser.FileSpan{parser.NewFileSpan("a.sql", 0)})
+	assert.Same(t, err, got)
+}
+
+func TestAnnotateError_CursorPastInput(t *testing.T) {
+	sql := "CREATE"
+	err := parser.NewLocatedError("boom", 100)
+	got := parser.AnnotateError(err, sql, []parser.FileSpan{parser.NewFileSpan("a.sql", 0)})
+	assert.Equal(t, `boom
+ --> a.sql:1:7
+  |
+1 | CREATE
+  |       ^`, got.Error())
+}
+
+func TestAnnotateError_WideGutter(t *testing.T) {
+	sql := "-- 1\n-- 2\n-- 3\n-- 4\n-- 5\n-- 6\n-- 7\n-- 8\n-- 9\nCREATE x"
+	err := parser.NewLocatedError("boom", len(sql)-1)
+	got := parser.AnnotateError(err, sql, []parser.FileSpan{parser.NewFileSpan("a.sql", 0)})
+	assert.Equal(t, `boom
+  --> a.sql:10:8
+   |
+10 | CREATE x
+   |        ^`, got.Error())
+}

--- a/parser/location_test.go
+++ b/parser/location_test.go
@@ -166,6 +166,31 @@ func TestParseSQLFiles_DirectiveWithArgsLocation(t *testing.T) {
   | ^`, err.Error())
 }
 
+func TestParseSQLFiles_SyntaxErrorOnStdin(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = origStdin
+		r.Close()
+	}()
+
+	go func() {
+		w.WriteString("CREATE TABEL public.items (id integer);\n")
+		w.Close()
+	}()
+
+	_, err = parser.ParseSQLFilesWithSchema([]string{"-"}, "public")
+	require.Error(t, err)
+	assert.Equal(t, `failed to parse SQL: syntax error at or near "TABEL"
+ --> <stdin>:1:8
+  |
+1 | CREATE TABEL public.items (id integer);
+  |        ^`, err.Error())
+}
+
 func TestAnnotateError_NoPosition(t *testing.T) {
 	err := assert.AnError
 	got := parser.AnnotateError(err, "CREATE TABLE t (id int);", []parser.FileSpan{parser.NewFileSpan("a.sql", 0)})

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -198,7 +198,11 @@ func ParseSQLFilesWithSchema(paths []string, defaultSchema string) (*ParseResult
 		if err != nil {
 			return nil, err
 		}
-		spans = append(spans, fileSpan{path: path, start: offset})
+		spanPath := path
+		if path == "-" {
+			spanPath = "<stdin>"
+		}
+		spans = append(spans, fileSpan{path: spanPath, start: offset})
 		sqls = append(sqls, sql)
 		offset += len(sql) + 1 // the "\n" the join puts between files
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -191,15 +191,24 @@ func readSQLFile(path string) (string, error) {
 
 func ParseSQLFilesWithSchema(paths []string, defaultSchema string) (*ParseResult, error) {
 	var sqls []string
+	var spans []fileSpan
+	offset := 0
 	for _, path := range paths {
 		sql, err := readSQLFile(path)
 		if err != nil {
 			return nil, err
 		}
+		spans = append(spans, fileSpan{path: path, start: offset})
 		sqls = append(sqls, sql)
+		offset += len(sql) + 1 // the "\n" the join puts between files
 	}
 
-	return parseSQLWithSchema(strings.Join(sqls, "\n"), defaultSchema)
+	joined := strings.Join(sqls, "\n")
+	result, err := parseSQLWithSchema(joined, defaultSchema)
+	if err != nil {
+		return nil, annotateError(err, joined, spans)
+	}
+	return result, nil
 }
 
 func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) {


### PR DESCRIPTION
A typo reported only `failed to parse SQL: syntax error at or near "TABEL"`, with nothing to say which file or line, and the desired schema often spans several files. pg_query's error carries the cursor position, a 1-based character index into the parsed SQL, so the location was always there; it was just dropped.

## What changed

`ParseSQLFilesWithSchema` records where each file starts in the SQL it joins, and a failed parse renders the position in the style of a compiler:

```
pista: error: failed to parse SQL: syntax error at or near "TABEL"
 --> schema/items.sql:6:8
  |
6 | CREATE TABEL public.items (
  |        ^
```

The line number is local to the file the error is in. Directive validation returns the match offset its regexes already had, so an unknown or malformed `-- pista:` directive gets the same block. The caret pad keeps tabs so it lands under the column however the line is indented, and the column counts runes, matching how PostgreSQL counts the cursor. An error without a position is returned as it was, and no message text changed.

Duplicate-object errors still carry no position; giving them one means threading locations through every parse function.

## Tests

Twelve cases: a typo mid-file, an error in the second and in the middle of three files, an error at a file's first character, tab indentation, a multibyte line, an error at end of input, an unknown directive, a directive given arguments, an error without a position, a cursor past the input, and a two-digit line number. The parser fuzz target now runs the renderer on every failed parse, so arbitrary input cannot panic it.

Parser coverage goes from 93.7% to 93.9%; the new file is fully covered.