### PR TITLE
Upload test results through codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,11 @@ jobs:
           flags: windows
       # Uploaded even when the tests failed, since a failed test is what the
       # report is there to describe.
-      - uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           files: junit.xml
           disable_search: true
           flags: windows
@@ -180,10 +181,11 @@ jobs:
           # counted as covered when any matrix entry exercises them.
       # Uploaded even when the tests failed, since a failed test is what the
       # report is there to describe.
-      - uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           files: junit.xml
           disable_search: true
           flags: pg${{ matrix.postgres }}


### PR DESCRIPTION
`codecov/test-results-action` prints a deprecation warning on every CI run:

```
Warning: This action is being deprecated in favor of 'codecov-action'.
      Please update CI accordingly to use 'codecov-action@v5' with
      'report_type: test_results'.
```

Replace both JUnit upload steps with `codecov/codecov-action`, using the same
version and SHA pin already used for the coverage upload, and set
`report_type: test_results`. The test results stay in their own step, separate
from the coverage upload, as the warning asks.

`if: ${{ !cancelled() }}`, `disable_search` and `flags` are unchanged.
Verified with `actionlint`.