### PR TITLE
Poll for the apply exclusion instead of blocking on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Wait for the apply exclusion by retrying rather than by blocking in `pg_advisory_lock`. A blocked statement holds a snapshot while it waits, and the apply it waits for may run `CREATE INDEX CONCURRENTLY`, whose build waits for every backend that holds one. The two waits close a cycle, and since advisory locks share a lock manager with table locks the deadlock detector saw it and killed the waiter: a wait died a second in with `failed to acquire the apply exclusion: ERROR: deadlock detected`, with the other apply still making progress. The wait now retries `pg_try_advisory_lock` once a second, so between attempts the session is idle and holds no snapshot and no cycle can form. The deadline, the unlimited wait and the messages are unchanged; a lock that frees is taken within a second rather than at once, and the queue is no longer first-come-first-served.
+
 ## [1.41.0] - 2026-09-03
 
 * Read a directive that follows a `/* ... */` comment. The scan for the comments before a statement stopped at the first block comment, so a directive written after one was never seen: a `-- pista:renamed-from` under a block comment planned a drop and a create instead of a rename, and a block comment left at the end of the line above did the same. Both comment forms are now skipped, nested block comments included, and a directive inside a block comment stays commented out. The position an error or a warning points at skips them as well, so it lands on the statement rather than on the `/*` line or on the indent.

--- a/docs/guides/exclusive-apply.md
+++ b/docs/guides/exclusive-apply.md
@@ -20,4 +20,6 @@ The exclusion is a session-level [advisory lock](https://www.postgresql.org/docs
 
 Transaction boundaries do not affect a session-level lock, so it works the same with and without `--with-tx` and across `CREATE INDEX CONCURRENTLY`. The lock key includes a hash of the database name; applies to different databases on one cluster do not exclude each other.
 
+A wait retries once a second instead of blocking in the lock. A blocked statement holds a snapshot while it waits, and `CREATE INDEX CONCURRENTLY` in the apply being waited for waits for every backend that holds one. That is a cycle, and PostgreSQL breaks a cycle by killing a session in it, the waiter being the one it picks. Advisory locks share a lock manager with table locks, so the detector sees it. Between attempts the waiting session is idle and holds no snapshot, so there is no cycle. A lock that frees is taken within a second, and the queue is not first-come-first-served.
+
 Only apply runs that pass `--exclusive` or `--exclusive-wait` are excluded. DDL from any other source is not blocked.

--- a/exclusive.go
+++ b/exclusive.go
@@ -17,6 +17,11 @@ import (
 // database.
 const exclusiveLockClassID = 0x50697374
 
+// exclusivePollInterval is how long a wait sleeps between attempts. The runs
+// it waits for take minutes, so a second of latency costs nothing, and one
+// statement a second costs the database nothing.
+const exclusivePollInterval = time.Second
+
 // UnsignedDuration is a time.Duration that rejects a negative value at
 // parse time, so a flag, env var or config key using it cannot be set below
 // zero. kong decodes it through UnmarshalText like any other duration.
@@ -34,6 +39,15 @@ func (d *UnsignedDuration) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// tryExclusive makes one non-blocking attempt at the exclusion.
+func tryExclusive(ctx context.Context, conn *pgx.Conn) (bool, error) {
+	var acquired bool
+	if err := conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1, hashtext(current_database()))", exclusiveLockClassID).Scan(&acquired); err != nil {
+		return false, fmt.Errorf("pistachio: failed to acquire the apply exclusion: %w", err)
+	}
+	return acquired, nil
+}
+
 // acquireExclusive makes this apply run mutually exclusive with other
 // exclusive apply runs on the same database. It runs right after connecting,
 // before the catalog is read, so the diff cannot be computed against a state
@@ -44,15 +58,23 @@ func (d *UnsignedDuration) UnmarshalText(text []byte) error {
 // CONCURRENTLY index DDL, and it is released when the connection closes,
 // including on a crash.
 //
-// With wait == nil a held lock is an immediate error. Otherwise a second,
-// blocking attempt waits for the holder, bounded by *wait through a context
-// deadline (0 waits without limit); a server-side setting like lock_timeout
-// is deliberately not used, so nothing leaks into the session the DDL then
-// runs on.
+// With wait == nil a held lock is an immediate error. Otherwise the attempt is
+// retried on a timer until the holder is gone, bounded by *wait through a
+// context deadline (0 waits without limit); a server-side setting like
+// lock_timeout is deliberately not used, so nothing leaks into the session the
+// DDL then runs on.
+//
+// The wait retries rather than blocking in pg_advisory_lock because a blocked
+// statement holds a snapshot while it waits, and the apply it waits for may run
+// CREATE INDEX CONCURRENTLY, whose build waits for every backend that holds
+// one. That closes a cycle, and PostgreSQL breaks a cycle by killing a session
+// in it, the waiter being the one it picks. Advisory locks sit in the same lock
+// manager as table locks, so the detector sees it. Between attempts this
+// session is idle and holds no snapshot, so there is no cycle.
 func acquireExclusive(ctx context.Context, conn *pgx.Conn, wait *UnsignedDuration, w io.Writer) error {
-	var acquired bool
-	if err := conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1, hashtext(current_database()))", exclusiveLockClassID).Scan(&acquired); err != nil {
-		return fmt.Errorf("pistachio: failed to acquire the apply exclusion: %w", err)
+	acquired, err := tryExclusive(ctx, conn)
+	if err != nil {
+		return err
 	}
 	if acquired {
 		return nil
@@ -69,11 +91,31 @@ func acquireExclusive(ctx context.Context, conn *pgx.Conn, wait *UnsignedDuratio
 		waitCtx, cancel = context.WithTimeout(ctx, time.Duration(*wait))
 		defer cancel()
 	}
-	if _, err := conn.Exec(waitCtx, "SELECT pg_advisory_lock($1, hashtext(current_database()))", exclusiveLockClassID); err != nil {
-		if waitCtx.Err() != nil && ctx.Err() == nil {
+
+	ticker := time.NewTicker(exclusivePollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			// The caller's own context going away, Ctrl-C for example, is not
+			// the wait running out.
+			if ctx.Err() != nil {
+				return fmt.Errorf("pistachio: failed to acquire the apply exclusion: %w", ctx.Err())
+			}
 			return fmt.Errorf("pistachio: another exclusive apply did not finish within %s", time.Duration(*wait))
+		case <-ticker.C:
 		}
-		return fmt.Errorf("pistachio: failed to acquire the apply exclusion: %w", err)
+
+		// ctx, not waitCtx: an attempt is a single fast statement, and letting
+		// the wait deadline cancel it mid-flight would report the query rather
+		// than the wait.
+		acquired, err := tryExclusive(ctx, conn)
+		if err != nil {
+			return err
+		}
+		if acquired {
+			return nil
+		}
 	}
-	return nil
 }

--- a/exclusive_test.go
+++ b/exclusive_test.go
@@ -126,8 +126,11 @@ func TestApplyExclusiveWaitTimeout(t *testing.T) {
 		Files:         []string{writeDesiredFile(t, exclusiveDesired)},
 		ExclusiveWait: durationPtr(wait),
 	}, &buf)
+	elapsed := time.Since(start)
 	require.ErrorContains(t, err, "did not finish within")
-	assert.GreaterOrEqual(t, time.Since(start), wait)
+	assert.GreaterOrEqual(t, elapsed, wait)
+	// The wait ends on its own deadline, not on the next poll.
+	assert.Less(t, elapsed, pistachio.ExclusivePollInterval)
 	assert.Contains(t, buf.String(), "-- Waiting for another exclusive apply to finish")
 }
 
@@ -288,4 +291,174 @@ func TestUnsignedDuration(t *testing.T) {
 	assert.Equal(t, pistachio.UnsignedDuration(0), d)
 	require.ErrorContains(t, d.UnmarshalText([]byte("-3s")), "negative")
 	require.Error(t, d.UnmarshalText([]byte("bad")))
+}
+
+const exclusiveIndexDesired = `CREATE TABLE items (
+    id integer NOT NULL
+);
+CREATE INDEX items_id_idx ON items (id);
+CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);`
+
+func TestApplyExclusiveWaitDuringConcurrentIndexBuild(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "CREATE TABLE items (id integer NOT NULL);")
+
+	holder := testutil.ConnectDB(t)
+	defer holder.Close(ctx)
+	holdExclusive(t, ctx, holder)
+
+	// The holder builds an index CONCURRENTLY while it owns the exclusion.
+	// CREATE INDEX CONCURRENTLY waits for every backend that holds an older
+	// snapshot, whatever table that backend is touching, so a waiter that
+	// sits inside a statement of its own closes a lock cycle: the index build
+	// waits for the waiter's snapshot, and the waiter waits for the exclusion
+	// the index build's session holds. The wait must therefore hold no
+	// snapshot between attempts.
+	done := make(chan error, 1)
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		if _, err := holder.Exec(ctx, "CREATE INDEX CONCURRENTLY items_id_idx ON items (id)"); err != nil {
+			done <- err
+			return
+		}
+		done <- releaseExclusive(ctx, holder)
+	}()
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	var buf bytes.Buffer
+	result, err := client.Apply(ctx, &pistachio.ApplyOptions{
+		Files:         []string{writeDesiredFile(t, exclusiveIndexDesired)},
+		ExclusiveWait: durationPtr(30 * time.Second),
+	}, &buf)
+	require.NoError(t, err)
+	require.NoError(t, <-done)
+	assert.True(t, result.Applied)
+	assert.Contains(t, buf.String(), "CREATE TABLE")
+}
+
+func backendPID(t *testing.T, ctx context.Context, conn *pgx.Conn) int32 {
+	t.Helper()
+	var pid int32
+	require.NoError(t, conn.QueryRow(ctx, "SELECT pg_backend_pid()").Scan(&pid))
+	return pid
+}
+
+// waiterPID returns the backend of the apply that is waiting for the
+// exclusion: the one that ran an advisory lock function and is neither the
+// holder nor the backend asking.
+func waiterPID(t *testing.T, ctx context.Context, conn *pgx.Conn, holderPID int32) int32 {
+	t.Helper()
+	for range 100 {
+		var pid int32
+		err := conn.QueryRow(ctx, `SELECT pid FROM pg_stat_activity
+			WHERE datname = current_database()
+			AND pid NOT IN (pg_backend_pid(), $1)
+			AND query LIKE '%advisory_lock%'`, holderPID).Scan(&pid)
+		if err == nil {
+			return pid
+		}
+		require.ErrorIs(t, err, pgx.ErrNoRows)
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("the waiting backend did not appear")
+	return 0
+}
+
+func TestApplyExclusiveWaitHoldsNoSnapshot(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	holder := testutil.ConnectDB(t)
+	defer holder.Close(ctx)
+	holderPID := backendPID(t, ctx, holder)
+	holdExclusive(t, ctx, holder)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	desired := writeDesiredFile(t, exclusiveDesired)
+	applied := make(chan error, 1)
+	go func() {
+		_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+			Files:         []string{desired},
+			ExclusiveWait: durationPtr(0),
+		}, io.Discard)
+		applied <- err
+	}()
+
+	// A backend that holds a snapshot is one CREATE INDEX CONCURRENTLY waits
+	// for, so the wait has to leave none behind between attempts. Sampling
+	// can land on an attempt, which is a statement like any other, so this
+	// looks for a sample without one rather than requiring every sample to be
+	// free of it.
+	pid := waiterPID(t, ctx, conn, holderPID)
+	idle := false
+	for range 50 {
+		var state string
+		var noSnapshot bool
+		err := conn.QueryRow(ctx,
+			"SELECT state, backend_xmin IS NULL FROM pg_stat_activity WHERE pid = $1", pid).
+			Scan(&state, &noSnapshot)
+		require.NoError(t, err)
+		if state == "idle" && noSnapshot {
+			idle = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.True(t, idle, "the wait held a snapshot the whole time")
+
+	require.NoError(t, releaseExclusive(ctx, holder))
+	require.NoError(t, <-applied)
+}
+
+func TestApplyExclusiveWaitConnectionLost(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	holder := testutil.ConnectDB(t)
+	defer holder.Close(ctx)
+	holderPID := backendPID(t, ctx, holder)
+	holdExclusive(t, ctx, holder)
+	defer releaseExclusive(ctx, holder) //nolint:errcheck
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: conn.Config().ConnString(),
+		Schemas:    []string{"public"},
+	})
+
+	desired := writeDesiredFile(t, exclusiveDesired)
+	applied := make(chan error, 1)
+	go func() {
+		_, err := client.Apply(ctx, &pistachio.ApplyOptions{
+			Files:         []string{desired},
+			ExclusiveWait: durationPtr(30 * time.Second),
+		}, io.Discard)
+		applied <- err
+	}()
+
+	// A connection that dies during the wait is reported as the failure it is,
+	// not as the wait running out.
+	pid := waiterPID(t, ctx, conn, holderPID)
+	_, err := conn.Exec(ctx, "SELECT pg_terminate_backend($1)", pid)
+	require.NoError(t, err)
+
+	err = <-applied
+	require.ErrorContains(t, err, "failed to acquire the apply exclusion")
+	assert.NotContains(t, err.Error(), "did not finish within")
 }

--- a/export_test.go
+++ b/export_test.go
@@ -5,7 +5,10 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-const ExclusiveLockClassID = exclusiveLockClassID
+const (
+	ExclusiveLockClassID  = exclusiveLockClassID
+	ExclusivePollInterval = exclusivePollInterval
+)
 
 var (
 	ResolvePreSQL             = resolvePreSQL


### PR DESCRIPTION
`--exclusive-wait` waited by running `pg_advisory_lock`, which blocks in the server until the holder is gone. That statement holds a snapshot for as long as it waits, and the apply it waits for may run `CREATE INDEX CONCURRENTLY`, whose build waits for every backend holding an older snapshot, whatever table that backend is touching.

The two waits close a cycle: the build waits for the waiter's snapshot, and the waiter waits for the exclusion the build's session holds. Advisory locks sit in the same lock manager as table locks, so the deadlock detector sees it and breaks it, and the session it kills is the waiter, which was doing nothing but wait.

```
apply A  holds the exclusion, runs CREATE INDEX CONCURRENTLY
         --[ ShareLock on B's virtualxid ]--> apply B
apply B  blocked in pg_advisory_lock, holding a snapshot
         --[ advisory lock ]-----------------> apply A
```

On main, with a holder that builds an index concurrently:

```
pistachio: failed to acquire the apply exclusion: ERROR: deadlock detected (SQLSTATE 40P01)
```

a second after the wait started, with the other apply still making progress and minutes of the wait budget left.

The wait now retries `pg_try_advisory_lock` on a one-second ticker. An attempt is a single fast statement, so between attempts the session is idle and holds no snapshot, and there is nothing for a concurrent index build to wait on: the cycle cannot form.

The deadline, the `0` unlimited wait, the message a wait that runs out reports and the one a canceled context reports are unchanged. What changes is that a lock that frees is picked up within a second rather than at once, and that the queue is no longer first-come-first-served, neither of which matters for a wait measured in minutes.

## Tests

`TestApplyExclusiveWaitDuringConcurrentIndexBuild` reproduces the deadlock end to end. It rests on how a given PostgreSQL decides which backends an index build has to wait for, so `TestApplyExclusiveWaitHoldsNoSnapshot` asserts the property the fix rests on instead: while it waits, the session reaches `pg_stat_activity` `idle` with a null `backend_xmin`. Both fail on the blocking wait, the second with `the wait held a snapshot the whole time`, on 15 through 18.

`TestApplyExclusiveWaitConnectionLost` terminates the waiting backend and checks the failure is reported as itself rather than as the wait running out, which also covers the retry loop's error path. `TestApplyExclusiveWaitTimeout` now also pins that a deadline shorter than the poll interval ends on the deadline rather than at the next attempt.

`make lint`, `make test` and `make test-scenario` pass, and the exclusive tests pass on 15, 16, 17 and 18. Package coverage is 98.3%, the same as on main: `tryExclusive` is at 100% and `acquireExclusive` at 96.8%, its one uncovered statement the error return of the first attempt, which was uncovered on main as well.
