### PR TITLE
Manage a view's WITH CHECK OPTION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Manage a view's `WITH [LOCAL | CASCADED] CHECK OPTION`. Neither side read it, so `dump` dropped the clause and an updatable view lost the constraint on restore, and a desired schema that wrote it planned nothing. `dump` now writes the clause after the query, the way pg_dump does, and a change on a view whose definition stays goes out as `ALTER VIEW ... SET (check_option=...)` or `RESET (check_option)`. A definition change carries the clause on its `CREATE OR REPLACE VIEW`, which replaces the option along with the query. The `WITH (check_option = ...)` spelling before `AS` is read as well.
+
 ## [1.43.0] - 2026-09-05
 
 * Manage an `INHERITS` child as the columns and constraints it declares itself. `dump` wrote such a child as its constraints alone, the parent's included, and dropped every column, so the output did not even reload: the constraint named a column the statement no longer declared. Fed back as the desired schema it planned a `DROP COLUMN` for every column and a `DROP CONSTRAINT` PostgreSQL rejects. Both sides now read the local half alone, `attislocal` and `conislocal`, which is what the child's `CREATE TABLE` writes and what `pg_dump` writes for it. A NOT VALID check on the child is added by its own `ALTER` rather than written inline, so a reload no longer validates it. A comment on an inherited column and a child of more than one parent stay unmanaged, both symmetric on the two sides.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Manage a view's `WITH [LOCAL | CASCADED] CHECK OPTION`. Neither side read it, so `dump` dropped the clause and an updatable view lost the constraint on restore, and a desired schema that wrote it planned nothing. `dump` now writes the clause after the query, the way pg_dump does, and a change on a view whose definition stays goes out as `ALTER VIEW ... SET (check_option=...)` or `RESET (check_option)`. A definition change carries the clause on its `CREATE OR REPLACE VIEW`, which replaces the option along with the query. The `WITH (check_option = ...)` spelling before `AS` is read as well.
+* Manage a view's `WITH [LOCAL | CASCADED] CHECK OPTION`. Neither side read it, so `dump` dropped the clause and a reload lost the constraint, and a desired schema that wrote it planned nothing. `dump` now writes the clause after the query. A change on a view whose definition stays goes out as `ALTER VIEW ... SET (check_option=...)` or `RESET (check_option)`; a definition change carries the clause on its `CREATE OR REPLACE VIEW`. `WITH (check_option = ...)` before `AS` is read too.
 
 ## [1.43.0] - 2026-09-05
 

--- a/TODO.md
+++ b/TODO.md
@@ -614,8 +614,8 @@ A view carries `security_barrier`, a materialized view the autovacuum
 settings, and neither side reads them. `dump` drops the clause, and a desired
 schema that writes it plans nothing, the way a table's parameters behaved
 before they were read. Losing `security_barrier` from a dump is the one that
-matters, since the view is a security boundary without it. `check_option` sits
-in the same column and is managed, as the view's `WITH CHECK OPTION`.
+matters, since the view is a security boundary without it. `check_option`, in
+the same column, is managed.
 
 `pg_class.reloptions` holds them for both, next to the table's, and
 `ALTER VIEW ... SET (...)` / `RESET (...)` and the `ALTER MATERIALIZED VIEW`

--- a/TODO.md
+++ b/TODO.md
@@ -610,11 +610,12 @@ Origin: [#459](https://github.com/winebarrel/pistachio/pull/459).
 
 Priority: low.
 
-A view carries `security_barrier` and `check_option`, a materialized view the
-autovacuum settings, and neither side reads them. `dump` drops the clause, and
-a desired schema that writes it plans nothing, the way a table's parameters
-behaved before they were read. Losing `security_barrier` from a dump is the
-one that matters, since the view is a security boundary without it.
+A view carries `security_barrier`, a materialized view the autovacuum
+settings, and neither side reads them. `dump` drops the clause, and a desired
+schema that writes it plans nothing, the way a table's parameters behaved
+before they were read. Losing `security_barrier` from a dump is the one that
+matters, since the view is a security boundary without it. `check_option` sits
+in the same column and is managed, as the view's `WITH CHECK OPTION`.
 
 `pg_class.reloptions` holds them for both, next to the table's, and
 `ALTER VIEW ... SET (...)` / `RESET (...)` and the `ALTER MATERIALIZED VIEW`
@@ -941,18 +942,3 @@ and pistachio takes a rename from a `-- pista:renamed-from` directive rather
 than inferring one, so a directive would have to reach a column's sequence.
 
 Origin: identity sequence options, 2026-09-02.
-
-## `WITH CHECK OPTION` on a view is not managed
-
-Nothing reads `pg_class.reloptions` `check_option` or parses the trailing
-`WITH [CASCADED | LOCAL] CHECK OPTION`, so the clause is dropped from a view in
-the desired schema without an error and `pista dump` does not emit one. An
-updatable view loses the constraint on restore.
-
-The work is a field on `model.View`, a catalog read, the parser clause, and
-emission from the create and replace paths. Related to the view storage
-parameters entry above, which reads the same `reloptions` column.
-
-Origin: the restore fidelity check, 2026-09-02.
-`test/fidelity/schemas/view_columns.sql` notes what it leaves out.
-

--- a/catalog/views.go
+++ b/catalog/views.go
@@ -68,7 +68,7 @@ func (c *Catalog) ListViews(ctx context.Context) ([]*model.View, error) {
 			c.relkind = 'm' AS materialized,
 			(
 				SELECT
-					split_part(o, '=', 2)
+					lower(split_part(o, '=', 2))
 				FROM
 					unnest(c.reloptions) AS o
 				WHERE

--- a/catalog/views.go
+++ b/catalog/views.go
@@ -66,6 +66,14 @@ func (c *Catalog) ListViews(ctx context.Context) ([]*model.View, error) {
 			c.relname,
 			pg_catalog.pg_get_viewdef(c.oid, true) AS definition,
 			c.relkind = 'm' AS materialized,
+			(
+				SELECT
+					split_part(o, '=', 2)
+				FROM
+					unnest(c.reloptions) AS o
+				WHERE
+					o LIKE 'check_option=%'
+			) AS check_option,
 			d.description
 		FROM
 			pg_catalog.pg_class c
@@ -95,16 +103,21 @@ func (c *Catalog) ListViews(ctx context.Context) ([]*model.View, error) {
 	var views []*model.View
 	for rows.Next() {
 		var v model.View
+		var checkOption *string
 		err := rows.Scan(
 			&v.OID,
 			&v.Schema,
 			&v.Name,
 			&v.Definition,
 			&v.Materialized,
+			&checkOption,
 			&v.Comment,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan view info: %w", err)
+		}
+		if checkOption != nil {
+			v.CheckOption = *checkOption
 		}
 		v.Indexes = orderedmap.New[string, *model.Index]()
 		v.Triggers = orderedmap.New[string, *model.Trigger]()

--- a/catalog/views_test.go
+++ b/catalog/views_test.go
@@ -89,6 +89,30 @@ func TestViews(t *testing.T) {
 		assert.Equal(t, "user_stats", idx.Table)
 	})
 
+	t.Run("view check option", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.items (
+				id integer NOT NULL,
+				status text NOT NULL,
+				CONSTRAINT items_pkey PRIMARY KEY (id)
+			);
+			CREATE VIEW public.cascaded_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+			CREATE VIEW public.local_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+			CREATE VIEW public.barrier_items WITH (security_barrier = true) AS SELECT id, status FROM public.items WHERE status = 'active';
+			CREATE VIEW public.plain_items AS SELECT id, status FROM public.items WHERE status = 'active';
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		views, err := cat.Views(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, "cascaded", views.Get("public.cascaded_items").CheckOption)
+		assert.Equal(t, "local", views.Get("public.local_items").CheckOption)
+		// Another option in reloptions does not stand in for it.
+		assert.Empty(t, views.Get("public.barrier_items").CheckOption)
+		assert.Empty(t, views.Get("public.plain_items").CheckOption)
+	})
+
 	t.Run("view comment", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE TABLE public.users (

--- a/catalog/views_test.go
+++ b/catalog/views_test.go
@@ -99,6 +99,7 @@ func TestViews(t *testing.T) {
 			CREATE VIEW public.cascaded_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
 			CREATE VIEW public.local_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
 			CREATE VIEW public.barrier_items WITH (security_barrier = true) AS SELECT id, status FROM public.items WHERE status = 'active';
+			CREATE VIEW public.upper_items WITH (check_option = 'CASCADED') AS SELECT id, status FROM public.items WHERE status = 'active';
 			CREATE VIEW public.plain_items AS SELECT id, status FROM public.items WHERE status = 'active';
 		`)
 		cat, err := catalog.NewCatalog(conn, []string{"public"})
@@ -108,6 +109,8 @@ func TestViews(t *testing.T) {
 
 		assert.Equal(t, "cascaded", views.Get("public.cascaded_items").CheckOption)
 		assert.Equal(t, "local", views.Get("public.local_items").CheckOption)
+		// The value is stored as written and validated case-insensitively.
+		assert.Equal(t, "cascaded", views.Get("public.upper_items").CheckOption)
 		// Another option in reloptions does not stand in for it.
 		assert.Empty(t, views.Get("public.barrier_items").CheckOption)
 		assert.Empty(t, views.Get("public.plain_items").CheckOption)

--- a/diff/views.go
+++ b/diff/views.go
@@ -354,10 +354,10 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 				result.HasConcurrently = true
 			}
 		} else if currentView.CheckOption != desiredView.CheckOption {
-			// Definition unchanged, the check option alone moved. A replaced
-			// definition carries the clause on its CREATE OR REPLACE, which
-			// swaps the options as a whole, so only this branch needs the
-			// ALTER.
+			// Definition unchanged, check option changed. A replaced
+			// definition carries the clause on its CREATE OR REPLACE VIEW,
+			// which replaces the options as a whole, so only this branch
+			// needs an ALTER.
 			result.CreateStmts = append(result.CreateStmts, model.SetCheckOptionSQL(k, desiredView.CheckOption))
 		}
 

--- a/diff/views.go
+++ b/diff/views.go
@@ -353,6 +353,12 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 			if viewIdxHasConcurrently {
 				result.HasConcurrently = true
 			}
+		} else if currentView.CheckOption != desiredView.CheckOption {
+			// Definition unchanged, the check option alone moved. A replaced
+			// definition carries the clause on its CREATE OR REPLACE, which
+			// swaps the options as a whole, so only this branch needs the
+			// ALTER.
+			result.CreateStmts = append(result.CreateStmts, model.SetCheckOptionSQL(k, desiredView.CheckOption))
 		}
 
 		// A view that stayed in place, whether its definition was replaced or

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -97,6 +97,53 @@ func TestDiffViews_formattingDifferenceIgnored(t *testing.T) {
 	assert.Empty(t, result.DropStmts)
 }
 
+func TestDiffViews_checkOptionSet(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", CheckOption: "local"})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER VIEW public.v1 SET (check_option='local');"}, result.CreateStmts)
+	assert.Empty(t, result.DropStmts)
+}
+
+func TestDiffViews_checkOptionReset(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", CheckOption: "cascaded"})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ALTER VIEW public.v1 RESET (check_option);"}, result.CreateStmts)
+}
+
+func TestDiffViews_checkOptionNoChange(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", CheckOption: "cascaded"})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", CheckOption: "cascaded"})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, result.CreateStmts)
+}
+
+// A definition change carries the clause on CREATE OR REPLACE VIEW, which
+// replaces the options as a whole, so no ALTER follows it.
+func TestDiffViews_checkOptionWithDefinitionChange(t *testing.T) {
+	current := orderedmap.New[string, *model.View]()
+	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1", CheckOption: "cascaded"})
+	desired := orderedmap.New[string, *model.View]()
+	desired.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 2", CheckOption: "local"})
+
+	result, err := DiffViews(current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CREATE OR REPLACE VIEW public.v1 AS\nSELECT 2\n  WITH LOCAL CHECK OPTION;"}, result.CreateStmts)
+}
+
 func TestDiffViews_commentAdd(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.v1", &model.View{Schema: "public", Name: "v1", Definition: "SELECT 1"})

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -6,7 +6,7 @@
 - Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`, including unlogged sequences). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables, and `INHERITS` children). See [Table inheritance](#table-inheritance).
 - Storage parameters, the `WITH (...)` clause. An index's parameters are always managed; a table's are opt-in with `--manage-storage-param`. See [Table storage parameters](#table-storage-parameters).
-- Views
+- Views, including `WITH [LOCAL | CASCADED] CHECK OPTION`. A change of the check option alone goes out as `ALTER VIEW ... SET (check_option=...)` / `RESET (check_option)`; `security_barrier` is not managed.
 - Materialized views
 - Columns (serial/bigserial/smallserial, identity, generated, TOAST storage and compression). An identity column's sequence options, the `( ... )` after `AS IDENTITY`, are managed; a change goes out as `ALTER TABLE ... ALTER COLUMN ... SET`. No `RESTART` is planned, the same as `ALTER SEQUENCE`, so a change that puts the sequence's current value outside the new range fails at apply with the server's error.
 - Constraints (primary key, unique, check, exclusion, foreign key)

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -6,7 +6,7 @@
 - Sequences (`CREATE SEQUENCE`, `ALTER SEQUENCE`, `DROP SEQUENCE`, including unlogged sequences). Only standalone sequences are managed; sequences owned by a serial or identity column are handled as part of that column, not as separate objects.
 - Tables (including unlogged and partitioned tables, and `INHERITS` children). See [Table inheritance](#table-inheritance).
 - Storage parameters, the `WITH (...)` clause. An index's parameters are always managed; a table's are opt-in with `--manage-storage-param`. See [Table storage parameters](#table-storage-parameters).
-- Views, including `WITH [LOCAL | CASCADED] CHECK OPTION`. A change of the check option alone goes out as `ALTER VIEW ... SET (check_option=...)` / `RESET (check_option)`; `security_barrier` is not managed.
+- Views, including `WITH [LOCAL | CASCADED] CHECK OPTION`. `security_barrier` is not managed.
 - Materialized views
 - Columns (serial/bigserial/smallserial, identity, generated, TOAST storage and compression). An identity column's sequence options, the `( ... )` after `AS IDENTITY`, are managed; a change goes out as `ALTER TABLE ... ALTER COLUMN ... SET`. No `RESTART` is planned, the same as `ALTER SEQUENCE`, so a change that puts the sequence's current value outside the new range fails at apply with the server's error.
 - Constraints (primary key, unique, check, exclusion, foreign key)

--- a/model/view.go
+++ b/model/view.go
@@ -13,9 +13,12 @@ type View struct {
 	RenameFrom   *string
 	Definition   string
 	Materialized bool
-	Indexes      *orderedmap.Map[string, *Index]
-	Triggers     *orderedmap.Map[string, *Trigger]
-	Comment      *string
+	// CheckOption is the view's WITH CHECK OPTION, "local" or "cascaded", and
+	// empty when the view has none. A materialized view never has one.
+	CheckOption string
+	Indexes     *orderedmap.Map[string, *Index]
+	Triggers    *orderedmap.Map[string, *Trigger]
+	Comment     *string
 	// Ignore marks the view as unmanaged (set by -- pista:ignore). Ignored
 	// objects are not created, altered, or dropped; always false on the
 	// catalog side.
@@ -32,7 +35,26 @@ func (v View) SQL() string {
 	if v.Materialized {
 		return "CREATE MATERIALIZED VIEW " + Ident(v.Schema, v.Name) + " AS\n" + def + ";"
 	}
-	return "CREATE OR REPLACE VIEW " + Ident(v.Schema, v.Name) + " AS\n" + def + ";"
+	return "CREATE OR REPLACE VIEW " + Ident(v.Schema, v.Name) + " AS\n" + def + v.checkOptionClause() + ";"
+}
+
+// checkOptionClause renders the WITH CHECK OPTION that follows the query,
+// indented the way pg_dump writes it, or nothing for a view without one.
+func (v View) checkOptionClause() string {
+	if v.CheckOption == "" {
+		return ""
+	}
+	return "\n  WITH " + strings.ToUpper(v.CheckOption) + " CHECK OPTION"
+}
+
+// SetCheckOptionSQL returns the statement that puts the view's check option
+// at option, or resets it when option is empty. Both forms leave the
+// definition alone.
+func SetCheckOptionSQL(fqvn, option string) string {
+	if option == "" {
+		return "ALTER VIEW " + fqvn + " RESET (check_option);"
+	}
+	return "ALTER VIEW " + fqvn + " SET (check_option=" + QuoteLiteral(option) + ");"
 }
 
 // TrigSQL renders the view's INSTEAD OF triggers. PostgreSQL rejects

--- a/model/view_test.go
+++ b/model/view_test.go
@@ -76,3 +76,15 @@ func TestViewToSQL_materializedWithIndex(t *testing.T) {
 	assert.Contains(t, got, "CREATE MATERIALIZED VIEW")
 	assert.Contains(t, got, "CREATE INDEX idx_mv_n")
 }
+
+func TestView_SQL_checkOption(t *testing.T) {
+	v := model.View{Schema: "public", Name: "v1", Definition: "SELECT id FROM t WHERE ok", CheckOption: "cascaded"}
+	assert.Equal(t, "CREATE OR REPLACE VIEW public.v1 AS\nSELECT id FROM t WHERE ok\n  WITH CASCADED CHECK OPTION;", v.SQL())
+	v.CheckOption = "local"
+	assert.Equal(t, "CREATE OR REPLACE VIEW public.v1 AS\nSELECT id FROM t WHERE ok\n  WITH LOCAL CHECK OPTION;", v.SQL())
+}
+
+func TestSetCheckOptionSQL(t *testing.T) {
+	assert.Equal(t, "ALTER VIEW public.v1 SET (check_option='local');", model.SetCheckOptionSQL("public.v1", "local"))
+	assert.Equal(t, "ALTER VIEW public.v1 RESET (check_option);", model.SetCheckOptionSQL("public.v1", ""))
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1302,12 +1302,41 @@ func parseViewStmt(vs *pg_query.ViewStmt, defaultSchema string) (*model.View, er
 	}
 
 	return &model.View{
-		Schema:     schema,
-		Name:       vs.View.Relname,
-		Definition: def,
-		Indexes:    orderedmap.New[string, *model.Index](),
-		Triggers:   orderedmap.New[string, *model.Trigger](),
+		Schema:      schema,
+		Name:        vs.View.Relname,
+		Definition:  def,
+		CheckOption: viewCheckOption(vs),
+		Indexes:     orderedmap.New[string, *model.Index](),
+		Triggers:    orderedmap.New[string, *model.Trigger](),
 	}, nil
+}
+
+// viewCheckOption reads a view's check option from either place the statement
+// can carry it: the trailing WITH [LOCAL | CASCADED] CHECK OPTION, which is
+// what pg_dump and pista dump write, or a check_option entry in the WITH (...)
+// options before AS. A bare WITH CHECK OPTION is CASCADED. The trailing clause
+// wins when both are written, the way PostgreSQL resolves it.
+func viewCheckOption(vs *pg_query.ViewStmt) string {
+	switch vs.WithCheckOption {
+	case pg_query.ViewCheckOption_LOCAL_CHECK_OPTION:
+		return "local"
+	case pg_query.ViewCheckOption_CASCADED_CHECK_OPTION:
+		return "cascaded"
+	}
+	for _, opt := range vs.Options {
+		de := opt.GetDefElem()
+		if de == nil || de.Defname != "check_option" || de.Arg == nil {
+			continue
+		}
+		// A quoted value arrives as a string, a bare one as a type name.
+		if s := de.Arg.GetString_(); s != nil {
+			return strings.ToLower(s.Sval)
+		}
+		if tn := de.Arg.GetTypeName(); tn != nil && len(tn.Names) > 0 {
+			return strings.ToLower(tn.Names[len(tn.Names)-1].GetString_().GetSval())
+		}
+	}
+	return ""
 }
 
 func parseCreateMatViewStmt(as *pg_query.CreateTableAsStmt, defaultSchema string) (*model.View, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1311,11 +1311,11 @@ func parseViewStmt(vs *pg_query.ViewStmt, defaultSchema string) (*model.View, er
 	}, nil
 }
 
-// viewCheckOption reads a view's check option from either place the statement
-// can carry it: the trailing WITH [LOCAL | CASCADED] CHECK OPTION, which is
-// what pg_dump and pista dump write, or a check_option entry in the WITH (...)
-// options before AS. A bare WITH CHECK OPTION is CASCADED. The trailing clause
-// wins when both are written, the way PostgreSQL resolves it.
+// viewCheckOption reads a view's check option from the trailing
+// WITH [LOCAL | CASCADED] CHECK OPTION, which pg_dump and pista dump write, or
+// from a check_option entry in the WITH (...) before AS. A bare WITH CHECK
+// OPTION is CASCADED. The trailing clause wins when both are written, as in
+// PostgreSQL.
 func viewCheckOption(vs *pg_query.ViewStmt) string {
 	switch vs.WithCheckOption {
 	case pg_query.ViewCheckOption_LOCAL_CHECK_OPTION:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1314,8 +1314,8 @@ func parseViewStmt(vs *pg_query.ViewStmt, defaultSchema string) (*model.View, er
 // viewCheckOption reads a view's check option from the trailing
 // WITH [LOCAL | CASCADED] CHECK OPTION, which pg_dump and pista dump write, or
 // from a check_option entry in the WITH (...) before AS. A bare WITH CHECK
-// OPTION is CASCADED. The trailing clause wins when both are written, as in
-// PostgreSQL.
+// OPTION is CASCADED. PostgreSQL rejects a statement that writes both, so the
+// order here does not matter.
 func viewCheckOption(vs *pg_query.ViewStmt) string {
 	switch vs.WithCheckOption {
 	case pg_query.ViewCheckOption_LOCAL_CHECK_OPTION:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -575,7 +575,6 @@ CREATE VIEW public.cascaded_items AS SELECT id, status FROM public.items WHERE s
 CREATE VIEW public.local_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
 CREATE VIEW public.bare_param WITH (check_option = local) AS SELECT id, status FROM public.items WHERE status = 'active';
 CREATE VIEW public.quoted_param WITH (security_barrier = true, check_option = 'cascaded') AS SELECT id, status FROM public.items WHERE status = 'active';
-CREATE VIEW public.both_forms WITH (check_option = local) AS SELECT id, status FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
 CREATE VIEW public.none AS SELECT id, status FROM public.items WHERE status = 'active';`
 
 	result, err := parseSQLWithPublicSchema(sql)
@@ -586,7 +585,6 @@ CREATE VIEW public.none AS SELECT id, status FROM public.items WHERE status = 'a
 		"local_items":    "local",
 		"bare_param":     "local",
 		"quoted_param":   "cascaded",
-		"both_forms":     "cascaded",
 		"none":           "",
 	} {
 		v, ok := result.Views.GetOk("public." + name)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -569,6 +569,36 @@ COMMENT ON VIEW public.active_users IS 'Active users';`
 	assert.Equal(t, expected, got)
 }
 
+func TestParseSQL_ViewCheckOption(t *testing.T) {
+	sql := `CREATE TABLE public.items (id integer NOT NULL, status text NOT NULL);
+CREATE VIEW public.cascaded_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+CREATE VIEW public.local_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+CREATE VIEW public.bare_param WITH (check_option = local) AS SELECT id, status FROM public.items WHERE status = 'active';
+CREATE VIEW public.quoted_param WITH (check_option = 'cascaded') AS SELECT id, status FROM public.items WHERE status = 'active';
+CREATE VIEW public.both_forms WITH (check_option = local) AS SELECT id, status FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
+CREATE VIEW public.none AS SELECT id, status FROM public.items WHERE status = 'active';`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	for name, want := range map[string]string{
+		"cascaded_items": "cascaded",
+		"local_items":    "local",
+		"bare_param":     "local",
+		"quoted_param":   "cascaded",
+		"both_forms":     "cascaded",
+		"none":           "",
+	} {
+		v, ok := result.Views.GetOk("public." + name)
+		require.True(t, ok, name)
+		assert.Equal(t, want, v.CheckOption, name)
+		assert.Equal(t, "SELECT id, status FROM public.items WHERE status = 'active'", v.Definition, name)
+	}
+
+	v := result.Views.Get("public.local_items")
+	assert.Equal(t, "CREATE OR REPLACE VIEW public.local_items AS\nSELECT id, status FROM public.items WHERE status = 'active'\n  WITH LOCAL CHECK OPTION;", v.SQL())
+}
+
 func TestParseSQL_ViewCommentOnColumn(t *testing.T) {
 	sql := `CREATE TABLE public.users (
     id integer NOT NULL,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -574,7 +574,7 @@ func TestParseSQL_ViewCheckOption(t *testing.T) {
 CREATE VIEW public.cascaded_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
 CREATE VIEW public.local_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
 CREATE VIEW public.bare_param WITH (check_option = local) AS SELECT id, status FROM public.items WHERE status = 'active';
-CREATE VIEW public.quoted_param WITH (check_option = 'cascaded') AS SELECT id, status FROM public.items WHERE status = 'active';
+CREATE VIEW public.quoted_param WITH (security_barrier = true, check_option = 'cascaded') AS SELECT id, status FROM public.items WHERE status = 'active';
 CREATE VIEW public.both_forms WITH (check_option = local) AS SELECT id, status FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
 CREATE VIEW public.none AS SELECT id, status FROM public.items WHERE status = 'active';`
 

--- a/test/fidelity/schemas/view_columns.sql
+++ b/test/fidelity/schemas/view_columns.sql
@@ -1,5 +1,3 @@
--- No WITH CHECK OPTION: it is not managed, so the dump restores the view
--- without it. TODO.md records it.
 CREATE TABLE public.staff (
     id integer NOT NULL,
     name text NOT NULL,
@@ -7,4 +5,8 @@ CREATE TABLE public.staff (
     CONSTRAINT staff_pkey PRIMARY KEY (id)
 );
 CREATE VIEW public.sales_staff (staff_id, staff_name) AS SELECT staff.id, staff.name FROM public.staff WHERE (staff.dept = 'sales'::text);
+CREATE VIEW public.checked_staff AS SELECT staff.id, staff.name, staff.dept FROM public.staff WHERE (staff.dept = 'sales'::text)
+  WITH CASCADED CHECK OPTION;
+CREATE VIEW public.local_staff AS SELECT checked_staff.id, checked_staff.name FROM public.checked_staff WHERE (checked_staff.name <> ''::text)
+  WITH LOCAL CHECK OPTION;
 CREATE MATERIALIZED VIEW public.staff_by_dept (dept_name, n) AS SELECT staff.dept, count(*) AS count FROM public.staff GROUP BY staff.dept;

--- a/testdata/apply/alter_view_check_option.yml
+++ b/testdata/apply/alter_view_check_option.yml
@@ -1,0 +1,80 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.added AS SELECT id, status FROM public.items WHERE status = 'active';
+  CREATE VIEW public.changed AS SELECT id, status FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
+  CREATE VIEW public.removed AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.added AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+  CREATE VIEW public.changed AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+  CREATE VIEW public.removed AS SELECT id, status FROM public.items WHERE status = 'active';
+applied: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.added
+  CREATE OR REPLACE VIEW public.added AS
+  SELECT items.id,
+      items.status
+     FROM items
+    WHERE (items.status = 'active'::text)
+    WITH CASCADED CHECK OPTION;
+
+  -- public.changed
+  CREATE OR REPLACE VIEW public.changed AS
+  SELECT items.id,
+      items.status
+     FROM items
+    WHERE (items.status = 'active'::text)
+    WITH LOCAL CHECK OPTION;
+
+  -- public.removed
+  CREATE OR REPLACE VIEW public.removed AS
+  SELECT items.id,
+      items.status
+     FROM items
+    WHERE (items.status = 'active'::text);
+applied_pg16: &applied_pg16plus |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.added
+  CREATE OR REPLACE VIEW public.added AS
+  SELECT id,
+      status
+     FROM items
+    WHERE status = 'active'::text
+    WITH CASCADED CHECK OPTION;
+
+  -- public.changed
+  CREATE OR REPLACE VIEW public.changed AS
+  SELECT id,
+      status
+     FROM items
+    WHERE status = 'active'::text
+    WITH LOCAL CHECK OPTION;
+
+  -- public.removed
+  CREATE OR REPLACE VIEW public.removed AS
+  SELECT id,
+      status
+     FROM items
+    WHERE status = 'active'::text;
+applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/alter_view_check_option.yml
+++ b/testdata/apply/alter_view_check_option.yml
@@ -29,7 +29,7 @@ applied: |
   SELECT items.id,
       items.status
      FROM items
-    WHERE (items.status = 'active'::text)
+    WHERE items.status = 'active'::text
     WITH CASCADED CHECK OPTION;
 
   -- public.changed
@@ -37,7 +37,7 @@ applied: |
   SELECT items.id,
       items.status
      FROM items
-    WHERE (items.status = 'active'::text)
+    WHERE items.status = 'active'::text
     WITH LOCAL CHECK OPTION;
 
   -- public.removed
@@ -45,7 +45,7 @@ applied: |
   SELECT items.id,
       items.status
      FROM items
-    WHERE (items.status = 'active'::text);
+    WHERE items.status = 'active'::text;
 applied_pg16: &applied_pg16plus |
   -- public.items
   CREATE TABLE public.items (

--- a/testdata/apply/create_view_check_option.yml
+++ b/testdata/apply/create_view_check_option.yml
@@ -25,7 +25,7 @@ applied: |
   SELECT items.id,
       items.status
      FROM items
-    WHERE (items.status = 'active'::text)
+    WHERE items.status = 'active'::text
     WITH CASCADED CHECK OPTION;
 
   -- public.local_items
@@ -33,7 +33,7 @@ applied: |
   SELECT items.id,
       items.status
      FROM items
-    WHERE (items.status = 'active'::text)
+    WHERE items.status = 'active'::text
     WITH LOCAL CHECK OPTION;
 applied_pg16: &applied_pg16plus |
   -- public.items

--- a/testdata/apply/create_view_check_option.yml
+++ b/testdata/apply/create_view_check_option.yml
@@ -1,0 +1,62 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+  CREATE VIEW public.local_items WITH (check_option = local) AS SELECT id, status FROM public.items WHERE status = 'active';
+applied: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_items
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT items.id,
+      items.status
+     FROM items
+    WHERE (items.status = 'active'::text)
+    WITH CASCADED CHECK OPTION;
+
+  -- public.local_items
+  CREATE OR REPLACE VIEW public.local_items AS
+  SELECT items.id,
+      items.status
+     FROM items
+    WHERE (items.status = 'active'::text)
+    WITH LOCAL CHECK OPTION;
+applied_pg16: &applied_pg16plus |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_items
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT id,
+      status
+     FROM items
+    WHERE status = 'active'::text
+    WITH CASCADED CHECK OPTION;
+
+  -- public.local_items
+  CREATE OR REPLACE VIEW public.local_items AS
+  SELECT id,
+      status
+     FROM items
+    WHERE status = 'active'::text
+    WITH LOCAL CHECK OPTION;
+applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/apply/modify_view_check_option.yml
+++ b/testdata/apply/modify_view_check_option.yml
@@ -28,7 +28,7 @@ applied: |
   SELECT items.id,
       items.status
      FROM items
-    WHERE (items.status = 'active'::text);
+    WHERE items.status = 'active'::text;
 applied_pg16: &applied_pg16plus |
   -- public.items
   CREATE TABLE public.items (

--- a/testdata/apply/modify_view_check_option.yml
+++ b/testdata/apply/modify_view_check_option.yml
@@ -1,0 +1,47 @@
+# CREATE OR REPLACE VIEW replaces the options as a whole, so a definition change
+# that drops the clause leaves no check option behind. The re-plan after the
+# apply is what checks that.
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active';
+applied: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_items
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT items.id,
+      items.status
+     FROM items
+    WHERE (items.status = 'active'::text);
+applied_pg16: &applied_pg16plus |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_items
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT id,
+      status
+     FROM items
+    WHERE status = 'active'::text;
+applied_pg17: *applied_pg16plus
+applied_pg18: *applied_pg16plus

--- a/testdata/dump/view_check_option.yml
+++ b/testdata/dump/view_check_option.yml
@@ -20,7 +20,7 @@ dump: |
   SELECT items.id,
       items.status
      FROM items
-    WHERE (items.status = 'active'::text)
+    WHERE items.status = 'active'::text
     WITH CASCADED CHECK OPTION;
 
   -- public.local_items
@@ -28,7 +28,7 @@ dump: |
   SELECT items.id,
       items.status
      FROM items
-    WHERE (items.status = 'active'::text)
+    WHERE items.status = 'active'::text
     WITH LOCAL CHECK OPTION;
   COMMENT ON VIEW public.local_items IS 'Local only';
 dump_pg16: &dump_pg16plus |

--- a/testdata/dump/view_check_option.yml
+++ b/testdata/dump/view_check_option.yml
@@ -1,0 +1,59 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+  CREATE VIEW public.local_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+  COMMENT ON VIEW public.local_items IS 'Local only';
+dump: |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_items
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT items.id,
+      items.status
+     FROM items
+    WHERE (items.status = 'active'::text)
+    WITH CASCADED CHECK OPTION;
+
+  -- public.local_items
+  CREATE OR REPLACE VIEW public.local_items AS
+  SELECT items.id,
+      items.status
+     FROM items
+    WHERE (items.status = 'active'::text)
+    WITH LOCAL CHECK OPTION;
+  COMMENT ON VIEW public.local_items IS 'Local only';
+dump_pg16: &dump_pg16plus |
+  -- public.items
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+
+  -- public.active_items
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT id,
+      status
+     FROM items
+    WHERE status = 'active'::text
+    WITH CASCADED CHECK OPTION;
+
+  -- public.local_items
+  CREATE OR REPLACE VIEW public.local_items AS
+  SELECT id,
+      status
+     FROM items
+    WHERE status = 'active'::text
+    WITH LOCAL CHECK OPTION;
+  COMMENT ON VIEW public.local_items IS 'Local only';
+dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus

--- a/testdata/plan/alter_view_check_option.yml
+++ b/testdata/plan/alter_view_check_option.yml
@@ -1,0 +1,22 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.added AS SELECT id, status FROM public.items WHERE status = 'active';
+  CREATE VIEW public.changed AS SELECT id, status FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
+  CREATE VIEW public.removed AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.added AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+  CREATE VIEW public.changed AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+  CREATE VIEW public.removed AS SELECT id, status FROM public.items WHERE status = 'active';
+plan: |
+  ALTER VIEW public.added SET (check_option='cascaded');
+  ALTER VIEW public.changed SET (check_option='local');
+  ALTER VIEW public.removed RESET (check_option);

--- a/testdata/plan/create_view_check_option.yml
+++ b/testdata/plan/create_view_check_option.yml
@@ -1,0 +1,25 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+  CREATE VIEW public.local_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+  CREATE VIEW public.param_items WITH (check_option = cascaded) AS SELECT id, status FROM public.items WHERE status = 'active';
+plan: |
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT id, status FROM public.items WHERE status = 'active'
+    WITH CASCADED CHECK OPTION;
+  CREATE OR REPLACE VIEW public.local_items AS
+  SELECT id, status FROM public.items WHERE status = 'active'
+    WITH LOCAL CHECK OPTION;
+  CREATE OR REPLACE VIEW public.param_items AS
+  SELECT id, status FROM public.items WHERE status = 'active'
+    WITH CASCADED CHECK OPTION;

--- a/testdata/plan/modify_view_check_option.yml
+++ b/testdata/plan/modify_view_check_option.yml
@@ -1,0 +1,20 @@
+# A definition change goes out as CREATE OR REPLACE VIEW, which replaces the
+# view's options as a whole, so the clause rides on it and no ALTER follows.
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+plan: |
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT id, status FROM public.items WHERE status = 'active'
+    WITH LOCAL CHECK OPTION;

--- a/testdata/plan/no_diff_view_check_option.yml
+++ b/testdata/plan/no_diff_view_check_option.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+  CREATE VIEW public.local_items WITH (check_option = local) AS SELECT id, status FROM public.items WHERE status = 'active';
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items WITH (check_option = 'cascaded') AS SELECT id, status FROM public.items WHERE status = 'active';
+  CREATE VIEW public.local_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+plan: ""

--- a/testdata/plan/no_diff_view_check_option_case.yml
+++ b/testdata/plan/no_diff_view_check_option_case.yml
@@ -1,0 +1,17 @@
+# The value is stored as written, so a view created with an uppercase value
+# keeps it in reloptions.
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items WITH (check_option = 'CASCADED') AS SELECT id, status FROM public.items WHERE status = 'active';
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CHECK OPTION;
+plan: ""

--- a/testdata/plan/rename_view_check_option.yml
+++ b/testdata/plan/rename_view_check_option.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  -- pista:renamed-from public.active_items
+  CREATE VIEW public.live_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH LOCAL CHECK OPTION;
+plan: |
+  ALTER VIEW public.active_items RENAME TO live_items;
+  ALTER VIEW public.live_items SET (check_option='local');

--- a/testdata/plan/view_recreate_check_option.yml
+++ b/testdata/plan/view_recreate_check_option.yml
@@ -1,0 +1,24 @@
+# A view recreated for a column change is created with its clause.
+drop_policy:
+  allow_drop: [view]
+init: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      note text,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status, note FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
+desired: |
+  CREATE TABLE public.items (
+      id integer NOT NULL,
+      status text NOT NULL,
+      note text,
+      CONSTRAINT items_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.active_items AS SELECT id, status FROM public.items WHERE status = 'active' WITH CASCADED CHECK OPTION;
+plan: |
+  DROP VIEW public.active_items;
+  CREATE OR REPLACE VIEW public.active_items AS
+  SELECT id, status FROM public.items WHERE status = 'active'
+    WITH CASCADED CHECK OPTION;


### PR DESCRIPTION
Neither side read it, so dump dropped the clause and an updatable view
lost the constraint on restore, and a desired schema that wrote it
planned nothing. The catalog reads check_option from pg_class.reloptions,
the parser reads the trailing WITH [LOCAL | CASCADED] CHECK OPTION and
the WITH (check_option = ...) spelling before AS, and dump writes the
clause after the query the way pg_dump does.

A change on a view whose definition stays goes out as ALTER VIEW ... SET
(check_option=...) or RESET (check_option). A definition change carries
the clause on its CREATE OR REPLACE VIEW, which replaces the option along
with the query, so no ALTER follows it.

The fidelity schema that left the clause out now carries it.