### PR TITLE
Read the storage parameters of the index a constraint owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Read the storage parameters of the index a constraint owns. `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE (v) WITH (fillfactor = 70)` puts them on the index, which `pg_get_constraintdef` does not print, so the two sides never matched and the constraint was dropped and re-added on every plan, rebuilding the index under an ACCESS EXCLUSIVE lock. `dump` dropped the clause the same way and now writes it. A parameter set on such an index outside the schema file shows up as a diff, the same as on a plain index. A quoted parameter value and the bare spelling, `deduplicate_items = 'off'` and `off`, also compare equal now, on a plain index too.
+
 * Normalize an EXCLUDE constraint's elements and predicate the way a CHECK body is normalized. They were compared as written, so a hand-written exclusion drifted on a schema-qualified function or operator, a cast the catalog adds, a BETWEEN in the predicate, or an explicit ASC, and was dropped and re-added on every plan. A dump fed back was already clean; only a desired schema written another way hit this.
 
 * Track `UNLOGGED` on a standalone sequence. It was read by neither side, so `dump` wrote an unlogged sequence as a plain `CREATE SEQUENCE` and a `LOGGED` <-> `UNLOGGED` change produced no diff. `dump` now writes `CREATE UNLOGGED SEQUENCE` and a change goes out as `ALTER SEQUENCE ... SET LOGGED/UNLOGGED`. Temporary sequences stay out of scope.

--- a/TODO.md
+++ b/TODO.md
@@ -578,31 +578,6 @@ clean and only a hand-written view reaches this.
 
 Origin: review of [#458](https://github.com/winebarrel/pistachio/pull/458).
 
-## A constraint's index storage parameters are not read
-
-Priority: low.
-
-`ALTER TABLE t ADD CONSTRAINT t_v_key UNIQUE (v) WITH (fillfactor = 70)` puts
-the parameters on the index the constraint owns. `pg_get_constraintdef` does
-not print them, so the current side reads the constraint as `UNIQUE (v)` and
-the two never match: the plan is `DROP CONSTRAINT` + `ADD CONSTRAINT` on every
-run, which rebuilds the index under an ACCESS EXCLUSIVE lock. `dump` drops the
-clause for the same reason, so a table's parameters survive a dump and a
-constraint's do not.
-
-The parameters are on `pg_class` under `pg_constraint.conindid`, next to the
-ones `ListIndexes` already reads, and appending them to the definition is what
-would make both sides agree. `normalizeStorageParams` then folds the quoting
-the way it does for a plain index.
-
-`dump` writes the catalog form, so a dump fed back plans clean and only a
-hand-written constraint reaches this.
-
-Workaround: create the index separately, `CREATE UNIQUE INDEX ... WITH
-(fillfactor = 70)`, where the parameters are read.
-
-Origin: [#458](https://github.com/winebarrel/pistachio/pull/458).
-
 ## Perpetual drift on a typed literal the catalog re-prints
 
 Priority: low.

--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -48,6 +48,13 @@ func (c *Catalog) ListConstraintsByTables(ctx context.Context, tables []*model.T
 			con.condeferrable,
 			con.condeferred,
 			con.convalidated,
+			-- The storage parameters of the index the constraint owns.
+			-- pg_get_constraintdef does not print them for a primary key or a
+			-- unique constraint, so they are appended to the definition below.
+			-- It does print them for an exclusion constraint, and a foreign
+			-- key's conindid names the referenced table's index, whose
+			-- parameters are not part of the key, so the CASE keeps both out.
+			CASE WHEN con.contype = ANY ('{p,u}'::"char"[]) THEN ci.reloptions END AS index_options,
 			rn.nspname AS ref_schema,
 			rc.relname AS ref_table
 		FROM
@@ -55,6 +62,7 @@ func (c *Catalog) ListConstraintsByTables(ctx context.Context, tables []*model.T
 			pg_catalog.pg_constraint con
 			LEFT JOIN pg_catalog.pg_class rc ON rc.oid = con.confrelid
 			LEFT JOIN pg_catalog.pg_namespace rn ON rn.oid = rc.relnamespace
+			LEFT JOIN pg_catalog.pg_class ci ON ci.oid = con.conindid
 			LEFT JOIN column_t col ON col.con_oid = con.oid
 		WHERE
 			con.conrelid = ANY(@table_oids::oid[])
@@ -99,6 +107,7 @@ func (c *Catalog) ListConstraintsByTables(ctx context.Context, tables []*model.T
 	for rows.Next() {
 		var con model.Constraint
 		var tableOID uint32
+		var indexOptions []string
 		var refSchema, refTable *string
 
 		err := rows.Scan(
@@ -111,6 +120,7 @@ func (c *Catalog) ListConstraintsByTables(ctx context.Context, tables []*model.T
 			&con.Deferrable,
 			&con.Deferred,
 			&con.Validated,
+			&indexOptions,
 			&refSchema,
 			&refTable,
 		)
@@ -122,6 +132,30 @@ func (c *Catalog) ListConstraintsByTables(ctx context.Context, tables []*model.T
 		// for unvalidated constraints. Strip it so Definition only contains
 		// the constraint body; validation state is tracked via Validated.
 		con.Definition = strings.TrimSuffix(con.Definition, " NOT VALID")
+
+		// Append the owned index's storage parameters, which
+		// pg_get_constraintdef leaves out. Values are quoted the way
+		// pg_get_indexdef quotes an index's, so a dump reloads. The grammar
+		// takes WITH before the deferral clause and pg_get_constraintdef
+		// prints DEFERRABLE last, so the clause goes in between.
+		if len(indexOptions) > 0 {
+			opts := make([]string, 0, len(indexOptions))
+			for _, o := range indexOptions {
+				name, value, _ := strings.Cut(o, "=")
+				opts = append(opts, name+"="+model.QuoteLiteral(value))
+			}
+			deferral := ""
+			if con.Deferrable {
+				for _, s := range []string{" DEFERRABLE INITIALLY DEFERRED", " DEFERRABLE"} {
+					if strings.HasSuffix(con.Definition, s) {
+						deferral = s
+						break
+					}
+				}
+			}
+			con.Definition = strings.TrimSuffix(con.Definition, deferral) +
+				" WITH (" + strings.Join(opts, ", ") + ")" + deferral
+		}
 
 		if con.Type.IsForeignKeyConstraint() {
 			table := tableByOID[tableOID]

--- a/catalog/constraints_test.go
+++ b/catalog/constraints_test.go
@@ -64,6 +64,45 @@ func TestListConstraintsByTables(t *testing.T) {
 		assert.Equal(t, []string{"email"}, con.Columns)
 	})
 
+	t.Run("index storage parameters", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.users (
+				id integer NOT NULL,
+				email text NOT NULL,
+				name text NOT NULL,
+				CONSTRAINT users_pkey PRIMARY KEY (id) WITH (fillfactor = 90),
+				CONSTRAINT users_email_key UNIQUE (email) WITH (fillfactor = 70),
+				CONSTRAINT users_email_excl EXCLUDE USING btree (email WITH =) WITH (fillfactor = 60),
+				CONSTRAINT users_name_key UNIQUE (name) WITH (fillfactor = 50) DEFERRABLE INITIALLY DEFERRED
+			);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.users")
+		pk, ok := tbl.Constraints.GetOk("users_pkey")
+		require.True(t, ok)
+		assert.Equal(t, "PRIMARY KEY (id) WITH (fillfactor='90')", pk.Definition)
+
+		uq, ok := tbl.Constraints.GetOk("users_email_key")
+		require.True(t, ok)
+		assert.Equal(t, "UNIQUE (email) WITH (fillfactor='70')", uq.Definition)
+
+		// pg_get_constraintdef prints an exclusion's parameters itself, so
+		// nothing is appended.
+		ex, ok := tbl.Constraints.GetOk("users_email_excl")
+		require.True(t, ok)
+		assert.Equal(t, "EXCLUDE USING btree (email WITH =) WITH (fillfactor='60')", ex.Definition)
+
+		// The WITH goes before the deferral clause, which the grammar takes
+		// last.
+		df, ok := tbl.Constraints.GetOk("users_name_key")
+		require.True(t, ok)
+		assert.Equal(t, "UNIQUE (name) WITH (fillfactor='50') DEFERRABLE INITIALLY DEFERRED", df.Definition)
+	})
+
 	t.Run("check", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE TABLE public.products (

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -1003,6 +1003,10 @@ func equalConstraintDef(current, desired string) bool {
 	normalizeExclusion(curCon)
 	normalizeExclusion(desCon)
 	alignExclusionCasts(desCon, curCon)
+	// The WITH clause of a unique, primary key, or exclusion constraint,
+	// folded the way a plain index's is.
+	normalizeStorageParams(curCon.Options)
+	normalizeStorageParams(desCon.Options)
 	curStr, deparseErrCur := pg_query.Deparse(curResult)
 	desStr, deparseErrDes := pg_query.Deparse(desResult)
 	if deparseErrCur != nil || deparseErrDes != nil {
@@ -1601,15 +1605,21 @@ func normalizeIndexElem(ie *pg_query.IndexElem) {
 // parameters were created in. Without this an index carrying a parameter was
 // dropped and recreated on every run.
 //
-// Only an integer is folded. No index storage parameter takes a fractional
-// value, and a value that reads as a bare word arrives as a String from both
-// sides already.
+// An integer is folded to its decimal string; no index storage parameter
+// takes a fractional value. A bare word, `deduplicate_items=off`, parses as a
+// single-name TypeName while the quoted spelling parses as a String, so the
+// TypeName is folded to a String too.
 func normalizeStorageParams(options []*pg_query.Node) {
 	for _, o := range options {
 		de := o.GetDefElem()
 		if i := de.GetArg().GetInteger(); i != nil {
 			sval := strconv.FormatInt(int64(i.Ival), 10)
 			de.Arg = &pg_query.Node{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: sval}}}
+		}
+		if tn := de.GetArg().GetTypeName(); tn != nil && len(tn.Names) == 1 {
+			if s := tn.Names[0].GetString_(); s != nil {
+				de.Arg = &pg_query.Node{Node: &pg_query.Node_String_{String_: &pg_query.String{Sval: s.Sval}}}
+			}
 		}
 	}
 	// No index storage parameter has a namespace, unlike a table's toast.

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -3811,3 +3811,24 @@ func TestEqualConstraintDef_exclusionQualifiedOperator(t *testing.T) {
 		"EXCLUDE USING btree (v WITH OPERATOR(pg_catalog.=))",
 	))
 }
+
+func TestEqualConstraintDef_storageParams(t *testing.T) {
+	// The catalog quotes the value; the file writes it bare.
+	assert.True(t, equalConstraintDef(
+		"UNIQUE (v) WITH (fillfactor='70')",
+		"UNIQUE (v) WITH (fillfactor = 70)",
+	))
+	// The order the parameters were created in is not part of the setting.
+	assert.True(t, equalConstraintDef(
+		"UNIQUE (v) WITH (fillfactor='70', deduplicate_items='off')",
+		"UNIQUE (v) WITH (deduplicate_items = off, fillfactor = 70)",
+	))
+	assert.False(t, equalConstraintDef(
+		"UNIQUE (v) WITH (fillfactor='70')",
+		"UNIQUE (v) WITH (fillfactor = 80)",
+	))
+	assert.False(t, equalConstraintDef(
+		"UNIQUE (v) WITH (fillfactor='70')",
+		"UNIQUE (v)",
+	))
+}

--- a/test/fidelity/schemas/storage_params.sql
+++ b/test/fidelity/schemas/storage_params.sql
@@ -1,6 +1,7 @@
 CREATE TABLE public.events (
     id integer NOT NULL,
     body text,
-    CONSTRAINT events_pkey PRIMARY KEY (id)
+    CONSTRAINT events_pkey PRIMARY KEY (id) WITH (fillfactor='90'),
+    CONSTRAINT events_body_key UNIQUE (body) WITH (fillfactor='60')
 ) WITH (autovacuum_enabled='off', autovacuum_vacuum_scale_factor='0.05', fillfactor='70', toast.autovacuum_enabled='off');
 CREATE INDEX events_body_idx ON public.events USING btree (body) WITH (deduplicate_items='off', fillfactor='80');

--- a/testdata/apply/deferrable_unique_storage_params.yml
+++ b/testdata/apply/deferrable_unique_storage_params.yml
@@ -1,0 +1,12 @@
+init: ""
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70) DEFERRABLE
+  );
+applied: |
+  -- public.items
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor='70') DEFERRABLE
+  );

--- a/testdata/apply/unique_constraint_storage_params.yml
+++ b/testdata/apply/unique_constraint_storage_params.yml
@@ -1,0 +1,12 @@
+init: ""
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70)
+  );
+applied: |
+  -- public.items
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor='70')
+  );

--- a/testdata/dump/constraint_storage_params.yml
+++ b/testdata/dump/constraint_storage_params.yml
@@ -1,0 +1,15 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      v text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id) WITH (fillfactor = 90),
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70, deduplicate_items = off)
+  );
+dump: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      v text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id) WITH (fillfactor='90'),
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor='70', deduplicate_items='off')
+  );

--- a/testdata/plan/alter_unique_constraint_remove_storage_params.yml
+++ b/testdata/plan/alter_unique_constraint_remove_storage_params.yml
@@ -1,0 +1,15 @@
+# A parameter the desired schema does not write is a difference now, the same
+# as on a plain index.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v)
+  );
+plan: |
+  ALTER TABLE public.items DROP CONSTRAINT items_v_key;
+  ALTER TABLE public.items ADD CONSTRAINT items_v_key UNIQUE (v);

--- a/testdata/plan/alter_unique_constraint_storage_params.yml
+++ b/testdata/plan/alter_unique_constraint_storage_params.yml
@@ -1,0 +1,14 @@
+# A parameter change is a definition change: DROP + ADD, like any other.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 80)
+  );
+plan: |
+  ALTER TABLE public.items DROP CONSTRAINT items_v_key;
+  ALTER TABLE public.items ADD CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor=80);

--- a/testdata/plan/no_diff_deferrable_unique_storage_params.yml
+++ b/testdata/plan/no_diff_deferrable_unique_storage_params.yml
@@ -1,0 +1,13 @@
+# pg_get_constraintdef prints DEFERRABLE last, and the grammar takes WITH
+# before it, so the appended clause goes in between.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70) DEFERRABLE INITIALLY DEFERRED
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: ""

--- a/testdata/plan/no_diff_exclude_storage_params.yml
+++ b/testdata/plan/no_diff_exclude_storage_params.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (v WITH =) WITH (fillfactor = 70)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_excl EXCLUDE USING btree (v WITH =) WITH (fillfactor = 70)
+  );
+plan: ""

--- a/testdata/plan/no_diff_index_storage_param_quoted_word.yml
+++ b/testdata/plan/no_diff_index_storage_param_quoted_word.yml
@@ -1,0 +1,13 @@
+# The file quotes the value and pg_get_indexdef prints it bare; the quoted
+# spelling parses as a String and the bare one as a TypeName.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL
+  );
+  CREATE INDEX items_v_idx ON public.items (v) WITH (deduplicate_items = 'off');
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL
+  );
+  CREATE INDEX items_v_idx ON public.items (v) WITH (deduplicate_items = 'off');
+plan: ""

--- a/testdata/plan/no_diff_pkey_storage_params.yml
+++ b/testdata/plan/no_diff_pkey_storage_params.yml
@@ -1,0 +1,11 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id) WITH (fillfactor = 90)
+  );
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id) WITH (fillfactor = 90)
+  );
+plan: ""

--- a/testdata/plan/no_diff_unique_constraint_storage_params.yml
+++ b/testdata/plan/no_diff_unique_constraint_storage_params.yml
@@ -1,0 +1,13 @@
+# The parameters sit on the index the constraint owns, which
+# pg_get_constraintdef does not print; the catalog read appends them.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70, deduplicate_items = off)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70, deduplicate_items = off)
+  );
+plan: ""

--- a/testdata/plan/rename_constraint_with_storage_params.yml
+++ b/testdata/plan/rename_constraint_with_storage_params.yml
@@ -1,0 +1,14 @@
+# A rename with matching parameters stays a rename; the index is not rebuilt.
+init: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      CONSTRAINT items_v_key UNIQUE (v) WITH (fillfactor = 70)
+  );
+desired: |
+  CREATE TABLE public.items (
+      v text NOT NULL,
+      -- pista:renamed-from items_v_key
+      CONSTRAINT items_v_uniq UNIQUE (v) WITH (fillfactor = 70)
+  );
+plan: |
+  ALTER TABLE public.items RENAME CONSTRAINT items_v_key TO items_v_uniq;


### PR DESCRIPTION
Closes the TODO entry "A constraint's index storage parameters are not read".

`ALTER TABLE ... ADD CONSTRAINT ... UNIQUE (v) WITH (fillfactor = 70)` puts the parameters on the index the constraint owns, and `pg_get_constraintdef` does not print them for a primary key or a unique constraint. The current side read `UNIQUE (v)`, the two sides never matched, and the plan dropped and re-added the constraint on every run, rebuilding the index under an ACCESS EXCLUSIVE lock. `dump` dropped the clause the same way.

## Changes

- The catalog reads `pg_class.reloptions` under `pg_constraint.conindid` and appends the `WITH` clause to the definition, values quoted the way `pg_get_indexdef` quotes an index's. The clause goes before the deferral suffix, which the grammar takes last; appended after it, a deferrable constraint's definition does not parse (found while writing tests, verified on 15).
- An exclusion constraint gets no append: `pg_get_constraintdef` prints its parameters itself (verified on 15). A foreign key's `conindid` names the referenced table's index, which is not part of the key, so the CASE keeps it out too.
- `equalConstraintDef` runs `normalizeStorageParams` over the constraint's options. The function also folds a bare-word value into the String its quoted spelling parses as: `deduplicate_items = off` arrives as a single-name TypeName and `'off'` as a String, a mismatch that also made a plain index written with the quoted spelling drift.

Not gated behind `--manage-storage-param` (confirmed with the repository owner): no SET or RESET is emitted, the parameters are part of the definition the way a plain index's already are, and gating the read would leave the drift in place when the flag is off. The flag keeps gating a table's own parameters. A parameter set on a constraint's index outside the schema file now shows up as a diff, the same as on a plain index.

## Tests

- Fixtures (each confirmed failing first): no-diff plans for PK / UNIQUE / EXCLUDE / deferrable UNIQUE / two params in reversed order / quoted bare word on a plain index; a parameter change and a parameter removal both plan DROP + ADD; a rename with matching parameters stays a rename; dump pins the two-param format; applies for the plain and the deferrable case, both re-plan drift-free.
- Package tests: catalog (live read asserting the appended definitions, the deferral insert position, and no double append on an exclusion) and diff (`equalConstraintDef` on quoting, order, value change, presence).
- Coverage: diff 97.6% unchanged, catalog 93.1% -> 93.3%; the only uncovered lines in the touched files are two pre-existing scan-error paths.
- `make test`, `make test-scenario`, `make test-fidelity` (30 passed; `storage_params.sql` gains a PK and a UNIQUE with parameters), `make lint` all pass.