### PR TITLE
Read a directive that follows a block comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## [Unreleased]
 
+* Read a directive that follows a `/* ... */` comment. The scan for the comments before a statement stopped at the first block comment, so a directive written after one was never seen: a `-- pista:renamed-from` under a block comment planned a drop and a create instead of a rename, and a block comment left at the end of the line above did the same. Both comment forms are now skipped, nested block comments included, and a directive inside a block comment stays commented out. The position an error or a warning points at skips them as well, so it lands on the statement rather than on the `/*` line or on the indent.
+
 * Apply a directive on a file's last statement when it ends without a semicolon. pg_query reports no length for such a statement, so the scans that carve out a statement's text got an empty region: `-- pista:renamed-from` planned a drop and a create instead of a rename, `-- pista:ignore` left the object managed, and `-- pista:execute` left the statement to the ignored-statement warning instead of running it at apply. `-- pista:concurrently`, `-- pista:bulk-alter` and the inline column, enum value and composite attribute renames went the same way. The scans now share one helper, which reads such a statement to the end of the input.
 
 * Name the file, line and column in the ignored-statement warning. It carried the statement text alone, which does not say where the statement is when the schema spans several files, or when the same `GRANT` appears in more than one of them. It now reads `pistachio: schema/items.sql:12:1: ignored unsupported statement: DROP TABLE public.items`. A parse that came from no file names no position.
+
 * Read the desired schema before connecting. `plan` and `apply` opened the connection first, so a missing file, a syntax error or a duplicate name was reported only once the database answered, and a run against an unreachable database reported the connection rather than the file. Both now read and parse the schema files, and resolve `--pre-sql-file` and `--concurrently-pre-sql-file`, before connecting. A successful run is unchanged; one that cannot read its own files opens no connection, and takes no lock under `--exclusive`.
+
 * Name the object and the position in a duplicate-name error. `duplicate column: id` said neither which table the column was on nor where the file repeats it. It now reads `duplicate column: id on public.users` and prints the line with a caret under it, as a syntax error does. A column or constraint is pointed at where it is defined, everything else at the statement that repeats the name. The checks that report a clash between two objects, a table and a view of one name for example, are unchanged.
 
 ## [1.40.0] - 2026-09-04

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -1,6 +1,6 @@
 # Directives
 
-pistachio reads directives from SQL comments in schema files. A directive is a line comment of the form `-- pista:<name>` placed on its own line immediately before the target statement. Unknown directive names are rejected at parse time. A directive placed before a statement it does not apply to is ignored.
+pistachio reads directives from SQL comments in schema files. A directive is a line comment of the form `-- pista:<name>` placed on its own line before the target statement. Blank lines and further comments of either form may come between the two, so a `/* ... */` note above the statement does not detach the directive from it. A directive written inside a `/* ... */` comment is commented out and does not apply, but it is still checked, so a typo or a stray argument in one fails the parse rather than passing unnoticed. Unknown directive names are rejected at parse time. A directive placed before a statement it does not apply to is ignored.
 
 | Directive | Arguments | Applies to | Purpose |
 |---|---|---|---|

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -91,9 +91,7 @@ func extractExecuteDirectives(rawSQL string, stmts []*pg_query.RawStmt) ([]*Exec
 
 	for _, stmt := range stmts {
 		loc := stmt.StmtLocation
-		region := stmtRegion(rawSQL, stmt)
-		leadingEnd := findLeadingCommentEnd(region)
-		leading := region[:leadingEnd]
+		leading := leadingDirectiveText(stmtRegion(rawSQL, stmt))
 
 		// The two directives put the statement on opposite sides of the
 		// managed DDL, so carrying both is a contradiction rather than a
@@ -203,12 +201,7 @@ func extractStmtDirectives(rawSQL string, stmts []*pg_query.RawStmt) map[int32]s
 
 	for _, stmt := range stmts {
 		loc := stmt.StmtLocation
-		region := stmtRegion(rawSQL, stmt)
-
-		// Only scan the leading comment block before the actual SQL keyword.
-		// Find where the first non-comment, non-whitespace content starts.
-		leadingEnd := findLeadingCommentEnd(region)
-		leading := region[:leadingEnd]
+		leading := leadingDirectiveText(stmtRegion(rawSQL, stmt))
 
 		matches := renameDirectivePattern.FindAllStringSubmatch(leading, -1)
 		if len(matches) > 0 {
@@ -252,9 +245,7 @@ func extractFlagDirectives(pattern *regexp.Regexp, rawSQL string, stmts []*pg_qu
 
 	for _, stmt := range stmts {
 		loc := stmt.StmtLocation
-		region := stmtRegion(rawSQL, stmt)
-		leadingEnd := findLeadingCommentEnd(region)
-		leading := region[:leadingEnd]
+		leading := leadingDirectiveText(stmtRegion(rawSQL, stmt))
 
 		if pattern.MatchString(leading) {
 			directives[loc] = true
@@ -264,23 +255,108 @@ func extractFlagDirectives(pattern *regexp.Regexp, rawSQL string, stmts []*pg_qu
 	return directives
 }
 
-// findLeadingCommentEnd returns the byte offset where leading comments and
-// whitespace end and the statement begins. A string of nothing but comments
-// returns its length, so the offset always stays within the string.
+// findLeadingCommentEnd returns the byte offset where the whitespace and
+// comments before a statement end and the statement begins. Both comment forms
+// count, so a directive written after a `/* ... */` block is still part of the
+// leading text. A string of nothing but comments returns its length, so the
+// offset always stays within the string.
 func findLeadingCommentEnd(s string) int {
 	offset := 0
 	for offset < len(s) {
-		line := s[offset:]
-		if i := strings.IndexByte(line, '\n'); i >= 0 {
-			line = line[:i+1]
+		switch {
+		case isSQLSpace(s[offset]):
+			offset++
+		case strings.HasPrefix(s[offset:], "--"):
+			i := strings.IndexByte(s[offset:], '\n')
+			if i < 0 {
+				return len(s)
+			}
+			offset += i + 1
+		case strings.HasPrefix(s[offset:], "/*"):
+			end := blockCommentEnd(s, offset)
+			if end < 0 {
+				return len(s)
+			}
+			offset = end
+		default:
+			return offset
 		}
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" && !strings.HasPrefix(trimmed, "--") {
-			break
-		}
-		offset += len(line)
 	}
 	return offset
+}
+
+func isSQLSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
+}
+
+// leadingDirectiveText returns the whitespace and comments before a statement,
+// with the body of every block comment blanked out. A directive inside a block
+// comment is commented out like anything else, so a scan must not see it, while
+// blanking rather than removing keeps the offsets extractExecuteDirectives
+// slices a check SQL out of.
+func leadingDirectiveText(region string) string {
+	return blankBlockComments(region[:findLeadingCommentEnd(region)])
+}
+
+// blankBlockComments replaces every byte of a block comment, its delimiters
+// included, with a space, leaving newlines in place so line-anchored patterns
+// still see the same lines.
+func blankBlockComments(s string) string {
+	if !strings.Contains(s, "/*") {
+		return s
+	}
+
+	out := []byte(s)
+	for i := 0; i < len(s); {
+		switch {
+		case strings.HasPrefix(s[i:], "--"):
+			// A line comment runs to the end of the line, so a `/*` in it
+			// opens nothing.
+			j := strings.IndexByte(s[i:], '\n')
+			if j < 0 {
+				i = len(s)
+			} else {
+				i += j + 1
+			}
+		case strings.HasPrefix(s[i:], "/*"):
+			end := blockCommentEnd(s, i)
+			if end < 0 {
+				end = len(s)
+			}
+			for k := i; k < end; k++ {
+				if out[k] != '\n' {
+					out[k] = ' '
+				}
+			}
+			i = end
+		default:
+			i++
+		}
+	}
+	return string(out)
+}
+
+// blockCommentEnd returns the offset just past the block comment that starts at
+// pos, or -1 when it is never closed. PostgreSQL nests block comments, so an
+// inner `/*` takes a `*/` of its own to close.
+func blockCommentEnd(s string, pos int) int {
+	depth := 0
+	for i := pos; i+1 < len(s); {
+		switch {
+		case s[i] == '/' && s[i+1] == '*':
+			depth++
+			i += 2
+		case s[i] == '*' && s[i+1] == '/':
+			depth--
+			i += 2
+			if depth == 0 {
+				return i
+			}
+		default:
+			i++
+		}
+	}
+	return -1
 }
 
 // inlineDirectives holds rename directives for columns and constraints within a CREATE TABLE.

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -746,3 +746,103 @@ GRANT SELECT ON public.a TO someone`,
 		})
 	}
 }
+
+func TestFindLeadingCommentEnd(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want int
+	}{
+		{"empty", "", 0},
+		{"statement only", "CREATE TABLE t (id int);", 0},
+		{"indented statement", "    CREATE TABLE t (id int);", 4},
+		{"whitespace only", " \t\n", 3},
+		{"line comment", "-- c\nCREATE", 5},
+		{"line comment without newline", "-- c", 4},
+		{"blank line between comments", "-- a\n\n-- b\nCREATE", 11},
+		{"block comment", "/* c */\nCREATE", 8},
+		{"block comment on the statement line", "/* c */ CREATE", 8},
+		{"multi-line block comment", "/* a\n   b */\nCREATE", 13},
+		{"nested block comment", "/* a /* b */ c */\nCREATE", 18},
+		{"unterminated block comment", "/* a\n-- b\nCREATE", 16},
+		{"comment forms mixed", "-- a\n/* b */\n-- c\nCREATE", 18},
+		{"block comment holding a line comment", "/* -- a */\nCREATE", 11},
+		{"line comment holding a block comment", "-- /* a\nCREATE", 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, findLeadingCommentEnd(tt.s))
+		})
+	}
+}
+
+func TestBlankBlockComments(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want string
+	}{
+		{"no block comment", "-- a\n", "-- a\n"},
+		{"block comment", "/* a */\n", "       \n"},
+		{"multi-line block comment", "/* a\nb */\n", "    \n    \n"},
+		{"nested block comment", "/* a /* b */ c */", "                 "},
+		{"unterminated block comment", "/* a\nb", "    \n "},
+		{"line comment kept", "-- a\n/* b */\n-- c\n", "-- a\n       \n-- c\n"},
+		{"block comment opened inside a line comment", "-- /* a\n-- b\n", "-- /* a\n-- b\n"},
+		{"line comment last, no newline", "/* a */\n-- b", "       \n-- b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := blankBlockComments(tt.s)
+			assert.Equal(t, tt.want, got)
+			assert.Len(t, got, len(tt.s), "blanking must not change the length")
+		})
+	}
+}
+
+// A directive after a block comment belongs to the statement, and one inside a
+// block comment is commented out.
+func TestDirectivesAroundBlockComments(t *testing.T) {
+	t.Run("after a block comment", func(t *testing.T) {
+		r, err := parseSQLWithSchema(`/* the table this replaces */
+-- pista:renamed-from public.old_b
+CREATE TABLE public.b (id integer);`, "public", nil)
+		require.NoError(t, err)
+		b := r.Tables.Get("public.b")
+		require.NotNil(t, b.RenameFrom)
+		assert.Equal(t, "public.old_b", *b.RenameFrom)
+	})
+
+	t.Run("inside a block comment", func(t *testing.T) {
+		r, err := parseSQLWithSchema(`/*
+-- pista:renamed-from public.old_b
+*/
+CREATE TABLE public.b (id integer);`, "public", nil)
+		require.NoError(t, err)
+		assert.Nil(t, r.Tables.Get("public.b").RenameFrom)
+	})
+
+	t.Run("schema commented out with a block comment", func(t *testing.T) {
+		r, err := parseSQLWithSchema(`/*
+-- pista:ignore
+CREATE TABLE public.b (id integer);
+*/
+CREATE TABLE public.c (id integer);`, "public", nil)
+		require.NoError(t, err)
+		assert.Nil(t, r.Tables.Get("public.b"))
+		assert.False(t, r.Tables.Get("public.c").Ignore)
+	})
+
+	t.Run("check SQL after a block comment", func(t *testing.T) {
+		r, err := parseSQLWithSchema(`CREATE TABLE public.a (id integer);
+/* why */
+-- pista:execute-first SELECT count(*) = 0 FROM public.a
+GRANT SELECT ON public.a TO someone;`, "public", nil)
+		require.NoError(t, err)
+		require.Len(t, r.ExecuteStmts, 1)
+		assert.True(t, r.ExecuteStmts[0].First)
+		assert.Equal(t, "SELECT count(*) = 0 FROM public.a", r.ExecuteStmts[0].CheckSQL)
+	})
+}

--- a/parser/location_test.go
+++ b/parser/location_test.go
@@ -408,3 +408,26 @@ func TestParseSQL_IgnoredStatementWarningWithoutFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "pistachio: ignored unsupported statement: DROP TABLE public.items\n", buf.String())
 }
+
+// The caret points at the statement's first token, so it has to skip the
+// indent, a block comment, and whatever shares the line before it.
+func TestParseSQLFiles_IgnoredStatementWarningSkipsToTheStatement(t *testing.T) {
+	var buf bytes.Buffer
+	defer parser.SetWarnWriter(&buf)()
+
+	paths := writeSQLFiles(t, map[string]string{
+		"items.sql": `CREATE TABLE public.items (id integer); DROP TABLE public.items;
+/* no longer wanted */
+DROP TABLE public.items;
+    DROP TABLE public.items;
+`,
+	})
+
+	_, err := parser.ParseSQLFilesWithSchema(paths, "public")
+	require.NoError(t, err)
+	assert.Equal(t,
+		"pistachio: "+paths[0]+":1:41: ignored unsupported statement: DROP TABLE public.items\n"+
+			"pistachio: "+paths[0]+":3:1: ignored unsupported statement: DROP TABLE public.items\n"+
+			"pistachio: "+paths[0]+":4:5: ignored unsupported statement: DROP TABLE public.items\n",
+		buf.String())
+}

--- a/testdata/plan/rename_table_after_block_comment.yml
+++ b/testdata/plan/rename_table_after_block_comment.yml
@@ -1,0 +1,16 @@
+# The directive sits after a block comment. The scan used to stop at the `/*`
+# and never see it, so the rename planned a drop and a create.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  /* renamed in release 3 */
+  -- pista:renamed-from public.users
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  ALTER TABLE public.users RENAME TO accounts;


### PR DESCRIPTION
`findLeadingCommentEnd` walked the text before a statement line by line and stopped at the first line that was neither blank nor a `--` comment, so a `/* ... */` block ended the scan. A directive written after one was never seen.

On main:

```
directive alone                        RenameFrom=public.old_b
block comment before directive         RenameFrom=<nil>
ignore after block comment             Ignore=false
trailing block comment on prev line    RenameFrom=<nil>
```

```sql
/* renamed in release 3 */
-- pista:renamed-from public.users
CREATE TABLE public.accounts (...);   -- planned a drop and a create
```

A block comment left at the end of the line above the statement does the same, since pg_query counts it as part of the next statement.

The scan now walks the text rather than its lines, skipping whitespace, `--` comments and `/* ... */` comments, the last of these nested the way PostgreSQL nests them. `stmtStart` therefore lands on the statement's first token whatever precedes it: the caret in a warning or a duplicate-name error no longer points at the `/*` line, at the indent, or at the space after the previous statement on the same line. That is the cosmetic half of the note on #497 and #499.

Skipping a block comment means the directive scans can see inside one, so `leadingDirectiveText` blanks a block comment's body before they read it. Commenting a schema out with `/* ... */` therefore comments out the directives in it, and blanking rather than removing keeps the offsets `extractExecuteDirectives` slices a check SQL out of.

`validateDirectives` scans the whole file and still reports an unknown `-- pista:` name inside a block comment. That is unchanged, and it keeps a typo from passing unnoticed.

## Tests

`TestFindLeadingCommentEnd` and `TestBlankBlockComments` cover the two helpers directly, including the inputs the parser cannot produce: an unterminated comment and a comment that ends the string without a newline. `TestDirectivesAroundBlockComments` covers the behavior end to end: a directive after a block comment applies, one inside a block comment does not, a schema commented out with `/* ... */` keeps its directives commented out, and a check SQL after a block comment still comes through. `TestParseSQLFiles_IgnoredStatementWarningSkipsToTheStatement` pins the three caret positions. A plan fixture covers the user-visible half, a rename under a block comment planning `ALTER TABLE ... RENAME TO`.

`go test ./parser/...`, `make lint` and `deadcode` pass. Parser coverage is 94.4% against 94.3% on main, with every new function at 100% and the uncovered statements in `directive.go` unchanged at 5. The suites that need PostgreSQL were not run here; the plan fixture's parse half was checked without one.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bs8AvcMuU5ea5tcym8uKi

---
_Generated by [Claude Code](https://claude.ai/code/session_017bs8AvcMuU5ea5tcym8uKi)_