### PR TITLE
Normalize an EXCLUDE constraint's elements and predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Normalize an EXCLUDE constraint's elements and predicate the way a CHECK body is normalized. They were compared as written, so a hand-written exclusion drifted on a schema-qualified function or operator, a cast the catalog adds, a BETWEEN in the predicate, or an explicit ASC, and was dropped and re-added on every plan. A dump fed back was already clean; only a desired schema written another way hit this.
+
 * Track `UNLOGGED` on a standalone sequence. It was read by neither side, so `dump` wrote an unlogged sequence as a plain `CREATE SEQUENCE` and a `LOGGED` <-> `UNLOGGED` change produced no diff. `dump` now writes `CREATE UNLOGGED SEQUENCE` and a change goes out as `ALTER SEQUENCE ... SET LOGGED/UNLOGGED`. Temporary sequences stay out of scope.
 
 * Restore a `NOT VALID` check constraint unvalidated. A table's checks are written inside `CREATE TABLE`, where the clause cannot be spelled, so `dump` printed such a constraint as validated and the reload scanned the table to validate it. Such a check is now left out of `CREATE TABLE` and added by its own `ALTER TABLE ... ADD CONSTRAINT ... NOT VALID`, the way a foreign key is. This also stops a plan that created the table from re-emitting the constraint on every later run.

--- a/TODO.md
+++ b/TODO.md
@@ -652,7 +652,8 @@ normalization of any kind beyond the walk.
 
 A function moved between two schemas is the cost of the symmetric strip:
 `a.f(v)` and `b.f(v)` compare equal, so the move produces no diff. This is the
-tradeoff a view body's table reference already carries. Telling them apart
+tradeoff a view body's table reference already carries, and an exclusion
+element's `OPERATOR(a.=)` carries it too since #507. Telling them apart
 means the search_path-aware stripping described in the cross-schema user-type
 entry above, which the diff cannot do today because it does not thread the
 schema list.

--- a/TODO.md
+++ b/TODO.md
@@ -603,35 +603,6 @@ Workaround: create the index separately, `CREATE UNIQUE INDEX ... WITH
 
 Origin: [#458](https://github.com/winebarrel/pistachio/pull/458).
 
-## An EXCLUDE constraint is not normalized at all
-
-Priority: low.
-
-`equalConstraintDef` normalizes `RawExpr`, which is where a `CHECK` body sits.
-An exclusion constraint puts its elements in `Constraint.Exclusions` and its
-predicate in `Constraint.WhereClause`, and neither goes through
-`normalizeCheckExpr`, so the two sides are compared as the parser left them.
-
-Every normalization the walk performs is therefore missing there. A
-schema-qualified call drifts, `EXCLUDE USING btree (public.lower_v(v) WITH =)`
-being re-emitted as `DROP CONSTRAINT` + `ADD CONSTRAINT` on every plan, and so
-does a cast the catalog adds and the file does not: `((v || 'x') WITH =)` is
-stored as `((v || 'x'::text) WITH =)`. The folds in `diff/desugar.go` are
-missing too, so the `BETWEEN` in
-`EXCLUDE USING gist (r WITH &&) WHERE (a BETWEEN 1 AND 10)` drifts here alone.
-This is wider than the schema question and predates the strip.
-
-Passing `Exclusions` and `WhereClause` through the same walk is the obvious
-shape, and the elements are `IndexElem` nodes, which `normalizeIndexStmt`
-already knows how to handle.
-
-`dump` writes the catalog form, so a dump fed back plans clean and only a
-hand-written exclusion reaches this.
-
-Workaround: write the exclusion the way `pg_get_constraintdef` prints it.
-
-Origin: review of [#455](https://github.com/winebarrel/pistachio/pull/455).
-
 ## Perpetual drift on a typed literal the catalog re-prints
 
 Priority: low.

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -1000,12 +1000,71 @@ func equalConstraintDef(current, desired string) bool {
 	curCon.RawExpr = normalizeCheckExpr(curCon.RawExpr)
 	desCon.RawExpr = normalizeCheckExpr(desCon.RawExpr)
 	curCon.RawExpr = alignCurrentCasts(desCon.RawExpr, curCon.RawExpr)
+	normalizeExclusion(curCon)
+	normalizeExclusion(desCon)
+	alignExclusionCasts(desCon, curCon)
 	curStr, deparseErrCur := pg_query.Deparse(curResult)
 	desStr, deparseErrDes := pg_query.Deparse(desResult)
 	if deparseErrCur != nil || deparseErrDes != nil {
 		return current == desired
 	}
 	return curStr == desStr
+}
+
+// normalizeExclusion runs the symmetric normalizations over an exclusion
+// constraint's elements and predicate, which sit in Exclusions and WhereClause
+// rather than in the RawExpr a CHECK body uses. Each element is an IndexElem,
+// so it takes the same canonicalization as an index column. A non-exclusion
+// constraint holds neither field and passes through untouched.
+func normalizeExclusion(con *pg_query.Constraint) {
+	for _, ex := range con.Exclusions {
+		list := ex.GetList()
+		if list == nil {
+			continue
+		}
+		for _, item := range list.Items {
+			if ie := item.GetIndexElem(); ie != nil {
+				normalizeIndexElem(ie)
+			}
+			// The operator name list. The catalog prints a visible operator
+			// bare, so the qualification is dropped from both sides, the way
+			// stripFuncSchema treats a function name.
+			if ops := item.GetList(); ops != nil && len(ops.Items) > 1 {
+				ops.Items = ops.Items[len(ops.Items)-1:]
+			}
+		}
+	}
+	if con.WhereClause != nil {
+		con.WhereClause = normalizeCheckExpr(con.WhereClause)
+	}
+}
+
+// alignExclusionCasts strips the casts pg_get_constraintdef adds from the
+// current side of an exclusion, pairing each element expression and the
+// predicate with its desired counterpart the way a CHECK body is paired.
+// Sides whose element counts differ are left alone; the definitions differ
+// anyway.
+func alignExclusionCasts(desired, current *pg_query.Constraint) {
+	if len(desired.Exclusions) == len(current.Exclusions) {
+		for i, ex := range current.Exclusions {
+			curList := ex.GetList()
+			desList := desired.Exclusions[i].GetList()
+			if curList == nil || desList == nil || len(curList.Items) != len(desList.Items) {
+				continue
+			}
+			for j, item := range curList.Items {
+				curIe := item.GetIndexElem()
+				desIe := desList.Items[j].GetIndexElem()
+				if curIe == nil || desIe == nil || curIe.Expr == nil || desIe.Expr == nil {
+					continue
+				}
+				curIe.Expr = alignCurrentCasts(desIe.Expr, curIe.Expr)
+			}
+		}
+	}
+	if desired.WhereClause != nil && current.WhereClause != nil {
+		current.WhereClause = alignCurrentCasts(desired.WhereClause, current.WhereClause)
+	}
 }
 
 // alignCurrentCasts walks desired and current in step, stripping TypeCast
@@ -1500,34 +1559,38 @@ func normalizeIndexStmt(is *pg_query.IndexStmt) {
 		is.Relation.Schemaname = ""
 	}
 	for _, p := range is.IndexParams {
-		ie := p.GetIndexElem()
-		if ie == nil {
-			continue
-		}
-		// Canonicalise sort order: SORTBY_ASC and SORTBY_DEFAULT are equivalent.
-		if ie.Ordering == pg_query.SortByDir_SORTBY_ASC {
-			ie.Ordering = pg_query.SortByDir_SORTBY_DEFAULT
-		}
-		// Canonicalise nulls order: NULLS LAST is the default for ASC/DEFAULT,
-		// NULLS FIRST is the default for DESC.
-		switch ie.Ordering {
-		case pg_query.SortByDir_SORTBY_DEFAULT:
-			if ie.NullsOrdering == pg_query.SortByNulls_SORTBY_NULLS_LAST {
-				ie.NullsOrdering = pg_query.SortByNulls_SORTBY_NULLS_DEFAULT
-			}
-		case pg_query.SortByDir_SORTBY_DESC:
-			if ie.NullsOrdering == pg_query.SortByNulls_SORTBY_NULLS_FIRST {
-				ie.NullsOrdering = pg_query.SortByNulls_SORTBY_NULLS_DEFAULT
-			}
-		}
-		if ie.Expr != nil {
-			ie.Expr = normalizeCheckExpr(ie.Expr)
+		if ie := p.GetIndexElem(); ie != nil {
+			normalizeIndexElem(ie)
 		}
 	}
 	if is.WhereClause != nil {
 		is.WhereClause = normalizeCheckExpr(is.WhereClause)
 	}
 	normalizeStorageParams(is.Options)
+}
+
+// normalizeIndexElem canonicalises one index element in place, for an index
+// column and an exclusion element alike. An explicit ASC and the default sort
+// order compare equal, so does the NULLS order that is the default for the
+// chosen direction, and the expression takes the symmetric expression
+// normalizations.
+func normalizeIndexElem(ie *pg_query.IndexElem) {
+	if ie.Ordering == pg_query.SortByDir_SORTBY_ASC {
+		ie.Ordering = pg_query.SortByDir_SORTBY_DEFAULT
+	}
+	switch ie.Ordering {
+	case pg_query.SortByDir_SORTBY_DEFAULT:
+		if ie.NullsOrdering == pg_query.SortByNulls_SORTBY_NULLS_LAST {
+			ie.NullsOrdering = pg_query.SortByNulls_SORTBY_NULLS_DEFAULT
+		}
+	case pg_query.SortByDir_SORTBY_DESC:
+		if ie.NullsOrdering == pg_query.SortByNulls_SORTBY_NULLS_FIRST {
+			ie.NullsOrdering = pg_query.SortByNulls_SORTBY_NULLS_DEFAULT
+		}
+	}
+	if ie.Expr != nil {
+		ie.Expr = normalizeCheckExpr(ie.Expr)
+	}
 }
 
 // normalizeStorageParams canonicalises an index's WITH clause so the two

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -3747,3 +3747,67 @@ func TestDiffTables_newTable_withStorageRLSAndTrigger(t *testing.T) {
 	assert.Equal(t, "CREATE TRIGGER stamp BEFORE INSERT ON public.docs FOR EACH ROW EXECUTE FUNCTION stamp();", result.Stmts[5])
 	assert.False(t, result.HasConcurrently)
 }
+
+func TestEqualConstraintDef_exclusionSchemaQualifiedFunc(t *testing.T) {
+	// The catalog drops the schema from a function on the search_path.
+	assert.True(t, equalConstraintDef(
+		"EXCLUDE USING btree (lower(v) WITH =)",
+		"EXCLUDE USING btree (pg_catalog.lower(v) WITH =)",
+	))
+}
+
+func TestEqualConstraintDef_exclusionTextCast(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"EXCLUDE USING btree ((v || 'x'::text) WITH =)",
+		"EXCLUDE USING btree (((v || 'x')) WITH =)",
+	))
+}
+
+func TestEqualConstraintDef_exclusionAsc(t *testing.T) {
+	assert.True(t, equalConstraintDef(
+		"EXCLUDE USING btree (v WITH =)",
+		"EXCLUDE USING btree (v ASC WITH =)",
+	))
+}
+
+func TestEqualConstraintDef_exclusionWhereBetween(t *testing.T) {
+	// The catalog stores a BETWEEN in the predicate expanded.
+	assert.True(t, equalConstraintDef(
+		"EXCLUDE USING gist (r WITH &&) WHERE (a >= 1 AND a <= 10)",
+		"EXCLUDE USING gist (r WITH &&) WHERE (a BETWEEN 1 AND 10)",
+	))
+}
+
+func TestEqualConstraintDef_exclusionWhereNumericCast(t *testing.T) {
+	// The cast the catalog adds is stripped from the current side only.
+	assert.True(t, equalConstraintDef(
+		"EXCLUDE USING gist (r WITH &&) WHERE (price > 0::numeric)",
+		"EXCLUDE USING gist (r WITH &&) WHERE (price > 0)",
+	))
+	assert.False(t, equalConstraintDef(
+		"EXCLUDE USING gist (r WITH &&) WHERE (price > 0)",
+		"EXCLUDE USING gist (r WITH &&) WHERE (price > 0::numeric)",
+	))
+}
+
+func TestEqualConstraintDef_exclusionOperatorDiff(t *testing.T) {
+	assert.False(t, equalConstraintDef(
+		"EXCLUDE USING btree (v WITH =)",
+		"EXCLUDE USING btree (v WITH <>)",
+	))
+}
+
+func TestEqualConstraintDef_exclusionElementCountDiff(t *testing.T) {
+	assert.False(t, equalConstraintDef(
+		"EXCLUDE USING gist (r WITH &&)",
+		"EXCLUDE USING gist (r WITH &&, v WITH =)",
+	))
+}
+
+func TestEqualConstraintDef_exclusionQualifiedOperator(t *testing.T) {
+	// The catalog prints a visible operator bare.
+	assert.True(t, equalConstraintDef(
+		"EXCLUDE USING btree (v WITH =)",
+		"EXCLUDE USING btree (v WITH OPERATOR(pg_catalog.=))",
+	))
+}

--- a/testdata/plan/alter_exclude_where.yml
+++ b/testdata/plan/alter_exclude_where.yml
@@ -1,0 +1,16 @@
+# A real change to the predicate still surfaces as DROP + ADD.
+init: |
+  CREATE TABLE public.slots (
+      r int4range NOT NULL,
+      a integer NOT NULL,
+      CONSTRAINT slots_excl EXCLUDE USING gist (r WITH &&) WHERE (a > 0)
+  );
+desired: |
+  CREATE TABLE public.slots (
+      r int4range NOT NULL,
+      a integer NOT NULL,
+      CONSTRAINT slots_excl EXCLUDE USING gist (r WITH &&) WHERE (a > 10)
+  );
+plan: |
+  ALTER TABLE public.slots DROP CONSTRAINT slots_excl;
+  ALTER TABLE public.slots ADD CONSTRAINT slots_excl EXCLUDE USING gist (r WITH &&) WHERE (a > 10);

--- a/testdata/plan/no_diff_exclude_asc.yml
+++ b/testdata/plan/no_diff_exclude_asc.yml
@@ -1,0 +1,12 @@
+# An explicit ASC is the default and the catalog does not print it.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (v ASC WITH =)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (v ASC WITH =)
+  );
+plan: ""

--- a/testdata/plan/no_diff_exclude_default_using.yml
+++ b/testdata/plan/no_diff_exclude_default_using.yml
@@ -1,0 +1,12 @@
+# EXCLUDE without USING means btree, and the catalog prints the method.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE (v WITH =)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE (v WITH =)
+  );
+plan: ""

--- a/testdata/plan/no_diff_exclude_qualified_operator.yml
+++ b/testdata/plan/no_diff_exclude_qualified_operator.yml
@@ -1,0 +1,13 @@
+# The catalog prints a visible operator bare, so the qualification is
+# stripped from both sides, like a function name's schema.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (v WITH OPERATOR(pg_catalog.=))
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (v WITH OPERATOR(pg_catalog.=))
+  );
+plan: ""

--- a/testdata/plan/no_diff_exclude_schema_qualified_func.yml
+++ b/testdata/plan/no_diff_exclude_schema_qualified_func.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (pg_catalog.lower(v) WITH =)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (pg_catalog.lower(v) WITH =)
+  );
+plan: ""

--- a/testdata/plan/no_diff_exclude_text_cast.yml
+++ b/testdata/plan/no_diff_exclude_text_cast.yml
@@ -1,0 +1,13 @@
+# The catalog stores the concatenation operand cast, (v || 'x'::text), while
+# the file leaves it off.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (((v || 'x')) WITH =)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (((v || 'x')) WITH =)
+  );
+plan: ""

--- a/testdata/plan/no_diff_exclude_where_between.yml
+++ b/testdata/plan/no_diff_exclude_where_between.yml
@@ -1,0 +1,14 @@
+# The catalog stores the predicate's BETWEEN expanded to a >= 1 AND a <= 10.
+init: |
+  CREATE TABLE public.slots (
+      r int4range NOT NULL,
+      a integer NOT NULL,
+      CONSTRAINT slots_excl EXCLUDE USING gist (r WITH &&) WHERE (a BETWEEN 1 AND 10)
+  );
+desired: |
+  CREATE TABLE public.slots (
+      r int4range NOT NULL,
+      a integer NOT NULL,
+      CONSTRAINT slots_excl EXCLUDE USING gist (r WITH &&) WHERE (a BETWEEN 1 AND 10)
+  );
+plan: ""

--- a/testdata/plan/no_diff_exclude_where_numeric_cast.yml
+++ b/testdata/plan/no_diff_exclude_where_numeric_cast.yml
@@ -1,0 +1,15 @@
+# The catalog stores the predicate as (price > 0::numeric); the cast the file
+# did not write is stripped from the current side only, like a CHECK body's.
+init: |
+  CREATE TABLE public.slots (
+      r int4range NOT NULL,
+      price numeric NOT NULL,
+      CONSTRAINT slots_excl EXCLUDE USING gist (r WITH &&) WHERE (price > 0)
+  );
+desired: |
+  CREATE TABLE public.slots (
+      r int4range NOT NULL,
+      price numeric NOT NULL,
+      CONSTRAINT slots_excl EXCLUDE USING gist (r WITH &&) WHERE (price > 0)
+  );
+plan: ""


### PR DESCRIPTION
Closes the TODO entry "An EXCLUDE constraint is not normalized at all".

`equalConstraintDef` normalized `RawExpr`, where a CHECK body sits. An exclusion constraint puts its elements in `Exclusions` and its predicate in `WhereClause`, so the two sides were compared as the parser left them, and a hand-written exclusion was dropped and re-added on every plan for a difference the CHECK path already folds. A dump fed back was already clean, since dump writes the catalog form.

## Changes

- `normalizeExclusion` runs each element expression and the predicate through the same walk (`normalizeCheckExpr`).
- The element canonicalization (explicit ASC, default NULLS order) is shared with the index path as `normalizeIndexElem`.
- An operator's qualification is dropped from both sides, the way `stripFuncSchema` treats a function name: the catalog prints a visible operator bare.
- `alignExclusionCasts` strips the casts only the catalog wrote, pairing element for element and predicate for predicate the way a CHECK body is paired.

## Tests

- Each drift shape was reproduced on 15 before being pinned as a no-diff fixture: schema-qualified function, qualified operator, text cast, BETWEEN in the predicate, numeric cast in the predicate, explicit ASC, and EXCLUDE without USING (already clean, pinned).
- Negative cases: a predicate change still plans DROP + ADD (fixture), and operator, element-count, and desired-side-cast differences still compare unequal (package tests in `diff`).
- Coverage: diff stays at 97.6%. The only uncovered new statements are two nil guards; the exclusion AST always carries `[IndexElem, operator list]`, so they are defensive, in the shape rename.go already uses.
- `make test`, `make test-scenario`, `make test-fidelity` (30 passed), `make lint` all pass. Dump output is unchanged, so no fidelity schema was added.