### PR TITLE
Name the object and the position in a duplicate-name error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Name the object and the position in a duplicate-name error. `duplicate column: id` said neither which table the column was on nor where the file repeats it. It now reads `duplicate column: id on public.users` and prints the line with a caret under it, as a syntax error does. A column or constraint is pointed at where it is defined, everything else at the statement that repeats the name. The checks that report a clash between two objects, a table and a view of one name for example, are unchanged.
+
 ## [1.40.0] - 2026-09-04
 
 * Name the file, line and column in parse errors. A syntax error or a bad `-- pista:` directive now prints the offending line with a caret under the column, in the style of a compiler, instead of the bare message. With several schema files the line number is local to the file the error is in.

--- a/parser/location.go
+++ b/parser/location.go
@@ -7,8 +7,22 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	pg_query "github.com/pganalyze/pg_query_go/v6"
 	pgparser "github.com/pganalyze/pg_query_go/v6/parser"
 )
+
+// stmtStart returns the byte offset of a statement's first token. pg_query
+// counts the blank lines and comments before a statement as part of it, so
+// StmtLocation on its own can point at whitespace rather than at the keyword.
+func stmtStart(sql string, rawStmt *pg_query.RawStmt) int32 {
+	start := rawStmt.StmtLocation
+	end := start + rawStmt.StmtLen
+	// pg_query leaves StmtLen at 0 for the final statement in the input.
+	if rawStmt.StmtLen == 0 || end > int32(len(sql)) {
+		end = int32(len(sql))
+	}
+	return start + int32(findLeadingCommentEnd(sql[start:end]))
+}
 
 // fileSpan records where a desired-schema file starts in the SQL handed to
 // the parser, which parses every file joined into one input.

--- a/parser/location_test.go
+++ b/parser/location_test.go
@@ -166,6 +166,133 @@ func TestParseSQLFiles_DirectiveWithArgsLocation(t *testing.T) {
   | ^`, err.Error())
 }
 
+func TestParseSQLFiles_DuplicateColumnLocation(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"users.sql": `CREATE TABLE public.users (
+    id integer NOT NULL,
+    name text,
+    id bigint
+);
+`,
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `duplicate column: id on public.users
+ --> `+paths[0]+`:4:5
+  |
+4 |     id bigint
+  |     ^`, err.Error())
+}
+
+func TestParseSQLFiles_DuplicateConstraintLocation(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"users.sql": `CREATE TABLE public.users (
+    id integer,
+    CONSTRAINT users_check CHECK (id > 0),
+    CONSTRAINT users_check UNIQUE (id)
+);
+`,
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `duplicate constraint: users_check on public.users
+ --> `+paths[0]+`:4:5
+  |
+4 |     CONSTRAINT users_check UNIQUE (id)
+  |     ^`, err.Error())
+}
+
+// A constraint written on the column carries its own position, so the caret
+// lands on it rather than on the start of the line.
+func TestParseSQLFiles_DuplicateColumnConstraintLocation(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"users.sql": `CREATE TABLE public.users (
+    id integer CONSTRAINT users_key PRIMARY KEY,
+    code text CONSTRAINT users_key UNIQUE
+);
+`,
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `duplicate constraint: users_key on public.users
+ --> `+paths[0]+`:3:15
+  |
+3 |     code text CONSTRAINT users_key UNIQUE
+  |               ^`, err.Error())
+}
+
+// The leading comment and blank line belong to the second statement as far as
+// pg_query is concerned, so the caret has to skip them to reach CREATE.
+func TestParseSQLFiles_DuplicateTableLocationSkipsLeadingComment(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"users.sql": `CREATE TABLE public.users (id integer);
+
+-- the same table again
+CREATE TABLE public.users (id integer);
+`,
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `duplicate table: public.users
+ --> `+paths[0]+`:4:1
+  |
+4 | CREATE TABLE public.users (id integer);
+  | ^`, err.Error())
+}
+
+// pg_query leaves StmtLen at 0 for a final statement with no semicolon, so
+// the statement region runs to the end of the input.
+func TestParseSQLFiles_DuplicateTableLocationWithoutTrailingSemicolon(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"users.sql": "CREATE TABLE public.users (id integer);\n\n-- again\nCREATE TABLE public.users (id integer)",
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `duplicate table: public.users
+ --> `+paths[0]+`:4:1
+  |
+4 | CREATE TABLE public.users (id integer)
+  | ^`, err.Error())
+}
+
+func TestParseSQLFiles_DuplicateTableInSecondFile(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "a.sql")
+	second := filepath.Join(dir, "b.sql")
+	require.NoError(t, os.WriteFile(first, []byte("CREATE TABLE public.users (id integer);\n"), 0o644))
+	require.NoError(t, os.WriteFile(second, []byte("CREATE TABLE public.items (id integer);\nCREATE TABLE public.users (id bigint);\n"), 0o644))
+
+	_, err := parser.ParseSQLFilesWithSchema([]string{first, second}, "public")
+	require.Error(t, err)
+	assert.Equal(t, `duplicate table: public.users
+ --> `+second+`:2:1
+  |
+2 | CREATE TABLE public.users (id bigint);
+  | ^`, err.Error())
+}
+
+func TestParseSQLFiles_DuplicatePolicyLocation(t *testing.T) {
+	paths := writeSQLFiles(t, map[string]string{
+		"users.sql": `CREATE TABLE public.users (id integer);
+CREATE POLICY p ON public.users USING (true);
+CREATE POLICY p ON public.users USING (false);
+`,
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.Error(t, err)
+	assert.Equal(t, `duplicate policy: p on public.users
+ --> `+paths[0]+`:3:1
+  |
+3 | CREATE POLICY p ON public.users USING (false);
+  | ^`, err.Error())
+}
+
 func TestParseSQLFiles_SyntaxErrorOnStdin(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -161,9 +161,20 @@ func warnIgnoredAlterTableCmds(sql string, rawStmt *pg_query.RawStmt, as *pg_que
 	})
 }
 
-func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V) error {
+// setUnique records v under key and rejects a name the map already holds.
+// on names the object the key belongs to, empty for a name that stands on its
+// own in a schema. offset is where in the parsed SQL the message points, so
+// the error can name the file, line and column of the repeat.
+func setUnique[V any](m *orderedmap.Map[string, V], key, kind string, v V, on string, offset int32) error {
 	if _, ok := m.GetOk(key); ok {
-		return fmt.Errorf("duplicate %s: %s", kind, key)
+		scope := ""
+		if on != "" {
+			scope = " on " + on
+		}
+		return &locatedError{
+			msg:    fmt.Sprintf("duplicate %s: %s%s", kind, key, scope),
+			offset: int(offset),
+		}
 	}
 	m.Set(key, v)
 	return nil
@@ -251,6 +262,9 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 		node := rawStmt.Stmt
 		renameFrom := stmtDirectives[rawStmt.StmtLocation]
 		ignore := ignoreDirectives[rawStmt.StmtLocation]
+		// Where a duplicate-name error points when the repeat is the
+		// statement itself rather than a part of one.
+		stmtOffset := stmtStart(sql, rawStmt)
 
 		switch {
 		case node.GetCreateEnumStmt() != nil:
@@ -283,7 +297,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			}
 
 			enum.Ignore = ignore
-			if err := setUnique(enums, enum.FQEN(), "enum", enum); err != nil {
+			if err := setUnique(enums, enum.FQEN(), "enum", enum, "", stmtOffset); err != nil {
 				return nil, err
 			}
 
@@ -297,7 +311,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				domain.RenameFrom = &qualified
 			}
 			domain.Ignore = ignore
-			if err := setUnique(domains, domain.FQDN(), "domain", domain); err != nil {
+			if err := setUnique(domains, domain.FQDN(), "domain", domain, "", stmtOffset); err != nil {
 				return nil, err
 			}
 
@@ -328,7 +342,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			}
 
 			compositeType.Ignore = ignore
-			if err := setUnique(compositeTypes, compositeType.FQCN(), "composite type", compositeType); err != nil {
+			if err := setUnique(compositeTypes, compositeType.FQCN(), "composite type", compositeType, "", stmtOffset); err != nil {
 				return nil, err
 			}
 
@@ -369,7 +383,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			}
 
 			table.Ignore = ignore
-			if err := setUnique(tables, table.FQTN(), "table", table); err != nil {
+			if err := setUnique(tables, table.FQTN(), "table", table, "", stmtOffset); err != nil {
 				return nil, err
 			}
 
@@ -383,7 +397,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				view.RenameFrom = &qualified
 			}
 			view.Ignore = ignore
-			if err := setUnique(views, view.FQVN(), "view", view); err != nil {
+			if err := setUnique(views, view.FQVN(), "view", view, "", stmtOffset); err != nil {
 				return nil, err
 			}
 
@@ -399,7 +413,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 					view.RenameFrom = &qualified
 				}
 				view.Ignore = ignore
-				if err := setUnique(views, view.FQVN(), "materialized view", view); err != nil {
+				if err := setUnique(views, view.FQVN(), "materialized view", view, "", stmtOffset); err != nil {
 					return nil, err
 				}
 			}
@@ -418,11 +432,11 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			}
 			fqtn := model.Ident(idx.Schema, idx.Table)
 			if t, ok := tables.GetOk(fqtn); ok {
-				if err := setUnique(t.Indexes, idx.Name, "index", idx); err != nil {
+				if err := setUnique(t.Indexes, idx.Name, "index", idx, fqtn, stmtOffset); err != nil {
 					return nil, err
 				}
 			} else if v, ok := views.GetOk(fqtn); ok && v.Materialized {
-				if err := setUnique(v.Indexes, idx.Name, "index", idx); err != nil {
+				if err := setUnique(v.Indexes, idx.Name, "index", idx, fqtn, stmtOffset); err != nil {
 					return nil, err
 				}
 			}
@@ -467,7 +481,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 					unquoted := normalizeUnqualifiedDirective(renameFrom)
 					fk.RenameFrom = &unquoted
 				}
-				if err := setUnique(t.ForeignKeys, fk.Name, "foreign key", fk); err != nil {
+				if err := setUnique(t.ForeignKeys, fk.Name, "foreign key", fk, fqtn, stmtOffset); err != nil {
 					return nil, err
 				}
 			}
@@ -476,13 +490,13 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 					unquoted := normalizeUnqualifiedDirective(renameFrom)
 					con.RenameFrom = &unquoted
 				}
-				if err := setUnique(t.Constraints, con.Name, "constraint", con); err != nil {
+				if err := setUnique(t.Constraints, con.Name, "constraint", con, fqtn, stmtOffset); err != nil {
 					return nil, err
 				}
 			}
 
 		case node.GetCreatePolicyStmt() != nil:
-			policy, err := parseCreatePolicyStmt(node.GetCreatePolicyStmt(), defaultSchema, tables)
+			policy, err := parseCreatePolicyStmt(node.GetCreatePolicyStmt(), defaultSchema, tables, stmtOffset)
 			if err != nil {
 				return nil, err
 			}
@@ -500,7 +514,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				unquoted := normalizeUnqualifiedDirective(renameFrom)
 				trg.RenameFrom = &unquoted
 			}
-			if err := attachTrigger(trg, tables, views); err != nil {
+			if err := attachTrigger(trg, tables, views, stmtOffset); err != nil {
 				return nil, err
 			}
 
@@ -514,7 +528,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 				seq.RenameFrom = &qualified
 			}
 			seq.Ignore = ignore
-			if err := setUnique(sequences, seq.FQN(), "sequence", seq); err != nil {
+			if err := setUnique(sequences, seq.FQN(), "sequence", seq, "", stmtOffset); err != nil {
 				return nil, err
 			}
 
@@ -539,7 +553,7 @@ func parseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) 
 			// The parser sets Ignore itself for a routine it reads but cannot
 			// compare, so this must not clear it.
 			routine.Ignore = routine.Ignore || ignore
-			if err := setUnique(routines, routine.FQRN(), "routine", routine); err != nil {
+			if err := setUnique(routines, routine.FQRN(), "routine", routine, "", stmtOffset); err != nil {
 				return nil, err
 			}
 
@@ -633,7 +647,7 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 			if err != nil {
 				return nil, err
 			}
-			if err := setUnique(table.Columns, col.Name, "column", col); err != nil {
+			if err := setUnique(table.Columns, col.Name, "column", col, table.FQTN(), cd.Location); err != nil {
 				return nil, err
 			}
 
@@ -650,7 +664,7 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 					return nil, err
 				}
 				if fk != nil {
-					if err := setUnique(table.ForeignKeys, fk.Name, "foreign key", fk); err != nil {
+					if err := setUnique(table.ForeignKeys, fk.Name, "foreign key", fk, table.FQTN(), con.Location); err != nil {
 						return nil, err
 					}
 				}
@@ -660,7 +674,7 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 					return nil, err
 				}
 				if constraint != nil {
-					if err := setUnique(table.Constraints, constraint.Name, "constraint", constraint); err != nil {
+					if err := setUnique(table.Constraints, constraint.Name, "constraint", constraint, table.FQTN(), con.Location); err != nil {
 						return nil, err
 					}
 					// PK implies NOT NULL on all key columns
@@ -1161,7 +1175,7 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 				return err
 			}
 			if fk != nil {
-				if err := setUnique(table.ForeignKeys, fk.Name, "foreign key", fk); err != nil {
+				if err := setUnique(table.ForeignKeys, fk.Name, "foreign key", fk, table.FQTN(), con.Location); err != nil {
 					return err
 				}
 			}
@@ -1172,7 +1186,7 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 				return err
 			}
 			if constraint != nil {
-				if err := setUnique(table.Constraints, constraint.Name, "constraint", constraint); err != nil {
+				if err := setUnique(table.Constraints, constraint.Name, "constraint", constraint, table.FQTN(), con.Location); err != nil {
 					return err
 				}
 			}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1516,7 +1516,7 @@ CREATE INDEX ON public.t (a);
 CREATE INDEX ON public.t (a) WHERE b > 0;`
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate index: t_a_idx")
+	assert.Equal(t, "duplicate index: t_a_idx on public.t", err.Error())
 }
 
 func TestParseSQL_NullColumnConstraintIsNotAConstraint(t *testing.T) {
@@ -1712,7 +1712,7 @@ CREATE INDEX idx ON public.mv (cnt);`
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate index")
+	assert.Equal(t, "duplicate index: idx on public.mv", err.Error())
 }
 
 func TestParseSQL_IndexOnSchemalessTable(t *testing.T) {
@@ -2055,7 +2055,7 @@ CREATE INDEX idx_name ON public.users (name);`
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate index")
+	assert.Equal(t, "duplicate index: idx_name on public.users", err.Error())
 }
 
 func TestParseSQL_DuplicateConstraint(t *testing.T) {
@@ -2068,7 +2068,7 @@ func TestParseSQL_DuplicateConstraint(t *testing.T) {
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate constraint")
+	assert.Equal(t, "duplicate constraint: items_pkey on public.items", err.Error())
 }
 
 func TestParseSQL_DuplicateColumn(t *testing.T) {
@@ -2080,7 +2080,7 @@ func TestParseSQL_DuplicateColumn(t *testing.T) {
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate column")
+	assert.Equal(t, "duplicate column: id on public.users", err.Error())
 }
 
 func TestParseSQL_DuplicateForeignKeyAlterTable(t *testing.T) {
@@ -2091,7 +2091,7 @@ ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCE
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate foreign key")
+	assert.Equal(t, "duplicate foreign key: fk_user on public.orders", err.Error())
 }
 
 func TestParseSQL_DuplicateConstraintAlterTable(t *testing.T) {
@@ -2101,7 +2101,7 @@ ALTER TABLE public.items ADD CONSTRAINT items_code_unique UNIQUE (code);`
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate constraint")
+	assert.Equal(t, "duplicate constraint: items_code_unique on public.items", err.Error())
 }
 
 func TestParseSQL_DuplicateInlineForeignKey(t *testing.T) {
@@ -2115,7 +2115,7 @@ CREATE TABLE public.items (
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate foreign key")
+	assert.Equal(t, "duplicate foreign key: items_fk on public.items", err.Error())
 }
 
 func TestParseSQL_DuplicateColumnLevelConstraint(t *testing.T) {
@@ -2126,7 +2126,7 @@ func TestParseSQL_DuplicateColumnLevelConstraint(t *testing.T) {
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate constraint")
+	assert.Equal(t, "duplicate constraint: items_pkey on public.items", err.Error())
 }
 
 func TestParseSQL_DuplicateColumnLevelForeignKey(t *testing.T) {
@@ -2138,7 +2138,7 @@ CREATE TABLE public.items (
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate foreign key")
+	assert.Equal(t, "duplicate foreign key: items_fk on public.items", err.Error())
 }
 
 func TestParseSQL_PolicyOnUnknownTable(t *testing.T) {
@@ -2157,7 +2157,7 @@ CREATE POLICY p ON public.documents FOR ALL USING (owner = current_user);`
 
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate policy")
+	assert.Equal(t, "duplicate policy: p on public.documents", err.Error())
 }
 
 func TestParseSQLWithSchema_ViewComment(t *testing.T) {

--- a/parser/policy.go
+++ b/parser/policy.go
@@ -36,11 +36,13 @@ func applyAlterTableRLS(as *pg_query.AlterTableStmt, t *model.Table) {
 // parseCreatePolicyStmt converts a CreatePolicyStmt into a model.Policy and
 // attaches it to the owning table. Returns the created policy so the caller
 // can apply post-parse decorations (e.g. RenameFrom). The table must already
-// exist in `tables`, otherwise an error is returned.
+// exist in `tables`, otherwise an error is returned. offset is where the
+// statement starts, which a duplicate-name error points at.
 func parseCreatePolicyStmt(
 	cps *pg_query.CreatePolicyStmt,
 	defaultSchema string,
 	tables *orderedmap.Map[string, *model.Table],
+	offset int32,
 ) (*model.Policy, error) {
 	if cps.Table == nil {
 		return nil, fmt.Errorf("CREATE POLICY: missing table reference")
@@ -89,7 +91,7 @@ func parseCreatePolicyStmt(
 		policy.WithCheck = &wc
 	}
 
-	if err := setUnique(tbl.Policies, policy.Name, "policy", policy); err != nil {
+	if err := setUnique(tbl.Policies, policy.Name, "policy", policy, fqtn, offset); err != nil {
 		return nil, err
 	}
 	return policy, nil

--- a/parser/trigger.go
+++ b/parser/trigger.go
@@ -48,18 +48,20 @@ func parseCreateTrigStmt(ct *pg_query.CreateTrigStmt, defaultSchema string) (*mo
 
 // attachTrigger files a parsed trigger under the table or view it is on. A
 // trigger names its relation, so the relation has to be declared first, the
-// way CREATE POLICY needs its table.
+// way CREATE POLICY needs its table. offset is where the statement starts,
+// which a duplicate-name error points at.
 func attachTrigger(
 	trg *model.Trigger,
 	tables *orderedmap.Map[string, *model.Table],
 	views *orderedmap.Map[string, *model.View],
+	offset int32,
 ) error {
 	fqtn := trg.FQTN()
 	if t, ok := tables.GetOk(fqtn); ok {
-		return setUnique(t.Triggers, trg.Name, "trigger", trg)
+		return setUnique(t.Triggers, trg.Name, "trigger", trg, fqtn, offset)
 	}
 	if v, ok := views.GetOk(fqtn); ok {
-		return setUnique(v.Triggers, trg.Name, "trigger", trg)
+		return setUnique(v.Triggers, trg.Name, "trigger", trg, fqtn, offset)
 	}
 	return fmt.Errorf("CREATE TRIGGER %s: relation %s not defined", trg.Name, fqtn)
 }

--- a/parser/trigger_test.go
+++ b/parser/trigger_test.go
@@ -105,7 +105,7 @@ CREATE TRIGGER t_ins BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION sta
 CREATE TRIGGER t_ins BEFORE DELETE ON public.t FOR EACH ROW EXECUTE FUNCTION stamp();`
 	_, err := parseSQLWithPublicSchema(sql)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate trigger")
+	assert.Equal(t, "duplicate trigger: t_ins on public.t", err.Error())
 }
 
 // The same trigger name on two tables is legal: a trigger name is unique


### PR DESCRIPTION
`duplicate column: id` said neither which table the column was on nor where the file repeats it. The parse-error location added in 1.40.0 covered syntax errors and directives only; duplicates were left out because giving them one meant threading locations through the parse functions.

`setUnique` now takes the object the name belongs to and the offset to point at, and returns a `locatedError`, so a duplicate gets the block a syntax error already gets:

```
duplicate column: id on public.users
 --> schema/users.sql:4:5
  |
4 |     id bigint
  |     ^
```

A column or constraint carries the location pg_query records on its own node, so the caret lands on the definition that repeats the name; every other kind points at the statement. pg_query counts the blank lines and comments before a statement as part of it, so `stmtStart` skips them by the rule the directive scan already uses.

The checks in `validateNamespaces` are unchanged. They report a clash between two objects rather than within one, and already name the scope.

## Tests

Location tests cover a duplicate column, a column-level constraint, a table-level constraint, a statement after a comment, a statement with no trailing semicolon, a second file, and a policy. The existing duplicate tests move from `Contains` to `Equal` so every kind's scope is fixed.

`go test ./parser/...` and `make lint` pass; parser coverage is 94.1% against 94.0% on main, with `setUnique` and `stmtStart` at 100%. The suites that need PostgreSQL were not run here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bs8AvcMuU5ea5tcym8uKi

---
_Generated by [Claude Code](https://claude.ai/code/session_017bs8AvcMuU5ea5tcym8uKi)_