### PR TITLE
Read the desired schema before connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Read the desired schema before connecting. `plan` and `apply` opened the connection first, so a missing file, a syntax error or a duplicate name was reported only once the database answered, and a run against an unreachable database reported the connection rather than the file. Both now read and parse the schema files, and resolve `--pre-sql-file` and `--concurrently-pre-sql-file`, before connecting. A successful run is unchanged; one that cannot read its own files opens no connection, and takes no lock under `--exclusive`.
+
 ## [1.40.0] - 2026-09-04
 
 * Name the file, line and column in parse errors. A syntax error or a bad `-- pista:` directive now prints the offending line with a caret under the column, in the style of a compiler, instead of the bare message. With several schema files the line number is local to the file the error is in.

--- a/apply.go
+++ b/apply.go
@@ -55,6 +55,15 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	if err := client.validateSchemas(); err != nil {
 		return nil, err
 	}
+	desired, err := client.loadDesiredInput(
+		options.Files,
+		options.PreSQL, options.PreSQLFile,
+		options.ConcurrentlyPreSQL, options.ConcurrentlyPreSQLFile,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	conn, err := client.connect(ctx, false)
 	if err != nil {
 		return nil, err
@@ -73,11 +82,7 @@ func (client *Client) Apply(ctx context.Context, options *ApplyOptions, w io.Wri
 	result, err := client.diffAll(ctx, conn, &diffAllOptions{
 		FilterOptions:            options.FilterOptions,
 		DropPolicy:               options.DropPolicy,
-		Files:                    options.Files,
-		PreSQL:                   options.PreSQL,
-		PreSQLFile:               options.PreSQLFile,
-		ConcurrentlyPreSQL:       options.ConcurrentlyPreSQL,
-		ConcurrentlyPreSQLFile:   options.ConcurrentlyPreSQLFile,
+		Desired:                  desired,
 		DisableIndexConcurrently: options.DisableIndexConcurrently,
 		ForceIndexConcurrently:   options.ForceIndexConcurrently,
 		BulkAlter:                options.BulkAlter,

--- a/desired_input_test.go
+++ b/desired_input_test.go
@@ -1,0 +1,96 @@
+package pistachio_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio"
+)
+
+// unreachableConnStr points at a port nothing listens on, so a run that
+// reaches the connection fails with a connect error instead of the error under
+// test. These cases need no database precisely because the files are read
+// first.
+const unreachableConnStr = "postgres://postgres@127.0.0.1:1/postgres?connect_timeout=1"
+
+func unreachableClient() *pistachio.Client {
+	return pistachio.NewClient(&pistachio.Options{
+		ConnString: unreachableConnStr,
+		Schemas:    []string{"public"},
+	})
+}
+
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestPlan_SyntaxErrorWithoutDatabase(t *testing.T) {
+	path := writeTempFile(t, "desired.sql", "CREATE TABEL public.items (id integer);\n")
+
+	_, err := unreachableClient().Plan(context.Background(), &pistachio.PlanOptions{Files: []string{path}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `syntax error at or near "TABEL"`)
+	assert.NotContains(t, err.Error(), "failed to connect database")
+}
+
+func TestApply_SyntaxErrorWithoutDatabase(t *testing.T) {
+	path := writeTempFile(t, "desired.sql", "CREATE TABEL public.items (id integer);\n")
+
+	_, err := unreachableClient().Apply(context.Background(), &pistachio.ApplyOptions{Files: []string{path}}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `syntax error at or near "TABEL"`)
+	assert.NotContains(t, err.Error(), "failed to connect database")
+}
+
+func TestPlan_MissingDesiredFileWithoutDatabase(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.sql")
+
+	_, err := unreachableClient().Plan(context.Background(), &pistachio.PlanOptions{Files: []string{missing}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read SQL file")
+	assert.NotContains(t, err.Error(), "failed to connect database")
+}
+
+func TestPlan_MissingPreSQLFileWithoutDatabase(t *testing.T) {
+	desired := writeTempFile(t, "desired.sql", "CREATE TABLE public.items (id integer);\n")
+	missing := filepath.Join(t.TempDir(), "pre.sql")
+
+	_, err := unreachableClient().Plan(context.Background(), &pistachio.PlanOptions{
+		Files:      []string{desired},
+		PreSQLFile: missing,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read pre-SQL file")
+	assert.NotContains(t, err.Error(), "failed to connect database")
+}
+
+func TestApply_MissingConcurrentlyPreSQLFileWithoutDatabase(t *testing.T) {
+	desired := writeTempFile(t, "desired.sql", "CREATE TABLE public.items (id integer);\n")
+	missing := filepath.Join(t.TempDir(), "pre.sql")
+
+	_, err := unreachableClient().Apply(context.Background(), &pistachio.ApplyOptions{
+		Files:                  []string{desired},
+		ConcurrentlyPreSQLFile: missing,
+	}, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read concurrently-pre-SQL file")
+	assert.NotContains(t, err.Error(), "failed to connect database")
+}
+
+// A schema file that parses still needs the database, so the run gets no
+// further than the connection.
+func TestPlan_ValidSchemaStillNeedsDatabase(t *testing.T) {
+	path := writeTempFile(t, "desired.sql", "CREATE TABLE public.items (id integer);\n")
+
+	_, err := unreachableClient().Plan(context.Background(), &pistachio.PlanOptions{Files: []string{path}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect database")
+}

--- a/diff_all.go
+++ b/diff_all.go
@@ -19,15 +19,51 @@ import (
 type diffAllOptions struct {
 	FilterOptions
 	DropPolicy
-	Files                    []string
-	PreSQL                   string
-	PreSQLFile               string
-	ConcurrentlyPreSQL       string
-	ConcurrentlyPreSQLFile   string
+	Desired                  *desiredInput
 	DisableIndexConcurrently bool
 	ForceIndexConcurrently   bool
 	BulkAlter                bool
 	AssumeValidated          bool
+}
+
+// desiredInput is what a run reads from the file system: the parsed desired
+// schema and the pre-SQL that goes with it.
+type desiredInput struct {
+	schema             *parser.ParseResult
+	preSQL             string
+	concurrentlyPreSQL string
+}
+
+// loadDesiredInput reads and parses every file a diff needs. Plan and Apply
+// call it before they connect, so a missing file, a syntax error or a
+// duplicate name is reported without a database, and an exclusive apply does
+// not take its lock before it can read its own input.
+func (client *Client) loadDesiredInput(
+	files []string,
+	preSQL, preSQLFile string,
+	concurrentlyPreSQL, concurrentlyPreSQLFile string,
+) (*desiredInput, error) {
+	// Not wrapped: the parser's message already names the file.
+	schema, err := parser.ParseSQLFilesWithSchema(files, client.Schemas[0])
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedPreSQL, err := resolvePreSQL(preSQL, preSQLFile)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedConcurrentlyPreSQL, err := resolveConcurrentlyPreSQL(concurrentlyPreSQL, concurrentlyPreSQLFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &desiredInput{
+		schema:             schema,
+		preSQL:             resolvedPreSQL,
+		concurrentlyPreSQL: resolvedConcurrentlyPreSQL,
+	}, nil
 }
 
 // diffAllResult holds the result of diffAll.
@@ -90,11 +126,7 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		}
 	}
 
-	// Not wrapped: the parser's message already names the file.
-	desired, err := parser.ParseSQLFilesWithSchema(options.Files, client.Schemas[0])
-	if err != nil {
-		return nil, err
-	}
+	desired := options.Desired.schema
 
 	filterDesiredBySchemas(desired, client.Schemas, client.SchemaMap)
 
@@ -218,16 +250,6 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		enumDiff, domainDiff, compositeTypeDiff, tableDiff, viewDiff, sequenceDiff, routineDiff,
 	)
 
-	preSQL, err := resolvePreSQL(options.PreSQL, options.PreSQLFile)
-	if err != nil {
-		return nil, err
-	}
-
-	concurrentlyPreSQL, err := resolveConcurrentlyPreSQL(options.ConcurrentlyPreSQL, options.ConcurrentlyPreSQLFile)
-	if err != nil {
-		return nil, err
-	}
-
 	var disallowed []string
 	disallowed = append(disallowed, viewDiff.DisallowedDropStmts...)
 	disallowed = append(disallowed, tableDiff.DisallowedDropStmts...)
@@ -241,8 +263,8 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		Stmts:                stmts,
 		DisallowedDrops:      disallowed,
 		Ignored:              ignoredComments,
-		PreSQL:               preSQL,
-		ConcurrentlyPreSQL:   concurrentlyPreSQL,
+		PreSQL:               options.Desired.preSQL,
+		ConcurrentlyPreSQL:   options.Desired.concurrentlyPreSQL,
 		Count:                count,
 		ExecuteStmts:         desired.ExecuteStmts,
 		HasConcurrentlyIndex: tableDiff.HasConcurrently || viewDiff.HasConcurrently,

--- a/docs/guides/exclusive-apply.md
+++ b/docs/guides/exclusive-apply.md
@@ -1,6 +1,6 @@
 # Preventing concurrent applies
 
-Two apply runs on one database can interleave: each computes its diff from a state the other is changing. `--exclusive` makes apply runs mutually exclusive. While another exclusive apply is running, the command fails at once, before anything is read or applied:
+Two apply runs on one database can interleave: each computes its diff from a state the other is changing. `--exclusive` makes apply runs mutually exclusive. While another exclusive apply is running, the command fails at once, before the database is read or anything is applied:
 
 ```bash
 pista apply schema.sql --exclusive
@@ -16,7 +16,7 @@ Also available as `$PISTA_EXCLUSIVE` / `$PISTA_EXCLUSIVE_WAIT`.
 
 ## How it works
 
-The exclusion is a session-level [advisory lock](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS), taken right after connecting and before the current schema is read, so the diff never reflects a state another exclusive apply is changing. It holds no table lock and does not block reads or writes. It is released when the connection closes, including on a crash.
+The exclusion is a session-level [advisory lock](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS), taken right after connecting and before the current schema is read, so the diff never reflects a state another exclusive apply is changing. The desired schema files are read before the connection is opened, so a file that cannot be read or parsed fails without taking the lock. It holds no table lock and does not block reads or writes. It is released when the connection closes, including on a crash.
 
 Transaction boundaries do not affect a session-level lock, so it works the same with and without `--with-tx` and across `CREATE INDEX CONCURRENTLY`. The lock key includes a hash of the database name; applies to different databases on one cluster do not exclude each other.
 

--- a/plan.go
+++ b/plan.go
@@ -82,6 +82,15 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	if err := client.validateSchemas(); err != nil {
 		return nil, err
 	}
+	desired, err := client.loadDesiredInput(
+		options.Files,
+		options.PreSQL, options.PreSQLFile,
+		options.ConcurrentlyPreSQL, options.ConcurrentlyPreSQLFile,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	conn, err := client.connect(ctx, !options.NoReadOnly)
 	if err != nil {
 		return nil, err
@@ -91,11 +100,7 @@ func (client *Client) Plan(ctx context.Context, options *PlanOptions) (*PlanResu
 	result, err := client.diffAll(ctx, conn, &diffAllOptions{
 		FilterOptions:            options.FilterOptions,
 		DropPolicy:               options.DropPolicy,
-		Files:                    options.Files,
-		PreSQL:                   options.PreSQL,
-		PreSQLFile:               options.PreSQLFile,
-		ConcurrentlyPreSQL:       options.ConcurrentlyPreSQL,
-		ConcurrentlyPreSQLFile:   options.ConcurrentlyPreSQLFile,
+		Desired:                  desired,
 		DisableIndexConcurrently: options.DisableIndexConcurrently,
 		ForceIndexConcurrently:   options.ForceIndexConcurrently,
 		BulkAlter:                options.BulkAlter,


### PR DESCRIPTION
`plan` and `apply` opened the connection first and only then read their files, so a missing file, a syntax error or a duplicate name was reported once the database had answered. A run against an unreachable database reported the connection rather than the file that was wrong whatever the database said, and an exclusive apply took its advisory lock before finding out it could not read its own input.

Nothing in the parse depends on the server: it needs the file paths and the first target schema, both of which are options. `loadDesiredInput` gathers what a run reads from the file system, the parsed schema and the resolved pre-SQL, and `Plan` and `Apply` call it before `connect` and hand the result to `diffAll`.

A successful run is unchanged, and so is every message. What changes is which error a broken run reports first, and that no connection is opened for one that cannot read its own files.

## Tests

`desired_input_test.go` points at a port nothing listens on and checks that `plan` and `apply` report a syntax error, a missing schema file and a missing pre-SQL file without a database, and that a schema that parses still reports the connection. All five fail without the change.

`go test` on the packages that need no database, `make lint` and `deadcode` pass. `loadDesiredInput` is at 100% from those tests alone. The suites that need PostgreSQL were not run here, so the claim that `--exclusive` no longer takes its lock for an unreadable file is not covered by a test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bs8AvcMuU5ea5tcym8uKi

---
_Generated by [Claude Code](https://claude.ai/code/session_017bs8AvcMuU5ea5tcym8uKi)_