### PR TITLE
Document installing with mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Declarative schema management tool for PostgreSQL with a Terraform-like plan/app
 brew install winebarrel/pistachio/pistachio
 ```
 
+### mise
+
+```bash
+mise use github:winebarrel/pistachio            # latest
+mise use github:winebarrel/pistachio@<version>  # a specific version
+```
+
 ### Download binary
 
 Download the latest binary from [Releases](https://github.com/winebarrel/pistachio/releases).

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,13 @@ The source for the image is under [`demo/`](https://github.com/winebarrel/pistac
 brew install winebarrel/pistachio/pistachio
 ```
 
+### mise
+
+```bash
+mise use github:winebarrel/pistachio            # latest
+mise use github:winebarrel/pistachio@<version>  # a specific version
+```
+
 ### Download binary
 
 Download the latest binary from [Releases](https://github.com/winebarrel/pistachio/releases).


### PR DESCRIPTION
Adds a `mise` section to the installation list in `README.md` and `docs/index.md`.

`pista` is already installable with mise, and nothing has to be registered anywhere for it. mise's `github:` backend reads the GitHub release assets directly, and the goreleaser names carry the OS and the architecture it matches on (`pistachio_1.47.0_darwin_arm64.tar.gz`).

## Verified

```
$ mise use github:winebarrel/pistachio
mise ... tools: github:winebarrel/pistachio@1.46.0

$ mise exec -- pista --version
1.46.0
```

The install also reports `GitHub artifact attestations verified`, since the releases carry attestations.

The command is written with `@<version>` rather than a number, which would go stale within a day at the current release cadence.

No CHANGELOG entry: documentation only.