### PR TITLE
Add Google Analytics to the docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,11 @@ plugins:
 hooks:
   - hooks.py
 
+extra:
+  analytics:
+    provider: google
+    property: G-L2YHGE2CEF
+
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
Enable Material for MkDocs built-in Google Analytics (GA4) on the docs site by setting the measurement ID in mkdocs.yml. Verified that `mkdocs build --strict` passes and the built pages include the gtag snippet.