### PR TITLE
Track UNLOGGED on a standalone sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Track `UNLOGGED` on a standalone sequence. It was read by neither side, so `dump` wrote an unlogged sequence as a plain `CREATE SEQUENCE` and a `LOGGED` <-> `UNLOGGED` change produced no diff. `dump` now writes `CREATE UNLOGGED SEQUENCE` and a change goes out as `ALTER SEQUENCE ... SET LOGGED/UNLOGGED`. Temporary sequences stay out of scope.
+
 * Restore a `NOT VALID` check constraint unvalidated. A table's checks are written inside `CREATE TABLE`, where the clause cannot be spelled, so `dump` printed such a constraint as validated and the reload scanned the table to validate it. Such a check is now left out of `CREATE TABLE` and added by its own `ALTER TABLE ... ADD CONSTRAINT ... NOT VALID`, the way a foreign key is. This also stops a plan that created the table from re-emitting the constraint on every later run.
 
 ## [1.41.1] - 2026-09-04

--- a/TODO.md
+++ b/TODO.md
@@ -271,19 +271,6 @@ and is not pursued.
 
 Origin: discussion during [#124](https://github.com/winebarrel/pistachio/pull/124). No current plan to implement.
 
-## UNLOGGED sequence support
-
-Standalone sequence management does not track the `UNLOGGED` attribute. An
-`UNLOGGED SEQUENCE` is read and dumped as a plain `CREATE SEQUENCE` (as if
-`LOGGED`), and a `LOGGED` <-> `UNLOGGED` change produces no diff. Closing
-this would follow the existing table pattern: add an `Unlogged` field to
-`model.Sequence`, read `pg_class.relpersistence = 'u'` in the catalog,
-emit `CREATE UNLOGGED SEQUENCE`, and emit `ALTER SEQUENCE ... SET
-LOGGED/UNLOGGED` for transitions. `TEMPORARY` sequences stay out of scope
-(session-local, never dumped).
-
-Origin: [#296](https://github.com/winebarrel/pistachio/pull/296).
-
 ## Amazon Aurora DSQL support: findings from live testing
 
 Verified against a live DSQL cluster (PostgreSQL 16 wire protocol,

--- a/catalog/sequences.go
+++ b/catalog/sequences.go
@@ -54,6 +54,7 @@ func (c *Catalog) ListSequences(ctx context.Context) ([]*model.Sequence, error) 
 			s.seqincrement,
 			s.seqcache,
 			s.seqcycle,
+			c.relpersistence = 'u' AS unlogged,
 			-- deptype 'a' covers serial columns, 'i' covers identity
 			-- columns. Both mark auto-created sequences owned by a table
 			-- column, so owner_table is non-null only for those; standalone
@@ -108,6 +109,7 @@ func (c *Catalog) ListSequences(ctx context.Context) ([]*model.Sequence, error) 
 			&s.Increment,
 			&s.Cache,
 			&s.Cycle,
+			&s.Unlogged,
 			&s.OwnerTable,
 			&s.OwnerColumn,
 			&s.Comment,

--- a/catalog/sequences_test.go
+++ b/catalog/sequences_test.go
@@ -79,6 +79,22 @@ func TestListSequences(t *testing.T) {
 		assert.Nil(t, seqs[0].OwnerTable)
 	})
 
+	t.Run("unlogged sequence", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE UNLOGGED SEQUENCE public.jobs_seq;
+			CREATE SEQUENCE public.plain_seq;
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		seqs, err := cat.ListSequences(ctx)
+		require.NoError(t, err)
+		require.Len(t, seqs, 2)
+		assert.Equal(t, "jobs_seq", seqs[0].Name)
+		assert.True(t, seqs[0].Unlogged)
+		assert.Equal(t, "plain_seq", seqs[1].Name)
+		assert.False(t, seqs[1].Unlogged)
+	})
+
 	t.Run("sequence with comment", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE SEQUENCE public.my_seq;

--- a/diff/sequences.go
+++ b/diff/sequences.go
@@ -62,6 +62,18 @@ func DiffSequences(current, desired *orderedmap.Map[string, *model.Sequence], dc
 // diffSequence emits a single ALTER SEQUENCE combining every changed option,
 // plus a separate COMMENT statement when the comment changed.
 func diffSequence(fqn string, current, desired *model.Sequence) []string {
+	var stmts []string
+
+	// SET LOGGED / SET UNLOGGED is a form of its own; the option list of
+	// ALTER SEQUENCE does not take it.
+	if current.Unlogged != desired.Unlogged {
+		if desired.Unlogged {
+			stmts = append(stmts, "ALTER SEQUENCE "+fqn+" SET UNLOGGED;")
+		} else {
+			stmts = append(stmts, "ALTER SEQUENCE "+fqn+" SET LOGGED;")
+		}
+	}
+
 	var clauses []string
 
 	if current.DataType != desired.DataType {
@@ -90,7 +102,6 @@ func diffSequence(fqn string, current, desired *model.Sequence) []string {
 		}
 	}
 
-	var stmts []string
 	if len(clauses) > 0 {
 		stmts = append(stmts, "ALTER SEQUENCE "+fqn+" "+strings.Join(clauses, " ")+";")
 	}

--- a/diff/sequences_test.go
+++ b/diff/sequences_test.go
@@ -65,13 +65,15 @@ func TestDiffSequences_NoDiff(t *testing.T) {
 func TestDiffSequences_AlterOptions(t *testing.T) {
 	desired := baseSeq()
 	desired.Increment = 2
+	desired.Min = 5
 	desired.Max = 5000
+	desired.Start = 100
 	desired.Cache = 10
 	desired.Cycle = true
 	result, err := diff.DiffSequences(newSeqMap(baseSeq()), newSeqMap(desired), diff.AllowAllDrops{})
 	require.NoError(t, err)
 	require.Len(t, result.Stmts, 1)
-	assert.Equal(t, "ALTER SEQUENCE public.s INCREMENT BY 2 MAXVALUE 5000 CACHE 10 CYCLE;", result.Stmts[0])
+	assert.Equal(t, "ALTER SEQUENCE public.s INCREMENT BY 2 MINVALUE 5 MAXVALUE 5000 START WITH 100 CACHE 10 CYCLE;", result.Stmts[0])
 }
 
 func TestDiffSequences_AlterType(t *testing.T) {
@@ -154,4 +156,20 @@ func TestDiffSequences_RenameCrossSchemaError(t *testing.T) {
 	_, err := diff.DiffSequences(newSeqMap(current), newSeqMap(desired), diff.AllowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-schema rename")
+}
+
+func TestDiffSequences_SetUnlogged(t *testing.T) {
+	desired := baseSeq()
+	desired.Unlogged = true
+	result, err := diff.DiffSequences(newSeqMap(baseSeq()), newSeqMap(desired), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER SEQUENCE public.s SET UNLOGGED;"}, result.Stmts)
+}
+
+func TestDiffSequences_SetLogged(t *testing.T) {
+	current := baseSeq()
+	current.Unlogged = true
+	result, err := diff.DiffSequences(newSeqMap(current), newSeqMap(baseSeq()), diff.AllowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER SEQUENCE public.s SET LOGGED;"}, result.Stmts)
 }

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -3,7 +3,7 @@
 - Domain types (`CREATE DOMAIN`, `ALTER DOMAIN SET/DROP DEFAULT`, `SET/DROP NOT NULL`, `ADD/DROP/VALIDATE CONSTRAINT`)
 - Enum types (`CREATE TYPE ... AS ENUM`, `ALTER TYPE ... ADD VALUE`)
 - Composite types (`CREATE TYPE ... AS (...)`, `ALTER TYPE ... ADD/DROP/ALTER ATTRIBUTE`, `RENAME ATTRIBUTE`). Attributes are matched by name, so reordering them produces no diff (PostgreSQL cannot reorder attributes). `ALTER ATTRIBUTE ... TYPE` fails at apply while a table column uses the type; PostgreSQL does not allow it and `CASCADE` does not help.
-- Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
+- Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`, including unlogged sequences). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables)
 - Storage parameters, the `WITH (...)` clause. An index's parameters are always managed; a table's are opt-in with `--manage-storage-param`. See [Table storage parameters](#table-storage-parameters).
 - Views

--- a/model/sequence.go
+++ b/model/sequence.go
@@ -23,6 +23,7 @@ type Sequence struct {
 	Increment int64
 	Cache     int64
 	Cycle     bool
+	Unlogged  bool
 	// OwnerTable and OwnerColumn are set from the OWNED BY relationship
 	// (pg_depend deptype 'a' for serial, 'i' for identity). They are nil for
 	// standalone sequences, which are the only ones the pipeline manages.
@@ -47,8 +48,12 @@ func (seq Sequence) Owned() bool {
 }
 
 func (seq Sequence) SQL() string {
+	create := "CREATE SEQUENCE "
+	if seq.Unlogged {
+		create = "CREATE UNLOGGED SEQUENCE "
+	}
 	lines := []string{
-		"CREATE SEQUENCE " + seq.FQN(),
+		create + seq.FQN(),
 		"    AS " + seq.DataType,
 		"    START WITH " + strconv.FormatInt(seq.Start, 10),
 		"    INCREMENT BY " + strconv.FormatInt(seq.Increment, 10),

--- a/model/sequence_test.go
+++ b/model/sequence_test.go
@@ -80,3 +80,9 @@ func TestSequence_String(t *testing.T) {
 	seq := &model.Sequence{Schema: "public", Name: "users_id_seq", DataType: "bigint"}
 	assert.Contains(t, seq.String(), "users_id_seq")
 }
+
+func TestSequence_SQL_Unlogged(t *testing.T) {
+	seq := sampleSequence()
+	seq.Unlogged = true
+	assert.Contains(t, seq.SQL(), "CREATE UNLOGGED SEQUENCE public.order_seq\n")
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1658,6 +1658,7 @@ func parseCreateSeqStmt(cs *pg_query.CreateSeqStmt, defaultSchema string) (*mode
 	return &model.Sequence{
 		Schema:      schema,
 		Name:        cs.Sequence.Relname,
+		Unlogged:    cs.Sequence.Relpersistence == "u",
 		DataType:    p.dataType,
 		Start:       p.start,
 		Min:         p.min,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3273,3 +3273,19 @@ func TestParseSQL_IdentityValueOverflow(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse identity options for column id")
 	assert.Contains(t, err.Error(), `invalid value "99999999999999999999" for sequence option start`)
 }
+
+func TestParseSQL_UnloggedSequence(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE UNLOGGED SEQUENCE public.jobs_seq;
+		CREATE SEQUENCE public.plain_seq;
+	`)
+	require.NoError(t, err)
+
+	seq, ok := result.Sequences.GetOk("public.jobs_seq")
+	require.True(t, ok)
+	assert.True(t, seq.Unlogged)
+
+	seq, ok = result.Sequences.GetOk("public.plain_seq")
+	require.True(t, ok)
+	assert.False(t, seq.Unlogged)
+}

--- a/test/fidelity/schemas/sequences.sql
+++ b/test/fidelity/schemas/sequences.sql
@@ -5,3 +5,4 @@ CREATE SEQUENCE public.counter
     MAXVALUE 1000
     CACHE 5
     CYCLE;
+CREATE UNLOGGED SEQUENCE public.jobs_seq;

--- a/testdata/apply/alter_sequence_set_unlogged.yml
+++ b/testdata/apply/alter_sequence_set_unlogged.yml
@@ -1,0 +1,13 @@
+init: |
+  CREATE SEQUENCE public.jobs_seq;
+desired: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq;
+applied: |
+  -- public.jobs_seq
+  CREATE UNLOGGED SEQUENCE public.jobs_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;

--- a/testdata/apply/create_unlogged_sequence.yml
+++ b/testdata/apply/create_unlogged_sequence.yml
@@ -1,0 +1,12 @@
+init: ""
+desired: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq;
+applied: |
+  -- public.jobs_seq
+  CREATE UNLOGGED SEQUENCE public.jobs_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;

--- a/testdata/dump/unlogged_sequence.yml
+++ b/testdata/dump/unlogged_sequence.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq;
+dump: |
+  -- public.jobs_seq
+  CREATE UNLOGGED SEQUENCE public.jobs_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;

--- a/testdata/plan/alter_sequence_set_logged.yml
+++ b/testdata/plan/alter_sequence_set_logged.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq;
+desired: |
+  CREATE SEQUENCE public.jobs_seq;
+plan: |
+  ALTER SEQUENCE public.jobs_seq SET LOGGED;

--- a/testdata/plan/alter_sequence_set_unlogged.yml
+++ b/testdata/plan/alter_sequence_set_unlogged.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE SEQUENCE public.jobs_seq;
+desired: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq;
+plan: |
+  ALTER SEQUENCE public.jobs_seq SET UNLOGGED;

--- a/testdata/plan/alter_sequence_set_unlogged_with_options.yml
+++ b/testdata/plan/alter_sequence_set_unlogged_with_options.yml
@@ -1,0 +1,10 @@
+# A persistence change and an option change on the same sequence: the SET
+# UNLOGGED is its own statement, since the option list of ALTER SEQUENCE does
+# not take it.
+init: |
+  CREATE SEQUENCE public.jobs_seq;
+desired: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq CACHE 10;
+plan: |
+  ALTER SEQUENCE public.jobs_seq SET UNLOGGED;
+  ALTER SEQUENCE public.jobs_seq CACHE 10;

--- a/testdata/plan/create_unlogged_sequence.yml
+++ b/testdata/plan/create_unlogged_sequence.yml
@@ -1,0 +1,11 @@
+init: ""
+desired: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq;
+plan: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq
+      AS bigint
+      START WITH 1
+      INCREMENT BY 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;

--- a/testdata/plan/no_diff_unlogged_sequence.yml
+++ b/testdata/plan/no_diff_unlogged_sequence.yml
@@ -1,0 +1,5 @@
+init: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq;
+desired: |
+  CREATE UNLOGGED SEQUENCE public.jobs_seq;
+plan: ""


### PR DESCRIPTION
Closes the TODO entry "UNLOGGED sequence support".

An `UNLOGGED SEQUENCE` was read by neither side: `dump` wrote it as a plain `CREATE SEQUENCE`, and a `LOGGED` <-> `UNLOGGED` change in the desired schema produced no diff.

## Changes

Follows the table pattern, as the TODO entry laid out:

- `model.Sequence` gains an `Unlogged` field; `SQL()` renders `CREATE UNLOGGED SEQUENCE`.
- The catalog reads `pg_class.relpersistence = 'u'`.
- The parser reads the persistence off `CreateSeqStmt`.
- The diff emits `ALTER SEQUENCE ... SET LOGGED/UNLOGGED` for a transition. The SET form is its own statement, since the option list of `ALTER SEQUENCE` does not take it; a plan that also changes options emits both, persistence first.

Temporary sequences stay out of scope: session-local, never dumped.

## Tests

- Fixtures: dump, plan (create, both transitions, transition combined with an option change, no diff), apply (create and transition; both re-plan and require no drift).
- Package tests in model, diff, parser, and catalog (live read of an unlogged and a plain sequence).
- `test/fidelity/schemas/sequences.sql` gains an unlogged sequence, the regression test for the dump side.
- Coverage: model 99.8%, parser 94.4%, catalog 93.1% unchanged; diff 97.5% -> 97.6% (the `MINVALUE` / `START WITH` clauses of `diffSequence` were uncovered in the package before and are now exercised).
- `make test`, `make test-scenario`, `make test-fidelity` (30 passed), `make lint` all pass.