### PR TITLE
Test the pista entrypoint and drop it from the codecov ignore list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Test the `pista` entrypoint. `main` now hands the arguments, the output streams and the exit function to a `run` function, so the argument parsing, the pager hookup and the exit codes are covered by `go test`, and `cmd/pista` is no longer left out of the coverage report. No change in behavior.
+
 ## [1.47.0] - 2026-09-07
 
 * Add `pista fmt`, which lays out schema SQL files in place. It works on the token stream, so only the whitespace moves: the keyword case, the identifier spelling and the line breaks are left as they were written, and no schema name is added. The definition list of a `CREATE TABLE` and a `CREATE TYPE` is written one element per line, a line inside parentheses is indented four spaces past the line that opened them, a routine's clauses take one level, and the space before a comma, just inside a parenthesis, and around a subscript or a cast is closed up. A quoted identifier loses its quotes when the statement parses to the same thing without them. A view body and a routine body are left alone. The result is checked to carry the same tokens as the input, and a file that fails the check or does not parse is not written. `--check` reports the files that are not formatted and exits with code 2.

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -13,7 +13,7 @@ import (
 
 var version string
 
-var cli struct {
+type cli struct {
 	pistachio.Options
 	Config  kong.ConfigFlag `short:"C" name:"config" placeholder:"FILE" env:"PISTA_CONFIG" help:"Load options from a YAML file."`
 	Version kong.VersionFlag
@@ -26,21 +26,37 @@ var cli struct {
 }
 
 func main() {
+	run(os.Args[1:], os.Stdout, os.Stderr, os.Exit)
+}
+
+// run parses args and runs the command. The command writes to stdout, which
+// is also where the pager writes when one is started, and stderr takes the
+// usage and error messages. exit stands in for os.Exit and is not expected
+// to return; a test passes one that panics.
+func run(args []string, stdout, stderr io.Writer, exit func(int)) {
+	var cli cli
 	ctx := context.Background()
-	kctx := kong.Parse(&cli,
+	parser, err := kong.New(&cli,
 		kong.Vars{"version": version},
 		kong.Configuration(pistachio.YAMLConfig),
+		kong.Writers(stdout, stderr),
+		kong.Exit(exit),
 		kong.BindTo(ctx, (*context.Context)(nil)),
-		kong.BindTo(os.Stdout, (*io.Writer)(nil)),
+		kong.BindTo(stdout, (*io.Writer)(nil)),
 	)
+	if err != nil {
+		panic(err)
+	}
+	kctx, err := parser.Parse(args)
+	parser.FatalIfErrorf(err)
 
-	w, closePager, err := command.StartPager(os.Stdout, cli.Pager)
+	w, closePager, err := command.StartPager(stdout, cli.Pager)
 	kctx.FatalIfErrorf(err)
 	// Defer covers panics; the explicit closePager() below covers the
 	// os.Exit path inside FatalIfErrorf so the pager always finishes
 	// flushing before the parent exits.
 	defer closePager()
-	if w != io.Writer(os.Stdout) {
+	if w != stdout {
 		kctx.BindTo(w, (*io.Writer)(nil))
 	}
 
@@ -51,6 +67,7 @@ func main() {
 	// of a fatal error. The output has already been written.
 	if errors.Is(err, command.ErrPlanDiff) || errors.Is(err, command.ErrFormatDiff) {
 		kctx.Exit(2)
+		return
 	}
 	kctx.FatalIfErrorf(err)
 }

--- a/cmd/pista/main_test.go
+++ b/cmd/pista/main_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/internal/testutil"
+)
+
+// exitCode is what the exit function passed to run panics with, so that run
+// stops where os.Exit would have.
+type exitCode int
+
+// runCLI runs the command line and returns the exit code and what was
+// written to stderr. A run that returns without calling exit is 0.
+func runCLI(t *testing.T, stdout io.Writer, args ...string) (code int, stderr string) {
+	t.Helper()
+	var errBuf bytes.Buffer
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c, ok := r.(exitCode)
+				if !ok {
+					panic(r)
+				}
+				code = int(c)
+			}
+		}()
+		run(args, stdout, &errBuf, func(c int) { panic(exitCode(c)) })
+	}()
+	return code, errBuf.String()
+}
+
+func writeFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+const usersTable = `CREATE TABLE public.users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`
+
+func TestRun_Plan(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desired := writeFile(t, "desired.sql", usersTable)
+
+	var out bytes.Buffer
+	code, stderr := runCLI(t, &out, "plan", "-c", testutil.ConnString(), desired)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Contains(t, out.String(), "CREATE TABLE public.users")
+}
+
+func TestRun_PlanCheckDiff(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desired := writeFile(t, "desired.sql", usersTable)
+
+	var out bytes.Buffer
+	code, stderr := runCLI(t, &out, "plan", "--check", "-c", testutil.ConnString(), desired)
+	assert.Equal(t, 2, code)
+	assert.Empty(t, stderr)
+	assert.Contains(t, out.String(), "CREATE TABLE public.users")
+}
+
+func TestRun_FmtCheckDiff(t *testing.T) {
+	path := writeFile(t, "schema.sql", "CREATE TABLE users (id integer NOT NULL, name text);\n")
+
+	var out bytes.Buffer
+	code, stderr := runCLI(t, &out, "fmt", "--check", path)
+	assert.Equal(t, 2, code)
+	assert.Empty(t, stderr)
+	assert.Contains(t, out.String(), path)
+}
+
+func TestRun_Help(t *testing.T) {
+	var out bytes.Buffer
+	code, stderr := runCLI(t, &out, "--help")
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Contains(t, out.String(), "Usage:")
+	for _, cmd := range []string{"apply", "plan", "dump", "fmt"} {
+		assert.Contains(t, out.String(), cmd)
+	}
+}
+
+func TestRun_Version(t *testing.T) {
+	var out bytes.Buffer
+	code, stderr := runCLI(t, &out, "--version")
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	// version is set by the linker and empty under go test.
+	assert.Equal(t, "\n", out.String())
+}
+
+func TestRun_ParseError(t *testing.T) {
+	var out bytes.Buffer
+	code, stderr := runCLI(t, &out, "no-such-command")
+	// kong exits with 80 on a usage error.
+	assert.Equal(t, 80, code)
+	assert.Contains(t, stderr, "error: unexpected argument no-such-command")
+}
+
+func TestRun_RunError(t *testing.T) {
+	desired := writeFile(t, "desired.sql", usersTable)
+
+	var out bytes.Buffer
+	code, stderr := runCLI(t, &out, "plan", "-c", "invalid://connection", desired)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "error:")
+	assert.Empty(t, out.String())
+}
+
+func TestRun_Pager(t *testing.T) {
+	ctx := context.Background()
+	conn := testutil.ConnectDB(t)
+	defer conn.Close(ctx)
+	testutil.SetupDB(t, ctx, conn, "")
+
+	desired := writeFile(t, "desired.sql", usersTable)
+
+	// StartPager only wraps an *os.File, and --pager skips the TTY check.
+	t.Setenv("PISTA_PAGER", "cat")
+	f, err := os.CreateTemp(t.TempDir(), "out")
+	require.NoError(t, err)
+	defer f.Close()
+
+	code, stderr := runCLI(t, f, "plan", "--pager", "-c", testutil.ConnString(), desired)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	got, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(got), "-- Connected to "), "got: %q", got)
+	assert.Contains(t, string(got), "CREATE TABLE public.users")
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,4 +22,3 @@ coverage:
 
 ignore:
   - "internal/testutil"
-  - "cmd/pista"


### PR DESCRIPTION
main only read os.Args and exited through os.Exit, so cmd/pista could not
be tested in-process and codecov.yml left it out. Move the body into a run
function that takes the arguments, the output streams and the exit
function, and test the parsing, the pager hookup and the exit codes from
there. No change in behavior.
