### PR TITLE
Fold the pg_dump line into the drift policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,7 @@ Pistachio is a declarative schema management tool for PostgreSQL, written in Go.
 
 `pista dump` output fed back as the desired schema must plan clean. A break in that round trip is a bug.
 
-Drift that appears only with a desired schema written some other way is low priority, since matching what `dump` writes avoids it.
-
-`pg_dump` output is not the workflow, so do not force a fix for a statement it writes that pistachio does not read.
+Drift that appears only with a desired schema written some other way is low priority, since matching what `dump` writes avoids it. `pg_dump` output is one such schema: a statement it writes that pistachio does not read needs no fix where `dump` writes the same thing another way.
 
 `CREATE EXTENSION`, `CREATE ROLE` and `GRANT` are out of scope. They sit at a different privilege layer, so manage them where the rest of the infrastructure is managed, Terraform for example.
 


### PR DESCRIPTION
#525 added the `pg_dump` line as a paragraph of its own, which read as a
second rule. It is the same rule as the one above it seen from another end: a
`pg_dump` file is a desired schema written some other way, and what settles it
is that `dump` writes the same thing another way. A `serial` column is the
case in point, `serial` in `dump` against an `integer` and a separate
`SET DEFAULT` in `pg_dump`.

The two paragraphs are one now, and the sentence says where the fix is not
needed rather than telling the reader not to chase.

Docs only.