### PR TITLE
Say that pg_dump output is not the workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ Pistachio is a declarative schema management tool for PostgreSQL, written in Go.
 
 Drift that appears only with a desired schema written some other way is low priority, since matching what `dump` writes avoids it.
 
+`pg_dump` output is not the workflow, so do not force a fix for a statement it writes that pistachio does not read.
+
 `CREATE EXTENSION`, `CREATE ROLE` and `GRANT` are out of scope. They sit at a different privilege layer, so manage them where the rest of the infrastructure is managed, Terraform for example.
 
 Avoid normalization that makes the diff complex.

--- a/TODO.md
+++ b/TODO.md
@@ -653,34 +653,6 @@ Workaround: write the sequence unqualified.
 Origin: found while adding `-- pista:execute-first`, 2026-07-31. The function
 call half was closed later; the literal half is what remains.
 
-## A pg_dump serial column loses its default
-
-Priority: low.
-
-`pg_dump` never writes `serial`. It splits the column into a plain `integer`, a
-`CREATE SEQUENCE`, an `ALTER SEQUENCE ... OWNED BY`, and a separate
-`SET DEFAULT`. The parser reads the first three and drops the fourth, since
-`ALTER TABLE ... ALTER COLUMN ... SET DEFAULT` has no handler. It warns and
-moves on.
-
-Against the database the file came from, this plans clean. The catalog reports
-such a column as `serial` with no default, the desired side holds `integer`
-with no default, and `equalTypeName` treats the two type names as equal.
-
-Against an empty database it does not reproduce the column. The plan is
-`CREATE TABLE public.t (id integer NOT NULL)` alone: the sequence is unmanaged
-because `OWNED BY` marks it so, and the default was dropped. What comes out is
-a plain integer column.
-
-Reading `AT_ColumnDefault` onto the column is the fix, next to the
-`AT_SetStorage` and `AT_SetCompression` actions `applyAlterTableColumnStorage`
-already reads. The `nextval` argument names the sequence, so the serial shape
-is recoverable from it.
-
-Origin: bug audit, 2026-07-31. Rewritten once the drift it described stopped
-happening: the warn-and-drop of an unsupported `ALTER TABLE` action, added in
-1.31.0, is what makes the two sides agree.
-
 ## Perpetual drift on a view defined with `SELECT *`
 
 Priority: low, with the caveat that the consequence is heavier than the rest


### PR DESCRIPTION
The design policy guarantees the round trip through `pista dump`. A `pg_dump`
file is read where it can be, and nothing more is promised, so a statement it
carries that pistachio does not read is left alone rather than fixed.

The TODO entry on a `serial` column losing its default was written the other
way round, as work waiting to be done. `pg_dump` splits such a column into a
plain `integer` and a separate `SET DEFAULT`, which pistachio warns about and
drops, so a file from `pg_dump` loaded into an empty database gives a plain
`integer` column. Against the database the file came from it plans clean. The
entry goes; the line in the design policy covers the class.

Docs only, no code change.