### PR TITLE
Bump goreleaser-cross to v1.27.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 env:
-  GOLANG_CROSS_VERSION: v1.26.0
+  GOLANG_CROSS_VERSION: v1.27.1
 
 jobs:
   goreleaser:


### PR DESCRIPTION
go.mod requires Go 1.27, but the release workflow still used the goreleaser-cross v1.26.0 image. Bump `GOLANG_CROSS_VERSION` to v1.27.1, the newest Go 1.27 tag.