### PR TITLE
Change a foreign key's deferral clause in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Change a foreign key's deferral clause in place. `DEFERRABLE` and `INITIALLY DEFERRED` were compared only as part of the definition string, so a toggle dropped the key and added it back, rescanning the table to validate it again. When nothing else about the key differs it now goes out as `ALTER TABLE ... ALTER CONSTRAINT`, which rewrites a catalog row, and a key that is also being validated takes `VALIDATE CONSTRAINT` next to it. PostgreSQL accepts the statement on a foreign key alone, so a unique, primary key or exclusion constraint is still dropped and added. A partition's copy of its parent's key takes no statement, since PostgreSQL rejects one and the parent's reaches the copy.
+
 * Manage a comment on an index. `COMMENT ON INDEX` was read by neither side, so `dump` dropped the line `pg_dump` writes and a schema file that carried one was warned about and ignored. A change now goes out as `COMMENT ON INDEX ... IS ...` or `IS NULL`, and a recreate writes the comment again, since PostgreSQL drops it with the index. A comment on a constraint, a trigger or a policy, and one on the index a constraint owns, stays unmanaged.
 
 ## [1.45.0] - 2026-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Change a foreign key's deferral clause in place. `DEFERRABLE` and `INITIALLY DEFERRED` were compared only as part of the definition string, so a toggle dropped the key and added it back, rescanning the table to validate it again. When nothing else about the key differs it now goes out as `ALTER TABLE ... ALTER CONSTRAINT`, which rewrites a catalog row, and a key that is also being validated takes `VALIDATE CONSTRAINT` next to it. PostgreSQL accepts the statement on a foreign key alone, so a unique, primary key or exclusion constraint is still dropped and added. A partition's copy of its parent's key takes no statement, since PostgreSQL rejects one and the parent's reaches the copy.
+* Change a foreign key's deferral clause in place. `DEFERRABLE` and `INITIALLY DEFERRED` were compared only as part of the definition string, so a toggle dropped the key and added it back, rescanning the table to validate it again. When nothing else about the key differs it now goes out as `ALTER TABLE ... ALTER CONSTRAINT`, with `VALIDATE CONSTRAINT` next to it when the key is also being validated. PostgreSQL takes the statement on a foreign key alone, so a unique, primary key or exclusion constraint is still dropped and added, and a partition's copy of its parent's key takes no statement at all.
 
 * Manage a comment on an index. `COMMENT ON INDEX` was read by neither side, so `dump` dropped the line `pg_dump` writes and a schema file that carried one was warned about and ignored. A change now goes out as `COMMENT ON INDEX ... IS ...` or `IS NULL`, and a recreate writes the comment again, since PostgreSQL drops it with the index. A comment on a constraint, a trigger or a policy, and one on the index a constraint owns, stays unmanaged.
 

--- a/TODO.md
+++ b/TODO.md
@@ -117,18 +117,26 @@ diff has no reason to walk otherwise.
 
 Origin: review of [#442](https://github.com/winebarrel/pistachio/pull/442).
 
-## Constraint `Deferrable` / `Deferred` granularity
+## A foreign key's definition change does not apply on a partitioned table
 
-`Constraint.Deferrable` / `Constraint.Deferred` are read from the
-catalog but not compared directly in the diff. Changes are still
-detected because they end up in the `pg_get_constraintdef` Definition
-string, which means a deferrable toggle currently triggers DROP+ADD
-of the constraint. PostgreSQL supports
-`ALTER TABLE ... ALTER CONSTRAINT ... [NOT] DEFERRABLE [INITIALLY ...]`
-for in-place changes; using it would avoid the round-trip.
+A partition holds a copy of every key its parent declares, and `dump` writes
+both, so a definition change is planned for each. The parent's
+`DROP CONSTRAINT` takes the copy with it, and the partition's own drop then
+fails with `constraint "fk_user" of relation "orders_2025" does not exist`
+(SQLSTATE 42704). Verified on 15.
 
-Origin: post-[#125](https://github.com/winebarrel/pistachio/pull/125) audit. Optimisation rather than a bug; current
-behaviour is correct, just heavier than necessary.
+The deferral change added in [#522](https://github.com/winebarrel/pistachio/pull/522) already leaves such a copy alone, using
+the `Inherited` flag `catalog.ListConstraintsByTables` reads from
+`conislocal`. Closing this means the drop and the add loops reading the same
+flag: a copy takes no statement of its own, whatever changed, because every
+statement on the parent reaches it. A key the partition declares itself is
+local and stays as it is today.
+
+The same holds for a check constraint a partition copies, which
+`diffConstraints` never reaches: the partition branch of `diffTable` returns
+before the constraint diff.
+
+Origin: [#522](https://github.com/winebarrel/pistachio/pull/522).
 
 ## Table rename: cross-table dependents
 

--- a/catalog/constraints.go
+++ b/catalog/constraints.go
@@ -140,6 +140,7 @@ func (c *Catalog) ListConstraintsByTables(ctx context.Context, tables []*model.T
 		if !isLocal && inheritsChildren[tableOID] {
 			continue
 		}
+		con.Inherited = !isLocal
 
 		// pg_get_constraintdef includes "NOT VALID" in the definition string
 		// for unvalidated constraints. Strip it so Definition only contains

--- a/catalog/constraints_test.go
+++ b/catalog/constraints_test.go
@@ -323,6 +323,46 @@ func TestListConstraintsByTables(t *testing.T) {
 		assert.Equal(t, []string{"z", "y"}, fk.Columns)
 	})
 
+	// A partition holds a copy of every key its parent declares. The copy is
+	// marked so the diff leaves it alone, while a key the partition declares
+	// itself is not.
+	t.Run("partition copy of a foreign key", func(t *testing.T) {
+		testutil.SetupDB(t, ctx, conn, `
+			CREATE TABLE public.users (
+				id integer NOT NULL,
+				CONSTRAINT users_pkey PRIMARY KEY (id)
+			);
+			CREATE TABLE public.orders (
+				id integer NOT NULL,
+				at date NOT NULL,
+				user_id integer,
+				CONSTRAINT orders_pkey PRIMARY KEY (id, at),
+				CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+			) PARTITION BY RANGE (at);
+			CREATE TABLE public.orders_2025 PARTITION OF public.orders
+				FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+			ALTER TABLE public.orders_2025 ADD CONSTRAINT own_fk
+				FOREIGN KEY (user_id) REFERENCES public.users(id);
+		`)
+		cat, err := catalog.NewCatalog(conn, []string{"public"})
+		require.NoError(t, err)
+		tables, err := cat.Tables(ctx)
+		require.NoError(t, err)
+
+		parentFk, ok := tables.Get("public.orders").ForeignKeys.GetOk("fk_user")
+		require.True(t, ok)
+		assert.False(t, parentFk.Inherited)
+
+		child := tables.Get("public.orders_2025")
+		childFk, ok := child.ForeignKeys.GetOk("fk_user")
+		require.True(t, ok)
+		assert.True(t, childFk.Inherited)
+
+		ownFk, ok := child.ForeignKeys.GetOk("own_fk")
+		require.True(t, ok)
+		assert.False(t, ownFk.Inherited)
+	})
+
 	// CHECK constraints with multiple column references must aggregate every
 	// referenced column in conkey order. The previous attrelid-grouped CTE
 	// would have produced the same union for any other constraint on the

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -1406,13 +1406,13 @@ func foreignKeyChanges(current, desired *orderedmap.Map[string, *model.ForeignKe
 		}
 		sameDef, deferralOnly := compareFKDef(currentFk.Definition, desiredFk.Definition, schema)
 		change := newDefinitionChange(sameDef, currentFk.Validated, desiredFk.Validated)
-		sameValidation := currentFk.Validated == desiredFk.Validated
 		switch {
 		case !deferralOnly:
-		case currentFk.Inherited && sameValidation:
+		case currentFk.Inherited:
 			// The partition's copy of the parent's key takes no statement of
-			// its own: PostgreSQL rejects one, and the parent's ALTER reaches
-			// the copy.
+			// its own: PostgreSQL rejects one, whatever it says. Both the
+			// parent's ALTER CONSTRAINT and its VALIDATE CONSTRAINT reach the
+			// copy, so leaving it out settles it either way.
 			change = definitionChange{}
 		case currentFk.Validated && !desiredFk.Validated:
 			// Nothing takes the validated flag away, so the key is added back
@@ -1421,7 +1421,7 @@ func foreignKeyChanges(current, desired *orderedmap.Map[string, *model.ForeignKe
 			change.deferralOnly = true
 			// The key stays, so a NOT VALID one the desired schema validates
 			// takes VALIDATE CONSTRAINT next to the ALTER.
-			change.validateOnly = !sameValidation
+			change.validateOnly = !currentFk.Validated && desiredFk.Validated
 		}
 		changes[name] = change
 	}

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -1121,7 +1121,7 @@ func alignCastNode(ctx pgast.Ctx, desired, current *pg_query.Node) *pg_query.Nod
 }
 
 // definitionChange records how one constraint or foreign key present on both
-// sides differs. equalConstraintDef and equalFKDef parse both definitions,
+// sides differs. equalConstraintDef and compareFKDef parse both definitions,
 // which is the most expensive thing a table diff does, and the rename, drop and
 // add loops below each ask the same question: comparing once and reading the
 // answer three times is what keeps a large schema off three parses per object.
@@ -1771,19 +1771,14 @@ func normalizeFKSchema(con *pg_query.Constraint, schema string) {
 	}
 }
 
-// equalFKDef compares two FK constraint definitions by their parse trees,
-// so that formatting differences do not cause false diffs.
-// schema is the schema of the table that owns the FK constraint and is used
-// to fill in an implicit (empty) schema on the referenced table.
-func equalFKDef(a, b, schema string) bool {
-	equal, _ := compareFKDef(a, b, schema)
-	return equal
-}
-
-// compareFKDef reports whether two foreign key definitions are equal, and
-// whether the only thing between them is the deferral clause. The second
-// answer routes the change to ALTER CONSTRAINT, which leaves the key in place
-// rather than rescanning the table to add it back.
+// compareFKDef compares two FK constraint definitions by their parse trees, so
+// that formatting differences do not cause false diffs. schema is the schema of
+// the table that owns the FK constraint and is used to fill in an implicit
+// (empty) schema on the referenced table.
+//
+// deferralOnly reports that the deferral clause is the only thing between the
+// two, which routes the change to ALTER CONSTRAINT rather than a drop and an
+// add that rescans the table.
 func compareFKDef(a, b, schema string) (equal, deferralOnly bool) {
 	nodeA, errA := parseFKDef(a)
 	nodeB, errB := parseFKDef(b)

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -1132,6 +1132,10 @@ type definitionChange struct {
 	// validateOnly says the definitions match and only the NOT VALID flag
 	// differs, which VALIDATE CONSTRAINT settles in place.
 	validateOnly bool
+	// deferralOnly says the definitions match apart from the deferral clause,
+	// which ALTER CONSTRAINT settles in place. Foreign keys only: PostgreSQL
+	// rejects ALTER CONSTRAINT on every other constraint type.
+	deferralOnly bool
 }
 
 // renameConstraintSQL renders the rename a constraint and a foreign key share;
@@ -1176,7 +1180,7 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 	// Determine which renamed constraints need recreation instead of just rename
 	needsRecreation := map[string]bool{}
 	for name := range renamedFrom {
-		if ch := changes[name]; ch.changed && !ch.validateOnly {
+		if ch := changes[name]; ch.changed && !ch.validateOnly && !ch.deferralOnly {
 			needsRecreation[name] = true
 		}
 	}
@@ -1200,7 +1204,7 @@ func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *mode
 	for name := range current.Keys() {
 		_, ok := desired.GetOk(name)
 		ch := changes[name]
-		if ok && (!ch.changed || ch.validateOnly) {
+		if ok && (!ch.changed || ch.validateOnly || ch.deferralOnly) {
 			continue
 		}
 		dropName := name
@@ -1400,11 +1404,42 @@ func foreignKeyChanges(current, desired *orderedmap.Map[string, *model.ForeignKe
 		if !ok {
 			continue
 		}
-		changes[name] = newDefinitionChange(
-			equalFKDef(currentFk.Definition, desiredFk.Definition, schema),
-			currentFk.Validated, desiredFk.Validated)
+		sameDef, deferralOnly := compareFKDef(currentFk.Definition, desiredFk.Definition, schema)
+		change := newDefinitionChange(sameDef, currentFk.Validated, desiredFk.Validated)
+		sameValidation := currentFk.Validated == desiredFk.Validated
+		switch {
+		case !deferralOnly:
+		case currentFk.Inherited && sameValidation:
+			// The partition's copy of the parent's key takes no statement of
+			// its own: PostgreSQL rejects one, and the parent's ALTER reaches
+			// the copy.
+			change = definitionChange{}
+		case currentFk.Validated && !desiredFk.Validated:
+			// Nothing takes the validated flag away, so the key is added back
+			// and the ADD carries the deferral clause with it.
+		default:
+			change.deferralOnly = true
+			// The key stays, so a NOT VALID one the desired schema validates
+			// takes VALIDATE CONSTRAINT next to the ALTER.
+			change.validateOnly = !sameValidation
+		}
+		changes[name] = change
 	}
 	return changes
+}
+
+// alterFKDeferralSQL renders the ALTER CONSTRAINT that moves a foreign key to
+// the desired deferral mode. The clause is spelled the way
+// pg_get_constraintdef prints it, and NOT DEFERRABLE clears both flags.
+func alterFKDeferralSQL(fqtn, name string, deferrable, deferred bool) string {
+	clause := "NOT DEFERRABLE"
+	switch {
+	case deferrable && deferred:
+		clause = "DEFERRABLE INITIALLY DEFERRED"
+	case deferrable:
+		clause = "DEFERRABLE"
+	}
+	return "ALTER TABLE " + fqtn + " ALTER CONSTRAINT " + model.Ident(name) + " " + clause + ";"
 }
 
 // diffForeignKeys returns (dropStmts, addStmts, disallowed, error).
@@ -1426,7 +1461,7 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 	// Determine which renamed FKs need recreation (drop+add) instead of just rename
 	needsRecreation := map[string]bool{}
 	for name := range renamedFrom {
-		if ch := changes[name]; ch.changed && !ch.validateOnly {
+		if ch := changes[name]; ch.changed && !ch.validateOnly && !ch.deferralOnly {
 			needsRecreation[name] = true
 		}
 	}
@@ -1448,7 +1483,7 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 	for name := range current.Keys() {
 		_, ok := desired.GetOk(name)
 		ch := changes[name]
-		if ok && (!ch.changed || ch.validateOnly) {
+		if ok && (!ch.changed || ch.validateOnly || ch.deferralOnly) {
 			continue
 		}
 		dropName := name
@@ -1470,8 +1505,15 @@ func diffForeignKeys(fqtn, schema string, current, desired *orderedmap.Map[strin
 		if ok && !ch.changed {
 			continue
 		}
-		if ch.validateOnly {
-			addStmts = append(addStmts, "ALTER TABLE "+fqtn+" VALIDATE CONSTRAINT "+model.Ident(name)+";")
+		if ch.deferralOnly || ch.validateOnly {
+			// The key stays in place. Each statement settles one half, and a
+			// change that needs both takes both.
+			if ch.deferralOnly {
+				addStmts = append(addStmts, alterFKDeferralSQL(fqtn, name, desiredFk.Deferrable, desiredFk.Deferred))
+			}
+			if ch.validateOnly {
+				addStmts = append(addStmts, "ALTER TABLE "+fqtn+" VALIDATE CONSTRAINT "+model.Ident(name)+";")
+			}
 			continue
 		}
 		addStmts = append(addStmts, desiredFk.SQL())
@@ -1734,14 +1776,32 @@ func normalizeFKSchema(con *pg_query.Constraint, schema string) {
 // schema is the schema of the table that owns the FK constraint and is used
 // to fill in an implicit (empty) schema on the referenced table.
 func equalFKDef(a, b, schema string) bool {
+	equal, _ := compareFKDef(a, b, schema)
+	return equal
+}
+
+// compareFKDef reports whether two foreign key definitions are equal, and
+// whether the only thing between them is the deferral clause. The second
+// answer routes the change to ALTER CONSTRAINT, which leaves the key in place
+// rather than rescanning the table to add it back.
+func compareFKDef(a, b, schema string) (equal, deferralOnly bool) {
 	nodeA, errA := parseFKDef(a)
 	nodeB, errB := parseFKDef(b)
 	if errA != nil || errB != nil {
-		return a == b
+		return a == b, false
 	}
 	normalizeFKSchema(nodeA, schema)
 	normalizeFKSchema(nodeB, schema)
-	return proto.Equal(nodeA, nodeB)
+	if proto.Equal(nodeA, nodeB) {
+		return true, false
+	}
+	strippedA := proto.Clone(nodeA).(*pg_query.Constraint)
+	strippedB := proto.Clone(nodeB).(*pg_query.Constraint)
+	for _, c := range []*pg_query.Constraint{strippedA, strippedB} {
+		c.Deferrable = false
+		c.Initdeferred = false
+	}
+	return false, proto.Equal(strippedA, strippedB)
 }
 
 // serialBaseTypes maps serial type names to their base types.

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1552,16 +1552,19 @@ func TestEqualDefault_customNumericNamedTypeNotCoerced(t *testing.T) {
 	))
 }
 
-func TestEqualFKDef(t *testing.T) {
+func TestCompareFKDef_formatting(t *testing.T) {
 	a := "FOREIGN KEY (user_id) REFERENCES users(id)"
 	b := "FOREIGN KEY (user_id) REFERENCES users (id)"
-	assert.True(t, equalFKDef(a, b, "public"))
+	equal, _ := compareFKDef(a, b, "public")
+	assert.True(t, equal)
 }
 
-func TestEqualFKDef_different(t *testing.T) {
+func TestCompareFKDef_different(t *testing.T) {
 	a := "FOREIGN KEY (user_id) REFERENCES users(id)"
 	b := "FOREIGN KEY (user_id) REFERENCES orders(id)"
-	assert.False(t, equalFKDef(a, b, "public"))
+	equal, deferralOnly := compareFKDef(a, b, "public")
+	assert.False(t, equal)
+	assert.False(t, deferralOnly)
 }
 
 func TestDiffTables_newTable_withForeignKey(t *testing.T) {
@@ -1585,28 +1588,35 @@ func TestDiffTables_newTable_withForeignKey(t *testing.T) {
 	assert.Contains(t, result.FKAddStmts[0], "ADD CONSTRAINT fk_user")
 }
 
-func TestEqualFKDef_implicitPublicSchema(t *testing.T) {
+func TestCompareFKDef_implicitPublicSchema(t *testing.T) {
 	a := "FOREIGN KEY (user_id) REFERENCES users(id)"
 	b := "FOREIGN KEY (user_id) REFERENCES public.users(id)"
-	assert.True(t, equalFKDef(a, b, "public"))
+	equal, _ := compareFKDef(a, b, "public")
+	assert.True(t, equal)
 }
 
-func TestEqualFKDef_implicitNonPublicSchema(t *testing.T) {
+func TestCompareFKDef_implicitNonPublicSchema(t *testing.T) {
 	a := "FOREIGN KEY (item_id) REFERENCES items(id)"
 	b := "FOREIGN KEY (item_id) REFERENCES myapp.items(id)"
-	assert.True(t, equalFKDef(a, b, "myapp"))
+	equal, _ := compareFKDef(a, b, "myapp")
+	assert.True(t, equal)
 }
 
-func TestEqualFKDef_implicitNonPublicSchema_different(t *testing.T) {
+func TestCompareFKDef_implicitNonPublicSchema_different(t *testing.T) {
 	a := "FOREIGN KEY (item_id) REFERENCES items(id)"
 	b := "FOREIGN KEY (item_id) REFERENCES other.items(id)"
-	assert.False(t, equalFKDef(a, b, "myapp"))
+	equal, _ := compareFKDef(a, b, "myapp")
+	assert.False(t, equal)
 }
 
-func TestEqualFKDef_parseError(t *testing.T) {
+func TestCompareFKDef_parseError(t *testing.T) {
 	// When both fail to parse, falls back to string comparison
-	assert.True(t, equalFKDef("not sql", "not sql", "public"))
-	assert.False(t, equalFKDef("not sql", "other", "public"))
+	equal, deferralOnly := compareFKDef("not sql", "not sql", "public")
+	assert.True(t, equal)
+	assert.False(t, deferralOnly)
+
+	equal, _ = compareFKDef("not sql", "other", "public")
+	assert.False(t, equal)
 }
 
 func TestEqualDefault_parseError(t *testing.T) {
@@ -1760,18 +1770,13 @@ func TestDiffForeignKeys_deferral(t *testing.T) {
 	})
 }
 
-// compareFKDef answers both questions the FK diff asks of a pair of
-// definitions: whether they are equal, and whether the deferral clause is all
-// that separates them.
-func TestCompareFKDef(t *testing.T) {
+// The deferral half of compareFKDef: the clause alone separates two
+// definitions, or something else does.
+func TestCompareFKDef_deferralOnly(t *testing.T) {
 	const plain = "FOREIGN KEY (user_id) REFERENCES users(id)"
 	const deferred = "FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED"
 
-	equal, deferralOnly := compareFKDef(plain, plain, "public")
-	assert.True(t, equal)
-	assert.False(t, deferralOnly)
-
-	equal, deferralOnly = compareFKDef(plain, deferred, "public")
+	equal, deferralOnly := compareFKDef(plain, deferred, "public")
 	assert.False(t, equal)
 	assert.True(t, deferralOnly)
 
@@ -1779,9 +1784,9 @@ func TestCompareFKDef(t *testing.T) {
 	assert.False(t, equal)
 	assert.False(t, deferralOnly)
 
-	// A definition neither side can parse falls back to a string comparison,
-	// which says nothing about the deferral clause.
-	equal, deferralOnly = compareFKDef("not sql", "not sql", "public")
+	// Two identical definitions are equal, which is not the same answer as
+	// the deferral clause being all that differs.
+	equal, deferralOnly = compareFKDef(deferred, deferred, "public")
 	assert.True(t, equal)
 	assert.False(t, deferralOnly)
 }

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1761,6 +1761,15 @@ func TestDiffForeignKeys_deferral(t *testing.T) {
 		assert.Empty(t, add)
 	})
 
+	t.Run("partition copy is left alone when it is also validated", func(t *testing.T) {
+		// A NOT VALID key on a partitioned table needs 18. The parent's
+		// VALIDATE reaches the copy the way its ALTER does, so the copy takes
+		// neither statement.
+		drop, add := run(fk(plain, false, false, false, true), fk(deferred, true, true, true, false))
+		assert.Empty(t, drop)
+		assert.Empty(t, add)
+	})
+
 	t.Run("definition change still recreates", func(t *testing.T) {
 		cascade := "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED"
 		drop, add := run(fk(plain, false, false, true, false), fk(cascade, true, true, true, false))

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -1685,6 +1685,107 @@ func TestDiffForeignKeys_notValidToValidated(t *testing.T) {
 	assert.Equal(t, "ALTER TABLE public.orders VALIDATE CONSTRAINT fk_user;", addStmts[0])
 }
 
+func TestDiffForeignKeys_deferral(t *testing.T) {
+	const plain = "FOREIGN KEY (user_id) REFERENCES users(id)"
+	const deferred = "FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED"
+
+	fk := func(def string, deferrable, deferredMode, validated, inherited bool) *model.ForeignKey {
+		f := &model.ForeignKey{Schema: "public", Table: "orders"}
+		f.Name = "fk_user"
+		f.Definition = def
+		f.Deferrable = deferrable
+		f.Deferred = deferredMode
+		f.Validated = validated
+		f.Inherited = inherited
+		return f
+	}
+	run := func(currentFk, desiredFk *model.ForeignKey) (drop, add []string) {
+		current := orderedmap.New[string, *model.ForeignKey]()
+		current.Set("fk_user", currentFk)
+		desired := orderedmap.New[string, *model.ForeignKey]()
+		desired.Set("fk_user", desiredFk)
+		dropStmts, addStmts, _, err := diffForeignKeys("public.orders", "public", current, desired, allowAllDrops{})
+		require.NoError(t, err)
+		return dropStmts, addStmts
+	}
+
+	t.Run("added", func(t *testing.T) {
+		drop, add := run(fk(plain, false, false, true, false), fk(deferred, true, true, true, false))
+		assert.Empty(t, drop)
+		assert.Equal(t, []string{"ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;"}, add)
+	})
+
+	t.Run("removed", func(t *testing.T) {
+		drop, add := run(fk(deferred, true, true, true, false), fk(plain, false, false, true, false))
+		assert.Empty(t, drop)
+		assert.Equal(t, []string{"ALTER TABLE public.orders ALTER CONSTRAINT fk_user NOT DEFERRABLE;"}, add)
+	})
+
+	t.Run("initially immediate", func(t *testing.T) {
+		immediate := "FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE"
+		drop, add := run(fk(deferred, true, true, true, false), fk(immediate, true, false, true, false))
+		assert.Empty(t, drop)
+		assert.Equal(t, []string{"ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE;"}, add)
+	})
+
+	t.Run("validated alongside", func(t *testing.T) {
+		drop, add := run(fk(plain, false, false, false, false), fk(deferred, true, true, true, false))
+		assert.Empty(t, drop)
+		assert.Equal(t, []string{
+			"ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;",
+			"ALTER TABLE public.orders VALIDATE CONSTRAINT fk_user;",
+		}, add)
+	})
+
+	t.Run("becomes not valid", func(t *testing.T) {
+		drop, add := run(fk(plain, false, false, true, false), fk(deferred, true, true, false, false))
+		assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, drop)
+		require.Len(t, add, 1)
+		assert.Contains(t, add[0], "ADD CONSTRAINT fk_user")
+		assert.Contains(t, add[0], "NOT VALID")
+	})
+
+	t.Run("partition copy is left alone", func(t *testing.T) {
+		drop, add := run(fk(plain, false, false, true, true), fk(deferred, true, true, true, false))
+		assert.Empty(t, drop)
+		assert.Empty(t, add)
+	})
+
+	t.Run("definition change still recreates", func(t *testing.T) {
+		cascade := "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED"
+		drop, add := run(fk(plain, false, false, true, false), fk(cascade, true, true, true, false))
+		assert.Equal(t, []string{"ALTER TABLE public.orders DROP CONSTRAINT fk_user;"}, drop)
+		require.Len(t, add, 1)
+		assert.Contains(t, add[0], "ADD CONSTRAINT fk_user")
+	})
+}
+
+// compareFKDef answers both questions the FK diff asks of a pair of
+// definitions: whether they are equal, and whether the deferral clause is all
+// that separates them.
+func TestCompareFKDef(t *testing.T) {
+	const plain = "FOREIGN KEY (user_id) REFERENCES users(id)"
+	const deferred = "FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED"
+
+	equal, deferralOnly := compareFKDef(plain, plain, "public")
+	assert.True(t, equal)
+	assert.False(t, deferralOnly)
+
+	equal, deferralOnly = compareFKDef(plain, deferred, "public")
+	assert.False(t, equal)
+	assert.True(t, deferralOnly)
+
+	equal, deferralOnly = compareFKDef(plain, "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE", "public")
+	assert.False(t, equal)
+	assert.False(t, deferralOnly)
+
+	// A definition neither side can parse falls back to a string comparison,
+	// which says nothing about the deferral clause.
+	equal, deferralOnly = compareFKDef("not sql", "not sql", "public")
+	assert.True(t, equal)
+	assert.False(t, deferralOnly)
+}
+
 func TestDiffForeignKeys_bothNotValid_noChange(t *testing.T) {
 	current := orderedmap.New[string, *model.ForeignKey]()
 	current.Set("fk_user", &model.ForeignKey{

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -9,7 +9,7 @@
 - Views, including `WITH [LOCAL | CASCADED] CHECK OPTION`, `security_barrier` and `security_invoker`.
 - Materialized views
 - Columns (serial/bigserial/smallserial, identity, generated, TOAST storage and compression). An identity column's sequence options, the `( ... )` after `AS IDENTITY`, are managed; a change goes out as `ALTER TABLE ... ALTER COLUMN ... SET`. No `RESTART` is planned, the same as `ALTER SEQUENCE`, so a change that puts the sequence's current value outside the new range fails at apply with the server's error.
-- Constraints (primary key, unique, check, exclusion, foreign key)
+- Constraints (primary key, unique, check, exclusion, foreign key). See [Constraints](#constraints).
 - Indexes (unique, partial, expression, hash, multi-column)
 - Comments (on tables, columns, views, materialized views, indexes, types, domains, composite types, composite attributes, sequences, routines). See [Comments](#comments).
 - Row-level security (`ALTER TABLE ... ENABLE/DISABLE/FORCE/NO FORCE ROW LEVEL SECURITY`, policies via `CREATE POLICY` / `ALTER POLICY` / `DROP POLICY`)
@@ -165,6 +165,18 @@ A trigger on a partitioned table is cloned onto every partition. pistachio reads
 
 The `ALL` and `USER` forms of `ENABLE TRIGGER` name no single trigger and are ignored, as are event triggers, which belong to the database rather than to a schema.
 
+
+## Constraints
+
+A change to a constraint's definition is a drop and an add, since PostgreSQL has no ALTER for one. A foreign key whose deferral clause is all that differs is the exception:
+
+```sql
+ALTER TABLE public.orders ALTER CONSTRAINT orders_user_id_fkey DEFERRABLE INITIALLY DEFERRED;
+```
+
+That rewrites a catalog row instead of rescanning the table. PostgreSQL takes the statement on a foreign key alone, so the same change to a unique, primary key or exclusion constraint is still a drop and an add, which rebuilds the index. A partition holds a copy of every key its parent declares, and the copy takes no statement of its own: PostgreSQL rejects one, and the parent's reaches it.
+
+A key that is also being validated takes `VALIDATE CONSTRAINT` next to the `ALTER CONSTRAINT`. A validated key the desired schema writes `NOT VALID` is added back, because nothing takes the flag away.
 
 ## Comments
 

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -168,13 +168,15 @@ The `ALL` and `USER` forms of `ENABLE TRIGGER` name no single trigger and are ig
 
 ## Constraints
 
-A change to a constraint's definition is a drop and an add, since PostgreSQL has no ALTER for one. A foreign key whose deferral clause is all that differs is the exception:
+PostgreSQL has no ALTER for a constraint's definition, so a change to one is a drop and an add. A foreign key whose deferral clause is all that differs is the exception:
 
 ```sql
 ALTER TABLE public.orders ALTER CONSTRAINT orders_user_id_fkey DEFERRABLE INITIALLY DEFERRED;
 ```
 
-That rewrites a catalog row instead of rescanning the table. PostgreSQL takes the statement on a foreign key alone, so the same change to a unique, primary key or exclusion constraint is still a drop and an add, which rebuilds the index. A partition holds a copy of every key its parent declares, and the copy takes no statement of its own: PostgreSQL rejects one, and the parent's reaches it.
+That rewrites a catalog row rather than rescanning the table. PostgreSQL takes the statement on a foreign key alone, so the same change to a unique, primary key or exclusion constraint still drops and adds, rebuilding the index.
+
+A partition holds a copy of every key its parent declares. The copy takes no statement of its own, since PostgreSQL rejects one and the parent's reaches it.
 
 A key that is also being validated takes `VALIDATE CONSTRAINT` next to the `ALTER CONSTRAINT`. A validated key the desired schema writes `NOT VALID` is added back, because nothing takes the flag away.
 

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -176,7 +176,7 @@ ALTER TABLE public.orders ALTER CONSTRAINT orders_user_id_fkey DEFERRABLE INITIA
 
 That rewrites a catalog row rather than rescanning the table. PostgreSQL takes the statement on a foreign key alone, so the same change to a unique, primary key or exclusion constraint still drops and adds, rebuilding the index.
 
-A partition holds a copy of every key its parent declares. The copy takes no statement of its own, since PostgreSQL rejects one and the parent's reaches it.
+A partition holds a copy of every key its parent declares. The copy takes no statement of its own, since PostgreSQL rejects one, and it needs none: the parent's `ALTER CONSTRAINT` and `VALIDATE CONSTRAINT` both reach it.
 
 A key that is also being validated takes `VALIDATE CONSTRAINT` next to the `ALTER CONSTRAINT`. A validated key the desired schema writes `NOT VALID` is added back, because nothing takes the flag away.
 

--- a/model/constraint.go
+++ b/model/constraint.go
@@ -40,6 +40,11 @@ type Constraint struct {
 	Deferrable bool
 	Deferred   bool
 	Validated  bool
+	// Inherited marks a constraint a partition child holds only because its
+	// parent has one. PostgreSQL refuses to alter or drop such a copy, and a
+	// statement on the parent reaches it, so the diff leaves it alone. Only
+	// the catalog sets it: a desired schema declares what it writes.
+	Inherited bool
 }
 
 func (con *Constraint) String() string {

--- a/testdata/apply/fk_deferrable.yml
+++ b/testdata/apply/fk_deferrable.yml
@@ -1,0 +1,39 @@
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT posts_pkey PRIMARY KEY (id),
+      CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
+applied_sql: |
+  ALTER TABLE public.posts ALTER CONSTRAINT posts_user_id_fkey DEFERRABLE INITIALLY DEFERRED;
+applied: |
+  -- public.posts
+  CREATE TABLE public.posts (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT posts_pkey PRIMARY KEY (id)
+  );
+
+  ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/fk_deferrable_partition_not_valid.yml
+++ b/testdata/apply/fk_deferrable_partition_not_valid.yml
@@ -1,0 +1,55 @@
+# The parent's ALTER CONSTRAINT and VALIDATE CONSTRAINT both reach the
+# partition's copy, so leaving the copy out of the plan still converges.
+min_pg: 18
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  ALTER TABLE ONLY public.orders_2025 ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED;
+applied_sql: |
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;
+  ALTER TABLE public.orders VALIDATE CONSTRAINT fk_user;
+applied: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at)
+  )
+  PARTITION BY RANGE (at);
+
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
+
+  -- public.orders_2025
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+
+  ALTER TABLE ONLY public.orders_2025 ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/fk_deferrable_partitioned.yml
+++ b/testdata/apply/fk_deferrable_partitioned.yml
@@ -1,0 +1,54 @@
+# The parent's ALTER reaches the partition's copy of the key. A statement on
+# the copy itself is rejected, whether it alters or drops the key, so none is
+# planned and the apply leaves no drift.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  ALTER TABLE ONLY public.orders_2025 ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED;
+applied_sql: |
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;
+applied: |
+  -- public.orders
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at)
+  )
+  PARTITION BY RANGE (at);
+
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
+
+  -- public.orders_2025
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+
+  ALTER TABLE ONLY public.orders_2025 ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/fk_deferrable_added.yml
+++ b/testdata/plan/fk_deferrable_added.yml
@@ -1,0 +1,26 @@
+# Only the deferral clause differs, so the key is altered in place instead of
+# being dropped and added back, which would rescan the table.
+init: |
+  CREATE TABLE public.parent (
+      id integer NOT NULL,
+      CONSTRAINT parent_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.child (
+      id integer NOT NULL,
+      pid integer,
+      CONSTRAINT child_pkey PRIMARY KEY (id),
+      CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent(id)
+  );
+desired: |
+  CREATE TABLE public.parent (
+      id integer NOT NULL,
+      CONSTRAINT parent_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.child (
+      id integer NOT NULL,
+      pid integer,
+      CONSTRAINT child_pkey PRIMARY KEY (id),
+      CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent(id) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.child ALTER CONSTRAINT child_pid_fkey DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_and_validate.yml
+++ b/testdata/plan/fk_deferrable_and_validate.yml
@@ -1,0 +1,27 @@
+# The key stays, so the deferral clause and the NOT VALID flag are each
+# settled in place.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;
+  ALTER TABLE public.orders VALIDATE CONSTRAINT fk_user;

--- a/testdata/plan/fk_deferrable_assume_validated.yml
+++ b/testdata/plan/fk_deferrable_assume_validated.yml
@@ -1,0 +1,27 @@
+# --assume-validated takes NOT VALID out of the comparison, so the deferral
+# clause is the whole change and no VALIDATE is emitted.
+assume_validated: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_becomes_not_valid.yml
+++ b/testdata/plan/fk_deferrable_becomes_not_valid.yml
@@ -1,0 +1,27 @@
+# Nothing takes the validated flag away, so a validated key the desired schema
+# writes NOT VALID is added back, with the deferral clause on the ADD.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED NOT VALID;
+plan: |
+  ALTER TABLE public.orders DROP CONSTRAINT fk_user;
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users (id) DEFERRABLE INITIALLY DEFERRED NOT VALID;

--- a/testdata/plan/fk_deferrable_bulk_alter.yml
+++ b/testdata/plan/fk_deferrable_bulk_alter.yml
@@ -1,0 +1,32 @@
+# The deferral statement is not an action --bulk-alter merges, so it stands on
+# its own next to the merged column changes.
+bulk_alter: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      note text,
+      total integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.orders
+    ADD COLUMN note text,
+    ADD COLUMN total integer;
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_drop_denied.yml
+++ b/testdata/plan/fk_deferrable_drop_denied.yml
@@ -1,0 +1,27 @@
+# The key is not dropped, so the change stands whatever the drop policy says.
+drop_policy:
+  allow_drop: []
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_initially_immediate.yml
+++ b/testdata/plan/fk_deferrable_initially_immediate.yml
@@ -1,0 +1,25 @@
+# The key stays deferrable and only the initial mode changes.
+init: |
+  CREATE TABLE public.parent (
+      id integer NOT NULL,
+      CONSTRAINT parent_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.child (
+      id integer NOT NULL,
+      pid integer,
+      CONSTRAINT child_pkey PRIMARY KEY (id),
+      CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent(id) DEFERRABLE INITIALLY DEFERRED
+  );
+desired: |
+  CREATE TABLE public.parent (
+      id integer NOT NULL,
+      CONSTRAINT parent_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.child (
+      id integer NOT NULL,
+      pid integer,
+      CONSTRAINT child_pkey PRIMARY KEY (id),
+      CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent(id) DEFERRABLE
+  );
+plan: |
+  ALTER TABLE public.child ALTER CONSTRAINT child_pid_fkey DEFERRABLE;

--- a/testdata/plan/fk_deferrable_not_valid_kept.yml
+++ b/testdata/plan/fk_deferrable_not_valid_kept.yml
@@ -1,0 +1,25 @@
+# Both sides leave the key unvalidated, so only the deferral clause moves.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED NOT VALID;
+plan: |
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_partition_not_valid.yml
+++ b/testdata/plan/fk_deferrable_partition_not_valid.yml
@@ -1,0 +1,34 @@
+# 18 is the first server that takes a NOT VALID foreign key on a partitioned
+# table. The partition's copy differs in both the deferral clause and the
+# validated flag, and still takes no statement: the parent's two reach it.
+min_pg: 18
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  ALTER TABLE public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  ALTER TABLE ONLY public.orders_2025 ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED;
+plan: |
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;
+  ALTER TABLE public.orders VALIDATE CONSTRAINT fk_user;

--- a/testdata/plan/fk_deferrable_partition_own_key.yml
+++ b/testdata/plan/fk_deferrable_partition_own_key.yml
@@ -1,0 +1,30 @@
+# A key the partition declares itself is not a copy of the parent's, so it
+# takes its own statement.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  ALTER TABLE public.orders_2025 ADD CONSTRAINT own_fk FOREIGN KEY (user_id) REFERENCES public.users(id);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  ALTER TABLE ONLY public.orders_2025 ADD CONSTRAINT own_fk FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED;
+plan: |
+  ALTER TABLE public.orders_2025 ALTER CONSTRAINT own_fk DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_partitioned.yml
+++ b/testdata/plan/fk_deferrable_partitioned.yml
@@ -1,0 +1,32 @@
+# A partition carries its own copy of the parent's key, which dump writes and
+# the desired schema declares. PostgreSQL rejects an ALTER CONSTRAINT on such a
+# copy and the parent's statement reaches it, so only the parent's is planned.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      at date NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id, at),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.orders_2025 PARTITION OF public.orders FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+  ALTER TABLE ONLY public.orders_2025 ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED;
+plan: |
+  ALTER TABLE public.orders ALTER CONSTRAINT fk_user DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_quoted_name.yml
+++ b/testdata/plan/fk_deferrable_quoted_name.yml
@@ -1,0 +1,26 @@
+# The key's name is quoted in the statement, the same as every other name
+# pistachio writes.
+init: |
+  CREATE TABLE public."user" (
+      id integer NOT NULL,
+      CONSTRAINT user_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT "fk user" FOREIGN KEY (user_id) REFERENCES public."user"(id)
+  );
+desired: |
+  CREATE TABLE public."user" (
+      id integer NOT NULL,
+      CONSTRAINT user_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT "fk user" FOREIGN KEY (user_id) REFERENCES public."user"(id) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.orders ALTER CONSTRAINT "fk user" DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_removed.yml
+++ b/testdata/plan/fk_deferrable_removed.yml
@@ -1,0 +1,24 @@
+init: |
+  CREATE TABLE public.parent (
+      id integer NOT NULL,
+      CONSTRAINT parent_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.child (
+      id integer NOT NULL,
+      pid integer,
+      CONSTRAINT child_pkey PRIMARY KEY (id),
+      CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent(id) DEFERRABLE INITIALLY DEFERRED
+  );
+desired: |
+  CREATE TABLE public.parent (
+      id integer NOT NULL,
+      CONSTRAINT parent_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.child (
+      id integer NOT NULL,
+      pid integer,
+      CONSTRAINT child_pkey PRIMARY KEY (id),
+      CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent(id)
+  );
+plan: |
+  ALTER TABLE public.child ALTER CONSTRAINT child_pid_fkey NOT DEFERRABLE;

--- a/testdata/plan/fk_deferrable_rename.yml
+++ b/testdata/plan/fk_deferrable_rename.yml
@@ -1,0 +1,27 @@
+# The rename stands and the deferral clause is settled under the new name.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      -- pista:renamed-from fk_user
+      CONSTRAINT orders_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.orders RENAME CONSTRAINT fk_user TO orders_user_id_fkey;
+  ALTER TABLE public.orders ALTER CONSTRAINT orders_user_id_fkey DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/fk_deferrable_with_definition_change.yml
+++ b/testdata/plan/fk_deferrable_with_definition_change.yml
@@ -1,0 +1,27 @@
+# The referential action changes as well, which no ALTER reaches, so the key
+# is dropped and added back with the deferral clause on the ADD.
+init: |
+  CREATE TABLE public.parent (
+      id integer NOT NULL,
+      CONSTRAINT parent_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.child (
+      id integer NOT NULL,
+      pid integer,
+      CONSTRAINT child_pkey PRIMARY KEY (id),
+      CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent(id)
+  );
+desired: |
+  CREATE TABLE public.parent (
+      id integer NOT NULL,
+      CONSTRAINT parent_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.child (
+      id integer NOT NULL,
+      pid integer,
+      CONSTRAINT child_pkey PRIMARY KEY (id),
+      CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.child DROP CONSTRAINT child_pid_fkey;
+  ALTER TABLE ONLY public.child ADD CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent (id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/plan/unique_deferrable_still_recreates.yml
+++ b/testdata/plan/unique_deferrable_still_recreates.yml
@@ -1,0 +1,19 @@
+# ALTER CONSTRAINT reaches a foreign key alone, so a unique constraint's
+# deferral change is still a drop and an add.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_code_key UNIQUE (code)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      code text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id),
+      CONSTRAINT users_code_key UNIQUE (code) DEFERRABLE INITIALLY DEFERRED
+  );
+plan: |
+  ALTER TABLE public.users DROP CONSTRAINT users_code_key;
+  ALTER TABLE public.users ADD CONSTRAINT users_code_key UNIQUE (code) DEFERRABLE INITIALLY DEFERRED;


### PR DESCRIPTION
DEFERRABLE and INITIALLY DEFERRED were compared only as part of the
definition string pg_get_constraintdef returns, so a toggle dropped the key
and added it back. Adding a foreign key back rescans the table to validate
it, under a lock, for a change that rewrites one catalog row.

compareFKDef now answers both questions the diff asks of a pair of
definitions: whether they are equal, and whether the deferral clause is all
that separates them. The second routes the change to
ALTER TABLE ... ALTER CONSTRAINT. A key that is also being validated takes
VALIDATE CONSTRAINT next to it; a validated key the desired schema writes
NOT VALID is still added back, since nothing takes the flag away; and a
change to anything else about the key is a drop and an add as before, with
the deferral clause riding on the ADD.

PostgreSQL accepts ALTER CONSTRAINT on a foreign key alone, verified on 15
and 18, so a unique, primary key or exclusion constraint keeps the drop and
the add. A partition holds a copy of every key its parent declares and
rejects a statement on the copy; the catalog now marks such a copy through
conislocal and the diff leaves it to the parent's ALTER, which recurses to
the partitions.

While confirming that last case I found an existing bug next to it: a
foreign key's *definition* change on a partitioned table plans a drop for
the copy as well, and the apply dies with `constraint "fk_user" of relation
"orders_2025" does not exist`. It is out of scope here and TODO.md records
it, with the note that the Inherited flag this PR adds is what closes it.

Eleven plan fixtures, two apply fixtures, diff and catalog package tests.
make test passes on 15, 16, 17 and 18; test-fidelity, test-scenario,
test-samples and lint pass on 15. Coverage does not drop: catalog 93.6 ->
93.7, diff 97.6 -> 97.7, the rest unchanged.