### PR TITLE
Drop the extensions before wiping the schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ make fix            # golangci-lint run --fix (auto-fix lint errors)
 
 - Tests require a running PostgreSQL instance. `compose.yaml` publishes each version of the CI matrix on its own port (15 -> 5415, 16 -> 5416, 17 -> 5417, 18 -> 5418), so several can run side by side; `PGPORT` (default 5415) selects which one every `psql`- and test-based target uses. The Makefile builds `TEST_PISTA_CONN_STR` from it; set that variable to point somewhere else entirely.
 - Tests run with `-p 1` (sequential packages) because integration tests share a single database.
-- `make test`, `make test-scenario` and `make test-fidelity` depend on `clean-schema`, so they wipe every user schema before running. The tests themselves reset only `public`, and a sample schema left over from `make schema` is otherwise still visible to them. `clean-schema` follows `PGHOST`/`PGUSER`/`PGPORT`, not `TEST_PISTA_CONN_STR`, so override `PGPORT` rather than the connection string.
+- `make test`, `make test-scenario` and `make test-fidelity` depend on `clean-schema`, so they wipe every extension and every user schema before running. The tests themselves reset only `public`, and a sample schema left over from `make schema` is otherwise still visible to them. `clean-schema` follows `PGHOST`/`PGUSER`/`PGPORT`, not `TEST_PISTA_CONN_STR`, so override `PGPORT` rather than the connection string.
 - `make schema` and other `psql`-based targets rely on `PGHOST=localhost` / `PGUSER=postgres` / `PGPORT` (exported from the Makefile).
 - The sample schema targets (`schema`, `sample-db-*`, `test-samples`, `clean-schema`, `reset-db`) live in `sample-db.mk`, which the Makefile includes. See `docs/contributing-samples.md`.
 

--- a/docs/contributing-samples.md
+++ b/docs/contributing-samples.md
@@ -36,9 +36,12 @@ checking them one at a time, use `make schema`.
 
 ## What the check does
 
-The runner starts with `make clean-schema`, so a schema left behind by an
-earlier run cannot make a load fail on objects that already exist. Then, for
-each sample, it:
+The runner starts with `make clean-schema`, which drops every extension and
+then every user schema, so neither a schema nor an extension left behind by an
+earlier run can make a load fail on objects that already exist. The extensions
+go first because a table an extension owns, PostGIS's `spatial_ref_sys` among
+them, cannot be dropped while the extension is there. Then, for each sample,
+it:
 
 1. Runs `make reset-db`, which drops and recreates `public` and drops every
    extension. The samples that load into `public` are the only ones that can

--- a/sample-db.mk
+++ b/sample-db.mk
@@ -397,21 +397,40 @@ sample-db-harbor:
 test-samples:
 	bash test/samples/run.sh
 
+# Drop every extension outside pg_catalog. An extension owns tables of its own,
+# PostGIS's spatial_ref_sys among them, and neither DROP TABLE nor DROP SCHEMA
+# will touch one while the extension is there, so a wipe has to drop the
+# extensions before it starts.
+#
+# Dropping them is also what makes a sample loadable after the one before it:
+# an extension is visible to the next sample whichever schema it sits in, so a
+# schema that says CREATE EXTENSION IF NOT EXISTS gets nothing when the
+# extension already exists in some other sample's schema, and then its types
+# and operator classes do not resolve. icingadb and sourcegraph both install
+# citext, and sourcegraph and gitlab both install pg_trgm.
+.PHONY: drop-extensions
+drop-extensions:
+	psql -X -q -At -v ON_ERROR_STOP=1 -c "SELECT quote_ident(extname) FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace WHERE n.nspname <> 'pg_catalog'" \
+	  | while read -r e; do \
+	      psql -X -q -v ON_ERROR_STOP=1 -c "SET client_min_messages TO warning; DROP EXTENSION IF EXISTS $$e CASCADE" || exit 1; \
+	    done
+
 # Wipe every user schema. Used by `schema` and `demo` to start from an empty
 # database, by test-samples once before its first sample, and by `test` and
 # `test-scenario`, which reset only `public` on their own.
 #
-# The tables go first, a batch at a time, and only then the schemas. A single
-# DROP SCHEMA ... CASCADE takes locks on every object it reaches, and the
-# larger samples do not fit: gitlab owns 1,400 tables and their indexes, which
-# runs the server out of lock table space at the default
+# The extensions go first, since a table one of them owns stops both of the
+# statements below. Then the tables, a batch at a time, and only then the
+# schemas. A single DROP SCHEMA ... CASCADE takes locks on every object it
+# reaches, and the larger samples do not fit: gitlab owns 1,400 tables and
+# their indexes, which runs the server out of lock table space at the default
 # max_locks_per_transaction. Each batch is a statement of its own, so its locks
 # are released before the next one starts, and the schemas are empty by the
 # time they are dropped.
 DROP_TABLE_BATCH = 50
 
 .PHONY: clean-schema
-clean-schema:
+clean-schema: drop-extensions
 	while :; do \
 	  batch=$$(psql -X -q -At -v ON_ERROR_STOP=1 -c "SELECT string_agg(format('%I.%I', schemaname, tablename), ', ') FROM (SELECT schemaname, tablename FROM pg_tables WHERE schemaname NOT LIKE 'pg_%' AND schemaname <> 'information_schema' LIMIT $(DROP_TABLE_BATCH)) t") || exit 1; \
 	  [ -n "$$batch" ] || break; \
@@ -432,16 +451,9 @@ clean-schema:
 # objects are close behind.
 #
 # Extensions are the exception, because they are visible to the next sample
-# whichever schema they sit in: a dump that says CREATE EXTENSION IF NOT EXISTS
-# does nothing when the extension already exists in some other sample's schema,
-# and then its types and operator classes do not resolve. icingadb and
-# sourcegraph both install citext, and sourcegraph and gitlab both install
-# pg_trgm. So drop the extensions too, before the next sample runs.
+# whichever schema they sit in; drop-extensions says why. They go first, so a
+# table one of them owns cannot stop the DROP SCHEMA below either.
 .PHONY: reset-db
-reset-db:
+reset-db: drop-extensions
 	psql -X -q -v ON_ERROR_STOP=1 -c 'SET client_min_messages TO warning; DROP SCHEMA IF EXISTS public CASCADE'
-	psql -X -q -At -v ON_ERROR_STOP=1 -c "SELECT quote_ident(extname) FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace WHERE n.nspname <> 'pg_catalog'" \
-	  | while read -r e; do \
-	      psql -X -q -v ON_ERROR_STOP=1 -c "SET client_min_messages TO warning; DROP EXTENSION IF EXISTS $$e CASCADE" || exit 1; \
-	    done
 	psql -X -q -v ON_ERROR_STOP=1 -c 'CREATE SCHEMA public'


### PR DESCRIPTION
## Problem

`make clean-schema` fails whenever an extension that owns a table is installed.

It drops the tables a batch at a time and then the schemas, and PostGIS's `spatial_ref_sys` belongs to the extension rather than to the schema, so the first batch stops with:

```
ERROR:  cannot drop table gis.spatial_ref_sys because extension postgis requires it
HINT:  You can drop extension postgis instead.
make: *** [clean-schema] Error 1
```

Dropping the extensions was `reset-db`'s job alone, and that target runs between samples rather than before a wipe.

CI never hits it, since the samples job runs `clean-schema` once against an empty database. Locally it lands right after `make schema`, which loads osm and inaturalist and installs PostGIS for them. From there `make test`, `make test-scenario` and `make test-fidelity` all fail on the prerequisite.

## Fix

The extension drop becomes its own `drop-extensions` target that both `clean-schema` and `reset-db` depend on, so it runs first in each and `reset-db` loses its copy of the loop. The order is now extensions, then tables, then schemas. It also keeps a table an extension owns from stopping `reset-db`'s `DROP SCHEMA public CASCADE`.

`docs/contributing-samples.md` and `AGENTS.md` each carried one line that describes what `clean-schema` wipes; both now mention the extensions.

No CHANGELOG entry: `sample-db.mk` changes do not take one.

## Verified

| Check | Result |
| --- | --- |
| `make clean-schema` with PostGIS installed, before the fix | Error 1, reproduced |
| Same, after the fix | rc=0, 0 extensions, `public` only, 0 relations in `public` |
| `make clean-schema` again on the empty database | rc=0, idempotent |
| PostGIS in `public`, then `make reset-db` | rc=0, 0 extensions, `public` recreated |
| Load osm (PostGIS), `pista dump` then `plan` | `-- No changes` |
| `make reset-db`, load chinook, `pista dump` then `plan` | `-- No changes` |
| `make test TEST_OPTS='-run TestPlan/add_column'` | Runs through the prerequisite and passes |