### PR TITLE
Play the demo as a video on the docs home page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ go.work.sum
 /*.sql
 *.bak
 /demo.gif
+/demo.webm
 
 # Generated documentation site
 site/

--- a/demo.tape
+++ b/demo.tape
@@ -1,4 +1,5 @@
 Output demo.gif
+Output demo.webm
 
 Set Shell "bash"
 Set FontSize 12

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,9 @@ schema in SQL; pistachio generates the DDL diff.
 
 ![pistachio workflow](workflow.svg)
 
-![](https://github.com/user-attachments/assets/8ceaef33-7d4e-4bd8-bf94-1a79342cf1e1)
+<video src="https://github.com/user-attachments/assets/7db0e761-2446-47cd-9e00-f37b1152dcff"
+       width="800" style="max-width: 100%"
+       controls autoplay muted loop playsinline></video>
 
 ## Try it with Docker
 


### PR DESCRIPTION
`demo.tape` now writes `demo.webm` next to `demo.gif`, and the docs home page embeds the WebM in a `<video>` element instead of linking the GIF as an image. The demo gets playback controls, a progress bar and a pause button.

The recording itself is unchanged: same tape, same timings.

Checked:

- The uploaded asset is VP9 / 800x600 / yuv420p / 100.7s / 1.47MB, served as `video/webm` with `Accept-Ranges: bytes`, so seeking works.
- Raw HTML passes through Python-Markdown unwrapped, so MkDocs renders the element as written.
- `width="800"` keeps the video at its native size instead of upscaling, and `max-width: 100%` keeps it inside narrow viewports.

One regression to be aware of: Safari on iOS/iPadOS only plays WebM from 17.4 on, so an iPad older than that loses the demo where the GIF used to play. Adding `Output demo.mp4` and a second `<source>` would cover it if that matters.

`README.md` still points at the GIF.