### PR TITLE
Fix four round-trip breaks with one-line causes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Fold a routine's `SET` name to lower case. GUC names are case-insensitive and `pg_get_functiondef` writes the spelling PostgreSQL keeps, so a routine created with `SET timezone` read back as `SET "TimeZone"` and was replaced on every plan. `DateStyle` and `IntervalStyle` behaved the same way.
 
-* Widen a `serial` column to `bigserial`. The change went out as `SET DATA TYPE bigserial`, which fails with `type bigserial does not exist`, since PostgreSQL takes a serial pseudo-type only in `CREATE TABLE` and `ADD COLUMN`. The base type is named instead, and the sequence the column owns follows it with `ALTER SEQUENCE ... AS`: `bigserial` is a `bigint` column and a `bigint` sequence, so widening the column alone left the numbers stopping at 2147483647. A column that owns no sequence takes the one statement it always did.
+* Widen a `serial` column to `bigserial`. The change went out as `SET DATA TYPE bigserial`, which fails: PostgreSQL takes a serial pseudo-type only in `CREATE TABLE` and `ADD COLUMN`. The base type goes out instead, with `ALTER SEQUENCE ... AS` for the sequence the column owns. `bigserial` is a `bigint` column and a `bigint` sequence, and widening the column alone left the numbers stopping at 2147483647. A column that owns no sequence takes the one statement it always did.
 
 * Test the `pista` entrypoint. `main` now hands the arguments, the output streams and the exit function to a `run` function, so the argument parsing, the pager hookup and the exit codes are covered by `go test`, and `cmd/pista` is no longer left out of the coverage report. No change in behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+* Read `CREATE INDEX IF NOT EXISTS` as the index it describes. The clause was kept in the stored definition, which `pg_get_indexdef` never writes, so an index a schema file spelled that way was dropped and created again on every plan.
+
+* Read an enum that has no labels. `CREATE TYPE ... AS ENUM ()` has no `pg_enum` row, and the catalog reached the labels through an inner join, so the type read as absent: every plan created it again and the second apply failed with `type already exists`. `dump` writes it now as well.
+
+* Fold a routine's `SET` name to lower case. GUC names are case-insensitive and `pg_get_functiondef` writes the spelling PostgreSQL keeps, so a routine created with `SET timezone` read back as `SET "TimeZone"` and was replaced on every plan. `DateStyle` and `IntervalStyle` behaved the same way.
+
+* Widen a `serial` column to `bigserial`. The change went out as `SET DATA TYPE bigserial`, which fails with `type bigserial does not exist`, since PostgreSQL takes a serial pseudo-type only in `CREATE TABLE` and `ADD COLUMN`. The base type is named instead; the column keeps the sequence it owns, and widening that sequence stays a separate change.
+
 * Test the `pista` entrypoint. `main` now hands the arguments, the output streams and the exit function to a `run` function, so the argument parsing, the pager hookup and the exit codes are covered by `go test`, and `cmd/pista` is no longer left out of the coverage report. No change in behavior.
 
 ## [1.47.0] - 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Fold a routine's `SET` name to lower case. GUC names are case-insensitive and `pg_get_functiondef` writes the spelling PostgreSQL keeps, so a routine created with `SET timezone` read back as `SET "TimeZone"` and was replaced on every plan. `DateStyle` and `IntervalStyle` behaved the same way.
 
-* Widen a `serial` column to `bigserial`. The change went out as `SET DATA TYPE bigserial`, which fails with `type bigserial does not exist`, since PostgreSQL takes a serial pseudo-type only in `CREATE TABLE` and `ADD COLUMN`. The base type is named instead; the column keeps the sequence it owns, and widening that sequence stays a separate change.
+* Widen a `serial` column to `bigserial`. The change went out as `SET DATA TYPE bigserial`, which fails with `type bigserial does not exist`, since PostgreSQL takes a serial pseudo-type only in `CREATE TABLE` and `ADD COLUMN`. The base type is named instead, and the sequence the column owns follows it with `ALTER SEQUENCE ... AS`: `bigserial` is a `bigint` column and a `bigint` sequence, so widening the column alone left the numbers stopping at 2147483647. A column that owns no sequence takes the one statement it always did.
 
 * Test the `pista` entrypoint. `main` now hands the arguments, the output streams and the exit function to a `run` function, so the argument parsing, the pager hookup and the exit codes are covered by `go test`, and `cmd/pista` is no longer left out of the coverage report. No change in behavior.
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -637,3 +637,37 @@ Managing the name also means `dump` writes `SEQUENCE NAME` on every identity
 column. No plan to close this.
 
 Origin: identity sequence options, 2026-09-02.
+
+## A `nextval` default is dropped from a column a sequence cannot type
+
+A column is read as a serial when it owns a sequence and its default draws from
+that sequence. The type is not part of the test, while the rendering is: the
+type name reads back as `serial` only for `integer`, `bigint` and `smallint`,
+and the default is dropped either way. A column of any other type that owns its
+sequence therefore loses its default:
+
+```sql
+CREATE TABLE public.t (id serial);
+ALTER TABLE public.t ALTER COLUMN id SET DATA TYPE text;
+```
+
+`pista dump` writes `id text NOT NULL`, though the column still carries
+`nextval('t_id_seq'::regclass)`, and the plan of that dump reports no changes,
+so nothing says the default was lost. Loading the dump gives a table without
+it.
+
+The same happens to a column whose sequence was attached by hand, and there the
+sequence goes too, since an owned one is left to the column that owns it:
+
+```sql
+CREATE SEQUENCE public.s;
+CREATE TABLE public.t (id numeric DEFAULT nextval('public.s'));
+ALTER SEQUENCE public.s OWNED BY public.t.id;
+```
+
+`pista dump` writes `id numeric` and no `CREATE SEQUENCE`.
+
+Closing it means gating the serial test on the type, so a column a sequence
+cannot type keeps its default and its sequence surfaces as a standalone one.
+
+Origin: review of the serial retype fix, 2026-09-08.

--- a/catalog/columns.go
+++ b/catalog/columns.go
@@ -34,6 +34,14 @@ func (c *Catalog) ListColumnsByTables(ctx context.Context, tables []*model.Table
 				END
 				ELSE pg_catalog.format_type(a.atttypid, a.atttypmod)
 			END AS type_name,
+			-- The sequence a serial column owns. The diff needs its name to
+			-- keep its type in step with the column's: bigserial is a bigint
+			-- column and a bigint sequence, and ALTER TABLE reaches only the
+			-- column. NULL for every other column.
+			CASE
+				WHEN s.is_serial
+				THEN pg_catalog.pg_get_serial_sequence(a.attrelid::regclass::text, a.attname)
+			END AS serial_sequence,
 			a.attnotnull,
 			-- PG18 stores per-column NOT NULL as pg_constraint rows with
 			-- contype='n' and a single conkey entry. Pre-PG18 has no such row,
@@ -161,6 +169,7 @@ func (c *Catalog) ListColumnsByTables(ctx context.Context, tables []*model.Table
 			&col.Name,
 			&isLocal,
 			&col.TypeName,
+			&col.SerialSequence,
 			&col.NotNull,
 			&col.NotNullName,
 			&col.Default,

--- a/catalog/enums.go
+++ b/catalog/enums.go
@@ -38,12 +38,15 @@ func (c *Catalog) ListEnums(ctx context.Context) ([]*model.Enum, error) {
 			t.oid,
 			n.nspname,
 			t.typname,
-			array_agg(e.enumlabel ORDER BY e.enumsortorder) AS vals,
+			array_remove(array_agg(e.enumlabel ORDER BY e.enumsortorder), NULL) AS vals,
 			d.description
 		FROM
 			pg_catalog.pg_type t
 			JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-			JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
+			-- An enum with no labels has no pg_enum row. An inner join would
+			-- drop the type from the result, so every plan would create it
+			-- again and the second apply would fail.
+			LEFT JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
 			LEFT JOIN pg_catalog.pg_description d ON d.objoid = t.oid
 			AND d.classoid = 'pg_type'::regclass
 			AND d.objsubid = 0

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -610,10 +610,8 @@ func isSerialType(typeName string) bool {
 }
 
 // alterTypeName renders a type name for SET DATA TYPE. PostgreSQL accepts a
-// serial pseudo-type only in CREATE TABLE and ADD COLUMN, where it stands for
-// the base type plus a sequence and a default; naming it in an ALTER fails
-// with "type bigserial does not exist". The column keeps the sequence it
-// already owns, so the base type is the whole change.
+// serial pseudo-type only in CREATE TABLE and ADD COLUMN, so naming one in an
+// ALTER fails with "type bigserial does not exist".
 func alterTypeName(typeName string) string {
 	if base, ok := serialBaseTypes[typeName]; ok {
 		return base
@@ -622,17 +620,14 @@ func alterTypeName(typeName string) string {
 }
 
 // alterSerialSequenceSQL keeps the sequence a serial column owns in step with
-// the column's type. serial means an integer column and an integer sequence,
-// bigserial a bigint one of each, and ALTER TABLE reaches only the column: a
-// widened column left with its old sequence stops handing out numbers at the
-// old type's maximum, which is not the state the schema declares. PostgreSQL
-// adjusts the bounds along with the type when they are the old type's
-// defaults.
+// the column's type. serial is an integer column and an integer sequence,
+// bigserial a bigint one of each, and ALTER TABLE reaches only the column, so
+// widening the column alone leaves the numbers stopping at the old type's
+// maximum. PostgreSQL moves the bounds with the type when they are the old
+// type's defaults.
 //
-// It returns "" unless the current column is a serial the catalog named a
-// sequence for, and the new type is one a sequence can hold. A column that is
-// not a serial owns no sequence, and one being retyped to something a
-// sequence cannot hold fails on the column anyway.
+// Returns "" for a column that owns no sequence, and for a type a sequence
+// cannot hold.
 func alterSerialSequenceSQL(current, desired *model.Column) string {
 	if current.SerialSequence == nil {
 		return ""

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -319,6 +319,7 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 	}
 
 	// Alter existing columns
+	var seqStmts []string
 	for name, desiredCol := range desired.All() {
 		if currentCol, ok := current.GetOk(name); ok {
 			cur := currentCol.Generated.IsStoredGeneratedColumn()
@@ -344,8 +345,18 @@ func diffColumns(fqtn string, current, desired *orderedmap.Map[string, *model.Co
 					fqtn, model.Ident(name))
 			}
 			stmts = append(stmts, alterColumnSQL(fqtn, currentCol, desiredCol)...)
+			if seqSQL := alterSerialSequenceSQL(fqtn, currentCol, desiredCol); seqSQL != "" {
+				seqStmts = append(seqStmts, seqSQL)
+			}
 		}
 	}
+
+	// The sequence statements go after every ALTER TABLE rather than next to
+	// the column they belong to. --bulk-alter merges a run of consecutive
+	// ALTER TABLE statements on one table, and one of these in the middle
+	// would break the run in two. The sort puts them ahead of the ALTER TABLE
+	// again, since the table's default draws from the sequence.
+	stmts = append(stmts, seqStmts...)
 
 	// Drop removed columns. When the column-drop policy disallows it, emit
 	// the same DROP as a comment for visibility. Two passes: generated
@@ -414,9 +425,6 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 			sql += " COLLATE " + *desired.Collation
 		}
 		stmts = append(stmts, sql+";")
-		if seqSQL := alterSerialSequenceSQL(current, desired); seqSQL != "" {
-			stmts = append(stmts, seqSQL)
-		}
 	}
 
 	curIsIdent := current.Identity.IsIdentityColumn()
@@ -626,10 +634,16 @@ func alterTypeName(typeName string) string {
 // maximum. PostgreSQL moves the bounds with the type when they are the old
 // type's defaults.
 //
-// Returns "" for a column that owns no sequence, and for a type a sequence
-// cannot hold.
-func alterSerialSequenceSQL(current, desired *model.Column) string {
+// Returns "" for a column that owns no sequence, for one whose type is not
+// changing, and for a type a sequence cannot hold.
+func alterSerialSequenceSQL(fqtn string, current, desired *model.Column) string {
 	if current.SerialSequence == nil {
+		return ""
+	}
+	// Only a type change reaches the sequence. Without this the statement
+	// would go out on every plan for every serial column, since the column
+	// itself is compared elsewhere.
+	if equalTypeName(current.TypeName, desired.TypeName, schemaOf(fqtn)) {
 		return ""
 	}
 	base := alterTypeName(desired.TypeName)

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -409,7 +409,7 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 	// SET DATA TYPE without COLLATE reverts to the type's default collation.
 	retyped := !equalTypeName(current.TypeName, desired.TypeName, schemaOf(fqtn)) || !equalCollation(current.Collation, desired.Collation)
 	if retyped {
-		sql := "ALTER TABLE " + fqtn + " ALTER COLUMN " + colIdent + " SET DATA TYPE " + desired.TypeName
+		sql := "ALTER TABLE " + fqtn + " ALTER COLUMN " + colIdent + " SET DATA TYPE " + alterTypeName(desired.TypeName)
 		if desired.Collation != nil {
 			sql += " COLLATE " + *desired.Collation
 		}
@@ -604,6 +604,18 @@ func identityKind(id model.ColumnIdentity) string {
 func isSerialType(typeName string) bool {
 	_, ok := serialBaseTypes[typeName]
 	return ok
+}
+
+// alterTypeName renders a type name for SET DATA TYPE. PostgreSQL accepts a
+// serial pseudo-type only in CREATE TABLE and ADD COLUMN, where it stands for
+// the base type plus a sequence and a default; naming it in an ALTER fails
+// with "type bigserial does not exist". The column keeps the sequence it
+// already owns, so the base type is the whole change.
+func alterTypeName(typeName string) string {
+	if base, ok := serialBaseTypes[typeName]; ok {
+		return base
+	}
+	return typeName
 }
 
 // normalizeCheckExpr normalizes an expression so that semantically equivalent

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -414,6 +414,9 @@ func alterColumnSQL(fqtn string, current, desired *model.Column) []string {
 			sql += " COLLATE " + *desired.Collation
 		}
 		stmts = append(stmts, sql+";")
+		if seqSQL := alterSerialSequenceSQL(current, desired); seqSQL != "" {
+			stmts = append(stmts, seqSQL)
+		}
 	}
 
 	curIsIdent := current.Identity.IsIdentityColumn()
@@ -616,6 +619,36 @@ func alterTypeName(typeName string) string {
 		return base
 	}
 	return typeName
+}
+
+// alterSerialSequenceSQL keeps the sequence a serial column owns in step with
+// the column's type. serial means an integer column and an integer sequence,
+// bigserial a bigint one of each, and ALTER TABLE reaches only the column: a
+// widened column left with its old sequence stops handing out numbers at the
+// old type's maximum, which is not the state the schema declares. PostgreSQL
+// adjusts the bounds along with the type when they are the old type's
+// defaults.
+//
+// It returns "" unless the current column is a serial the catalog named a
+// sequence for, and the new type is one a sequence can hold. A column that is
+// not a serial owns no sequence, and one being retyped to something a
+// sequence cannot hold fails on the column anyway.
+func alterSerialSequenceSQL(current, desired *model.Column) string {
+	if current.SerialSequence == nil {
+		return ""
+	}
+	base := alterTypeName(desired.TypeName)
+	if !sequenceTypes[base] {
+		return ""
+	}
+	return "ALTER SEQUENCE " + *current.SerialSequence + " AS " + base + ";"
+}
+
+// sequenceTypes lists the types a sequence can be declared AS.
+var sequenceTypes = map[string]bool{
+	"smallint": true,
+	"integer":  true,
+	"bigint":   true,
 }
 
 // normalizeCheckExpr normalizes an expression so that semantically equivalent

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -4059,3 +4059,51 @@ func TestEqualConstraintDef_storageParams(t *testing.T) {
 		"UNIQUE (v)",
 	))
 }
+
+func TestAlterTypeName(t *testing.T) {
+	// A serial pseudo-type resolves to the type SET DATA TYPE can name.
+	assert.Equal(t, "integer", alterTypeName("serial"))
+	assert.Equal(t, "bigint", alterTypeName("bigserial"))
+	assert.Equal(t, "smallint", alterTypeName("smallserial"))
+	// Everything else goes out as written.
+	assert.Equal(t, "text", alterTypeName("text"))
+	assert.Equal(t, "numeric(10,2)", alterTypeName("numeric(10,2)"))
+}
+
+func TestAlterSerialSequenceSQL(t *testing.T) {
+	seq := "public.t_id_seq"
+
+	t.Run("serial column widening", func(t *testing.T) {
+		current := &model.Column{Name: "id", TypeName: "serial", SerialSequence: &seq}
+		desired := &model.Column{Name: "id", TypeName: "bigserial"}
+		assert.Equal(t, "ALTER SEQUENCE public.t_id_seq AS bigint;", alterSerialSequenceSQL(current, desired))
+	})
+
+	t.Run("base type named directly", func(t *testing.T) {
+		current := &model.Column{Name: "id", TypeName: "serial", SerialSequence: &seq}
+		desired := &model.Column{Name: "id", TypeName: "bigint"}
+		assert.Equal(t, "ALTER SEQUENCE public.t_id_seq AS bigint;", alterSerialSequenceSQL(current, desired))
+	})
+
+	t.Run("column owns no sequence", func(t *testing.T) {
+		current := &model.Column{Name: "id", TypeName: "integer"}
+		desired := &model.Column{Name: "id", TypeName: "bigint"}
+		assert.Empty(t, alterSerialSequenceSQL(current, desired))
+	})
+
+	t.Run("type a sequence cannot hold", func(t *testing.T) {
+		current := &model.Column{Name: "id", TypeName: "serial", SerialSequence: &seq}
+		desired := &model.Column{Name: "id", TypeName: "text"}
+		assert.Empty(t, alterSerialSequenceSQL(current, desired))
+	})
+}
+
+func TestAlterColumnSQL_SerialWidening(t *testing.T) {
+	seq := "public.users_id_seq"
+	current := &model.Column{Name: "id", TypeName: "serial", NotNull: true, SerialSequence: &seq}
+	desired := &model.Column{Name: "id", TypeName: "bigserial", NotNull: true}
+	assert.Equal(t, []string{
+		"ALTER TABLE public.users ALTER COLUMN id SET DATA TYPE bigint;",
+		"ALTER SEQUENCE public.users_id_seq AS bigint;",
+	}, alterColumnSQL("public.users", current, desired))
+}

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -4076,34 +4076,41 @@ func TestAlterSerialSequenceSQL(t *testing.T) {
 	t.Run("serial column widening", func(t *testing.T) {
 		current := &model.Column{Name: "id", TypeName: "serial", SerialSequence: &seq}
 		desired := &model.Column{Name: "id", TypeName: "bigserial"}
-		assert.Equal(t, "ALTER SEQUENCE public.t_id_seq AS bigint;", alterSerialSequenceSQL(current, desired))
+		assert.Equal(t, "ALTER SEQUENCE public.t_id_seq AS bigint;", alterSerialSequenceSQL("public.t", current, desired))
 	})
 
 	t.Run("base type named directly", func(t *testing.T) {
 		current := &model.Column{Name: "id", TypeName: "serial", SerialSequence: &seq}
 		desired := &model.Column{Name: "id", TypeName: "bigint"}
-		assert.Equal(t, "ALTER SEQUENCE public.t_id_seq AS bigint;", alterSerialSequenceSQL(current, desired))
+		assert.Equal(t, "ALTER SEQUENCE public.t_id_seq AS bigint;", alterSerialSequenceSQL("public.t", current, desired))
+	})
+
+	t.Run("type unchanged", func(t *testing.T) {
+		current := &model.Column{Name: "id", TypeName: "serial", SerialSequence: &seq}
+		desired := &model.Column{Name: "id", TypeName: "serial"}
+		assert.Empty(t, alterSerialSequenceSQL("public.t", current, desired))
 	})
 
 	t.Run("column owns no sequence", func(t *testing.T) {
 		current := &model.Column{Name: "id", TypeName: "integer"}
 		desired := &model.Column{Name: "id", TypeName: "bigint"}
-		assert.Empty(t, alterSerialSequenceSQL(current, desired))
+		assert.Empty(t, alterSerialSequenceSQL("public.t", current, desired))
 	})
 
 	t.Run("type a sequence cannot hold", func(t *testing.T) {
 		current := &model.Column{Name: "id", TypeName: "serial", SerialSequence: &seq}
 		desired := &model.Column{Name: "id", TypeName: "text"}
-		assert.Empty(t, alterSerialSequenceSQL(current, desired))
+		assert.Empty(t, alterSerialSequenceSQL("public.t", current, desired))
 	})
 }
 
+// The sequence statement is not part of what alterColumnSQL returns; it is
+// collected separately so a --bulk-alter run of ALTER TABLE stays unbroken.
 func TestAlterColumnSQL_SerialWidening(t *testing.T) {
 	seq := "public.users_id_seq"
 	current := &model.Column{Name: "id", TypeName: "serial", NotNull: true, SerialSequence: &seq}
 	desired := &model.Column{Name: "id", TypeName: "bigserial", NotNull: true}
 	assert.Equal(t, []string{
 		"ALTER TABLE public.users ALTER COLUMN id SET DATA TYPE bigint;",
-		"ALTER SEQUENCE public.users_id_seq AS bigint;",
 	}, alterColumnSQL("public.users", current, desired))
 }

--- a/model/column.go
+++ b/model/column.go
@@ -33,13 +33,18 @@ func (b ColumnGenerated) IsVirtualGeneratedColumn() bool {
 }
 
 type Column struct {
-	Name        string
-	RenameFrom  *string
-	TypeName    string
-	NotNull     bool
-	NotNullName *string
-	Default     *string
-	Identity    ColumnIdentity
+	Name       string
+	RenameFrom *string
+	TypeName   string
+	// SerialSequence names the sequence a serial column owns, schema
+	// qualified. Only the catalog fills it: the desired side knows the column
+	// is a serial from its type name, but not what PostgreSQL called the
+	// sequence. nil on every other column.
+	SerialSequence *string
+	NotNull        bool
+	NotNullName    *string
+	Default        *string
+	Identity       ColumnIdentity
 	// IdentitySeq holds the sequence parameters of an identity column. It is
 	// nil when the column is not an identity column.
 	IdentitySeq *IdentitySequence

--- a/model/column.go
+++ b/model/column.go
@@ -37,9 +37,8 @@ type Column struct {
 	RenameFrom *string
 	TypeName   string
 	// SerialSequence names the sequence a serial column owns, schema
-	// qualified. Only the catalog fills it: the desired side knows the column
-	// is a serial from its type name, but not what PostgreSQL called the
-	// sequence. nil on every other column.
+	// qualified. Only the catalog fills it: a type name says the column is a
+	// serial, but not what PostgreSQL called its sequence. nil otherwise.
 	SerialSequence *string
 	NotNull        bool
 	NotNullName    *string

--- a/model/enum.go
+++ b/model/enum.go
@@ -28,6 +28,10 @@ func (e Enum) FQEN() string {
 }
 
 func (e Enum) SQL() string {
+	if len(e.Values) == 0 {
+		return "CREATE TYPE " + Ident(e.Schema, e.Name) + " AS ENUM (\n);"
+	}
+
 	quoted := make([]string, len(e.Values))
 	for i, v := range e.Values {
 		quoted[i] = QuoteLiteral(v)

--- a/model/enum_test.go
+++ b/model/enum_test.go
@@ -32,6 +32,11 @@ func TestEnum_SQL(t *testing.T) {
 	assert.Equal(t, expected, e.SQL())
 }
 
+func TestEnum_SQL_NoValues(t *testing.T) {
+	e := &model.Enum{Schema: "public", Name: "mood"}
+	assert.Equal(t, "CREATE TYPE public.mood AS ENUM (\n);", e.SQL())
+}
+
 func TestEnum_CommentSQL(t *testing.T) {
 	comment := "User status"
 	e := &model.Enum{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1255,6 +1255,11 @@ func parseIndexStmt(is *pg_query.IndexStmt, rawStmt *pg_query.RawStmt, defaultSc
 	concurrent := is.Concurrent
 	is.Concurrent = false
 
+	// IF NOT EXISTS says how to run the statement, not what the index is.
+	// pg_get_indexdef never writes it, so leaving it in would make the two
+	// sides differ and plan a drop and a create on every run.
+	is.IfNotExists = false
+
 	// Name the index before deparsing so the stored Definition carries the
 	// name PostgreSQL would have picked.
 	if is.Idxname == "" {

--- a/parser/routine.go
+++ b/parser/routine.go
@@ -297,7 +297,11 @@ func parseRoutineConfig(arg *pg_query.Node) (*model.RoutineConfig, error) {
 		return nil, fmt.Errorf("%w: SET %s", errRoutineConfigFromCurrent, vss.Name)
 	}
 
-	cfg := &model.RoutineConfig{Name: vss.Name}
+	// GUC names are case-insensitive, and PostgreSQL keeps its own spelling:
+	// pg_get_functiondef writes SET "TimeZone" for a routine created with
+	// SET timezone. Both sides reach this function, so folding the name here
+	// makes a written name and a read-back one compare equal.
+	cfg := &model.RoutineConfig{Name: strings.ToLower(vss.Name)}
 	for _, a := range vss.Args {
 		c := a.GetAConst()
 		if c == nil {

--- a/test/fidelity/schemas/types.sql
+++ b/test/fidelity/schemas/types.sql
@@ -1,4 +1,6 @@
 CREATE TYPE public.status AS ENUM ('active', 'inactive', 'banned');
+CREATE TYPE public.empty_enum AS ENUM (
+);
 CREATE TYPE public.address AS (city text, zip text);
 CREATE DOMAIN public.email AS text NOT NULL DEFAULT 'x@example.com'::text CONSTRAINT email_check CHECK ((VALUE ~ '@'::text));
 CREATE TABLE public.accounts (

--- a/testdata/apply/alter_column_serial_to_bigserial.yml
+++ b/testdata/apply/alter_column_serial_to_bigserial.yml
@@ -1,6 +1,5 @@
 # The column widens to bigint and keeps the sequence it owns, so the catalog
-# reads it back as bigserial. The sequence itself stays as it was created;
-# widening it is a separate change the column type does not imply.
+# reads it back as bigserial.
 init: |
   CREATE TABLE public.users (
       id serial NOT NULL,

--- a/testdata/apply/alter_column_serial_to_bigserial.yml
+++ b/testdata/apply/alter_column_serial_to_bigserial.yml
@@ -1,0 +1,19 @@
+# The column widens to bigint and keeps the sequence it owns, so the catalog
+# reads it back as bigserial. The sequence itself stays as it was created;
+# widening it is a separate change the column type does not imply.
+init: |
+  CREATE TABLE public.users (
+      id serial NOT NULL,
+      name text NOT NULL
+  );
+desired: |
+  CREATE TABLE public.users (
+      id bigserial NOT NULL,
+      name text NOT NULL
+  );
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id bigserial NOT NULL,
+      name text NOT NULL
+  );

--- a/testdata/apply/bulk_alter_serial_widening.yml
+++ b/testdata/apply/bulk_alter_serial_widening.yml
@@ -1,0 +1,30 @@
+# The sequence statement goes after every ALTER TABLE rather than next to the
+# column it belongs to. --bulk-alter merges a run of consecutive ALTER TABLE
+# statements on one table, and one of these in the middle would break the run
+# in two.
+bulk_alter: true
+init: |
+  CREATE TABLE public.t (
+      id serial NOT NULL,
+      a smallint,
+      b smallint
+  );
+desired: |
+  CREATE TABLE public.t (
+      id bigserial NOT NULL,
+      a integer,
+      b integer
+  );
+applied_sql: |
+  ALTER SEQUENCE public.t_id_seq AS bigint;
+  ALTER TABLE public.t
+    ALTER COLUMN id SET DATA TYPE bigint,
+    ALTER COLUMN a SET DATA TYPE integer,
+    ALTER COLUMN b SET DATA TYPE integer;
+applied: |
+  -- public.t
+  CREATE TABLE public.t (
+      id bigserial NOT NULL,
+      a integer,
+      b integer
+  );

--- a/testdata/apply/create_index_if_not_exists.yml
+++ b/testdata/apply/create_index_if_not_exists.yml
@@ -1,0 +1,20 @@
+# The clause says how to run the statement, so it is not part of the index and
+# the emitted CREATE INDEX leaves it off.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS users_name_idx ON public.users USING btree (name);
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name);

--- a/testdata/apply/empty_enum.yml
+++ b/testdata/apply/empty_enum.yml
@@ -1,0 +1,10 @@
+# An enum with no labels is a real type: it can be a column's type and gain
+# labels later. The catalog has to read it back, or a second apply fails with
+# "type already exists".
+init: ""
+desired: |
+  CREATE TYPE public.mood AS ENUM ();
+applied: |
+  -- public.mood
+  CREATE TYPE public.mood AS ENUM (
+  );

--- a/testdata/dump/empty_enum.yml
+++ b/testdata/dump/empty_enum.yml
@@ -1,0 +1,6 @@
+init: |
+  CREATE TYPE public.mood AS ENUM ();
+dump: |
+  -- public.mood
+  CREATE TYPE public.mood AS ENUM (
+  );

--- a/testdata/plan/add_value_to_empty_enum.yml
+++ b/testdata/plan/add_value_to_empty_enum.yml
@@ -1,0 +1,12 @@
+# Labels are added to an enum that has none the same way they are added to one
+# that already has some.
+init: |
+  CREATE TYPE public.mood AS ENUM ();
+desired: |
+  CREATE TYPE public.mood AS ENUM (
+      'happy',
+      'sad'
+  );
+plan: |
+  ALTER TYPE public.mood ADD VALUE 'happy';
+  ALTER TYPE public.mood ADD VALUE 'sad' AFTER 'happy';

--- a/testdata/plan/alter_column_serial_to_bigserial.yml
+++ b/testdata/plan/alter_column_serial_to_bigserial.yml
@@ -1,6 +1,11 @@
 # serial and its siblings are pseudo-types PostgreSQL accepts only in
 # CREATE TABLE and ADD COLUMN. Widening such a column has to name the base
 # type; SET DATA TYPE bigserial fails with "type bigserial does not exist".
+#
+# The sequence the column owns goes with it: bigserial means a bigint column
+# and a bigint sequence, so widening only the column leaves the numbers
+# stopping at 2147483647. ALTER SEQUENCE ... AS is what reaches the rest, and
+# the sort puts it first because the table's default draws from the sequence.
 init: |
   CREATE TABLE public.users (
       id serial NOT NULL,
@@ -12,4 +17,5 @@ desired: |
       name text NOT NULL
   );
 plan: |
+  ALTER SEQUENCE public.users_id_seq AS bigint;
   ALTER TABLE public.users ALTER COLUMN id SET DATA TYPE bigint;

--- a/testdata/plan/alter_column_serial_to_bigserial.yml
+++ b/testdata/plan/alter_column_serial_to_bigserial.yml
@@ -1,0 +1,15 @@
+# serial and its siblings are pseudo-types PostgreSQL accepts only in
+# CREATE TABLE and ADD COLUMN. Widening such a column has to name the base
+# type; SET DATA TYPE bigserial fails with "type bigserial does not exist".
+init: |
+  CREATE TABLE public.users (
+      id serial NOT NULL,
+      name text NOT NULL
+  );
+desired: |
+  CREATE TABLE public.users (
+      id bigserial NOT NULL,
+      name text NOT NULL
+  );
+plan: |
+  ALTER TABLE public.users ALTER COLUMN id SET DATA TYPE bigint;

--- a/testdata/plan/alter_column_serial_to_bigserial.yml
+++ b/testdata/plan/alter_column_serial_to_bigserial.yml
@@ -1,11 +1,8 @@
-# serial and its siblings are pseudo-types PostgreSQL accepts only in
-# CREATE TABLE and ADD COLUMN. Widening such a column has to name the base
-# type; SET DATA TYPE bigserial fails with "type bigserial does not exist".
-#
-# The sequence the column owns goes with it: bigserial means a bigint column
-# and a bigint sequence, so widening only the column leaves the numbers
-# stopping at 2147483647. ALTER SEQUENCE ... AS is what reaches the rest, and
-# the sort puts it first because the table's default draws from the sequence.
+# A serial pseudo-type is accepted only in CREATE TABLE and ADD COLUMN, so
+# widening the column names the base type. The sequence it owns goes with it:
+# bigserial is a bigint column and a bigint sequence, and the column alone
+# leaves the numbers stopping at 2147483647. ALTER SEQUENCE sorts first,
+# because the table's default draws from the sequence.
 init: |
   CREATE TABLE public.users (
       id serial NOT NULL,

--- a/testdata/plan/alter_column_serial_to_text.yml
+++ b/testdata/plan/alter_column_serial_to_text.yml
@@ -1,0 +1,12 @@
+# A sequence holds an integer type and nothing else, so a column leaving the
+# integer types takes the ALTER TABLE alone.
+init: |
+  CREATE TABLE public.t (
+      id serial NOT NULL
+  );
+desired: |
+  CREATE TABLE public.t (
+      id text NOT NULL
+  );
+plan: |
+  ALTER TABLE public.t ALTER COLUMN id SET DATA TYPE text;

--- a/testdata/plan/no_diff_empty_enum.yml
+++ b/testdata/plan/no_diff_empty_enum.yml
@@ -1,0 +1,10 @@
+# An enum with no labels has no pg_enum row, so the catalog has to reach it
+# through an outer join. Missing it, the type reads as absent and every plan
+# creates it again.
+init: |
+  CREATE TYPE public.mood AS ENUM ();
+desired: |
+  CREATE TYPE public.mood AS ENUM ();
+plan: ""
+count:
+  enums: 1

--- a/testdata/plan/no_diff_empty_enum.yml
+++ b/testdata/plan/no_diff_empty_enum.yml
@@ -1,6 +1,5 @@
-# An enum with no labels has no pg_enum row, so the catalog has to reach it
-# through an outer join. Missing it, the type reads as absent and every plan
-# creates it again.
+# An enum with no labels has no pg_enum row, so the catalog reaches it through
+# an outer join. Missing it, the type reads as absent.
 init: |
   CREATE TYPE public.mood AS ENUM ();
 desired: |

--- a/testdata/plan/no_diff_index_if_not_exists.yml
+++ b/testdata/plan/no_diff_index_if_not_exists.yml
@@ -1,7 +1,5 @@
-# CREATE INDEX IF NOT EXISTS describes the same index as CREATE INDEX.
-# pg_get_indexdef never writes the clause, so keeping it in the stored
-# definition would make the two sides differ and plan a drop and a create on
-# every run.
+# CREATE INDEX IF NOT EXISTS describes the same index as CREATE INDEX, and
+# pg_get_indexdef never writes the clause.
 init: |
   CREATE TABLE public.users (
       id integer NOT NULL,

--- a/testdata/plan/no_diff_index_if_not_exists.yml
+++ b/testdata/plan/no_diff_index_if_not_exists.yml
@@ -1,0 +1,17 @@
+# CREATE INDEX IF NOT EXISTS describes the same index as CREATE INDEX.
+# pg_get_indexdef never writes the clause, so keeping it in the stored
+# definition would make the two sides differ and plan a drop and a create on
+# every run.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL
+  );
+  CREATE INDEX users_name_idx ON public.users USING btree (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS users_name_idx ON public.users USING btree (name);
+plan: ""

--- a/testdata/plan/no_diff_routine_set_timezone.yml
+++ b/testdata/plan/no_diff_routine_set_timezone.yml
@@ -1,7 +1,6 @@
-# GUC names are case-insensitive, and pg_get_functiondef writes the canonical
-# spelling PostgreSQL keeps in proconfig ("TimeZone"), not the one the file
-# used. Both sides are parsed by the same code, so folding the name to lower
-# case there makes the two compare equal.
+# GUC names are case-insensitive, and pg_get_functiondef writes the spelling
+# PostgreSQL keeps in proconfig ("TimeZone"), not the one the file used. Both
+# sides parse through the same code, so folding the name there settles it.
 manage_routine: true
 init: |
   CREATE FUNCTION public.f() RETURNS integer

--- a/testdata/plan/no_diff_routine_set_timezone.yml
+++ b/testdata/plan/no_diff_routine_set_timezone.yml
@@ -1,0 +1,18 @@
+# GUC names are case-insensitive, and pg_get_functiondef writes the canonical
+# spelling PostgreSQL keeps in proconfig ("TimeZone"), not the one the file
+# used. Both sides are parsed by the same code, so folding the name to lower
+# case there makes the two compare equal.
+manage_routine: true
+init: |
+  CREATE FUNCTION public.f() RETURNS integer
+      LANGUAGE sql
+      SET timezone TO 'UTC'
+      SET datestyle TO 'ISO, MDY'
+      AS $$ SELECT 1 $$;
+desired: |
+  CREATE FUNCTION public.f() RETURNS integer
+      LANGUAGE sql
+      SET timezone TO 'UTC'
+      SET datestyle TO 'ISO, MDY'
+      AS $$ SELECT 1 $$;
+plan: ""


### PR DESCRIPTION
Four unrelated bugs that each break the `apply` then `plan` round trip. Every one has a one-line cause, so they are grouped here; the follow-up PR carries the ones that need a few lines each.

Every case below was reproduced against PostgreSQL 16 before the fix.

## `CREATE INDEX IF NOT EXISTS` is dropped and created on every plan

`parseIndexStmt` clears `Concurrent` before deparsing but not `IfNotExists`, so the clause stayed in the stored definition. `pg_get_indexdef` never writes it, so the two sides never compared equal.

```
DROP INDEX public.users_name_idx;
CREATE INDEX IF NOT EXISTS users_name_idx ON public.users USING btree (name);
```

The clause says how to run the statement, not what the index is, so it is dropped rather than carried into the emitted `CREATE INDEX`.

## An enum with no labels is invisible to the catalog

`CREATE TYPE mood AS ENUM ()` has no `pg_enum` row, and the labels were reached through an inner join, so the type read as absent. Every plan created it again, `dump` left it out, and the second apply failed with `type "mood" already exists`.

The join is now outer, and rendering an empty enum writes `AS ENUM (\n);`, which is what `pg_dump` writes for the same type. PostgreSQL accepts the form: `CREATE TYPE` takes an optional label list, the result is a usable type, and labels can be added later with `ALTER TYPE ... ADD VALUE`.

## A routine's `SET timezone` is replaced on every plan

GUC names are case-insensitive and `pg_get_functiondef` writes the spelling PostgreSQL keeps in `proconfig`, so a routine created with `SET timezone` reads back as `SET "TimeZone"` and never matched what the file wrote. `DateStyle` and `IntervalStyle` behaved the same way; `work_mem` and `search_path` did not, which is why it went unnoticed. Both sides parse through `parseRoutineConfig`, so folding the name there is symmetric.

The emitted `CREATE FUNCTION` writes the name in lower case, which is valid and need not match what `pg_dump` writes.

## Widening a `serial` column fails at apply

The change went out as `ALTER TABLE ... SET DATA TYPE bigserial`, which PostgreSQL rejects with `type "bigserial" does not exist`: a serial pseudo-type is accepted only in `CREATE TABLE` and `ADD COLUMN`.

Naming the base type alone is not the whole change. `bigserial` is a `bigint` column and a `bigint` sequence, and `ALTER TABLE` reaches only the column, so the sequence stayed as `serial` created it and kept handing out numbers up to 2147483647. By hand the change is two statements, and both go out now:

```
ALTER SEQUENCE public.users_id_seq AS bigint;
ALTER TABLE public.users ALTER COLUMN id SET DATA TYPE bigint;
```

The catalog reads the name of the sequence a serial column owns, which it already had at hand for the `is_serial` test. PostgreSQL moves the sequence bounds with the type when they are the old type's defaults, so nothing else is needed. The `ALTER SEQUENCE` sorts first because the table's default draws from the sequence; that order applies cleanly and leaves the column, the sequence and the next value all as `bigserial` would have created them.

A column that owns no sequence, and one being retyped to something a sequence cannot hold, take the single statement they always did.

## Tests

Ten fixtures and five unit tests. Each fixture was checked to fail with its fix reverted: removing the `ALTER SEQUENCE` fails the widening fixture, removing only the type guard emits `ALTER SEQUENCE ... AS text` and fails the `serial` to `text` fixture, and restoring the inner join fails the fidelity check.

- `plan/no_diff_index_if_not_exists.yml`, `apply/create_index_if_not_exists.yml`
- `plan/no_diff_empty_enum.yml`, `dump/empty_enum.yml`, `apply/empty_enum.yml`, `plan/add_value_to_empty_enum.yml`
- `plan/no_diff_routine_set_timezone.yml`
- `plan/alter_column_serial_to_bigserial.yml`, `apply/alter_column_serial_to_bigserial.yml`, `plan/alter_column_serial_to_text.yml`
- `test/fidelity/schemas/types.sql` carries an empty enum, so the restore check compares it against `pg_dump`
- unit tests for `alterTypeName`, `alterSerialSequenceSQL`, `alterColumnSQL` and `Enum.SQL`, since CI measures coverage per package and the root fixtures credit nothing to `diff` and `model`

Per-package coverage is 96.2%, the same as `main`. The lines still uncovered in the touched files are pre-existing defensive paths that valid SQL does not reach.

## Also

`LIMITATIONS.md` gains a bug this work turned up rather than introduced. A column is read as a serial when it owns a sequence and its default draws from it, without regard to type, and the default is then dropped from the dump. A serial column retyped to `text` loses its default, and a hand-attached sequence on a `numeric` column loses both the default and the sequence.

`make vet`, `make test`, `make test-scenario` and `make test-fidelity` pass against PostgreSQL 16. `make lint` could not run here: the installed golangci-lint is built with Go 1.25 and refuses a module targeting 1.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iZFWSeiGCSNGi6zT4R81Q