### PR TITLE
Manage a comment on an index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Manage a comment on an index. `COMMENT ON INDEX` was read by neither side, so `dump` dropped the line `pg_dump` writes and a schema file that carried one was warned about and ignored. A change now goes out as `COMMENT ON INDEX ... IS ...` or `IS NULL`, and a recreate writes the comment again, since PostgreSQL drops it with the index. A comment on a constraint, a trigger or a policy, and one on the index a constraint owns, stays unmanaged.
+
 ## [1.45.0] - 2026-09-06
 
 * Manage the storage parameters of a view and a materialized view, the `WITH (...)` clause before `AS`. Neither side read them, so `dump` dropped the clause and a schema file that wrote one was applied without it. A plain view holds `security_barrier` and `security_invoker` and nothing else. Both decide what the view means rather than how it is stored, so they are managed without a flag: a dump that dropped them restored a view that leaks rows, or one that reads the base table with the wrong privileges. A materialized view holds what a table holds, tuning included, so it sits behind `--manage-storage-param` with the table. A change to a view whose definition stays goes out as `ALTER [MATERIALIZED] VIEW ... SET (...)` / `RESET (...)`; a definition change carries the clause on its own statement, which replaces the view's options as a whole. Two things that used to plan nothing now plan something: a view carrying `security_barrier` the schema file does not name is reset, and, under the flag, a materialized view's parameters are diffed like a table's.

--- a/TODO.md
+++ b/TODO.md
@@ -881,29 +881,27 @@ symmetric. `CREATE AGGREGATE` has a shape `model.Routine` does not cover.
 
 Origin: routine support.
 
-## `COMMENT ON INDEX` is not managed
+## A comment on a constraint, a trigger or a policy is not managed
 
 Priority: low.
 
-Comments are managed for tables, columns, views, materialized views, sequences,
-enums, composite types, domains and routines. Indexes, constraints, triggers and
-policies have no `Comment` field and no case in `parseCommentStmt`, so a
-`COMMENT ON INDEX` in the desired schema is dropped without an error or a diff.
-`pista dump` does not emit one either, so a dump feeds back clean. `pg_dump`
-does emit them, and those lines are lost.
+Comments are managed for tables, columns, views, materialized views, indexes,
+sequences, enums, composite types, domains and routines. `model.Constraint`,
+`model.Trigger` and `model.Policy` have no `Comment` field and no case in
+`parseCommentStmt`, so a `COMMENT ON CONSTRAINT`, `COMMENT ON TRIGGER` or
+`COMMENT ON POLICY` in the desired schema warns and is dropped. `pista dump`
+writes none either, so a dump feeds back clean. `pg_dump` does write them, and
+those lines are lost.
 
-The work is a `Comment` field on `model.Index`, a `pg_description` join in
-`catalog.ListIndexes`, an `OBJECT_INDEX` case in the parser, and emission from
-`diffIndexes` and the create path, since recreating an index drops its comment.
-`COMMENT ON INDEX` names only the schema and the index, so the parser has to
-scan `Table.Indexes` and `View.Indexes` by name. Index names are unique per
-schema, and constraint-backed indexes are already excluded from `ListIndexes`.
+The work is the same shape the index comment took: a `Comment` field on the
+model, a `pg_description` join in the catalog read, a case in the parser, and
+emission from the diff and the create path, since an object that is dropped
+and recreated loses its comment. Each of the three names its relation, so the parser finds the
+owner without scanning. The index a `PRIMARY KEY`, `UNIQUE` or `EXCLUDE`
+constraint owns carries its comment as the constraint's, which is why a
+`COMMENT ON INDEX` naming one is dropped today.
 
-Better done together with constraint, trigger and policy comments. Shipping it
-makes `dump` emit index comments, so a database that has one where the desired
-schema does not will plan `COMMENT ON INDEX ... IS NULL;`.
-
-Origin: discussion, 2026-08-25.
+Origin: discussion, 2026-08-25. Narrowed once index comments shipped.
 
 ## An identity column's sequence name is not managed
 

--- a/catalog/indexes.go
+++ b/catalog/indexes.go
@@ -35,7 +35,8 @@ func (c *Catalog) ListIndexes(ctx context.Context) ([]*model.Index, error) {
 			ci.relname AS name,
 			ct.relname AS table,
 			pg_catalog.pg_get_indexdef(i.indexrelid) AS definition,
-			ts.spcname
+			ts.spcname,
+			descr.description AS comment
 		FROM
 			-- https://www.postgresql.org/docs/current/catalog-pg-index.html
 			pg_catalog.pg_index i
@@ -43,6 +44,10 @@ func (c *Catalog) ListIndexes(ctx context.Context) ([]*model.Index, error) {
 			JOIN pg_catalog.pg_class ct ON ct.oid = i.indrelid
 			JOIN pg_catalog.pg_namespace n ON n.oid = ci.relnamespace
 			LEFT JOIN pg_catalog.pg_tablespace ts ON ts.oid = ci.reltablespace
+			-- https://www.postgresql.org/docs/current/catalog-pg-description.html
+			LEFT JOIN pg_catalog.pg_description descr ON descr.objoid = ci.oid
+			AND descr.classoid = 'pg_class'::regclass
+			AND descr.objsubid = 0
 			LEFT JOIN dependency_extension de ON de.objid = ci.oid
 			LEFT JOIN constraint_t con ON con.conindid = ci.oid
 		WHERE
@@ -76,6 +81,7 @@ func (c *Catalog) ListIndexes(ctx context.Context) ([]*model.Index, error) {
 			&idx.Table,
 			&idx.Definition,
 			&idx.TableSpace,
+			&idx.Comment,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("catalog: failed to scan index info: %w", err)

--- a/catalog/indexes_test.go
+++ b/catalog/indexes_test.go
@@ -39,6 +39,33 @@ func TestListIndexes(t *testing.T) {
 		assert.Contains(t, idx.Definition, "btree")
 	})
 
+	t.Run("index comment", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.users (
+				id integer NOT NULL,
+				name text NOT NULL,
+				CONSTRAINT users_pkey PRIMARY KEY (id)
+			);
+			CREATE INDEX idx_users_name ON public.users USING btree (name);
+			CREATE INDEX idx_users_id ON public.users USING btree (id);
+			COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		tbl := tables.Get("public.users")
+		idx, ok := tbl.Indexes.GetOk("idx_users_name")
+		require.True(t, ok)
+		require.NotNil(t, idx.Comment)
+		assert.Equal(t, "Lookup by name", *idx.Comment)
+
+		bare, ok := tbl.Indexes.GetOk("idx_users_id")
+		require.True(t, ok)
+		assert.Nil(t, bare.Comment)
+	})
+
 	t.Run("unique index", func(t *testing.T) {
 		testutil.SetupDB(t, ctx, conn, `
 			CREATE TABLE public.users (

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -1301,7 +1301,10 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], dc Drop
 
 	// Add new or changed indexes
 	for name, desiredIdx := range desired.All() {
-		if _, ok := current.GetOk(name); ok && sameDef[name] {
+		currentIdx, ok := current.GetOk(name)
+		if ok && sameDef[name] {
+			// The index stays, so only a comment that differs is emitted.
+			result.Stmts = append(result.Stmts, indexCommentStmts(currentIdx.Comment, desiredIdx)...)
 			continue
 		}
 		stmt, err := createIndexSQL(desiredIdx.Definition, desiredIdx.Concurrently)
@@ -1312,9 +1315,24 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], dc Drop
 		if desiredIdx.Concurrently {
 			result.HasConcurrently = true
 		}
+		// A recreated index carries no comment, so the desired one is emitted
+		// against nothing rather than against what the old index had.
+		result.Stmts = append(result.Stmts, indexCommentStmts(nil, desiredIdx)...)
 	}
 
 	return result, nil
+}
+
+// indexCommentStmts returns the COMMENT ON INDEX the index needs to reach the
+// desired comment, or nothing when the two already agree.
+func indexCommentStmts(currentComment *string, desired *model.Index) []string {
+	if equalPtr(currentComment, desired.Comment) {
+		return nil
+	}
+	if desired.Comment != nil {
+		return []string{desired.CommentSQL()}
+	}
+	return []string{"COMMENT ON INDEX " + model.Ident(desired.Schema, desired.Name) + " IS NULL;"}
 }
 
 // dropIndexSQL builds a DROP INDEX statement, optionally with CONCURRENTLY

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -971,6 +971,64 @@ func TestDiffIndexes_change(t *testing.T) {
 	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING hash (name);", idxResult.Stmts[1])
 }
 
+func TestDiffIndexes_comment(t *testing.T) {
+	const def = "CREATE INDEX idx_name ON public.users USING btree (name)"
+
+	t.Run("added", func(t *testing.T) {
+		current := orderedmap.New[string, *model.Index]()
+		current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def})
+		desired := orderedmap.New[string, *model.Index]()
+		desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def, Comment: new("Lookup by name")})
+
+		idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"COMMENT ON INDEX public.idx_name IS 'Lookup by name';"}, idxResult.Stmts)
+	})
+
+	t.Run("removed", func(t *testing.T) {
+		current := orderedmap.New[string, *model.Index]()
+		current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def, Comment: new("Lookup by name")})
+		desired := orderedmap.New[string, *model.Index]()
+		desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def})
+
+		idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"COMMENT ON INDEX public.idx_name IS NULL;"}, idxResult.Stmts)
+	})
+
+	t.Run("unchanged", func(t *testing.T) {
+		current := orderedmap.New[string, *model.Index]()
+		current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def, Comment: new("Lookup by name")})
+		desired := orderedmap.New[string, *model.Index]()
+		desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def, Comment: new("Lookup by name")})
+
+		idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+		require.NoError(t, err)
+		assert.Empty(t, idxResult.Stmts)
+	})
+
+	t.Run("recreated", func(t *testing.T) {
+		// The recreate takes the comment with it, so the same comment on both
+		// sides still has to be applied again.
+		current := orderedmap.New[string, *model.Index]()
+		current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def, Comment: new("Lookup by name")})
+		desired := orderedmap.New[string, *model.Index]()
+		desired.Set("idx_name", &model.Index{
+			Schema: "public", Name: "idx_name",
+			Definition: "CREATE INDEX idx_name ON public.users USING hash (name)",
+			Comment:    new("Lookup by name"),
+		})
+
+		idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{
+			"DROP INDEX public.idx_name;",
+			"CREATE INDEX idx_name ON public.users USING hash (name);",
+			"COMMENT ON INDEX public.idx_name IS 'Lookup by name';",
+		}, idxResult.Stmts)
+	})
+}
+
 func TestDiffIndexes_add_uniqueConcurrently_perDirective(t *testing.T) {
 	current := orderedmap.New[string, *model.Index]()
 	desired := orderedmap.New[string, *model.Index]()

--- a/diff/views.go
+++ b/diff/views.go
@@ -281,6 +281,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 					if idx.Concurrently {
 						result.HasConcurrently = true
 					}
+					result.CreateStmts = append(result.CreateStmts, indexCommentStmts(nil, idx)...)
 				}
 			}
 		} else if !equalViewDef(currentView.Definition, desiredView.Definition) || currentView.Materialized != desiredView.Materialized {
@@ -327,6 +328,7 @@ func DiffViews(current, desired *orderedmap.Map[string, *model.View], dc DropChe
 							if idx.Concurrently {
 								result.HasConcurrently = true
 							}
+							result.CreateStmts = append(result.CreateStmts, indexCommentStmts(nil, idx)...)
 						}
 					}
 					recreated[k] = true
@@ -488,7 +490,9 @@ func diffViewIndexes(current, desired *model.View, dc DropChecker) (stmts []stri
 
 	// Add new or changed indexes
 	for name, desiredIdx := range desiredIndexes.All() {
-		if _, ok := currentIndexes.GetOk(name); ok && sameDef[name] {
+		currentIdx, ok := currentIndexes.GetOk(name)
+		if ok && sameDef[name] {
+			stmts = append(stmts, indexCommentStmts(currentIdx.Comment, desiredIdx)...)
 			continue
 		}
 		stmt, err := createIndexSQL(desiredIdx.Definition, desiredIdx.Concurrently)
@@ -499,6 +503,8 @@ func diffViewIndexes(current, desired *model.View, dc DropChecker) (stmts []stri
 		if desiredIdx.Concurrently {
 			hasConcurrently = true
 		}
+		// A recreated index carries no comment of its own.
+		stmts = append(stmts, indexCommentStmts(nil, desiredIdx)...)
 	}
 
 	return stmts, disallowed, hasConcurrently, nil

--- a/diff/views_test.go
+++ b/diff/views_test.go
@@ -662,6 +662,55 @@ func TestDiffViews_newMatviewWithIndex(t *testing.T) {
 	assert.Contains(t, result.CreateStmts[1], "CREATE INDEX idx_mv_n")
 }
 
+func TestDiffViews_matviewIndexComment(t *testing.T) {
+	const def = "CREATE INDEX idx_mv_n ON public.mv USING btree (n)"
+	matview := func(comment *string) *model.View {
+		mv := &model.View{
+			Schema: "public", Name: "mv", Materialized: true,
+			Definition: "SELECT 1 AS n",
+			Indexes:    orderedmap.New[string, *model.Index](),
+		}
+		mv.Indexes.Set("idx_mv_n", &model.Index{
+			Schema: "public", Name: "idx_mv_n", Table: "mv",
+			Definition: def, Comment: comment,
+		})
+		return mv
+	}
+
+	t.Run("changed", func(t *testing.T) {
+		current := orderedmap.New[string, *model.View]()
+		current.Set("public.mv", matview(new("old")))
+		desired := orderedmap.New[string, *model.View]()
+		desired.Set("public.mv", matview(new("new")))
+
+		result, err := DiffViews(current, desired, allowAllDrops{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"COMMENT ON INDEX public.idx_mv_n IS 'new';"}, result.CreateStmts)
+	})
+
+	t.Run("unchanged", func(t *testing.T) {
+		current := orderedmap.New[string, *model.View]()
+		current.Set("public.mv", matview(new("same")))
+		desired := orderedmap.New[string, *model.View]()
+		desired.Set("public.mv", matview(new("same")))
+
+		result, err := DiffViews(current, desired, allowAllDrops{})
+		require.NoError(t, err)
+		assert.Empty(t, result.CreateStmts)
+	})
+
+	t.Run("new matview", func(t *testing.T) {
+		current := orderedmap.New[string, *model.View]()
+		desired := orderedmap.New[string, *model.View]()
+		desired.Set("public.mv", matview(new("fresh")))
+
+		result, err := DiffViews(current, desired, allowAllDrops{})
+		require.NoError(t, err)
+		require.Len(t, result.CreateStmts, 3)
+		assert.Equal(t, "COMMENT ON INDEX public.idx_mv_n IS 'fresh';", result.CreateStmts[2])
+	})
+}
+
 func TestDiffViews_dropMatview(t *testing.T) {
 	current := orderedmap.New[string, *model.View]()
 	current.Set("public.mv", &model.View{

--- a/diff_all.go
+++ b/diff_all.go
@@ -451,6 +451,7 @@ func orderStatements(
 	for i, name := range createOrder {
 		createPosMap[name] = i
 	}
+	addIndexPositions(createPosMap, desiredTables, desiredViews)
 
 	// Build topological order from current schema for drops.
 	// Dropped objects are not in the desired schema, so we need the current
@@ -466,6 +467,7 @@ func orderStatements(
 	for i, name := range dropOrder {
 		dropPosMap[name] = i
 	}
+	addIndexPositions(dropPosMap, currentTables, currentViews)
 
 	// Phase 1: Creates/modifications in topological order.
 	// Statements whose owning object cannot be identified (pos < 0) are placed
@@ -573,6 +575,31 @@ func fallbackOrder(
 	return stmts
 }
 
+// addIndexPositions gives every index the position of the relation it sits on.
+// COMMENT ON INDEX names the index alone, so without this it would sort as an
+// unidentified statement and run before the CREATE INDEX it comments on.
+func addIndexPositions(
+	posMap map[string]int,
+	tables *orderedmap.Map[string, *model.Table],
+	views *orderedmap.Map[string, *model.View],
+) {
+	add := func(key string, indexes *orderedmap.Map[string, *model.Index]) {
+		pos, ok := posMap[key]
+		if !ok || indexes == nil {
+			return
+		}
+		for _, idx := range indexes.CollectValues() {
+			posMap[model.Ident(idx.Schema, idx.Name)] = pos
+		}
+	}
+	for k, t := range tables.All() {
+		add(k, t.Indexes)
+	}
+	for k, v := range views.All() {
+		add(k, v.Indexes)
+	}
+}
+
 // taggedStmt pairs a SQL statement with a sort position derived from
 // the topological order of the object it affects.
 type taggedStmt struct {
@@ -678,6 +705,7 @@ func extractObjectName(sql string) string {
 		{"COMMENT ON TYPE "},
 		{"COMMENT ON DOMAIN "},
 		{"COMMENT ON COLUMN "}, // schema.table.column -> take schema.table
+		{"COMMENT ON INDEX "},  // schema.index, positioned by addIndexPositions
 	}
 
 	upper := strings.ToUpper(sql)

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -11,7 +11,7 @@
 - Columns (serial/bigserial/smallserial, identity, generated, TOAST storage and compression). An identity column's sequence options, the `( ... )` after `AS IDENTITY`, are managed; a change goes out as `ALTER TABLE ... ALTER COLUMN ... SET`. No `RESTART` is planned, the same as `ALTER SEQUENCE`, so a change that puts the sequence's current value outside the new range fails at apply with the server's error.
 - Constraints (primary key, unique, check, exclusion, foreign key)
 - Indexes (unique, partial, expression, hash, multi-column)
-- Comments (on tables, columns, views, types, domains, composite types, composite attributes, sequences)
+- Comments (on tables, columns, views, materialized views, indexes, types, domains, composite types, composite attributes, sequences, routines). See [Comments](#comments).
 - Row-level security (`ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY`, policies via `CREATE POLICY` / `ALTER POLICY` / `DROP POLICY`)
 - Triggers (`CREATE TRIGGER`, `CREATE CONSTRAINT TRIGGER`, `INSTEAD OF` triggers on views, and the enable state via `ALTER TABLE ... ENABLE/DISABLE TRIGGER`); see [Triggers](#triggers)
 - Routines (`CREATE FUNCTION`, `CREATE PROCEDURE`), opt-in with `--manage-routine`. An overload set is several objects, keyed by argument type. See [Routines](#routines).
@@ -19,7 +19,7 @@
 - Array, JSON, UUID, and other built-in types
 - Quoted identifiers
 
-pistachio parses only the statements above. It drops any other statement in a schema file, such as `SET`, `GRANT`, or `CREATE EXTENSION`, and prints a `pistachio: <file>:<line>:<column>: ignored unsupported statement:` warning to standard error for each one. The same warning covers the parts it does not read of a statement it does parse, such as the `ALTER TABLE ... ADD COLUMN` and `ALTER COLUMN ... SET DEFAULT` a `pg_dump` file carries, or `COMMENT ON INDEX`. The `ALTER COLUMN ... SET STORAGE` and `SET COMPRESSION` such a file carries are read. To keep an unsupported statement in the file and run it during `apply`, mark it with `-- pista:execute`, which also silences the warning. A `BEGIN` or `COMMIT` warning points at `--with-tx` and `--try-tx`, which wrap the apply in a transaction.
+pistachio parses only the statements above. It drops any other statement in a schema file, such as `SET`, `GRANT`, or `CREATE EXTENSION`, and prints a `pistachio: <file>:<line>:<column>: ignored unsupported statement:` warning to standard error for each one. The same warning covers the parts it does not read of a statement it does parse, such as the `ALTER TABLE ... ADD COLUMN` and `ALTER COLUMN ... SET DEFAULT` a `pg_dump` file carries, or `COMMENT ON CONSTRAINT`. The `ALTER COLUMN ... SET STORAGE` and `SET COMPRESSION` such a file carries are read. To keep an unsupported statement in the file and run it during `apply`, mark it with `-- pista:execute`, which also silences the warning. A `BEGIN` or `COMMIT` warning points at `--with-tx` and `--try-tx`, which wrap the apply in a transaction.
 
 
 ## Storage parameters
@@ -165,6 +165,21 @@ A trigger on a partitioned table is cloned onto every partition. pistachio reads
 
 The `ALL` and `USER` forms of `ENABLE TRIGGER` name no single trigger and are ignored, as are event triggers, which belong to the database rather than to a schema.
 
+
+## Comments
+
+`dump` writes a comment after the object it belongs to, and a comment the schema file drops is cleared with `COMMENT ON ... IS NULL`.
+
+`COMMENT ON INDEX` names the index without the relation it sits on, so the index is found by name, which PostgreSQL keeps unique within a schema:
+
+```sql
+CREATE INDEX users_email_idx ON public.users USING btree (email);
+COMMENT ON INDEX public.users_email_idx IS 'Lookup by email';
+```
+
+Recreating an index drops its comment, so a definition change writes the comment again after the `CREATE INDEX`.
+
+A comment on a constraint, a trigger or a policy is not managed, and the index a `PRIMARY KEY`, `UNIQUE` or `EXCLUDE` constraint owns belongs to the constraint. A `COMMENT ON INDEX` naming one of those, or an index no schema file declares, is dropped without a warning. `pg_dump` writes such lines and they are lost on the way in.
 
 ## Constraint and index naming
 

--- a/model/index.go
+++ b/model/index.go
@@ -9,6 +9,7 @@ type Index struct {
 	Definition   string
 	TableSpace   *string
 	Concurrently bool
+	Comment      *string
 }
 
 func (idx Index) FQTN() string {
@@ -17,4 +18,14 @@ func (idx Index) FQTN() string {
 
 func (idx Index) SQL() string {
 	return idx.Definition + ";"
+}
+
+// CommentSQL renders the index's own COMMENT ON, or an empty string when it
+// carries none. COMMENT ON INDEX names the index alone, never the relation it
+// sits on.
+func (idx Index) CommentSQL() string {
+	if idx.Comment == nil {
+		return ""
+	}
+	return "COMMENT ON INDEX " + Ident(idx.Schema, idx.Name) + " IS " + QuoteLiteral(*idx.Comment) + ";"
 }

--- a/model/index_test.go
+++ b/model/index_test.go
@@ -16,3 +16,12 @@ func TestIndex_SQL(t *testing.T) {
 	idx := model.Index{Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"}
 	assert.Equal(t, "CREATE INDEX idx_name ON public.users USING btree (name);", idx.SQL())
 }
+
+func TestIndex_CommentSQL(t *testing.T) {
+	comment := "Lookup by name"
+	idx := model.Index{Schema: "public", Name: "idx_users_name", Comment: &comment}
+	assert.Equal(t, "COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';", idx.CommentSQL())
+
+	idx.Comment = nil
+	assert.Empty(t, idx.CommentSQL())
+}

--- a/model/table.go
+++ b/model/table.go
@@ -311,6 +311,11 @@ func (t Table) CommentSQL() string {
 			stmts = append(stmts, "COMMENT ON COLUMN "+Ident(t.Schema, t.Name)+"."+Ident(col.Name)+" IS "+QuoteLiteral(*col.Comment)+";")
 		}
 	}
+	for _, idx := range t.Indexes.CollectValues() {
+		if s := idx.CommentSQL(); s != "" {
+			stmts = append(stmts, s)
+		}
+	}
 	return strings.Join(stmts, "\n")
 }
 

--- a/model/table_test.go
+++ b/model/table_test.go
@@ -299,9 +299,22 @@ func TestTable_CommentSQL(t *testing.T) {
 	colComment := "User name"
 	tbl.Columns.Set("name", &model.Column{Name: "name", TypeName: "text", Comment: &colComment})
 
+	idxComment := "Lookup by name"
+	tbl.Indexes.Set("idx_users_name", &model.Index{
+		Schema: "public", Name: "idx_users_name", Table: "users",
+		Definition: "CREATE INDEX idx_users_name ON public.users USING btree (name)",
+		Comment:    &idxComment,
+	})
+	tbl.Indexes.Set("idx_users_id", &model.Index{
+		Schema: "public", Name: "idx_users_id", Table: "users",
+		Definition: "CREATE INDEX idx_users_id ON public.users USING btree (id)",
+	})
+
 	sql := tbl.CommentSQL()
 	assert.Contains(t, sql, "COMMENT ON TABLE public.users IS 'Main users table';")
 	assert.Contains(t, sql, "COMMENT ON COLUMN public.users.name IS 'User name';")
+	assert.Contains(t, sql, "COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';")
+	assert.NotContains(t, sql, "idx_users_id")
 }
 
 func TestTable_CommentSQL_noComments(t *testing.T) {

--- a/model/view.go
+++ b/model/view.go
@@ -117,10 +117,18 @@ func (v View) TrigSQL() string {
 }
 
 func (v View) CommentSQL() string {
+	var stmts []string
 	if v.Comment != nil {
-		return "COMMENT ON " + v.ObjType() + " " + Ident(v.Schema, v.Name) + " IS " + QuoteLiteral(*v.Comment) + ";"
+		stmts = append(stmts, "COMMENT ON "+v.ObjType()+" "+Ident(v.Schema, v.Name)+" IS "+QuoteLiteral(*v.Comment)+";")
 	}
-	return ""
+	if v.Indexes != nil {
+		for _, idx := range v.Indexes.CollectValues() {
+			if s := idx.CommentSQL(); s != "" {
+				stmts = append(stmts, s)
+			}
+		}
+	}
+	return strings.Join(stmts, "\n")
 }
 
 func ViewToSQL(v *View) string {

--- a/model/view_test.go
+++ b/model/view_test.go
@@ -75,6 +75,23 @@ func TestViewToSQL_materializedWithIndex(t *testing.T) {
 	got := model.ViewToSQL(v)
 	assert.Contains(t, got, "CREATE MATERIALIZED VIEW")
 	assert.Contains(t, got, "CREATE INDEX idx_mv_n")
+	assert.NotContains(t, got, "COMMENT ON INDEX")
+}
+
+func TestView_CommentSQL_indexComment(t *testing.T) {
+	indexes := orderedmap.New[string, *model.Index]()
+	comment := "Lookup by n"
+	indexes.Set("idx_mv_n", &model.Index{
+		Schema: "public", Name: "idx_mv_n", Table: "mv",
+		Definition: "CREATE INDEX idx_mv_n ON public.mv USING btree (n)",
+		Comment:    &comment,
+	})
+	v := model.View{Schema: "public", Name: "mv", Materialized: true, Indexes: indexes}
+	assert.Equal(t, "COMMENT ON INDEX public.idx_mv_n IS 'Lookup by n';", v.CommentSQL())
+
+	viewComment := "stats"
+	v.Comment = &viewComment
+	assert.Equal(t, "COMMENT ON MATERIALIZED VIEW public.mv IS 'stats';\nCOMMENT ON INDEX public.idx_mv_n IS 'Lookup by n';", v.CommentSQL())
 }
 
 func TestView_SQL_checkOption(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -117,6 +117,7 @@ var commentTargetSupported = map[pg_query.ObjectType]bool{
 	pg_query.ObjectType_OBJECT_VIEW:      true,
 	pg_query.ObjectType_OBJECT_MATVIEW:   true,
 	pg_query.ObjectType_OBJECT_COLUMN:    true,
+	pg_query.ObjectType_OBJECT_INDEX:     true,
 	pg_query.ObjectType_OBJECT_SEQUENCE:  true,
 	pg_query.ObjectType_OBJECT_TYPE:      true,
 	pg_query.ObjectType_OBJECT_DOMAIN:    true,
@@ -1893,6 +1894,24 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 				}
 			}
 		}
+	case pg_query.ObjectType_OBJECT_INDEX:
+		schema := defaultSchema
+		idxName := names[0]
+		if len(names) >= 2 {
+			schema = names[0]
+			idxName = names[1]
+		}
+		// COMMENT ON INDEX names the index alone, so the relation it sits on
+		// is found by scanning. An index name is unique within its schema, and
+		// the index a constraint owns is not in the model on either side.
+		if idx := findIndex(tables, views, schema, idxName); idx != nil {
+			if cs.Comment != "" {
+				c := cs.Comment
+				idx.Comment = &c
+			} else {
+				idx.Comment = nil
+			}
+		}
 	case pg_query.ObjectType_OBJECT_SEQUENCE:
 		schema := defaultSchema
 		seqName := names[0]
@@ -1910,6 +1929,23 @@ func parseCommentStmt(cs *pg_query.CommentStmt, defaultSchema string, tables *or
 			}
 		}
 	}
+}
+
+// findIndex returns the index of the given schema and name from the tables and
+// views that carry one, or nil when no relation declares it. Every table and
+// view the parser builds holds an index map, so neither is checked for nil.
+func findIndex(tables *orderedmap.Map[string, *model.Table], views *orderedmap.Map[string, *model.View], schema, name string) *model.Index {
+	for _, t := range tables.CollectValues() {
+		if idx, ok := t.Indexes.GetOk(name); ok && idx.Schema == schema {
+			return idx
+		}
+	}
+	for _, v := range views.CollectValues() {
+		if idx, ok := v.Indexes.GetOk(name); ok && idx.Schema == schema {
+			return idx
+		}
+	}
+	return nil
 }
 
 func parseCommentOnType(cs *pg_query.CommentStmt, defaultSchema string, enums *orderedmap.Map[string, *model.Enum], compositeTypes *orderedmap.Map[string, *model.CompositeType]) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -360,7 +360,6 @@ func TestParseSQL_NoWarnForAlterTableOnIgnoredTable(t *testing.T) {
 // dropped, so it warns like any other unsupported statement.
 func TestParseSQL_WarnsUnsupportedCommentTarget(t *testing.T) {
 	for _, stmt := range []string{
-		`COMMENT ON INDEX public.t_idx IS 'i';`,
 		`COMMENT ON CONSTRAINT t_id_check ON public.t IS 'c';`,
 		`COMMENT ON SCHEMA public IS 's';`,
 		`COMMENT ON TRIGGER trg ON public.t IS 'g';`,
@@ -388,6 +387,7 @@ func TestParseSQL_NoWarnForSupportedCommentTargets(t *testing.T) {
 		CREATE DOMAIN public.d AS text;
 		CREATE SEQUENCE public.s;
 		CREATE TABLE public.t (id integer);
+		CREATE INDEX t_id_idx ON public.t (id);
 		CREATE VIEW public.v AS SELECT id FROM public.t;
 		CREATE MATERIALIZED VIEW public.mv AS SELECT id FROM public.t;
 		CREATE FUNCTION public.f() RETURNS integer LANGUAGE sql AS $$ SELECT 1 $$;
@@ -401,9 +401,102 @@ func TestParseSQL_NoWarnForSupportedCommentTargets(t *testing.T) {
 		COMMENT ON DOMAIN public.d IS 'd';
 		COMMENT ON FUNCTION public.f() IS 'f';
 		COMMENT ON PROCEDURE public.p() IS 'p';
+		COMMENT ON INDEX public.t_id_idx IS 'i';
 	`)
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
+}
+
+// COMMENT ON INDEX names the index alone, so the relation carrying it is found
+// by scanning the tables and the views.
+func TestParseSQL_CommentOnIndex(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (id integer, n text);
+		CREATE INDEX t_n_idx ON public.t (n);
+		CREATE MATERIALIZED VIEW public.mv AS SELECT id FROM public.t;
+		CREATE INDEX mv_id_idx ON public.mv (id);
+		COMMENT ON INDEX public.t_n_idx IS 'on a table';
+		COMMENT ON INDEX public.mv_id_idx IS 'on a materialized view';
+	`)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.t")
+	require.True(t, ok)
+	idx, ok := tbl.Indexes.GetOk("t_n_idx")
+	require.True(t, ok)
+	require.NotNil(t, idx.Comment)
+	assert.Equal(t, "on a table", *idx.Comment)
+
+	mv, ok := result.Views.GetOk("public.mv")
+	require.True(t, ok)
+	mvIdx, ok := mv.Indexes.GetOk("mv_id_idx")
+	require.True(t, ok)
+	require.NotNil(t, mvIdx.Comment)
+	assert.Equal(t, "on a materialized view", *mvIdx.Comment)
+}
+
+// An index name written without a schema takes the default schema, which is
+// the one the run works in rather than public.
+func TestParseSQL_CommentOnIndexUnqualified(t *testing.T) {
+	result, err := parser.ParseSQLWithSchema(`
+		CREATE TABLE myschema.t (id integer, n text);
+		CREATE INDEX t_n_idx ON myschema.t (n);
+		COMMENT ON INDEX t_n_idx IS 'unqualified';
+	`, "myschema")
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("myschema.t")
+	require.True(t, ok)
+	idx, ok := tbl.Indexes.GetOk("t_n_idx")
+	require.True(t, ok)
+	require.NotNil(t, idx.Comment)
+	assert.Equal(t, "unqualified", *idx.Comment)
+}
+
+// An empty comment clears the one the index carries, the same as every other
+// COMMENT ON target, and one naming an index no relation declares is dropped.
+// Index names are unique per schema, not per database, so the schema decides
+// which of two same-named indexes the comment lands on.
+func TestParseSQL_CommentOnIndexSameNameOtherSchema(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (n text);
+		CREATE INDEX n_idx ON public.t (n);
+		CREATE TABLE other.t (n text);
+		CREATE INDEX n_idx ON other.t (n);
+		COMMENT ON INDEX other.n_idx IS 'the other one';
+	`)
+	require.NoError(t, err)
+
+	pub, ok := result.Tables.GetOk("public.t")
+	require.True(t, ok)
+	pubIdx, ok := pub.Indexes.GetOk("n_idx")
+	require.True(t, ok)
+	assert.Nil(t, pubIdx.Comment)
+
+	other, ok := result.Tables.GetOk("other.t")
+	require.True(t, ok)
+	otherIdx, ok := other.Indexes.GetOk("n_idx")
+	require.True(t, ok)
+	require.NotNil(t, otherIdx.Comment)
+	assert.Equal(t, "the other one", *otherIdx.Comment)
+}
+
+func TestParseSQL_CommentOnIndexEmptyAndUnknown(t *testing.T) {
+	result, err := parseSQLWithPublicSchema(`
+		CREATE TABLE public.t (id integer, n text);
+		CREATE INDEX t_n_idx ON public.t (n);
+		COMMENT ON INDEX public.t_n_idx IS 'kept for a moment';
+		COMMENT ON INDEX public.t_n_idx IS '';
+		COMMENT ON INDEX public.nope IS 'no such index';
+		COMMENT ON INDEX other.t_n_idx IS 'another schema';
+	`)
+	require.NoError(t, err)
+
+	tbl, ok := result.Tables.GetOk("public.t")
+	require.True(t, ok)
+	idx, ok := tbl.Indexes.GetOk("t_n_idx")
+	require.True(t, ok)
+	assert.Nil(t, idx.Comment)
 }
 
 // COMMENT ON COLUMN names a composite type attribute as well as a table

--- a/remap_test.go
+++ b/remap_test.go
@@ -591,6 +591,36 @@ CREATE INDEX users_name_idx ON myschema.users (name);
 	assert.Contains(t, output, "users_name_idx")
 }
 
+// An index comment is written under the mapped schema, the same as the index
+// itself.
+func TestDump_WithSchemaMap_IndexComment(t *testing.T) {
+	ctx := context.Background()
+
+	connString := setupSchemaDB(t, ctx, "myschema", `
+CREATE TABLE myschema.users (
+    id integer NOT NULL,
+    name text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX users_name_idx ON myschema.users (name);
+COMMENT ON INDEX myschema.users_name_idx IS 'Lookup by name';
+`)
+
+	client := pistachio.NewClient(&pistachio.Options{
+		ConnString: connString,
+		Schemas:    []string{"myschema"},
+		SchemaMap:  map[string]string{"myschema": "public"},
+	})
+
+	got, err := client.Dump(ctx, &pistachio.DumpOptions{})
+	require.NoError(t, err)
+
+	output := got.String()
+	t.Log(output)
+
+	assert.Contains(t, output, "COMMENT ON INDEX public.users_name_idx IS 'Lookup by name';")
+}
+
 func TestDump_WithSchemaMap_UnmappedSchema(t *testing.T) {
 	ctx := context.Background()
 

--- a/test/fidelity/schemas/comments.sql
+++ b/test/fidelity/schemas/comments.sql
@@ -3,7 +3,9 @@ CREATE TABLE public.notes (
     body text,
     CONSTRAINT notes_pkey PRIMARY KEY (id)
 );
+CREATE INDEX notes_body_idx ON public.notes USING btree (body);
 CREATE VIEW public.recent_notes AS SELECT notes.id, notes.body FROM public.notes;
 COMMENT ON TABLE public.notes IS 'user notes';
 COMMENT ON COLUMN public.notes.body IS 'the text';
 COMMENT ON VIEW public.recent_notes IS 'a view';
+COMMENT ON INDEX public.notes_body_idx IS 'body lookups';

--- a/test/fidelity/schemas/object_comments.sql
+++ b/test/fidelity/schemas/object_comments.sql
@@ -21,4 +21,6 @@ COMMENT ON DOMAIN public.pos IS 'a domain';
 COMMENT ON SEQUENCE public.ticker IS 'a sequence';
 COMMENT ON FUNCTION public.answer() IS 'a function';
 COMMENT ON PROCEDURE public.tick() IS 'a procedure';
+CREATE INDEX thing_count_n_idx ON public.thing_count USING btree (n);
 COMMENT ON MATERIALIZED VIEW public.thing_count IS 'a materialized view';
+COMMENT ON INDEX public.thing_count_n_idx IS 'an index on a materialized view';

--- a/testdata/apply/index_comment.yml
+++ b/testdata/apply/index_comment.yml
@@ -1,0 +1,24 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';

--- a/testdata/apply/recreate_index_reapplies_comment.yml
+++ b/testdata/apply/recreate_index_reapplies_comment.yml
@@ -1,0 +1,25 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (lower(email));
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (lower(email));
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';

--- a/testdata/dump/index_comment.yml
+++ b/testdata/dump/index_comment.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';

--- a/testdata/dump/matview_index_comment.yml
+++ b/testdata/dump/matview_index_comment.yml
@@ -22,3 +22,20 @@ dump: |
      FROM users;
   CREATE INDEX idx_user_names ON public.user_names USING btree (name);
   COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';
+dump_pg16: &dump_pg16plus |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_names
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id,
+      name
+     FROM users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';
+dump_pg17: *dump_pg16plus
+dump_pg18: *dump_pg16plus

--- a/testdata/dump/matview_index_comment.yml
+++ b/testdata/dump/matview_index_comment.yml
@@ -1,0 +1,24 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';
+dump: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+
+  -- public.user_names
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT users.id,
+      users.name
+     FROM users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';

--- a/testdata/dump/omit_schema_index_comment.yml
+++ b/testdata/dump/omit_schema_index_comment.yml
@@ -1,0 +1,16 @@
+omit_schema: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_id ON public.users (id);
+  COMMENT ON INDEX public.idx_users_id IS 'Lookup by id';
+dump: |
+  -- users
+  CREATE TABLE users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_id ON users USING btree (id);
+  COMMENT ON INDEX idx_users_id IS 'Lookup by id';

--- a/testdata/dump/partitioned_index_comment.yml
+++ b/testdata/dump/partitioned_index_comment.yml
@@ -1,0 +1,21 @@
+init: |
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      at date NOT NULL
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  CREATE INDEX logs_at_idx ON public.logs USING btree (at);
+  COMMENT ON INDEX public.logs_at_idx IS 'by date';
+dump: |
+  -- public.logs
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      at date NOT NULL
+  )
+  PARTITION BY RANGE (at);
+  CREATE INDEX logs_at_idx ON ONLY public.logs USING btree (at);
+  COMMENT ON INDEX public.logs_at_idx IS 'by date';
+
+  -- public.logs_2025
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  CREATE INDEX logs_2025_at_idx ON public.logs_2025 USING btree (at);

--- a/testdata/plan/add_index_comment.yml
+++ b/testdata/plan/add_index_comment.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+plan: |
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';

--- a/testdata/plan/change_index_comment.yml
+++ b/testdata/plan/change_index_comment.yml
@@ -1,0 +1,18 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Unique visitors';
+plan: |
+  COMMENT ON INDEX public.idx_users_email IS 'Unique visitors';

--- a/testdata/plan/constraint_index_comment_ignored.yml
+++ b/testdata/plan/constraint_index_comment_ignored.yml
@@ -1,0 +1,14 @@
+# The index a constraint owns is the constraint's, not an index pistachio
+# holds, so a comment naming it is dropped and nothing is planned.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  COMMENT ON INDEX public.users_pkey IS 'the primary key index';
+plan: ""

--- a/testdata/plan/create_index_concurrently_with_comment.yml
+++ b/testdata/plan/create_index_concurrently_with_comment.yml
@@ -1,0 +1,19 @@
+# The comment follows the index, which is built outside a transaction.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:concurrently
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+plan: |
+  CREATE INDEX CONCURRENTLY idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';

--- a/testdata/plan/create_index_with_comment.yml
+++ b/testdata/plan/create_index_with_comment.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+plan: |
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';

--- a/testdata/plan/create_matview_with_index_comment.yml
+++ b/testdata/plan/create_matview_with_index_comment.yml
@@ -1,0 +1,20 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';
+plan: |
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';

--- a/testdata/plan/create_table_with_index_comment.yml
+++ b/testdata/plan/create_table_with_index_comment.yml
@@ -1,0 +1,19 @@
+# A table created in the same run writes its index and the index's comment as
+# part of the table, not through the index diff.
+init: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+plan: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';

--- a/testdata/plan/drop_index_comment.yml
+++ b/testdata/plan/drop_index_comment.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+plan: |
+  COMMENT ON INDEX public.idx_users_email IS NULL;

--- a/testdata/plan/drop_index_with_comment.yml
+++ b/testdata/plan/drop_index_with_comment.yml
@@ -1,0 +1,18 @@
+# The index goes, so its comment goes with it and no COMMENT statement is
+# planned.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  DROP INDEX public.idx_users_email;

--- a/testdata/plan/drop_index_with_comment_denied.yml
+++ b/testdata/plan/drop_index_with_comment_denied.yml
@@ -1,0 +1,20 @@
+# The drop is skipped, so the index and its comment both stay as they are.
+drop_policy:
+  allow_drop: []
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: ""
+disallowed_drops: |
+  -- skipped: DROP INDEX public.idx_users_email;

--- a/testdata/plan/matview_index_comment.yml
+++ b/testdata/plan/matview_index_comment.yml
@@ -1,0 +1,19 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';
+plan: |
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';

--- a/testdata/plan/no_diff_index_comment.yml
+++ b/testdata/plan/no_diff_index_comment.yml
@@ -1,0 +1,17 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+plan: ""

--- a/testdata/plan/partitioned_index_comment.yml
+++ b/testdata/plan/partitioned_index_comment.yml
@@ -1,0 +1,20 @@
+# The comment sits on the parent index. PostgreSQL does not copy it to the
+# index it creates on the partition, and neither side reports one there.
+init: |
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      at date NOT NULL
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  CREATE INDEX logs_at_idx ON public.logs USING btree (at);
+desired: |
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      at date NOT NULL
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  CREATE INDEX logs_at_idx ON ONLY public.logs USING btree (at);
+  CREATE INDEX logs_2025_at_idx ON public.logs_2025 USING btree (at);
+  COMMENT ON INDEX public.logs_at_idx IS 'by date';
+plan: |
+  COMMENT ON INDEX public.logs_at_idx IS 'by date';

--- a/testdata/plan/recreate_index_reapplies_comment.yml
+++ b/testdata/plan/recreate_index_reapplies_comment.yml
@@ -1,0 +1,22 @@
+# A definition change drops and recreates the index, which takes its comment
+# with it, so the comment is emitted again.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (email);
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_email ON public.users USING btree (lower(email));
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';
+plan: |
+  DROP INDEX public.idx_users_email;
+  CREATE INDEX idx_users_email ON public.users USING btree (lower(email));
+  COMMENT ON INDEX public.idx_users_email IS 'Lookup by email';

--- a/testdata/plan/recreate_matview_reapplies_index_comment.yml
+++ b/testdata/plan/recreate_matview_reapplies_index_comment.yml
@@ -1,0 +1,28 @@
+# The matview is dropped and recreated, which takes its index and the index's
+# comment with it, so both are written again.
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS SELECT id, name FROM public.users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE MATERIALIZED VIEW public.user_names AS SELECT id, upper(name) AS name FROM public.users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';
+plan: |
+  DROP MATERIALIZED VIEW public.user_names;
+  CREATE MATERIALIZED VIEW public.user_names AS
+  SELECT id, upper(name) AS name FROM public.users;
+  CREATE INDEX idx_user_names ON public.user_names USING btree (name);
+  COMMENT ON INDEX public.idx_user_names IS 'Lookup by name';

--- a/testdata/plan/rename_column_keeps_index_comment.yml
+++ b/testdata/plan/rename_column_keeps_index_comment.yml
@@ -1,0 +1,21 @@
+# The column rename rewrites the index definition on the current side, and the
+# comment survives that rewrite, so only the rename is planned.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+  COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pista:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (display_name);
+  COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';
+plan: |
+  ALTER TABLE public.users RENAME COLUMN name TO display_name;

--- a/testdata/plan/rename_index_changes_comment.yml
+++ b/testdata/plan/rename_index_changes_comment.yml
@@ -1,0 +1,22 @@
+# The rename carries the comment, so the new one is applied to the index under
+# its new name.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+  COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:renamed-from idx_users_name
+  CREATE INDEX idx_users_display_name ON public.users (name);
+  COMMENT ON INDEX public.idx_users_display_name IS 'Lookup by display name';
+plan: |
+  ALTER INDEX public.idx_users_name RENAME TO idx_users_display_name;
+  COMMENT ON INDEX public.idx_users_display_name IS 'Lookup by display name';

--- a/testdata/plan/rename_index_keeps_comment.yml
+++ b/testdata/plan/rename_index_keeps_comment.yml
@@ -1,0 +1,21 @@
+# The comment follows the index through ALTER INDEX ... RENAME TO, so the
+# rename alone is planned.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+  COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:renamed-from idx_users_name
+  CREATE INDEX idx_users_display_name ON public.users (name);
+  COMMENT ON INDEX public.idx_users_display_name IS 'Lookup by name';
+plan: |
+  ALTER INDEX public.idx_users_name RENAME TO idx_users_display_name;

--- a/testdata/plan/rename_table_keeps_index_comment.yml
+++ b/testdata/plan/rename_table_keeps_index_comment.yml
@@ -1,0 +1,21 @@
+# The table rename carries its indexes, and the comment on one of them goes
+# with it, so the rename is all that is planned.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+  COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';
+desired: |
+  -- pista:renamed-from users
+  CREATE TABLE public.accounts (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.accounts (name);
+  COMMENT ON INDEX public.idx_users_name IS 'Lookup by name';
+plan: |
+  ALTER TABLE public.users RENAME TO accounts;


### PR DESCRIPTION
COMMENT ON INDEX was read by neither side, so dump dropped the line
pg_dump writes and a schema file that carried one was warned about and
ignored.

The catalog joins pg_description on the index, the parser reads the
statement onto the index the tables and views declare, and the diff
emits COMMENT ON INDEX ... IS ... or IS NULL for a change. An index that
is dropped and recreated loses its comment, so the recreate writes it
again, on a materialized view's index too.

The statement names the index without the relation it sits on, so the
plan's topological sort gives every index the position of the relation
it sits on. Without that the comment sorted as an unidentified statement
and ran before the CREATE INDEX it comments on.

The index a PRIMARY KEY, UNIQUE or EXCLUDE constraint owns is the
constraint's and is on neither side, so a comment naming it is dropped
without a warning, as is one naming an index no schema file declares.
Comments on constraints, triggers and policies stay unmanaged; TODO.md
records what is left and the shape the work takes.

Verified with the plan, dump and apply fixtures, package tests for the
catalog read, the parser, the diff and the SQL rendering, and two
fidelity schemas that pg_dump compares. Coverage is unchanged per
package, parser up 0.1 point. make test, test-fidelity, test-scenario,
test-samples and lint all pass.