### PR TITLE
Set the macOS deployment target to 13.0 for the release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,11 @@ builds:
       - CGO_ENABLED=1
       - CC=o64-clang
       - CXX=o64-clang++
+      # Go stamps its object with 13.0, the oldest macOS it supports, while
+      # osxcross clang aims at 10.9 here and 11.0 on arm64. clang and ld both
+      # read this variable, so it lines them up. Raise it when Go does. The
+      # arm64 build repeats it: the anchored env is replaced, not merged.
+      - MACOSX_DEPLOYMENT_TARGET=13.0
     ldflags:
       - -X main.version={{.Version}}
     goos: [darwin]
@@ -24,6 +29,7 @@ builds:
       - CGO_ENABLED=1
       - CC=oa64-clang
       - CXX=oa64-clang++
+      - MACOSX_DEPLOYMENT_TARGET=13.0
     goos: [darwin]
     goarch: [arm64]
   - <<: *build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Build the macOS release binaries against a deployment target of 13.0. The cross toolchain aimed at 10.9 on amd64 and 11.0 on arm64 while Go stamped its object with 13.0, so the release build warned on every link. Go binaries need macOS 13 either way.
+
 ## [1.44.0] - 2026-09-06
 
 * Manage a view's `WITH [LOCAL | CASCADED] CHECK OPTION`. Neither side read it, so `dump` dropped the clause and a reload lost the constraint, and a desired schema that wrote it planned nothing. `dump` now writes the clause after the query. A change on a view whose definition stays goes out as `ALTER VIEW ... SET (check_option=...)` or `RESET (check_option)`; a definition change carries the clause on its `CREATE OR REPLACE VIEW`. `WITH (check_option = ...)` before `AS` is read too.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Download the latest binary from [Releases](https://github.com/winebarrel/pistach
 | Linux   | amd64, arm64 |
 | Windows | amd64        |
 
+The macOS binaries need macOS 13 or later.
+
 ## Example
 
 Create a schema file:

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,8 @@ Download the latest binary from [Releases](https://github.com/winebarrel/pistach
 | Linux   | amd64, arm64 |
 | Windows | amd64        |
 
+The macOS binaries need macOS 13 or later.
+
 
 
 ## Example


### PR DESCRIPTION
## Problem

Every release build prints linker warnings for the two darwin targets:

```
ld: warning: object file (go.o) was built for newer macOS version (13.0) than being linked (11.0)   # arm64
ld: warning: object file (go.o) was built for newer macOS version (13.0) than being linked (10.9)   # amd64
```

plus 46 `-Wunguarded-availability-new` warnings on pg_query's `preadv` and `pwritev`, which need macOS 11.0.

Go's linker stamps its own object with 13.0, the oldest macOS it supports (`macOS = macVersionFlag{13, 0, 0}` in `cmd/link/internal/ld/macho.go`), while the osxcross clang in goreleaser-cross defaults to 10.9 on amd64 and 11.0 on arm64.

## Fix

clang and ld both read `MACOSX_DEPLOYMENT_TARGET`, so setting it to 13.0 on the two darwin builds lines the two up. Both warning kinds go away. Checked with a full rebuild:

```
$ MACOSX_DEPLOYMENT_TARGET=13.0 go build -a ./cmd/pista   # no ld warnings
$ otool -l pista | grep -A4 LC_BUILD_VERSION
 platform 1
    minos 13.0
```

A Go binary needs macOS 13 either way, so the Mach-O header now says so rather than claiming 10.9, and an older macOS gets a clear dyld error instead of a crash. README and the docs index note the minimum.

The value has to be repeated on the arm64 build because the anchored `env` is replaced, not merged.