### PR TITLE
Enable the modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - errorlint
     - fatcontext
     - makezero
+    - modernize
     - nilerr
     - nilnesserr
     - reassign
@@ -18,6 +19,9 @@ linters:
       - linters:
           - errcheck
         path: _test\.go
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 formatters:
   enable:
     - gofumpt

--- a/apply_test.go
+++ b/apply_test.go
@@ -121,16 +121,14 @@ func TestApply(t *testing.T) {
 			}
 			var buf bytes.Buffer
 			result, err := client.Apply(ctx, &pistachio.ApplyOptions{
-				DropPolicy: dropPolicy,
-				FilterOptions: pistachio.FilterOptions{
-					Include:            tc.Include,
-					Exclude:            tc.Exclude,
-					Enable:             tc.Enable,
-					Disable:            tc.Disable,
-					ManageRoutine:      tc.ManageRoutine,
-					ManageStorageParam: tc.ManageStorageParam,
-					SkipPartitionChild: tc.SkipPartitionChild,
-				},
+				DropPolicy:               dropPolicy,
+				Include:                  tc.Include,
+				Exclude:                  tc.Exclude,
+				Enable:                   tc.Enable,
+				Disable:                  tc.Disable,
+				ManageRoutine:            tc.ManageRoutine,
+				ManageStorageParam:       tc.ManageStorageParam,
+				SkipPartitionChild:       tc.SkipPartitionChild,
 				Files:                    []string{desiredFile},
 				DisableIndexConcurrently: tc.DisableIndexConcurrently,
 				ForceIndexConcurrently:   tc.ForceIndexConcurrently,
@@ -150,26 +148,22 @@ func TestApply(t *testing.T) {
 
 			// Verify
 			got, err := client.Dump(ctx, &pistachio.DumpOptions{
-				FilterOptions: pistachio.FilterOptions{
-					ManageRoutine:      tc.ManageRoutine,
-					ManageStorageParam: tc.ManageStorageParam,
-				},
+				ManageRoutine:      tc.ManageRoutine,
+				ManageStorageParam: tc.ManageStorageParam,
 			})
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.expectedApplied(pgMajor)), strings.TrimSpace(got.String()))
 
 			if !tc.SkipDriftCheck {
 				plan, err := client.Plan(ctx, &pistachio.PlanOptions{
-					DropPolicy: dropPolicy,
-					FilterOptions: pistachio.FilterOptions{
-						Include:            tc.Include,
-						Exclude:            tc.Exclude,
-						Enable:             tc.Enable,
-						Disable:            tc.Disable,
-						ManageRoutine:      tc.ManageRoutine,
-						ManageStorageParam: tc.ManageStorageParam,
-						SkipPartitionChild: tc.SkipPartitionChild,
-					},
+					DropPolicy:               dropPolicy,
+					Include:                  tc.Include,
+					Exclude:                  tc.Exclude,
+					Enable:                   tc.Enable,
+					Disable:                  tc.Disable,
+					ManageRoutine:            tc.ManageRoutine,
+					ManageStorageParam:       tc.ManageStorageParam,
+					SkipPartitionChild:       tc.SkipPartitionChild,
 					Files:                    []string{desiredFile},
 					DisableIndexConcurrently: tc.DisableIndexConcurrently,
 					ForceIndexConcurrently:   tc.ForceIndexConcurrently,

--- a/cmd/command/apply_test.go
+++ b/cmd/command/apply_test.go
@@ -34,7 +34,7 @@ func TestApply_Run(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
+	cmd := &command.Apply{AllowDrop: []string{"all"}, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
@@ -72,7 +72,7 @@ CREATE TABLE public.users (
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -111,7 +111,7 @@ CREATE TABLE public.legacy (
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -130,7 +130,7 @@ func TestApply_Run_Error(t *testing.T) {
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
+	cmd := &command.Apply{AllowDrop: []string{"all"}, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 }
@@ -157,11 +157,11 @@ func TestApply_Run_WithTx_FlushesBufferOnError(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{
+	cmd := &command.Apply{
 		Files:      []string{desiredFile},
 		PreSQLFile: preSQLFile,
 		WithTx:     true,
-	}}
+	}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 
@@ -191,7 +191,7 @@ func TestApply_Run_NoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
+	cmd := &command.Apply{AllowDrop: []string{"all"}, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "-- Apply to schema public (")
@@ -226,7 +226,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -269,7 +269,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -311,7 +311,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}, WithTx: true}}
+	cmd := &command.Apply{Files: []string{desiredFile}, WithTx: true}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -353,7 +353,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}, PreSQL: "SET statement_timeout = '5s'"}}
+	cmd := &command.Apply{Files: []string{desiredFile}, PreSQL: "SET statement_timeout = '5s'"}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -385,7 +385,7 @@ func TestApply_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -425,7 +425,7 @@ func TestApply_Run_ExecutedWithSkippedDrops(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Apply{ApplyOptions: pistachio.ApplyOptions{Files: []string{desiredFile}}}
+	cmd := &command.Apply{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()

--- a/cmd/command/dump_test.go
+++ b/cmd/command/dump_test.go
@@ -61,7 +61,7 @@ CREATE TABLE public.posts (
 
 	splitDir := filepath.Join(t.TempDir(), "split_output")
 	var buf bytes.Buffer
-	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	cmd := &command.Dump{Split: splitDir}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 
@@ -118,7 +118,7 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;`)
 
 	splitDir := filepath.Join(t.TempDir(), "split_output")
 	var buf bytes.Buffer
-	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	cmd := &command.Dump{Split: splitDir}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 
@@ -145,7 +145,7 @@ func TestDump_Run_Split_Empty(t *testing.T) {
 
 	splitDir := filepath.Join(t.TempDir(), "split_output")
 	var buf bytes.Buffer
-	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	cmd := &command.Dump{Split: splitDir}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 
@@ -174,7 +174,7 @@ CREATE TABLE public."My Table" (
 
 	splitDir := filepath.Join(t.TempDir(), "split_output")
 	var buf bytes.Buffer
-	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	cmd := &command.Dump{Split: splitDir}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 
@@ -205,7 +205,7 @@ CREATE TABLE public.users (
 	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o644))
 
 	var buf bytes.Buffer
-	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: filepath.Join(notADir, "invalid")}}
+	cmd := &command.Dump{Split: filepath.Join(notADir, "invalid")}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create directory")
@@ -237,7 +237,7 @@ CREATE TABLE public.users (
 	require.NoError(t, os.MkdirAll(filepath.Join(splitDir, "public.users.sql"), 0o755))
 
 	var buf bytes.Buffer
-	cmd := &command.Dump{DumpOptions: pistachio.DumpOptions{Split: splitDir}}
+	cmd := &command.Dump{Split: splitDir}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to write")

--- a/cmd/command/helper_test.go
+++ b/cmd/command/helper_test.go
@@ -20,8 +20,8 @@ func assertConnectedCommentFirst(t *testing.T, out string, cfg *pgx.ConnConfig) 
 }
 
 func firstLine(s string) string {
-	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		return s[:i]
+	if before, _, ok := strings.Cut(s, "\n"); ok {
+		return before
 	}
 	return s
 }

--- a/cmd/command/plan_test.go
+++ b/cmd/command/plan_test.go
@@ -34,7 +34,7 @@ func TestPlan_Run(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
+	cmd := &command.Plan{AllowDrop: []string{"all"}, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
@@ -52,7 +52,7 @@ func TestPlan_Run_Error(t *testing.T) {
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
+	cmd := &command.Plan{AllowDrop: []string{"all"}, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 }
@@ -77,7 +77,7 @@ func TestPlan_Run_NoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}}
+	cmd := &command.Plan{AllowDrop: []string{"all"}, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "-- Plan for schema public (")
@@ -119,7 +119,7 @@ CREATE TABLE public.users (
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -153,7 +153,7 @@ CREATE TABLE public.legacy (
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -184,14 +184,14 @@ func TestPlan_Run_DropDeniedShowsNoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
 	assert.Contains(t, got, "-- skipped: DROP TABLE public.users;")
 	assert.Contains(t, got, "-- No changes")
 	// Plain DROP (no comment) must NOT appear.
-	for _, line := range strings.Split(got, "\n") {
+	for line := range strings.SplitSeq(got, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "DROP TABLE") {
 			t.Fatalf("unexpected uncommented DROP TABLE: %q", line)
@@ -228,10 +228,10 @@ func TestPlan_Run_PreSQLBeforeSkippedDrops(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{
+	cmd := &command.Plan{
 		Files:  []string{desiredFile},
 		PreSQL: "SELECT 1;",
-	}}
+	}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -267,7 +267,7 @@ func TestPlan_Run_CheckWithDiff(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Check: true, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.ErrorIs(t, err, command.ErrPlanDiff)
 	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
@@ -294,7 +294,7 @@ func TestPlan_Run_CheckNoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Check: true, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "-- No changes")
@@ -321,7 +321,7 @@ func TestPlan_Run_CheckSkippedDropOnly(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Check: true, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -354,7 +354,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Check: true, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.ErrorIs(t, err, command.ErrPlanDiff)
 }
@@ -384,7 +384,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Check: true, Files: []string{desiredFile}}
 	require.NoError(t, cmd.Run(ctx, client, &buf))
 	assert.Contains(t, buf.String(), "-- No changes")
 }
@@ -415,7 +415,7 @@ CREATE TABLE public.audit_log (
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Check: true, Files: []string{desiredFile}}
 	// Undetermined counts as a pending change, so --check still reports a diff.
 	require.ErrorIs(t, cmd.Run(ctx, client, &buf), command.ErrPlanDiff)
 
@@ -448,7 +448,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Files: []string{desiredFile}}
 	require.NoError(t, cmd.Run(ctx, client, &buf))
 
 	got := buf.String()
@@ -478,10 +478,11 @@ func TestPlan_Run_CheckPreSQLNoChanges(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{
+	cmd := &command.Plan{
+		Check:  true,
 		Files:  []string{desiredFile},
 		PreSQL: "SELECT 1;",
-	}}
+	}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -501,7 +502,7 @@ func TestPlan_Run_CheckError(t *testing.T) {
 	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{Check: true, PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Check: true, Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.Error(t, err)
 	require.NotErrorIs(t, err, command.ErrPlanDiff)
@@ -532,7 +533,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()
@@ -571,7 +572,7 @@ CREATE OR REPLACE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ L
 	})
 
 	var buf bytes.Buffer
-	cmd := &command.Plan{PlanOptions: pistachio.PlanOptions{Files: []string{desiredFile}}}
+	cmd := &command.Plan{Files: []string{desiredFile}}
 	err := cmd.Run(ctx, client, &buf)
 	require.NoError(t, err)
 	got := buf.String()

--- a/diff/collation_test.go
+++ b/diff/collation_test.go
@@ -13,25 +13,25 @@ func TestEqualCollation(t *testing.T) {
 		expected bool
 	}{
 		{"both nil", nil, nil, true},
-		{"one nil", ptr(`pg_catalog."C"`), nil, false},
-		{"identical", ptr(`pg_catalog."C"`), ptr(`pg_catalog."C"`), true},
-		{"qualified vs bare", ptr(`pg_catalog."C"`), ptr(`"C"`), true},
-		{"different name", ptr(`pg_catalog."C"`), ptr(`pg_catalog."POSIX"`), false},
-		{"different schema", ptr(`pg_catalog."C"`), ptr(`public."C"`), false},
+		{"one nil", new(`pg_catalog."C"`), nil, false},
+		{"identical", new(`pg_catalog."C"`), new(`pg_catalog."C"`), true},
+		{"qualified vs bare", new(`pg_catalog."C"`), new(`"C"`), true},
+		{"different name", new(`pg_catalog."C"`), new(`pg_catalog."POSIX"`), false},
+		{"different schema", new(`pg_catalog."C"`), new(`public."C"`), false},
 		// A dot inside the name is part of the name, not a separator.
-		{"dotted name", ptr(`public."my.coll"`), ptr(`public."my.coll"`), true},
-		{"dotted name vs bare", ptr(`public."my.coll"`), ptr(`"my.coll"`), true},
-		{"dotted name differs", ptr(`public."C.utf8"`), ptr(`public."C.iso"`), false},
+		{"dotted name", new(`public."my.coll"`), new(`public."my.coll"`), true},
+		{"dotted name vs bare", new(`public."my.coll"`), new(`"my.coll"`), true},
+		{"dotted name differs", new(`public."C.utf8"`), new(`public."C.iso"`), false},
 		// Without the quote-aware split these would compare as schema "C" and
 		// name "utf8".
-		{"dotted vs undotted", ptr(`pg_catalog."C.utf8"`), ptr(`"C"`), false},
-		{"empty", ptr(""), ptr(""), true},
+		{"dotted vs undotted", new(`pg_catalog."C.utf8"`), new(`"C"`), false},
+		{"empty", new(""), new(""), true},
 		// quote_ident quotes col_name keywords, model.Ident does not; the two
 		// forms must still compare equal.
-		{"quoted vs bare name", ptr(`public."int"`), ptr(`public.int`), true},
-		{"quoted vs bare schema", ptr(`"int"."C"`), ptr(`int."C"`), true},
-		{"case folding", ptr(`public.mycoll`), ptr(`public.MyColl`), true},
-		{"quoted case is significant", ptr(`public."MyColl"`), ptr(`public.mycoll`), false},
+		{"quoted vs bare name", new(`public."int"`), new(`public.int`), true},
+		{"quoted vs bare schema", new(`"int"."C"`), new(`int."C"`), true},
+		{"case folding", new(`public.mycoll`), new(`public.MyColl`), true},
+		{"quoted case is significant", new(`public."MyColl"`), new(`public.mycoll`), false},
 	}
 
 	for _, tt := range tests {
@@ -40,5 +40,3 @@ func TestEqualCollation(t *testing.T) {
 		})
 	}
 }
-
-func ptr(s string) *string { return &s }

--- a/diff/policies_test.go
+++ b/diff/policies_test.go
@@ -376,7 +376,7 @@ func TestDiffPolicies_RenameOrderFollowsDesired(t *testing.T) {
 		want[i] = "ALTER POLICY old_" + n + " ON public.documents RENAME TO new_" + n + ";"
 	}
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		cur := orderedmap.New[string, *model.Policy]()
 		des := orderedmap.New[string, *model.Policy]()
 		for _, n := range names {

--- a/diff/rename_test.go
+++ b/diff/rename_test.go
@@ -307,10 +307,8 @@ func TestRenameColumnKeys_NoCascadeOnChain(t *testing.T) {
 func TestRewriteColumnRefsInForeignKeys_RewritesLocalAttrs(t *testing.T) {
 	in := orderedmap.New[string, *model.ForeignKey]()
 	in.Set("fk", &model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       "fk",
-			Definition: "FOREIGN KEY (user_id) REFERENCES users(id)",
-		},
+		Name:       "fk",
+		Definition: "FOREIGN KEY (user_id) REFERENCES users(id)",
 	})
 
 	out := rewriteColumnRefsInForeignKeys(in, one("user_id", "buyer_id"))

--- a/diff/routines_test.go
+++ b/diff/routines_test.go
@@ -37,8 +37,6 @@ func newRoutine(mutate ...func(*model.Routine)) *model.Routine {
 	return r
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func TestDiffRoutines_CreateNew(t *testing.T) {
 	result, err := diff.DiffRoutines(newRoutineMap(), newRoutineMap(newRoutine()), diff.AllowAllDrops{})
 	require.NoError(t, err)
@@ -48,7 +46,7 @@ func TestDiffRoutines_CreateNew(t *testing.T) {
 }
 
 func TestDiffRoutines_CreateNewWithComment(t *testing.T) {
-	desired := newRoutine(func(r *model.Routine) { r.Comment = ptr("hi") })
+	desired := newRoutine(func(r *model.Routine) { r.Comment = new("hi") })
 	result, err := diff.DiffRoutines(newRoutineMap(), newRoutineMap(desired), diff.AllowAllDrops{})
 	require.NoError(t, err)
 	require.Len(t, result.Stmts, 2)
@@ -77,7 +75,7 @@ func TestDiffRoutines_ReplaceInPlace(t *testing.T) {
 		{"security definer", func(r *model.Routine) { r.SecurityDefiner = true }},
 		{"leakproof", func(r *model.Routine) { r.Leakproof = true }},
 		{"parallel", func(r *model.Routine) { r.Parallel = "SAFE" }},
-		{"cost", func(r *model.Routine) { r.Cost = ptr(5.0) }},
+		{"cost", func(r *model.Routine) { r.Cost = new(5.0) }},
 		{"set config", func(r *model.Routine) {
 			r.Config = []*model.RoutineConfig{{Name: "search_path", Args: []string{"public"}}}
 		}},
@@ -134,10 +132,10 @@ func TestDiffRoutines_DropAndCreate(t *testing.T) {
 
 // A recreate loses the routine's comment, so the comment is re-applied with it.
 func TestDiffRoutines_DropAndCreateReappliesComment(t *testing.T) {
-	current := newRoutineMap(newRoutine(func(r *model.Routine) { r.Comment = ptr("v1") }))
+	current := newRoutineMap(newRoutine(func(r *model.Routine) { r.Comment = new("v1") }))
 	desired := newRoutineMap(newRoutine(func(r *model.Routine) {
 		r.ReturnType = "bigint"
-		r.Comment = ptr("v1")
+		r.Comment = new("v1")
 	}))
 	result, err := diff.DiffRoutines(current, desired, diff.AllowAllDrops{})
 	require.NoError(t, err)
@@ -163,9 +161,9 @@ func TestDiffRoutines_CommentChanges(t *testing.T) {
 		desired *string
 		want    string
 	}{
-		{"added", nil, ptr("v1"), "COMMENT ON FUNCTION public.f(integer) IS 'v1';"},
-		{"changed", ptr("v1"), ptr("v2"), "COMMENT ON FUNCTION public.f(integer) IS 'v2';"},
-		{"removed", ptr("v1"), nil, "COMMENT ON FUNCTION public.f(integer) IS NULL;"},
+		{"added", nil, new("v1"), "COMMENT ON FUNCTION public.f(integer) IS 'v1';"},
+		{"changed", new("v1"), new("v2"), "COMMENT ON FUNCTION public.f(integer) IS 'v2';"},
+		{"removed", new("v1"), nil, "COMMENT ON FUNCTION public.f(integer) IS NULL;"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			current := newRoutineMap(newRoutine(func(r *model.Routine) { r.Comment = tc.current }))

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -133,9 +133,9 @@ func TestDiffTables_dropTable_withFK(t *testing.T) {
 
 	posts := newTable("public", "posts")
 	posts.ForeignKeys.Set("posts_user_id_fkey", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "posts_user_id_fkey", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)"},
-		Schema:     "public",
-		Table:      "posts",
+		Name: "posts_user_id_fkey", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)",
+		Schema: "public",
+		Table:  "posts",
 	})
 	current.Set("public.posts", posts)
 
@@ -154,9 +154,9 @@ func TestDiffTables_dropTable_withFK_denied(t *testing.T) {
 
 	posts := newTable("public", "posts")
 	posts.ForeignKeys.Set("posts_user_id_fkey", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "posts_user_id_fkey", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)"},
-		Schema:     "public",
-		Table:      "posts",
+		Name: "posts_user_id_fkey", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)",
+		Schema: "public",
+		Table:  "posts",
 	})
 	current.Set("public.posts", posts)
 
@@ -1122,9 +1122,9 @@ func TestDiffForeignKeys_add(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	_, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1138,9 +1138,9 @@ func TestDiffForeignKeys_addNotValid(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false,
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	_, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1153,9 +1153,9 @@ func TestDiffForeignKeys_addNotValid(t *testing.T) {
 func TestDiffForeignKeys_drop(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 
@@ -1170,9 +1170,9 @@ func TestDiffForeignKeys_drop_denied(t *testing.T) {
 	// honor --allow-drop=foreign_key.
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 
@@ -1188,15 +1188,15 @@ func TestDiffForeignKeys_change_denied_alwaysExecutes(t *testing.T) {
 	// drops are denied.
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, denyAllDrops{})
@@ -1213,15 +1213,15 @@ func TestDiffForeignKeys_renamedAndChanged_denied_alwaysExecutes(t *testing.T) {
 	// suppress it.
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_old", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true, RenameFrom: new("fk_old")},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true, RenameFrom: new("fk_old"),
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, disallowed, err := diffForeignKeys("public.orders", "public", current, desired, denyAllDrops{})
@@ -1513,9 +1513,9 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 	tbl := newTable("public", "orders")
 	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 	tbl.ForeignKeys.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired.Set("public.orders", tbl)
 
@@ -1566,15 +1566,15 @@ func TestEqualViewDef_parseError(t *testing.T) {
 func TestDiffForeignKeys_change(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1587,15 +1587,15 @@ func TestDiffForeignKeys_change(t *testing.T) {
 func TestDiffForeignKeys_validatedToNotValid(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false,
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1609,15 +1609,15 @@ func TestDiffForeignKeys_validatedToNotValid(t *testing.T) {
 func TestDiffForeignKeys_notValidToValidated(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1630,15 +1630,15 @@ func TestDiffForeignKeys_notValidToValidated(t *testing.T) {
 func TestDiffForeignKeys_bothNotValid_noChange(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false,
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1650,15 +1650,15 @@ func TestDiffForeignKeys_bothNotValid_noChange(t *testing.T) {
 func TestDiffForeignKeys_changeDefinitionAndValidated(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: false},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: false,
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1673,15 +1673,15 @@ func TestDiffForeignKeys_changeDefinitionAndValidated(t *testing.T) {
 func TestDiffForeignKeys_renameAndValidate(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_old", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true, RenameFrom: new("fk_old")},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true, RenameFrom: new("fk_old"),
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1695,15 +1695,15 @@ func TestDiffForeignKeys_renameAndValidate(t *testing.T) {
 func TestDiffForeignKeys_renameOnly(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_old", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true, RenameFrom: new("fk_old")},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true, RenameFrom: new("fk_old"),
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1716,15 +1716,15 @@ func TestDiffForeignKeys_renameOnly(t *testing.T) {
 func TestDiffForeignKeys_renameAndNotValid(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_old", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false, RenameFrom: new("fk_old")},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false, RenameFrom: new("fk_old"),
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1741,15 +1741,15 @@ func TestDiffForeignKeys_renameAlreadyAppliedAndNotValid(t *testing.T) {
 	// Desired still has RenameFrom but also changes Validated.
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false, RenameFrom: new("fk_old")},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: false, RenameFrom: new("fk_old"),
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1764,15 +1764,15 @@ func TestDiffForeignKeys_renameAlreadyAppliedAndNotValid(t *testing.T) {
 func TestDiffForeignKeys_renameAndChangeDefinition(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_old", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_old", Definition: "FOREIGN KEY (user_id) REFERENCES users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true, RenameFrom: new("fk_old")},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_new", Definition: "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE", Validated: true, RenameFrom: new("fk_old"),
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -1902,9 +1902,9 @@ func TestDiffTable_partitionChild_fkRenameError(t *testing.T) {
 	desired.PartitionBound = &bound
 	oldName := "nonexistent"
 	desired.ForeignKeys.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", RenameFrom: &oldName, Definition: "FOREIGN KEY (id) REFERENCES public.events(id)"},
-		Schema:     "public",
-		Table:      "events_2024",
+		Name: "fk_new", RenameFrom: &oldName, Definition: "FOREIGN KEY (id) REFERENCES public.events(id)",
+		Schema: "public",
+		Table:  "events_2024",
 	})
 
 	_, err := diffTable(current, desired, allowAllDrops{})
@@ -1948,9 +1948,9 @@ func TestDiffTable_fkRenameError(t *testing.T) {
 	desired.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	oldName := "nonexistent"
 	desired.ForeignKeys.Set("fk_new", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_new", RenameFrom: &oldName, Definition: "FOREIGN KEY (id) REFERENCES public.other(id)"},
-		Schema:     "public",
-		Table:      "users",
+		Name: "fk_new", RenameFrom: &oldName, Definition: "FOREIGN KEY (id) REFERENCES public.other(id)",
+		Schema: "public",
+		Table:  "users",
 	})
 
 	_, err := diffTable(current, desired, allowAllDrops{})
@@ -2835,17 +2835,17 @@ func TestDiffIndexes_rename_selfRename_skipped(t *testing.T) {
 func TestDiffForeignKeys_rename_selfRename_skipped(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	oldName := "fk"
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -2905,9 +2905,9 @@ func TestDiffTables_renameTable_withFK(t *testing.T) {
 	ct.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	ct.Columns.Set("user_id", &model.Column{Name: "user_id", TypeName: "integer"})
 	ct.ForeignKeys.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 	current.Set("public.orders", ct)
 
@@ -2917,9 +2917,9 @@ func TestDiffTables_renameTable_withFK(t *testing.T) {
 	dt.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer"})
 	dt.Columns.Set("user_id", &model.Column{Name: "user_id", TypeName: "integer"})
 	dt.ForeignKeys.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "purchases",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "purchases",
 	})
 	desired.Set("public.purchases", dt)
 
@@ -3089,17 +3089,17 @@ func TestDiffIndexes_rename_sourceNotFound(t *testing.T) {
 func TestDiffForeignKeys_rename(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("old_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "old_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "old_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	oldName := "old_fk"
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("new_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -3111,17 +3111,17 @@ func TestDiffForeignKeys_rename(t *testing.T) {
 func TestDiffForeignKeys_rename_alreadyApplied(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("new_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "new_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "new_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	oldName := "old_fk"
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("new_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -3134,9 +3134,9 @@ func TestDiffForeignKeys_rename_sourceNotFound(t *testing.T) {
 	oldName := "nonexistent"
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("new_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -3175,22 +3175,22 @@ func TestDiffIndexes_rename_destinationExists_error(t *testing.T) {
 func TestDiffForeignKeys_rename_destinationExists_error(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("old_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "old_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "old_fk", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 	current.Set("new_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "new_fk", Definition: "FOREIGN KEY (item_id) REFERENCES public.items(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "new_fk", Definition: "FOREIGN KEY (item_id) REFERENCES public.items(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	oldName := "old_fk"
 	desired := orderedmap.New[string, *model.ForeignKey]()
 	desired.Set("new_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "new_fk", RenameFrom: &oldName, Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Schema: "public",
+		Table:  "orders",
 	})
 
 	_, _, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
@@ -3607,9 +3607,9 @@ func TestDiffConstraints_RenameSuppressionKeepsOtherRenames(t *testing.T) {
 func TestDiffForeignKeys_RenameSuppressionKeepsOtherRenames(t *testing.T) {
 	fk := func(name, refTable, renameFrom string) *model.ForeignKey {
 		f := &model.ForeignKey{
-			Constraint: model.Constraint{Name: name, Definition: "FOREIGN KEY (pid) REFERENCES " + refTable + "(id)", Validated: true},
-			Schema:     "public",
-			Table:      "t",
+			Name: name, Definition: "FOREIGN KEY (pid) REFERENCES " + refTable + "(id)", Validated: true,
+			Schema: "public",
+			Table:  "t",
 		}
 		if renameFrom != "" {
 			f.RenameFrom = new(renameFrom)

--- a/diff_all_test.go
+++ b/diff_all_test.go
@@ -88,9 +88,9 @@ func TestOrderStatements_Fallback(t *testing.T) {
 	tblA.Constraints = orderedmap.New[string, *model.Constraint]()
 	tblA.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tblA.ForeignKeys.Set("a_b_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "a_b_fk"},
-		RefSchema:  &schemaPublic,
-		RefTable:   &refB,
+		Name:      "a_b_fk",
+		RefSchema: &schemaPublic,
+		RefTable:  &refB,
 	})
 	desiredTables.Set("public.a", tblA)
 
@@ -100,9 +100,9 @@ func TestOrderStatements_Fallback(t *testing.T) {
 	tblB.Constraints = orderedmap.New[string, *model.Constraint]()
 	tblB.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tblB.ForeignKeys.Set("b_a_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "b_a_fk"},
-		RefSchema:  &schemaPublic,
-		RefTable:   &refA,
+		Name:      "b_a_fk",
+		RefSchema: &schemaPublic,
+		RefTable:  &refA,
 	})
 	desiredTables.Set("public.b", tblB)
 
@@ -197,9 +197,9 @@ func TestOrderStatements_DropFallbackOnCurrentCycle(t *testing.T) {
 		tbl.Constraints = orderedmap.New[string, *model.Constraint]()
 		tbl.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 		tbl.ForeignKeys.Set(cfg.name+"_fk", &model.ForeignKey{
-			Constraint: model.Constraint{Name: cfg.name + "_fk"},
-			RefSchema:  &schemaPublic,
-			RefTable:   &cfg.ref,
+			Name:      cfg.name + "_fk",
+			RefSchema: &schemaPublic,
+			RefTable:  &cfg.ref,
 		})
 		currentTables.Set("public."+cfg.name, tbl)
 	}

--- a/dump_test.go
+++ b/dump_test.go
@@ -206,7 +206,7 @@ CREATE TABLE public.posts (
 	})
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{
-		FilterOptions: pistachio.FilterOptions{Exclude: []string{"posts"}},
+		Exclude: []string{"posts"},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, got.Count.Tables)
@@ -672,15 +672,13 @@ func TestDumpResult_SortByDeps_NilMaps(t *testing.T) {
 	child := newTable("child")
 	refSchema, refTable := "public", "parent"
 	child.ForeignKeys.Set("child_parent_fkey", &model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       "child_parent_fkey",
-			Definition: "FOREIGN KEY (id) REFERENCES parent(id)",
-			Validated:  true,
-		},
-		Schema:    "public",
-		Table:     "child",
-		RefSchema: &refSchema,
-		RefTable:  &refTable,
+		Name:       "child_parent_fkey",
+		Definition: "FOREIGN KEY (id) REFERENCES parent(id)",
+		Validated:  true,
+		Schema:     "public",
+		Table:      "child",
+		RefSchema:  &refSchema,
+		RefTable:   &refTable,
 	})
 
 	tables := orderedmap.New[string, *model.Table]()
@@ -719,15 +717,13 @@ func TestDumpResult_SortByDeps_CycleFallsBackInString(t *testing.T) {
 		refSchema := "public"
 		ref := refTable
 		tbl.ForeignKeys.Set(name+"_fkey", &model.ForeignKey{
-			Constraint: model.Constraint{
-				Name:       name + "_fkey",
-				Definition: "FOREIGN KEY (id) REFERENCES " + refTable + "(id)",
-				Validated:  true,
-			},
-			Schema:    "public",
-			Table:     name,
-			RefSchema: &refSchema,
-			RefTable:  &ref,
+			Name:       name + "_fkey",
+			Definition: "FOREIGN KEY (id) REFERENCES " + refTable + "(id)",
+			Validated:  true,
+			Schema:     "public",
+			Table:      name,
+			RefSchema:  &refSchema,
+			RefTable:   &ref,
 		})
 		return tbl
 	}
@@ -869,17 +865,15 @@ func TestDump(t *testing.T) {
 				Schemas:    []string{"public"},
 			})
 			got, err := client.Dump(ctx, &pistachio.DumpOptions{
-				OmitSchema: tc.OmitSchema,
-				SortByDeps: tc.SortByDeps,
-				FilterOptions: pistachio.FilterOptions{
-					Include:            tc.Include,
-					Exclude:            tc.Exclude,
-					Enable:             tc.Enable,
-					Disable:            tc.Disable,
-					ManageRoutine:      tc.ManageRoutine,
-					ManageStorageParam: tc.ManageStorageParam,
-					SkipPartitionChild: tc.SkipPartitionChild,
-				},
+				OmitSchema:         tc.OmitSchema,
+				SortByDeps:         tc.SortByDeps,
+				Include:            tc.Include,
+				Exclude:            tc.Exclude,
+				Enable:             tc.Enable,
+				Disable:            tc.Disable,
+				ManageRoutine:      tc.ManageRoutine,
+				ManageStorageParam: tc.ManageStorageParam,
+				SkipPartitionChild: tc.SkipPartitionChild,
 			})
 			require.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tc.expectedDump(pgMajor)), strings.TrimSpace(got.String()))
@@ -905,7 +899,7 @@ CREATE PROCEDURE public.p() LANGUAGE sql AS $$ SELECT $$;`)
 	})
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{
-		FilterOptions: pistachio.FilterOptions{ManageRoutine: true},
+		ManageRoutine: true,
 	})
 	require.NoError(t, err)
 

--- a/model/constraint_test.go
+++ b/model/constraint_test.go
@@ -27,9 +27,9 @@ func TestConstraint_String(t *testing.T) {
 
 func TestForeignKey_String(t *testing.T) {
 	fk := &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Type: model.ConstraintType('f'), Definition: "FOREIGN KEY (user_id) REFERENCES users(id)"},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Type: model.ConstraintType('f'), Definition: "FOREIGN KEY (user_id) REFERENCES users(id)",
+		Schema: "public",
+		Table:  "orders",
 	}
 	s := fk.String()
 	assert.Contains(t, s, "fk_user")
@@ -37,28 +37,24 @@ func TestForeignKey_String(t *testing.T) {
 
 func TestForeignKey_SQL(t *testing.T) {
 	fk := model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       "fk_user",
-			Type:       model.ConstraintType('f'),
-			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
-			Validated:  true,
-		},
-		Schema: "public",
-		Table:  "orders",
+		Name:       "fk_user",
+		Type:       model.ConstraintType('f'),
+		Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Validated:  true,
+		Schema:     "public",
+		Table:      "orders",
 	}
 	assert.Equal(t, "ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id);", fk.SQL())
 }
 
 func TestForeignKey_SQL_NotValid(t *testing.T) {
 	fk := model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       "fk_user",
-			Type:       model.ConstraintType('f'),
-			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
-			Validated:  false,
-		},
-		Schema: "public",
-		Table:  "orders",
+		Name:       "fk_user",
+		Type:       model.ConstraintType('f'),
+		Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
+		Validated:  false,
+		Schema:     "public",
+		Table:      "orders",
 	}
 	assert.Equal(t, "ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;", fk.SQL())
 }

--- a/model/domain.go
+++ b/model/domain.go
@@ -36,25 +36,26 @@ func (d Domain) FQDN() string {
 }
 
 func (d Domain) SQL() string {
-	sql := "CREATE DOMAIN " + Ident(d.Schema, d.Name) + " AS " + d.BaseType
+	var sql strings.Builder
+	sql.WriteString("CREATE DOMAIN " + Ident(d.Schema, d.Name) + " AS " + d.BaseType)
 
 	if d.Collation != nil {
-		sql += " COLLATE " + *d.Collation
+		sql.WriteString(" COLLATE " + *d.Collation)
 	}
 
 	if d.Default != nil {
-		sql += " DEFAULT " + *d.Default
+		sql.WriteString(" DEFAULT " + *d.Default)
 	}
 
 	if d.NotNull {
-		sql += " NOT NULL"
+		sql.WriteString(" NOT NULL")
 	}
 
 	for _, c := range d.Constraints {
-		sql += "\n    CONSTRAINT " + Ident(c.Name) + " " + c.Definition
+		sql.WriteString("\n    CONSTRAINT " + Ident(c.Name) + " " + c.Definition)
 	}
 
-	return sql + ";"
+	return sql.String() + ";"
 }
 
 func (d Domain) CommentSQL() string {

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -285,9 +285,9 @@ func TestTable_IdxSQL_empty(t *testing.T) {
 func TestTable_FkSQL(t *testing.T) {
 	tbl := newTable("public", "orders")
 	tbl.ForeignKeys.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	assert.Contains(t, tbl.FkSQL(), "ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user")
 }
@@ -328,9 +328,9 @@ func TestTablesToSQL_withIndexAndFK(t *testing.T) {
 	tbl.Columns.Set("id", &model.Column{Name: "id", TypeName: "integer", NotNull: true})
 	tbl.Indexes.Set("idx_user", &model.Index{Definition: "CREATE INDEX idx_user ON public.orders USING btree (user_id)"})
 	tbl.ForeignKeys.Set("fk_user", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true},
-		Schema:     "public",
-		Table:      "orders",
+		Name: "fk_user", Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)", Validated: true,
+		Schema: "public",
+		Table:  "orders",
 	})
 	comment := "Orders table"
 	tbl.Comment = &comment

--- a/options.go
+++ b/options.go
@@ -69,19 +69,9 @@ type FilterOptions struct {
 // If neither is set, all types are enabled.
 func (f *FilterOptions) IsTypeEnabled(typeName string) bool {
 	if len(f.Enable) > 0 {
-		for _, t := range f.Enable {
-			if t == typeName {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(f.Enable, typeName)
 	}
-	for _, t := range f.Disable {
-		if t == typeName {
-			return false
-		}
-	}
-	return true
+	return !slices.Contains(f.Disable, typeName)
 }
 
 // regexpPattern returns the expression inside a /.../ pattern. An unquoted

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1987,19 +1987,17 @@ func parseAlterTableConstraints(as *pg_query.AlterTableStmt, defaultSchema strin
 			}
 
 			fks = append(fks, &model.ForeignKey{
-				Constraint: model.Constraint{
-					Name:       con.Conname,
-					Type:       model.ConstraintType('f'),
-					Definition: def,
-					Columns:    columns,
-					Deferrable: con.Deferrable,
-					Deferred:   con.Initdeferred,
-					Validated:  !con.SkipValidation,
-				},
-				Schema:    schema,
-				Table:     as.Relation.Relname,
-				RefSchema: refSchema,
-				RefTable:  refTable,
+				Name:       con.Conname,
+				Type:       model.ConstraintType('f'),
+				Definition: def,
+				Columns:    columns,
+				Deferrable: con.Deferrable,
+				Deferred:   con.Initdeferred,
+				Validated:  !con.SkipValidation,
+				Schema:     schema,
+				Table:      as.Relation.Relname,
+				RefSchema:  refSchema,
+				RefTable:   refTable,
 			})
 
 			continue
@@ -2048,19 +2046,17 @@ func parseInlineForeignKey(con *pg_query.Constraint, schema, table, defaultSchem
 	}
 
 	return &model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       con.Conname,
-			Type:       model.ConstraintType('f'),
-			Definition: def,
-			Columns:    columns,
-			Deferrable: con.Deferrable,
-			Deferred:   con.Initdeferred,
-			Validated:  !con.SkipValidation,
-		},
-		Schema:    schema,
-		Table:     table,
-		RefSchema: refSchema,
-		RefTable:  refTable,
+		Name:       con.Conname,
+		Type:       model.ConstraintType('f'),
+		Definition: def,
+		Columns:    columns,
+		Deferrable: con.Deferrable,
+		Deferred:   con.Initdeferred,
+		Validated:  !con.SkipValidation,
+		Schema:     schema,
+		Table:      table,
+		RefSchema:  refSchema,
+		RefTable:   refTable,
 	}, nil
 }
 
@@ -2094,11 +2090,10 @@ func deparseTypeName(tn *pg_query.TypeName) (string, error) {
 	}
 
 	const marker = "_c "
-	idx := strings.Index(sql, marker)
-	if idx == -1 {
+	_, rest, ok := strings.Cut(sql, marker)
+	if !ok {
 		return "", fmt.Errorf("unexpected deparse output for type: %s", sql)
 	}
-	rest := sql[idx+len(marker):]
 	lastParen := strings.LastIndex(rest, ")")
 	if lastParen < 0 {
 		return "", fmt.Errorf("unexpected deparse output for type: %s", sql)
@@ -2304,9 +2299,9 @@ func deparseConstraintDef(con *pg_query.Constraint) (string, error) {
 
 	if con.Conname != "" {
 		marker := "CONSTRAINT " + model.Ident(con.Conname) + " "
-		idx := strings.Index(sql, marker)
-		if idx != -1 {
-			return restorePlaceholders(strings.TrimSpace(sql[idx+len(marker):])), nil
+		_, after, ok := strings.Cut(sql, marker)
+		if ok {
+			return restorePlaceholders(strings.TrimSpace(after)), nil
 		}
 	}
 
@@ -2339,11 +2334,11 @@ func deparsePartitionSpec(cs *pg_query.CreateStmt) (string, error) {
 		return "", fmt.Errorf("failed to deparse partition spec: %w", err)
 	}
 	const prefix = "PARTITION BY "
-	idx := strings.Index(sql, prefix)
-	if idx == -1 {
+	_, after, ok := strings.Cut(sql, prefix)
+	if !ok {
 		return "", fmt.Errorf("could not extract partition spec from: %s", sql)
 	}
-	return strings.TrimSpace(sql[idx+len(prefix):]), nil
+	return strings.TrimSpace(after), nil
 }
 
 func deparsePartitionBound(cs *pg_query.CreateStmt) (string, error) {
@@ -2364,11 +2359,11 @@ func deparsePartitionBound(cs *pg_query.CreateStmt) (string, error) {
 		return "", fmt.Errorf("failed to deparse partition bound: %w", err)
 	}
 	const prefix = "PARTITION OF _parent "
-	idx := strings.Index(sql, prefix)
-	if idx == -1 {
+	_, after, ok := strings.Cut(sql, prefix)
+	if !ok {
 		return "", fmt.Errorf("could not extract partition bound from: %s", sql)
 	}
-	return strings.TrimSpace(sql[idx+len(prefix):]), nil
+	return strings.TrimSpace(after), nil
 }
 
 // parseStorageParams reads the WITH clause of a CREATE TABLE. A parameter of

--- a/parser/validate_test.go
+++ b/parser/validate_test.go
@@ -25,8 +25,6 @@ func newValidatableTable(name string, cols ...string) *model.Table {
 	return t
 }
 
-func ptr(s string) *string { return &s }
-
 func tablesMap(ts ...*model.Table) *orderedmap.Map[string, *model.Table] {
 	m := orderedmap.New[string, *model.Table]()
 	for _, t := range ts {
@@ -75,11 +73,9 @@ func TestValidateColumnRefs_CheckMissingColumn(t *testing.T) {
 func TestValidateColumnRefs_FKMissingLocalColumn(t *testing.T) {
 	tbl := newValidatableTable("orders", "id", "buyer_id")
 	tbl.ForeignKeys.Set("fk", &model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       "fk",
-			Type:       model.ConstraintType('f'),
-			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
-		},
+		Name:       "fk",
+		Type:       model.ConstraintType('f'),
+		Definition: "FOREIGN KEY (user_id) REFERENCES public.users(id)",
 	})
 	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
@@ -91,11 +87,9 @@ func TestValidateColumnRefs_FKReferencedColumnNotChecked(t *testing.T) {
 	// referenced column name should not surface as a violation.
 	tbl := newValidatableTable("orders", "id", "user_id")
 	tbl.ForeignKeys.Set("fk", &model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       "fk",
-			Type:       model.ConstraintType('f'),
-			Definition: "FOREIGN KEY (user_id) REFERENCES public.users(nonexistent_pk)",
-		},
+		Name:       "fk",
+		Type:       model.ConstraintType('f'),
+		Definition: "FOREIGN KEY (user_id) REFERENCES public.users(nonexistent_pk)",
 	})
 	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
@@ -183,11 +177,9 @@ func TestValidateColumnRefs_FKCompositeLocalPartialMiss(t *testing.T) {
 	// FK (a, b) REFERENCES ... where a exists but b is missing locally.
 	tbl := newValidatableTable("orders", "id", "tenant_id")
 	tbl.ForeignKeys.Set("fk_buyer", &model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       "fk_buyer",
-			Type:       model.ConstraintType('f'),
-			Definition: "FOREIGN KEY (tenant_id, user_id) REFERENCES public.users(tenant_id, id)",
-		},
+		Name:       "fk_buyer",
+		Type:       model.ConstraintType('f'),
+		Definition: "FOREIGN KEY (tenant_id, user_id) REFERENCES public.users(tenant_id, id)",
 	})
 	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
@@ -201,11 +193,9 @@ func TestValidateColumnRefs_SelfReferencingFK(t *testing.T) {
 	// (id) are out of scope. Validation must pass.
 	tbl := newValidatableTable("nodes", "id", "parent_id")
 	tbl.ForeignKeys.Set("fk_parent", &model.ForeignKey{
-		Constraint: model.Constraint{
-			Name:       "fk_parent",
-			Type:       model.ConstraintType('f'),
-			Definition: "FOREIGN KEY (parent_id) REFERENCES public.nodes(id)",
-		},
+		Name:       "fk_parent",
+		Type:       model.ConstraintType('f'),
+		Definition: "FOREIGN KEY (parent_id) REFERENCES public.nodes(id)",
 	})
 	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
@@ -748,7 +738,7 @@ func TestValidateColumnRefs_GeneratedMissingColumn(t *testing.T) {
 	tbl.Columns.Set("total", &model.Column{
 		Name:      "total",
 		Generated: model.ColumnGenerated('s'),
-		Default:   ptr("qty * 2"),
+		Default:   new("qty * 2"),
 	})
 	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
@@ -757,7 +747,7 @@ func TestValidateColumnRefs_GeneratedMissingColumn(t *testing.T) {
 
 func TestValidateColumnRefs_DefaultMissingColumn(t *testing.T) {
 	tbl := newValidatableTable("items", "id", "quantity")
-	tbl.Columns.Set("label", &model.Column{Name: "label", Default: ptr("upper(nmae)")})
+	tbl.Columns.Set("label", &model.Column{Name: "label", Default: new("upper(nmae)")})
 	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "column nmae referenced in the DEFAULT expression on column label does not exist on table public.items")
@@ -768,7 +758,7 @@ func TestValidateColumnRefs_ColumnExprValid(t *testing.T) {
 	tbl.Columns.Set("total", &model.Column{
 		Name:      "total",
 		Generated: model.ColumnGenerated('s'),
-		Default:   ptr("qty * 2"),
+		Default:   new("qty * 2"),
 	})
 	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
@@ -776,8 +766,8 @@ func TestValidateColumnRefs_ColumnExprValid(t *testing.T) {
 func TestValidateColumnRefs_ColumnExprWithoutColumnRefs(t *testing.T) {
 	// A DEFAULT that names no column must not be read as referencing one.
 	tbl := newValidatableTable("items", "id")
-	tbl.Columns.Set("seq", &model.Column{Name: "seq", Default: ptr("nextval('items_seq'::regclass)")})
-	tbl.Columns.Set("made", &model.Column{Name: "made", Default: ptr("CURRENT_DATE")})
+	tbl.Columns.Set("seq", &model.Column{Name: "seq", Default: new("nextval('items_seq'::regclass)")})
+	tbl.Columns.Set("made", &model.Column{Name: "made", Default: new("CURRENT_DATE")})
 	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
@@ -786,7 +776,7 @@ func TestValidateColumnRefs_ColumnExprDeduplicates(t *testing.T) {
 	tbl.Columns.Set("total", &model.Column{
 		Name:      "total",
 		Generated: model.ColumnGenerated('s'),
-		Default:   ptr("qty + qty"),
+		Default:   new("qty + qty"),
 	})
 	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
@@ -797,7 +787,7 @@ func TestValidateColumnRefs_ColumnExprUnparsable(t *testing.T) {
 	// Validation degrades to a no-op rather than failing the run on an
 	// expression pg_query cannot read.
 	tbl := newValidatableTable("items", "id")
-	tbl.Columns.Set("total", &model.Column{Name: "total", Default: ptr("qty > ")})
+	tbl.Columns.Set("total", &model.Column{Name: "total", Default: new("qty > ")})
 	require.NoError(t, validateColumnRefs(tablesMap(tbl)))
 }
 
@@ -808,12 +798,12 @@ func TestValidateColumnRefs_ColumnExprReportsPerColumn(t *testing.T) {
 	tbl.Columns.Set("total", &model.Column{
 		Name:      "total",
 		Generated: model.ColumnGenerated('s'),
-		Default:   ptr("qty * 2"),
+		Default:   new("qty * 2"),
 	})
 	tbl.Columns.Set("half", &model.Column{
 		Name:      "half",
 		Generated: model.ColumnGenerated('s'),
-		Default:   ptr("qty / 2"),
+		Default:   new("qty / 2"),
 	})
 	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)
@@ -825,7 +815,7 @@ func TestValidateColumnRefs_ColumnExprQuotedName(t *testing.T) {
 	tbl.Columns.Set("total", &model.Column{
 		Name:      "total",
 		Generated: model.ColumnGenerated('s'),
-		Default:   ptr(`"Qty" * 2`),
+		Default:   new(`"Qty" * 2`),
 	})
 	err := validateColumnRefs(tablesMap(tbl))
 	require.Error(t, err)

--- a/plan_test.go
+++ b/plan_test.go
@@ -132,7 +132,7 @@ func TestPlan_WithPassword(t *testing.T) {
 		Schemas:    []string{"public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Contains(t, got.SQL, "CREATE TABLE public.users")
 }
@@ -301,7 +301,7 @@ CREATE TABLE public.audit_log (
 	assert.Contains(t, result.SQL, "check SQL could not be evaluated at plan time")
 	assert.Contains(t, result.SQL, "apply will decide")
 	// The note must stay on one comment line so the plan is still valid SQL.
-	for _, line := range strings.Split(result.SQL, "\n") {
+	for line := range strings.SplitSeq(result.SQL, "\n") {
 		if strings.Contains(line, "could not be evaluated") {
 			assert.True(t, strings.HasPrefix(line, "-- "), "note must be a comment: %q", line)
 		}
@@ -385,16 +385,14 @@ func TestPlan(t *testing.T) {
 				dropPolicy = pistachio.DropPolicy{AllowDrop: tc.DropPolicy.AllowDrop}
 			}
 			got, err := client.Plan(ctx, &pistachio.PlanOptions{
-				DropPolicy: dropPolicy,
-				FilterOptions: pistachio.FilterOptions{
-					Include:            tc.Include,
-					Exclude:            tc.Exclude,
-					Enable:             tc.Enable,
-					Disable:            tc.Disable,
-					ManageRoutine:      tc.ManageRoutine,
-					ManageStorageParam: tc.ManageStorageParam,
-					SkipPartitionChild: tc.SkipPartitionChild,
-				},
+				DropPolicy:               dropPolicy,
+				Include:                  tc.Include,
+				Exclude:                  tc.Exclude,
+				Enable:                   tc.Enable,
+				Disable:                  tc.Disable,
+				ManageRoutine:            tc.ManageRoutine,
+				ManageStorageParam:       tc.ManageStorageParam,
+				SkipPartitionChild:       tc.SkipPartitionChild,
 				Files:                    []string{desiredFile},
 				DisableIndexConcurrently: tc.DisableIndexConcurrently,
 				ForceIndexConcurrently:   tc.ForceIndexConcurrently,

--- a/remap_test.go
+++ b/remap_test.go
@@ -128,7 +128,7 @@ func TestValidateSchemaMap(t *testing.T) {
 	// invocations of the same command.
 	t.Run("duplicate destinations name the same pair every run", func(t *testing.T) {
 		o := &pistachio.Options{SchemaMap: map[string]string{"c": "public", "a": "public", "b": "public"}}
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			err := o.ValidateSchemaMap()
 			require.Error(t, err)
 			assert.Equal(t, `duplicate schema-map destination "public": both "a" and "b" map to it`, err.Error())
@@ -255,7 +255,7 @@ CREATE TABLE myschema.events (id integer);
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -280,7 +280,7 @@ CREATE SEQUENCE myschema.order_seq INCREMENT BY 1;
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	// The desired public.order_seq is reverse-remapped to myschema.order_seq
@@ -306,14 +306,14 @@ func TestApply_UnqualifiedUserTypeInNonPublicSchema(t *testing.T) {
 	})
 
 	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
-		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
-		Files:      []string{desiredFile},
+		AllowDrop: []string{"all"},
+		Files:     []string{desiredFile},
 	}, io.Discard)
 	require.NoError(t, err)
 
 	plan, err := client.Plan(ctx, &pistachio.PlanOptions{
-		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
-		Files:      []string{desiredFile},
+		AllowDrop: []string{"all"},
+		Files:     []string{desiredFile},
 	})
 	require.NoError(t, err)
 	assert.Empty(t, plan.SQL, "expected no drift after apply")
@@ -341,8 +341,8 @@ func TestApply_PublicObjectFromNonPublicSchema(t *testing.T) {
 	})
 
 	_, err := client.Apply(ctx, &pistachio.ApplyOptions{
-		DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}},
-		Files:      []string{desiredFile},
+		AllowDrop: []string{"all"},
+		Files:     []string{desiredFile},
 	}, io.Discard)
 	require.NoError(t, err)
 }
@@ -389,7 +389,7 @@ CREATE TYPE myschema.address AS (street text, city text);
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	// The desired public.address is reverse-remapped to myschema.address
@@ -445,7 +445,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -475,7 +475,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	// No diff expected since schemas are remapped
@@ -525,7 +525,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got.SQL)
 }
@@ -638,7 +638,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	// "other" schema is not reverse-mapped, so it won't match myschema
@@ -682,7 +682,7 @@ ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (use
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -715,7 +715,7 @@ CREATE INDEX users_name_idx ON public.users (name);
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -746,7 +746,7 @@ CREATE VIEW public.active_users AS SELECT id FROM public.users;
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -777,7 +777,7 @@ CREATE TABLE myschema.users (
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	// Verify: dump without schema map should show myschema with new column
@@ -817,7 +817,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	t.Log(got)
 
@@ -845,7 +845,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got.SQL)
 }
@@ -887,7 +887,7 @@ CREATE DOMAIN myschema.pos_int AS integer;
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Contains(t, got.SQL, "ALTER DOMAIN myschema.pos_int SET NOT NULL;")
 }
@@ -929,7 +929,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 
 	assert.Contains(t, got.SQL, "ALTER TYPE myschema.status ADD VALUE 'pending' AFTER 'inactive';")
@@ -951,7 +951,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got.SQL)
 }
@@ -972,7 +972,7 @@ CREATE TYPE myschema.status AS ENUM ('active', 'inactive');
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	verifyClient := pistachio.NewClient(&pistachio.Options{
@@ -1007,7 +1007,7 @@ CREATE TABLE myschema.users (
 		Schemas:    []string{"myschema"},
 	})
 
-	_, err := client.Apply(ctx, &pistachio.ApplyOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}}, io.Discard)
+	_, err := client.Apply(ctx, &pistachio.ApplyOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}}, io.Discard)
 	require.NoError(t, err)
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
@@ -1047,7 +1047,7 @@ CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = current
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got.SQL)
 }
@@ -1084,7 +1084,7 @@ CREATE POLICY visible ON public.documents FOR SELECT USING (public.is_admin());`
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got.SQL, "schema replacement on policy USING should yield no diff")
 }
@@ -1121,7 +1121,7 @@ CREATE POLICY mod ON public.documents FOR ALL USING (public.is_admin()) WITH CHE
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Empty(t, got.SQL, "schema replacement on policy WITH CHECK should yield no diff")
 }
@@ -1156,7 +1156,7 @@ CREATE POLICY owner_select ON public.documents FOR SELECT USING (owner = session
 		SchemaMap:  map[string]string{"myschema": "public"},
 	})
 
-	got, err := client.Plan(ctx, &pistachio.PlanOptions{DropPolicy: pistachio.DropPolicy{AllowDrop: []string{"all"}}, Files: []string{desiredFile}})
+	got, err := client.Plan(ctx, &pistachio.PlanOptions{AllowDrop: []string{"all"}, Files: []string{desiredFile}})
 	require.NoError(t, err)
 	assert.Contains(t, got.SQL, "ALTER POLICY owner_select ON myschema.documents")
 	assert.NotContains(t, got.SQL, "ALTER POLICY owner_select ON public.documents")
@@ -1186,7 +1186,7 @@ CREATE FUNCTION myschema.label(s myschema.status) RETURNS text
 	})
 
 	got, err := client.Dump(ctx, &pistachio.DumpOptions{
-		FilterOptions: pistachio.FilterOptions{ManageRoutine: true},
+		ManageRoutine: true,
 	})
 	require.NoError(t, err)
 
@@ -1226,8 +1226,8 @@ CREATE FUNCTION myschema.label(s myschema.status) RETURNS text
 	})
 
 	got, err := client.Plan(ctx, &pistachio.PlanOptions{
-		DropPolicy:    pistachio.DropPolicy{AllowDrop: []string{"all"}},
-		FilterOptions: pistachio.FilterOptions{ManageRoutine: true},
+		AllowDrop:     []string{"all"},
+		ManageRoutine: true,
 		Files:         []string{desiredFile},
 	})
 	require.NoError(t, err)

--- a/toposort/schema_test.go
+++ b/toposort/schema_test.go
@@ -199,9 +199,9 @@ func TestOrderFromSchema_ForeignKey(t *testing.T) {
 	posts.Constraints = orderedmap.New[string, *model.Constraint]()
 	posts.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	posts.ForeignKeys.Set("posts_user_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "posts_user_fk"},
-		RefSchema:  &refSchema,
-		RefTable:   &refTable,
+		Name:      "posts_user_fk",
+		RefSchema: &refSchema,
+		RefTable:  &refTable,
 	})
 	tables.Set("public.posts", posts)
 
@@ -242,9 +242,9 @@ func TestOrderFromSchema_SelfReferencingFK(t *testing.T) {
 	nodes.Constraints = orderedmap.New[string, *model.Constraint]()
 	nodes.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	nodes.ForeignKeys.Set("nodes_parent_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "nodes_parent_fk"},
-		RefSchema:  &refSchema,
-		RefTable:   &refNodes,
+		Name:      "nodes_parent_fk",
+		RefSchema: &refSchema,
+		RefTable:  &refNodes,
 	})
 	tables.Set("public.nodes", nodes)
 
@@ -256,8 +256,8 @@ func TestOrderFromSchema_SelfReferencingFK(t *testing.T) {
 	edges.Constraints = orderedmap.New[string, *model.Constraint]()
 	edges.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	edges.ForeignKeys.Set("edges_parent_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "edges_parent_fk"},
-		RefTable:   &refEdges,
+		Name:     "edges_parent_fk",
+		RefTable: &refEdges,
 	})
 	tables.Set("public.edges", edges)
 
@@ -378,9 +378,9 @@ func TestOrderFromSchema_CyclicFK(t *testing.T) {
 	tblA.Constraints = orderedmap.New[string, *model.Constraint]()
 	tblA.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tblA.ForeignKeys.Set("a_b_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "a_b_fk"},
-		RefSchema:  &schemaPublic,
-		RefTable:   &refB,
+		Name:      "a_b_fk",
+		RefSchema: &schemaPublic,
+		RefTable:  &refB,
 	})
 	tables.Set("public.a", tblA)
 
@@ -390,9 +390,9 @@ func TestOrderFromSchema_CyclicFK(t *testing.T) {
 	tblB.Constraints = orderedmap.New[string, *model.Constraint]()
 	tblB.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	tblB.ForeignKeys.Set("b_a_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "b_a_fk"},
-		RefSchema:  &schemaPublic,
-		RefTable:   &refA,
+		Name:      "b_a_fk",
+		RefSchema: &schemaPublic,
+		RefTable:  &refA,
 	})
 	tables.Set("public.b", tblB)
 
@@ -543,7 +543,7 @@ func TestOrderFromSchema_UnqualifiedFKInPublicFromOtherSchema(t *testing.T) {
 
 	refTable := "users"
 	posts := newTable("app", "posts", &model.Column{Name: "user_id", TypeName: "integer"})
-	posts.ForeignKeys.Set("fk_user", &model.ForeignKey{Constraint: model.Constraint{Name: "fk_user"}, RefTable: &refTable})
+	posts.ForeignKeys.Set("fk_user", &model.ForeignKey{Name: "fk_user", RefTable: &refTable})
 	tables.Set("app.posts", posts)
 
 	order, err := orderFromSchema(orderedmap.New[string, *model.Enum](),
@@ -586,7 +586,7 @@ func TestOrderFromSchema_FKWithNilRefTable(t *testing.T) {
 	tables := orderedmap.New[string, *model.Table]()
 	tbl := newTable("public", "events", &model.Column{Name: "id", TypeName: "integer"})
 	tbl.ForeignKeys.Set("orphan_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "orphan_fk"},
+		Name: "orphan_fk",
 		// RefTable intentionally nil
 	})
 	tables.Set("public.events", tbl)
@@ -643,7 +643,7 @@ func TestOrderFromSchema_UnqualifiedFKInQuoteRequiringSchema(t *testing.T) {
 	users := newTable("MySchema", "users", &model.Column{Name: "id", TypeName: "integer"})
 	refTable := "users"
 	posts := newTable("MySchema", "posts", &model.Column{Name: "user_id", TypeName: "integer"})
-	posts.ForeignKeys.Set("fk_user", &model.ForeignKey{Constraint: model.Constraint{Name: "fk_user"}, RefTable: &refTable})
+	posts.ForeignKeys.Set("fk_user", &model.ForeignKey{Name: "fk_user", RefTable: &refTable})
 
 	tables := orderedmap.New[string, *model.Table]()
 	tables.Set(users.FQTN(), users)
@@ -769,9 +769,9 @@ func TestOrderFromSchema_FKWithQuotedRefTable(t *testing.T) {
 	comments.Constraints = orderedmap.New[string, *model.Constraint]()
 	comments.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	comments.ForeignKeys.Set("comments_user_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "comments_user_fk"},
-		RefSchema:  &refSchema,
-		RefTable:   &refTable,
+		Name:      "comments_user_fk",
+		RefSchema: &refSchema,
+		RefTable:  &refTable,
 	})
 	tables.Set(model.Ident("public", "Comments"), comments)
 
@@ -811,9 +811,9 @@ func TestOrderFromSchema_FKWithReservedWordRefTable(t *testing.T) {
 	items.Constraints = orderedmap.New[string, *model.Constraint]()
 	items.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	items.ForeignKeys.Set("items_order_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "items_order_fk"},
-		RefSchema:  &refSchema,
-		RefTable:   &refTable,
+		Name:      "items_order_fk",
+		RefSchema: &refSchema,
+		RefTable:  &refTable,
 	})
 	tables.Set(model.Ident("public", "Items"), items)
 
@@ -853,9 +853,9 @@ func TestOrderFromSchema_FKWithQuotedRefSchema(t *testing.T) {
 	posts.Constraints = orderedmap.New[string, *model.Constraint]()
 	posts.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	posts.ForeignKeys.Set("posts_user_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "posts_user_fk"},
-		RefSchema:  &refSchema,
-		RefTable:   &refTable,
+		Name:      "posts_user_fk",
+		RefSchema: &refSchema,
+		RefTable:  &refTable,
 	})
 	tables.Set(model.Ident("AppPublic", "posts"), posts)
 
@@ -892,9 +892,9 @@ func TestOrderFromSchema_FKWithDefaultSchema(t *testing.T) {
 	posts.Constraints = orderedmap.New[string, *model.Constraint]()
 	posts.ForeignKeys = orderedmap.New[string, *model.ForeignKey]()
 	posts.ForeignKeys.Set("posts_user_fk", &model.ForeignKey{
-		Constraint: model.Constraint{Name: "posts_user_fk"},
-		RefSchema:  nil, // nil schema -> defaults to "public"
-		RefTable:   &refTable,
+		Name:      "posts_user_fk",
+		RefSchema: nil, // nil schema -> defaults to "public"
+		RefTable:  &refTable,
 	})
 	tables.Set("public.posts", posts)
 


### PR DESCRIPTION
gopls reports `embedlit: embedded field type can be removed from struct literal` on the `model.ForeignKey` literals. The same analyzer set ships with golangci-lint as the `modernize` linter, so enable it and apply what it finds.

The first commit applies the suggestions, the second turns the linter on, so both commits pass `make lint`.

## Changes

- Initialize the fields promoted from the embedded `Constraint` directly, without the nested literal (Go 1.27).
- Replace `strings.Index` plus slicing with `strings.Cut` in the parser.
- Use `slices.Contains` in `FilterOptions.IsTypeEnabled`.
- Build the `CREATE DOMAIN` statement with `strings.Builder`.
- Drop the `ptr` test helpers, whose call sites are now `new(expr)`.

`issues.max-issues-per-linter` and `issues.max-same-issues` are set to 0 because the defaults report only 3 findings of the same kind, which hid 143 of the 146 `embedlit` sites.

## Verification

- `make lint`: 0 issues
- `make vet`, `make build`
- `make test`: all packages ok
- `make test-scenario`: 11 passed, 0 failed