### PR TITLE
Correct what the named NOT NULL entry waits on

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -141,9 +141,10 @@ following transitions are no-ops in v1:
   the current name in place.
 
 Both require PG18's standalone `ALTER TABLE ... ADD CONSTRAINT name NOT NULL col`
-syntax, which `pg_query_go` does not yet parse (libpg_query PR #317 is
-still in draft as of 2026-05). Once that lands, the parser can accept
-the standalone form and the diff can drop the no-op branches.
+syntax, which the parser cannot read: `pg_query_go` v6 embeds PostgreSQL 17.7
+and has no 18 release. libpg_query, the C library under it, shipped 18 on
+2026-05-21, so the Go binding is what is waited on. Once it lands, the parser
+can accept the standalone form and the diff can drop the no-op branches.
 
 A second limitation: `catalog.ListColumnsByTables` strips any constraint
 name with the `_not_null` suffix to mask PG18's auto-naming (which does


### PR DESCRIPTION
The entry said PG18's standalone `ALTER TABLE ... ADD CONSTRAINT name NOT NULL
col` was out of reach because "libpg_query PR #317 is still in draft as of
2026-05". It is not: libpg_query 18.0.0 shipped on 2026-05-21 with "Upgrade to
Postgres 18" at the top of its notes.

The wait is on the Go binding. `pg_query_go`'s latest release is v6.2.2, whose
`pg_config.h` reads `PostgreSQL 17.7 (libpg_query)`, and its main branch has
had no commit since 2026-01-28. There is no 18 branch and no issue tracking
one, so the entry names the binding rather than a PR that has landed.

Checked today against the module cache and the GitHub API. Docs only.