### PR TITLE
Restore a NOT VALID check constraint unvalidated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Restore a `NOT VALID` check constraint unvalidated. A table's checks are written inside `CREATE TABLE`, where the clause cannot be spelled, so `dump` printed such a constraint as validated and the reload scanned the table to validate it. Such a check is now left out of `CREATE TABLE` and added by its own `ALTER TABLE ... ADD CONSTRAINT ... NOT VALID`, the way a foreign key is. This also stops a plan that created the table from re-emitting the constraint on every later run.
+
 ## [1.41.1] - 2026-09-04
 
 * Wait for the apply exclusion by retrying rather than by blocking in `pg_advisory_lock`. A blocked statement holds a snapshot while it waits, and the apply it waits for may run `CREATE INDEX CONCURRENTLY`, whose build waits for every backend that holds one. The two waits close a cycle, and since advisory locks share a lock manager with table locks the deadlock detector saw it and killed the waiter: a wait died a second in with `failed to acquire the apply exclusion: ERROR: deadlock detected`, with the other apply still making progress. The wait now retries `pg_try_advisory_lock` once a second, so between attempts the session is idle and holds no snapshot and no cycle can form. The deadline, the unlimited wait and the messages are unchanged; a lock that frees is taken within a second rather than at once, and the queue is no longer first-come-first-served.

--- a/TODO.md
+++ b/TODO.md
@@ -971,3 +971,18 @@ parameters entry above, which reads the same `reloptions` column.
 
 Origin: the restore fidelity check, 2026-09-02.
 `test/fidelity/schemas/view_columns.sql` notes what it leaves out.
+
+## A NOT VALID check on an INHERITS child is restored validated
+
+[#505](https://github.com/winebarrel/pistachio/pull/505) fixed this for a
+plain and a partitioned table and left the INHERITS branch of `Table.SQL`
+alone: a child's constraints are all written inside `CREATE TABLE`, so a
+NOT VALID check declared directly on the child loses the clause, and the dump
+fed back plans a `VALIDATE CONSTRAINT` for it. Emitting the ALTER the way a
+plain table now does is not enough, because the child's constraint map also
+holds the unvalidated clones a NOT VALID check on the parent pushes down, and
+an ADD for one of those collides with the constraint the child already
+inherits. Telling the two apart needs `pg_constraint.conislocal`, which the
+catalog does not read.
+
+Origin: review of [#505](https://github.com/winebarrel/pistachio/pull/505).

--- a/TODO.md
+++ b/TODO.md
@@ -943,21 +943,6 @@ schema does not will plan `COMMENT ON INDEX ... IS NULL;`.
 
 Origin: discussion, 2026-08-25.
 
-## A NOT VALID CHECK constraint is restored validated
-
-`catalog.ListConstraints` reads `convalidated`, and `model.Constraint` carries
-it as `Validated`, but only `ForeignKey.SQL` writes `NOT VALID`. A table's
-check constraints are written inside `CREATE TABLE`, where the clause cannot be
-spelled, so `pista dump` prints the constraint as if it were validated and the
-reload scans the table to validate it.
-
-The work is to emit a `NOT VALID` check the way a foreign key is already
-emitted, as its own `ALTER TABLE ... ADD CONSTRAINT` after the table, and to
-leave the validated ones inline.
-
-Origin: the restore fidelity check, 2026-09-02.
-`test/fidelity/schemas/check_constraints.sql` notes what it leaves out.
-
 ## An identity column's sequence name is not managed
 
 The sequence behind an identity column is created as `<table>_<column>_seq` and

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -108,6 +108,9 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 
 // newTableExtras returns non-FK extras and FK statements separately.
 func newTableExtras(t *model.Table) (stmts []string, fkStmts []string, hasConcurrently bool, err error) {
+	if notValidSQL := t.NotValidConSQL(); notValidSQL != "" {
+		stmts = append(stmts, strings.Split(notValidSQL, "\n")...)
+	}
 	if storageSQL := t.StorageSQL(); storageSQL != "" {
 		stmts = append(stmts, strings.Split(storageSQL, "\n")...)
 	}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -57,6 +57,25 @@ func TestDiffTables_newTable_withExtras(t *testing.T) {
 	assert.Contains(t, result.Stmts[2], "COMMENT ON TABLE")
 }
 
+func TestDiffTables_newTable_notValidCheck(t *testing.T) {
+	current := orderedmap.New[string, *model.Table]()
+	desired := orderedmap.New[string, *model.Table]()
+
+	tbl := newTable("public", "users")
+	tbl.Columns.Set("age", &model.Column{Name: "age", TypeName: "integer", NotNull: true})
+	tbl.Constraints.Set("chk_age", &model.Constraint{
+		Name: "chk_age", Type: model.ConstraintType('c'), Definition: "CHECK (age > 0)",
+	})
+	desired.Set("public.users", tbl)
+
+	result, err := DiffTables(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Len(t, result.Stmts, 2)
+	assert.Contains(t, result.Stmts[0], "CREATE TABLE public.users")
+	assert.NotContains(t, result.Stmts[0], "chk_age")
+	assert.Equal(t, "ALTER TABLE ONLY public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;", result.Stmts[1])
+}
+
 func TestDiffTables_newTable_withExtras_perDirective(t *testing.T) {
 	current := orderedmap.New[string, *model.Table]()
 	desired := orderedmap.New[string, *model.Table]()

--- a/docs/contributing-samples.md
+++ b/docs/contributing-samples.md
@@ -413,16 +413,10 @@ covers the full schema.
 ## Check-time flags
 
 The last field of a `SAMPLES` record holds extra flags for the `pista plan`
-step. Only gitlab uses it, with `--assume-validated`.
-
-gitlab's schema has 68 constraints that are `NOT VALID`. `pista dump` writes
-CHECK constraints inline in `CREATE TABLE`, and PostgreSQL accepts `NOT VALID`
-only on `ALTER TABLE ... ADD CONSTRAINT`, so an inline constraint necessarily
-reads back as validated and the plan asks to validate 39 constraints that are
-already in the database. `--assume-validated` ignores validation state on both
-sides, which is what the check is after here: whether the tables, columns,
-indexes, constraints, and partitions round-trip. No other sample has an
-unvalidated constraint, so no other sample needs the flag.
+step. No sample uses it today. gitlab used `--assume-validated` while `pista
+dump` wrote every CHECK constraint inline in `CREATE TABLE`, where `NOT VALID`
+cannot be spelled; dump now writes such a check as its own `ALTER TABLE`, and
+gitlab's 68 `NOT VALID` constraints round-trip without the flag.
 
 ## Adding a sample
 

--- a/model/table.go
+++ b/model/table.go
@@ -114,9 +114,7 @@ func (t Table) SQL() string {
 					}
 					return q
 				}),
-				t.Constraints.TransformSlice(func(_ string, con *Constraint) string {
-					return "    CONSTRAINT " + Ident(con.Name) + " " + con.Definition
-				}),
+				t.inlineConstraintDefs(),
 			),
 			",\n",
 		) +
@@ -135,6 +133,44 @@ func (t Table) SQL() string {
 	}
 
 	return sql + ";"
+}
+
+// inlineConstraintDefs renders the constraints written inside CREATE TABLE.
+// A NOT VALID check is left out, since the clause cannot be spelled there and
+// writing the constraint without it would restore it validated; NotValidConSQL
+// adds it back.
+func (t Table) inlineConstraintDefs() []string {
+	var defs []string
+	for _, con := range t.Constraints.CollectValues() {
+		if con.Type.IsCheckConstraint() && !con.Validated {
+			continue
+		}
+		defs = append(defs, "    CONSTRAINT "+Ident(con.Name)+" "+con.Definition)
+	}
+	return defs
+}
+
+// NotValidConSQL renders the table's NOT VALID check constraints, each as its
+// own ALTER TABLE after the table. ONLY is dropped on a partitioned table,
+// which rejects it once a partition exists. A partition child renders nothing:
+// its unvalidated entries are the clones the parent's statement creates. An
+// INHERITS child keeps the inline form its branch of SQL writes.
+func (t Table) NotValidConSQL() string {
+	if t.PartitionOf != nil {
+		return ""
+	}
+	only := "ONLY "
+	if t.Partitioned {
+		only = ""
+	}
+	var stmts []string
+	for _, con := range t.Constraints.CollectValues() {
+		if !con.Type.IsCheckConstraint() || con.Validated {
+			continue
+		}
+		stmts = append(stmts, "ALTER TABLE "+only+t.FQTN()+" ADD CONSTRAINT "+Ident(con.Name)+" "+con.Definition+" NOT VALID;")
+	}
+	return strings.Join(stmts, "\n")
 }
 
 func (t Table) IdxSQL() string {
@@ -275,6 +311,9 @@ func (t Table) CommentSQL() string {
 
 func TableToSQL(t *Table) string {
 	parts := []string{"-- " + t.FQTN(), t.SQL()}
+	if s := t.NotValidConSQL(); s != "" {
+		parts = append(parts, s)
+	}
 	if s := t.StorageSQL(); s != "" {
 		parts = append(parts, s)
 	}

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -485,3 +485,84 @@ func TestSortedStorageParams(t *testing.T) {
 	assert.Equal(t, []string{"a", "b", "c"}, params.CollectKeys())
 	assert.Equal(t, []string{"1", "2", "3"}, params.CollectValues())
 }
+
+func TestTable_SQL_notValidCheckLeftOut(t *testing.T) {
+	tbl := newTable("public", "orders")
+	tbl.Columns.Set("qty", &model.Column{Name: "qty", TypeName: "integer", NotNull: true})
+	tbl.Constraints.Set("orders_pkey", &model.Constraint{
+		Name: "orders_pkey", Type: model.ConstraintType('p'), Definition: "PRIMARY KEY (qty)",
+	})
+	tbl.Constraints.Set("orders_qty_check", &model.Constraint{
+		Name: "orders_qty_check", Type: model.ConstraintType('c'), Definition: "CHECK (qty > 0)",
+	})
+
+	out := tbl.SQL()
+	assert.Contains(t, out, "CONSTRAINT orders_pkey PRIMARY KEY (qty)")
+	assert.NotContains(t, out, "orders_qty_check")
+}
+
+func TestTable_NotValidConSQL(t *testing.T) {
+	tbl := newTable("public", "orders")
+	tbl.Constraints.Set("orders_qty_check", &model.Constraint{
+		Name: "orders_qty_check", Type: model.ConstraintType('c'), Definition: "CHECK (qty > 0)",
+	})
+
+	assert.Equal(t,
+		"ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_qty_check CHECK (qty > 0) NOT VALID;",
+		tbl.NotValidConSQL())
+}
+
+func TestTable_NotValidConSQL_validatedCheck(t *testing.T) {
+	tbl := newTable("public", "orders")
+	tbl.Constraints.Set("orders_qty_check", &model.Constraint{
+		Name: "orders_qty_check", Type: model.ConstraintType('c'), Definition: "CHECK (qty > 0)", Validated: true,
+	})
+
+	assert.Empty(t, tbl.NotValidConSQL())
+}
+
+func TestTable_NotValidConSQL_partitioned(t *testing.T) {
+	// ALTER TABLE ONLY on a partitioned table is rejected once a partition
+	// exists, so ONLY is dropped there.
+	def := "RANGE (id)"
+	tbl := newTable("public", "orders")
+	tbl.Partitioned = true
+	tbl.PartitionDef = &def
+	tbl.Constraints.Set("orders_qty_check", &model.Constraint{
+		Name: "orders_qty_check", Type: model.ConstraintType('c'), Definition: "CHECK (qty > 0)",
+	})
+
+	assert.Equal(t,
+		"ALTER TABLE public.orders ADD CONSTRAINT orders_qty_check CHECK (qty > 0) NOT VALID;",
+		tbl.NotValidConSQL())
+}
+
+func TestTable_NotValidConSQL_partitionChild(t *testing.T) {
+	// A partition child's unvalidated entries are the clones the parent's
+	// statement creates, so the child renders nothing.
+	parent := "public.orders"
+	bound := "FOR VALUES FROM (0) TO (10)"
+	tbl := newTable("public", "orders_0")
+	tbl.PartitionOf = &parent
+	tbl.PartitionBound = &bound
+	tbl.Constraints.Set("orders_qty_check", &model.Constraint{
+		Name: "orders_qty_check", Type: model.ConstraintType('c'), Definition: "CHECK (qty > 0)",
+	})
+
+	assert.Empty(t, tbl.NotValidConSQL())
+}
+
+func TestTableToSQL_notValidCheck(t *testing.T) {
+	tbl := newTable("public", "orders")
+	tbl.Columns.Set("qty", &model.Column{Name: "qty", TypeName: "integer", NotNull: true})
+	tbl.Constraints.Set("orders_qty_check", &model.Constraint{
+		Name: "orders_qty_check", Type: model.ConstraintType('c'), Definition: "CHECK (qty > 0)",
+	})
+
+	expected := `-- public.orders
+CREATE TABLE public.orders (
+    qty integer NOT NULL
+);
+ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_qty_check CHECK (qty > 0) NOT VALID;`
+	assert.Equal(t, expected, model.TableToSQL(tbl))
+}

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -49,7 +49,7 @@ hive|sample-db-hive|URL=https://raw.githubusercontent.com/apache/hive/d98bfeda81
 ranger|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/ranger/0249cc1d8255c0370322508c7e1d30250e152340/security-admin/db/postgres/optimized/current/ranger_core_db_postgres.sql SCHEMA=ranger CLIENT_MIN_MESSAGES=error|ranger
 ambari|sample-db-url-schema|URL=https://raw.githubusercontent.com/apache/ambari/0347dc4503c09b0593d9cb12815e2f9784b6a86a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql SCHEMA=ambari|ambari
 ovirt|sample-db-url-schema|URL=https://raw.githubusercontent.com/oVirt/ovirt-engine/be1f6647db1ebbf39186bbe4dd6b1a777376815b/packaging/dbscripts/create_tables.sql SCHEMA=ovirt|ovirt
-gitlab|sample-db-url-schema|URL=https://raw.githubusercontent.com/gitlabhq/gitlabhq/35e789d8f1173a11a7724ae360a80d1f19ec92dc/db/structure.sql SCHEMA=gitlab|gitlab,gitlab_partitions_static,gitlab_partitions_dynamic|--assume-validated
+gitlab|sample-db-url-schema|URL=https://raw.githubusercontent.com/gitlabhq/gitlabhq/35e789d8f1173a11a7724ae360a80d1f19ec92dc/db/structure.sql SCHEMA=gitlab|gitlab,gitlab_partitions_static,gitlab_partitions_dynamic
 ledgersmb|sample-db-url-schema|URL=https://raw.githubusercontent.com/ledgersmb/LedgerSMB/34a05e7b58c161e008561e36a74dbede860fe4d9/sql/Pg-database.sql SCHEMA=ledgersmb|ledgersmb
 koji|sample-db-url-schema|URL=https://raw.githubusercontent.com/koji-project/koji/c3239d46c1abdcbda509739eb0182031b71d9f01/schemas/schema.sql SCHEMA=koji|koji
 kea|sample-db-url-schema|URL=https://raw.githubusercontent.com/isc-projects/kea/82440eddc70089a55892a42ca96b78a92eb3e484/src/share/database/scripts/pgsql/dhcpdb_create.pgsql SCHEMA=kea CLIENT_MIN_MESSAGES=warning|kea

--- a/test/fidelity/schemas/check_constraints.sql
+++ b/test/fidelity/schemas/check_constraints.sql
@@ -1,6 +1,3 @@
--- No NOT VALID check: the catalog reads the flag, but a table's checks are
--- written inside CREATE TABLE, where NOT VALID cannot be spelled, so the dump
--- restores the constraint validated. TODO.md records it.
 CREATE TABLE public.orders (
     id integer NOT NULL,
     qty integer NOT NULL,
@@ -11,3 +8,4 @@ CREATE TABLE public.orders (
     CONSTRAINT orders_status_check CHECK ((status = ANY (ARRAY['new'::text, 'done'::text]))),
     CONSTRAINT orders_total_check CHECK (((price * (qty)::numeric) < (1000000)::numeric))
 );
+ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_price_check CHECK ((price > (0)::numeric)) NOT VALID;

--- a/testdata/apply/not_valid_check_new_table.yml
+++ b/testdata/apply/not_valid_check_new_table.yml
@@ -1,0 +1,16 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0) NOT VALID
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;

--- a/testdata/apply/not_valid_check_partitioned.yml
+++ b/testdata/apply/not_valid_check_partitioned.yml
@@ -1,0 +1,22 @@
+# ALTER TABLE ONLY is rejected on a partitioned table, so the NOT VALID check
+# goes out without ONLY and recurses to the partitions.
+init: ""
+desired: |
+  CREATE TABLE public.measurements (
+      id integer NOT NULL,
+      val integer NOT NULL,
+      CONSTRAINT measurements_val_check CHECK (val > 0) NOT VALID
+  )
+  PARTITION BY RANGE (id);
+  CREATE TABLE public.measurements_0 PARTITION OF public.measurements FOR VALUES FROM (0) TO (100);
+applied: |
+  -- public.measurements
+  CREATE TABLE public.measurements (
+      id integer NOT NULL,
+      val integer NOT NULL
+  )
+  PARTITION BY RANGE (id);
+  ALTER TABLE public.measurements ADD CONSTRAINT measurements_val_check CHECK (val > 0) NOT VALID;
+
+  -- public.measurements_0
+  CREATE TABLE public.measurements_0 PARTITION OF public.measurements FOR VALUES FROM (0) TO (100);

--- a/testdata/dump/not_valid_check_constraint.yml
+++ b/testdata/dump/not_valid_check_constraint.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT orders_id_check CHECK (id > 0)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT orders_qty_check CHECK (qty > 0) NOT VALID;
+  ALTER TABLE public.orders ADD CONSTRAINT orders_id_max_check CHECK (id < 1000000) NOT VALID;
+dump: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT orders_id_check CHECK (id > 0)
+  );
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_id_max_check CHECK (id < 1000000) NOT VALID;
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_qty_check CHECK (qty > 0) NOT VALID;

--- a/testdata/dump/omit_schema_not_valid_check.yml
+++ b/testdata/dump/omit_schema_not_valid_check.yml
@@ -1,0 +1,14 @@
+omit_schema: true
+init: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT orders_id_check CHECK (id > 0) NOT VALID;
+dump: |
+  -- orders
+  CREATE TABLE orders (
+      id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY orders ADD CONSTRAINT orders_id_check CHECK (id > 0) NOT VALID;

--- a/testdata/plan/not_valid_check_new_table.yml
+++ b/testdata/plan/not_valid_check_new_table.yml
@@ -1,0 +1,15 @@
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT chk_age CHECK (age > 0) NOT VALID
+  );
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      age integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.users ADD CONSTRAINT chk_age CHECK (age > 0) NOT VALID;

--- a/testdata/plan/not_valid_check_round_trip.yml
+++ b/testdata/plan/not_valid_check_round_trip.yml
@@ -1,0 +1,18 @@
+# The dump form of a NOT VALID check: the constraint left out of CREATE TABLE
+# and added back by its own ALTER TABLE. Fed back as desired it must plan
+# clean.
+init: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT orders_qty_check CHECK (qty > 0) NOT VALID;
+desired: |
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      qty integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_qty_check CHECK (qty > 0) NOT VALID;
+plan: ""


### PR DESCRIPTION
Closes the TODO entry "A NOT VALID CHECK constraint is restored validated".

A table's check constraints were written inside `CREATE TABLE`, where `NOT VALID` cannot be spelled, so `dump` printed such a constraint as validated and the reload scanned the table to validate it. A plan that created the table had the same gap: the constraint was applied validated, and every later plan re-emitted DROP+ADD forever.

## Changes

- `Table.SQL` leaves a NOT VALID check out of `CREATE TABLE`; the new `Table.NotValidConSQL` renders it as its own `ALTER TABLE ONLY ... ADD CONSTRAINT ... NOT VALID`, the way a foreign key already is. Both `dump` and the new-table plan path emit it.
- `ONLY` is dropped on a partitioned table, which rejects it once a partition exists (verified on 15). A partition child renders nothing: its unvalidated entries are the clones the parent's statement creates. An INHERITS child keeps the inline form, since switching it to ALTER would collide with the constraint it inherits.
- `test/fidelity/schemas/check_constraints.sql` gets its NOT VALID line back, which is the regression test the TODO entry named.
- The gitlab sample round-trips without `--assume-validated` (verified against the live sample: 68 NOT VALID constraints, `-- No changes`), so the flag comes off its SAMPLES record and `docs/contributing-samples.md` follows.

## Tests

- Fixtures: dump (two NOT VALID checks, output order pinned), dump with `--omit-schema`, plan for a new table, plan round trip of the dump form, apply for a new table and for a partitioned parent. Every apply fixture re-plans and requires no drift.
- Package tests in `model` and `diff` keep per-package coverage where it was (model 99.8%, diff 97.5%).
- `make test`, `make test-scenario`, `make test-fidelity` (30 passed), `make lint` all pass.