### PR TITLE
Drop the macOS 13 note from the install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Download the latest binary from [Releases](https://github.com/winebarrel/pistach
 | Linux   | amd64, arm64 |
 | Windows | amd64        |
 
-The macOS binaries need macOS 13 or later.
-
 ## Example
 
 Create a schema file:

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,6 @@ Download the latest binary from [Releases](https://github.com/winebarrel/pistach
 | Linux   | amd64, arm64 |
 | Windows | amd64        |
 
-The macOS binaries need macOS 13 or later.
-
 
 
 ## Example


### PR DESCRIPTION
Remove the "The macOS binaries need macOS 13 or later." line from the install section of README.md and docs/index.md. CHANGELOG.md is unchanged.