### PR TITLE
Fix seven round-trip breaks that need a few lines each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Read a `serial` column as `NOT NULL`. The type expands to a `NOT NULL` column, and the catalog reports it as one, so a declaration that left the words off planned `DROP NOT NULL` right after the table was created. Applying it took the constraint away.
 
-* Read a column type the way PostgreSQL stores it. A `numeric` with only a precision gains a scale of zero, and an array forgets its dimensions and bounds, so `numeric(5)`, `integer[][]` and `integer[3]` each re-issued the same `ALTER` on every plan.
+* Read a `numeric` written with only a precision. PostgreSQL stores `numeric(5)` as `numeric(5,0)` and `format_type` prints both digits, so the declaration and the catalog never compared equal and every plan re-issued the same `ALTER`.
 
 * Drop a partition that carries a copy of its parent's foreign key. The copy was dropped first, which PostgreSQL rejects with `cannot drop inherited constraint`, and the copy goes with the partition anyway. Dropping the whole partitioned table failed the same way.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Read a primary key added by `ALTER TABLE` as implying `NOT NULL`. PostgreSQL sets the flag whichever way the key arrives, but only the inline form was read that way, so a schema file that adds the key in a later statement planned `DROP NOT NULL` on every run, and applying it failed with `column is in a primary key`.
+* Read a primary key added by `ALTER TABLE` as implying `NOT NULL`. PostgreSQL sets the flag whichever way the key arrives, and only the inline form was read that way. A file that adds the key in a later statement planned `DROP NOT NULL` on every run, and applying it failed with `column is in a primary key`.
 
 * Read a `serial` column as `NOT NULL`. The type expands to a `NOT NULL` column, and the catalog reports it as one, so a declaration that left the words off planned `DROP NOT NULL` right after the table was created. Applying it took the constraint away.
 
@@ -10,11 +10,11 @@
 
 * Drop a partition that carries a copy of its parent's foreign key. The copy was dropped first, which PostgreSQL rejects with `cannot drop inherited constraint`, and the copy goes with the partition anyway. Dropping the whole partitioned table failed the same way.
 
-* Compare a domain's base type the way a column's type is compared. `format_type` writes a base type on the search path unqualified, so a domain written over `public.status` was read as a base type change and every plan failed rather than reporting no changes.
+* Compare a domain's base type the way a column's type is compared. `format_type` writes a base type on the search path unqualified, so a domain written over `public.status` read as a base type change, which cannot be altered, and every plan failed.
 
-* Read only the collation a domain or a composite attribute sets itself. One typed over a collated domain inherits that collation, and reading the inherited one as declared made the desired side look like a collation change, which cannot be altered, so every plan failed.
+* Read only the collation a domain or a composite attribute sets itself. One typed over a collated domain inherits that collation without declaring it, and reading the inherited one as declared made the desired side, which writes none, look like a collation change. A domain's collation cannot be altered, so every plan failed. `dump` no longer writes the inherited clause either, which is what `pg_dump` does.
 
-* Read a `-- pista:` directive on a file written with CRLF line endings. The carriage return was taken as trailing content, which turned `ignore`, `concurrently`, `bulk-alter` and `execute` off silently, since the name is still a known one and nothing was reported.
+* Read a `-- pista:` directive on a file written with CRLF line endings. The carriage return was taken as trailing content, so `ignore`, `concurrently`, `bulk-alter` and `execute` turned off silently: the name is still a known one, so nothing was reported.
 
 * Read `CREATE INDEX IF NOT EXISTS` as the index it describes. The clause was kept in the stored definition, which `pg_get_indexdef` never writes, so an index a schema file spelled that way was dropped and created again on every plan.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 * Compare a domain's base type the way a column's type is compared. `format_type` writes a base type on the search path unqualified, so a domain written over `public.status` read as a base type change, which cannot be altered, and every plan failed.
 
-* Read only the collation a domain or a composite attribute sets itself. One typed over a collated domain inherits that collation without declaring it, and reading the inherited one as declared made the desired side, which writes none, look like a collation change. A domain's collation cannot be altered, so every plan failed. `dump` no longer writes the inherited clause either, which is what `pg_dump` does.
+* **BREAKING**: Read only the collation a domain or a composite attribute sets itself. One typed over a collated domain inherits that collation without declaring it, and reading the inherited one as declared made the desired side, which writes none, look like a collation change. A domain's collation cannot be altered, so every plan failed. `dump` no longer writes the inherited clause either, which is what `pg_dump` does.
+
+  A file an earlier `pista dump` wrote restates the inherited clause, since the old reading wrote it on both sides. Such a file no longer plans: a domain fails with `cannot change collation of domain`, which stops the whole plan, and a composite attribute drifts on every run. Run `pista dump` again to rewrite the file; the new output plans clean. Only a domain or an attribute over a collated type is affected.
 
 * Read a `-- pista:` directive on a file written with CRLF line endings. The carriage return was taken as trailing content, so `ignore`, `concurrently`, `bulk-alter` and `execute` turned off silently: the name is still a known one, so nothing was reported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Read a `serial` column as `NOT NULL`. The type expands to a `NOT NULL` column, and the catalog reports it as one, so a declaration that left the words off planned `DROP NOT NULL` right after the table was created. Applying it took the constraint away.
 
-* Read a column type and a `DEFAULT` the way PostgreSQL stores them. A `numeric` with only a precision gains a scale of zero, an array forgets its dimensions and bounds, and `DEFAULT NULL` is no default at all, so `numeric(5)`, `integer[][]`, `integer[3]` and `DEFAULT NULL` each re-issued the same `ALTER` on every plan.
+* Read a column type the way PostgreSQL stores it. A `numeric` with only a precision gains a scale of zero, and an array forgets its dimensions and bounds, so `numeric(5)`, `integer[][]` and `integer[3]` each re-issued the same `ALTER` on every plan.
 
 * Drop a partition that carries a copy of its parent's foreign key. The copy was dropped first, which PostgreSQL rejects with `cannot drop inherited constraint`, and the copy goes with the partition anyway. Dropping the whole partitioned table failed the same way.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+* Read a primary key added by `ALTER TABLE` as implying `NOT NULL`. PostgreSQL sets the flag whichever way the key arrives, but only the inline form was read that way, so a schema file that adds the key in a later statement planned `DROP NOT NULL` on every run, and applying it failed with `column is in a primary key`.
+
+* Read a `serial` column as `NOT NULL`. The type expands to a `NOT NULL` column, and the catalog reports it as one, so a declaration that left the words off planned `DROP NOT NULL` right after the table was created. Applying it took the constraint away.
+
+* Read a column type and a `DEFAULT` the way PostgreSQL stores them. A `numeric` with only a precision gains a scale of zero, an array forgets its dimensions and bounds, and `DEFAULT NULL` is no default at all, so `numeric(5)`, `integer[][]`, `integer[3]` and `DEFAULT NULL` each re-issued the same `ALTER` on every plan.
+
+* Drop a partition that carries a copy of its parent's foreign key. The copy was dropped first, which PostgreSQL rejects with `cannot drop inherited constraint`, and the copy goes with the partition anyway. Dropping the whole partitioned table failed the same way.
+
+* Compare a domain's base type the way a column's type is compared. `format_type` writes a base type on the search path unqualified, so a domain written over `public.status` was read as a base type change and every plan failed rather than reporting no changes.
+
+* Read only the collation a domain or a composite attribute sets itself. One typed over a collated domain inherits that collation, and reading the inherited one as declared made the desired side look like a collation change, which cannot be altered, so every plan failed.
+
+* Read a `-- pista:` directive on a file written with CRLF line endings. The carriage return was taken as trailing content, which turned `ignore`, `concurrently`, `bulk-alter` and `execute` off silently, since the name is still a known one and nothing was reported.
+
 * Read `CREATE INDEX IF NOT EXISTS` as the index it describes. The clause was kept in the stored definition, which `pg_get_indexdef` never writes, so an index a schema file spelled that way was dropped and created again on every plan.
 
 * Read an enum that has no labels. `CREATE TYPE ... AS ENUM ()` has no `pg_enum` row, and the catalog reached the labels through an inner join, so the type read as absent: every plan created it again and the second apply failed with `type already exists`. `dump` writes it now as well.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -692,3 +692,42 @@ declares a column this way.
 Workaround: write `integer[]`, which is what `pista dump` emits.
 
 Origin: review of the column type canonicalization, 2026-09-08.
+
+## `PRIMARY KEY USING INDEX` in a schema file does not converge
+
+Priority: low.
+
+A primary key can take its columns from an existing unique index rather than
+from a column list:
+
+```sql
+CREATE UNIQUE INDEX t_idx ON public.t (id);
+ALTER TABLE public.t ADD CONSTRAINT t_pkey PRIMARY KEY USING INDEX t_idx;
+```
+
+PostgreSQL takes the index over as the constraint's index and renames it to the
+constraint's name, so afterwards there is one object where the file wrote two.
+The desired side keeps both, so every plan drops the constraint, adds it again
+and creates the index, and the run does not converge:
+
+```
+ALTER TABLE public.t ALTER COLUMN id DROP NOT NULL;
+ALTER TABLE public.t DROP CONSTRAINT t_pkey;
+ALTER TABLE public.t ADD CONSTRAINT t_pkey PRIMARY KEY USING INDEX t_idx;
+CREATE UNIQUE INDEX t_idx ON public.t USING btree (id);
+```
+
+The `DROP NOT NULL` is part of the same gap. A primary key marks its columns
+NOT NULL whichever way it arrives, but this form carries no column list, so the
+key columns are not reached and the statement goes out. Applying it fails with
+`column "id" is in a primary key`.
+
+Closing it means resolving the constraint's columns through the index it names,
+and reading the index the constraint took over as the constraint rather than as
+an index of its own.
+
+`pista dump` writes the key inline, as `CONSTRAINT t_pkey PRIMARY KEY (id)`
+with no separate index, and that output plans clean. Only a file that writes
+`USING INDEX` reaches this.
+
+Origin: review of the primary key NOT NULL fix, 2026-09-09.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -671,3 +671,24 @@ Closing it means gating the serial test on the type, so a column a sequence
 cannot type keeps its default and its sequence surfaces as a standalone one.
 
 Origin: review of the serial retype fix, 2026-09-08.
+
+## Perpetual drift on an array written with dimensions or a bound
+
+Priority: low.
+
+PostgreSQL accepts `integer[3]` and `integer[][]` for SQL standard
+compatibility and enforces neither: a column declared `integer[3]` takes an
+array of any length, one declared `integer[][]` takes an array of any number of
+dimensions, and `format_type` prints both as `integer[]`. The desired side
+keeps what the file wrote, so the two never compare equal and the column is
+retyped on every plan. The statement is harmless to the data and takes an
+ACCESS EXCLUSIVE lock; `plan --check` stays non-zero.
+
+Folding every `[...]` to a single `[]` closes it, but the spelling means
+nothing to PostgreSQL either, so a schema carrying one has already lost what it
+was trying to say. `dump` writes `integer[]`, and none of the sample schemas
+declares a column this way.
+
+Workaround: write `integer[]`, which is what `pista dump` emits.
+
+Origin: review of the column type canonicalization, 2026-09-08.

--- a/catalog/composite_types.go
+++ b/catalog/composite_types.go
@@ -114,10 +114,14 @@ func (c *Catalog) listCompositeAttributes(ctx context.Context, relids []uint32) 
 			a.attrelid,
 			a.attname,
 			pg_catalog.format_type(a.atttypid, a.atttypmod) AS type,
-			(SELECT quote_ident(cn.nspname) || '.' || quote_ident(coll.collname) FROM pg_catalog.pg_collation coll JOIN pg_catalog.pg_namespace cn ON cn.oid = coll.collnamespace WHERE coll.oid = a.attcollation AND a.attcollation <> 0 AND coll.collname <> 'default') AS collation,
+			-- An attribute typed as a collated domain inherits that collation
+			-- rather than declaring one, so compare against the attribute type's
+			-- own collation the way columns.go does.
+			(SELECT quote_ident(cn.nspname) || '.' || quote_ident(coll.collname) FROM pg_catalog.pg_collation coll JOIN pg_catalog.pg_namespace cn ON cn.oid = coll.collnamespace WHERE coll.oid = a.attcollation AND a.attcollation <> at.typcollation) AS collation,
 			d.description
 		FROM
 			pg_catalog.pg_attribute a
+			JOIN pg_catalog.pg_type at ON at.oid = a.atttypid
 			LEFT JOIN pg_catalog.pg_description d ON d.objoid = a.attrelid
 			AND d.classoid = 'pg_class'::regclass
 			AND d.objsubid = a.attnum

--- a/catalog/domains.go
+++ b/catalog/domains.go
@@ -42,11 +42,16 @@ func (c *Catalog) ListDomains(ctx context.Context) ([]*model.Domain, error) {
 			pg_catalog.format_type(t.typbasetype, t.typtypmod) AS base_type,
 			t.typnotnull,
 			pg_catalog.pg_get_expr(t.typdefaultbin, 0) AS default_value,
-			(SELECT quote_ident(cn.nspname) || '.' || quote_ident(c.collname) FROM pg_catalog.pg_collation c JOIN pg_catalog.pg_namespace cn ON cn.oid = c.collnamespace WHERE c.oid = t.typcollation AND t.typcollation <> 0 AND c.collname <> 'default') AS collation,
+			-- A domain over a collated type inherits that collation rather than
+			-- declaring one, and a schema file writes only what was declared.
+			-- Comparing against the base type's collation, the way columns.go
+			-- does, reports only a collation the domain itself sets.
+			(SELECT quote_ident(cn.nspname) || '.' || quote_ident(c.collname) FROM pg_catalog.pg_collation c JOIN pg_catalog.pg_namespace cn ON cn.oid = c.collnamespace WHERE c.oid = t.typcollation AND t.typcollation <> bt.typcollation) AS collation,
 			d.description
 		FROM
 			pg_catalog.pg_type t
 			JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+			JOIN pg_catalog.pg_type bt ON bt.oid = t.typbasetype
 			LEFT JOIN pg_catalog.pg_description d ON d.objoid = t.oid
 			AND d.classoid = 'pg_type'::regclass
 			AND d.objsubid = 0

--- a/diff/domains.go
+++ b/diff/domains.go
@@ -68,9 +68,11 @@ func diffDomain(fqdn string, current, desired *model.Domain) ([]string, error) {
 	var stmts []string
 
 	// Base type change is not supported by PostgreSQL ALTER DOMAIN. The
-	// modifier is folded first, so a base type the catalog reports in mixed
-	// case (geometry(Polygon,4326)) matches the declaration it was read from.
-	if foldTypeMod(current.BaseType) != foldTypeMod(desired.BaseType) {
+	// comparison folds the modifier, so a base type the catalog reports in
+	// mixed case (geometry(Polygon,4326)) matches the declaration it was read
+	// from, and strips the domain's own schema, since format_type writes a base
+	// type on the search path unqualified while a file may name it in full.
+	if !equalTypeName(current.BaseType, desired.BaseType, current.Schema) {
 		return nil, fmt.Errorf("cannot change base type of domain %s from %s to %s: PostgreSQL does not support this", fqdn, current.BaseType, desired.BaseType)
 	}
 

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -86,16 +86,24 @@ func DiffTables(current, desired *orderedmap.Map[string, *model.Table], dc DropC
 	// Dropped tables: drop FKs on dropped tables first to avoid dependency errors.
 	// When the table-drop policy disallows it, emit the same DROPs as comments
 	// (with "-- skipped: " prefix) into DisallowedDropStmts for visibility.
+	// A partition's copy of its parent's key takes no statement: PostgreSQL
+	// rejects dropping it on its own, and it goes with the partition anyway.
 	tableAllowed := dc.IsDropAllowed("table")
 	for k, tbl := range current.All() {
 		if _, ok := desired.GetOk(k); !ok {
 			if tableAllowed {
-				for name := range tbl.ForeignKeys.Keys() {
+				for name, fk := range tbl.ForeignKeys.All() {
+					if fk.Inherited {
+						continue
+					}
 					result.FKDropStmts = append(result.FKDropStmts, "ALTER TABLE "+k+" DROP CONSTRAINT "+model.Ident(name)+";")
 				}
 				result.DropStmts = append(result.DropStmts, "DROP TABLE "+k+";")
 			} else {
-				for name := range tbl.ForeignKeys.Keys() {
+				for name, fk := range tbl.ForeignKeys.All() {
+					if fk.Inherited {
+						continue
+					}
 					result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: ALTER TABLE "+k+" DROP CONSTRAINT "+model.Ident(name)+";")
 				}
 				result.DisallowedDropStmts = append(result.DisallowedDropStmts, "-- skipped: DROP TABLE "+k+";")

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -4114,3 +4114,38 @@ func TestAlterColumnSQL_SerialWidening(t *testing.T) {
 		"ALTER TABLE public.users ALTER COLUMN id SET DATA TYPE bigint;",
 	}, alterColumnSQL("public.users", current, desired))
 }
+
+// A partition holds a copy of its parent's foreign key that PostgreSQL refuses
+// to drop on its own, and the copy goes with the partition, so dropping the
+// partition takes one statement. A key the table owns still takes its own.
+func TestDiffTables_dropTableWithInheritedForeignKey(t *testing.T) {
+	build := func() *orderedmap.Map[string, *model.Table] {
+		m := orderedmap.New[string, *model.Table]()
+		tbl := newTable("public", "logs_2024")
+		tbl.ForeignKeys.Set("logs_user_id_fkey", &model.ForeignKey{
+			Schema: "public", Table: "logs_2024", Name: "logs_user_id_fkey", Inherited: true,
+		})
+		tbl.ForeignKeys.Set("logs_own_fkey", &model.ForeignKey{
+			Schema: "public", Table: "logs_2024", Name: "logs_own_fkey",
+		})
+		m.Set("public.logs_2024", tbl)
+		return m
+	}
+
+	t.Run("drop allowed", func(t *testing.T) {
+		result, err := DiffTables(build(), orderedmap.New[string, *model.Table](), allowAllDrops{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"ALTER TABLE public.logs_2024 DROP CONSTRAINT logs_own_fkey;"}, result.FKDropStmts)
+		assert.Equal(t, []string{"DROP TABLE public.logs_2024;"}, result.DropStmts)
+	})
+
+	t.Run("drop disallowed", func(t *testing.T) {
+		result, err := DiffTables(build(), orderedmap.New[string, *model.Table](), denyAllDrops{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{
+			"-- skipped: ALTER TABLE public.logs_2024 DROP CONSTRAINT logs_own_fkey;",
+			"-- skipped: DROP TABLE public.logs_2024;",
+		}, result.DisallowedDropStmts)
+		assert.Empty(t, result.DropStmts)
+	})
+}

--- a/parser/directive.go
+++ b/parser/directive.go
@@ -9,20 +9,25 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
+// Each anchored pattern ends with \r? so a file written with CRLF line
+// endings reads the same as one written with LF. The carriage return belongs
+// to the line ending, not to the directive, and without this a directive on
+// such a file was silently ignored: it still carries a known name, so
+// validateDirectives raised nothing either.
 var (
-	renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:renamed-from[ \t]+(.+?)[ \t]*$`)
+	renameDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:renamed-from[ \t]+(.+?)[ \t]*\r?$`)
 	// execute-first shares a prefix with execute. The execute pattern accepts
 	// only whitespace or end-of-line after the name, so an execute-first
 	// comment never matches it.
-	executeDirectivePattern      = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:execute(?:[ \t]+(.+?))?[ \t]*$`)
-	executeFirstDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:execute-first(?:[ \t]+(.+?))?[ \t]*$`)
-	concurrentlyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:concurrently[ \t]*$`)
+	executeDirectivePattern      = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:execute(?:[ \t]+(.+?))?[ \t]*\r?$`)
+	executeFirstDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:execute-first(?:[ \t]+(.+?))?[ \t]*\r?$`)
+	concurrentlyDirectivePattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:concurrently[ \t]*\r?$`)
 	// Matches -- pista:concurrently with trailing content (invalid usage).
 	concurrentlyWithArgsPattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:concurrently[ \t]+\S`)
-	bulkAlterDirectivePattern   = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:bulk-alter[ \t]*$`)
+	bulkAlterDirectivePattern   = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:bulk-alter[ \t]*\r?$`)
 	// Matches -- pista:bulk-alter with trailing content (invalid usage).
 	bulkAlterWithArgsPattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:bulk-alter[ \t]+\S`)
-	ignoreDirectivePattern   = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:ignore[ \t]*$`)
+	ignoreDirectivePattern   = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:ignore[ \t]*\r?$`)
 	// Matches -- pista:ignore with trailing content (invalid usage).
 	ignoreWithArgsPattern = regexp.MustCompile(`(?m)^[ \t]*--[ \t]*pista:ignore[ \t]+\S`)
 	// Matches any -- pista: directive, capturing the name (if any) after the colon.

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	pg_query "github.com/pganalyze/pg_query_go/v6"
@@ -751,18 +752,17 @@ GRANT SELECT ON public.a TO someone`,
 // belongs to the line ending, not to the directive, so a directive has to read
 // the same either way. Reading it as trailing content silently turned the
 // directive off, since validateDirectives still saw a known name and raised
-// nothing.
-func TestDirectivesWithCRLFLineEndings(t *testing.T) {
-	tests := []struct {
+// nothing. Trailing spaces are covered alongside, since they reach the same
+// part of each pattern.
+func TestDirectivesAcrossLineEndings(t *testing.T) {
+	bodies := []struct {
 		name  string
 		sql   string
 		check func(t *testing.T, r *ParseResult)
 	}{
 		{
 			name: "ignore",
-			sql: "CREATE TABLE public.a (id integer);\n" +
-				"-- pista:ignore\r\n" +
-				"CREATE TABLE public.b (id integer);\n",
+			sql:  "-- pista:ignore%s\nCREATE TABLE public.b (id integer);\n",
 			check: func(t *testing.T, r *ParseResult) {
 				t.Helper()
 				assert.True(t, r.Tables.Get("public.b").Ignore)
@@ -770,9 +770,7 @@ func TestDirectivesWithCRLFLineEndings(t *testing.T) {
 		},
 		{
 			name: "concurrently",
-			sql: "CREATE TABLE public.a (id integer);\n" +
-				"-- pista:concurrently\r\n" +
-				"CREATE INDEX idx ON public.a (id);\n",
+			sql:  "CREATE TABLE public.a (id integer);\n-- pista:concurrently%s\nCREATE INDEX idx ON public.a (id);\n",
 			check: func(t *testing.T, r *ParseResult) {
 				t.Helper()
 				assert.True(t, r.Tables.Get("public.a").Indexes.Get("idx").Concurrently)
@@ -780,8 +778,7 @@ func TestDirectivesWithCRLFLineEndings(t *testing.T) {
 		},
 		{
 			name: "bulk-alter",
-			sql: "-- pista:bulk-alter\r\n" +
-				"CREATE TABLE public.a (id integer);\n",
+			sql:  "-- pista:bulk-alter%s\nCREATE TABLE public.a (id integer);\n",
 			check: func(t *testing.T, r *ParseResult) {
 				t.Helper()
 				assert.True(t, r.Tables.Get("public.a").BulkAlter)
@@ -789,20 +786,35 @@ func TestDirectivesWithCRLFLineEndings(t *testing.T) {
 		},
 		{
 			name: "execute",
-			sql: "CREATE TABLE public.a (id integer);\n" +
-				"-- pista:execute\r\n" +
-				"GRANT SELECT ON public.a TO someone;\n",
+			sql:  "CREATE TABLE public.a (id integer);\n-- pista:execute%s\nGRANT SELECT ON public.a TO someone;\n",
 			check: func(t *testing.T, r *ParseResult) {
 				t.Helper()
 				require.Len(t, r.ExecuteStmts, 1)
-				assert.Contains(t, r.ExecuteStmts[0].SQL, "GRANT")
+				assert.False(t, r.ExecuteStmts[0].First)
+				assert.Empty(t, r.ExecuteStmts[0].CheckSQL)
+			},
+		},
+		{
+			name: "execute with check",
+			sql:  "CREATE TABLE public.a (id integer);\n-- pista:execute SELECT true%s\nGRANT SELECT ON public.a TO someone;\n",
+			check: func(t *testing.T, r *ParseResult) {
+				t.Helper()
+				require.Len(t, r.ExecuteStmts, 1)
+				assert.Equal(t, "SELECT true", r.ExecuteStmts[0].CheckSQL)
+			},
+		},
+		{
+			name: "execute-first",
+			sql:  "CREATE TABLE public.a (id integer);\n-- pista:execute-first%s\nGRANT SELECT ON public.a TO someone;\n",
+			check: func(t *testing.T, r *ParseResult) {
+				t.Helper()
+				require.Len(t, r.ExecuteStmts, 1)
+				assert.True(t, r.ExecuteStmts[0].First)
 			},
 		},
 		{
 			name: "renamed-from",
-			sql: "CREATE TABLE public.a (id integer);\n" +
-				"-- pista:renamed-from public.old_b\r\n" +
-				"CREATE TABLE public.b (id integer);\n",
+			sql:  "-- pista:renamed-from public.old_b%s\nCREATE TABLE public.b (id integer);\n",
 			check: func(t *testing.T, r *ParseResult) {
 				t.Helper()
 				b := r.Tables.Get("public.b")
@@ -812,14 +824,40 @@ func TestDirectivesWithCRLFLineEndings(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var warnings bytes.Buffer
-			defer SetWarnWriter(&warnings)()
+	endings := []struct{ name, text string }{
+		{"lf", ""},
+		{"crlf", "\r"},
+		{"trailing space, lf", "   "},
+		{"trailing space, crlf", "  \r"},
+	}
 
-			r, err := parseSQLWithSchema(tt.sql, "public", nil)
-			require.NoError(t, err)
-			tt.check(t, r)
+	for _, body := range bodies {
+		t.Run(body.name, func(t *testing.T) {
+			for _, ending := range endings {
+				t.Run(ending.name, func(t *testing.T) {
+					r, err := parseSQLWithSchema(strings.ReplaceAll(body.sql, "%s", ending.text), "public", nil)
+					require.NoError(t, err)
+					body.check(t, r)
+				})
+			}
+		})
+	}
+}
+
+// The carriage return is part of the line ending, so it is not an argument.
+// The patterns that reject an argument look for a space or a tab and then a
+// non-space, which a bare CRLF directive does not match.
+func TestValidateDirectivesAcrossLineEndings(t *testing.T) {
+	for _, ending := range []struct{ name, text string }{{"lf", ""}, {"crlf", "\r"}} {
+		t.Run(ending.name, func(t *testing.T) {
+			assert.NoError(t, validateDirectives("-- pista:ignore"+ending.text))
+			assert.NoError(t, validateDirectives("-- pista:concurrently"+ending.text))
+			assert.NoError(t, validateDirectives("-- pista:bulk-alter"+ending.text))
+
+			assert.Error(t, validateDirectives("-- pista:ignore extra"+ending.text))
+			assert.Error(t, validateDirectives("-- pista:concurrently extra"+ending.text))
+			assert.Error(t, validateDirectives("-- pista:bulk-alter extra"+ending.text))
+			assert.Error(t, validateDirectives("-- pista:unknown"+ending.text))
 		})
 	}
 }

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -747,6 +747,83 @@ GRANT SELECT ON public.a TO someone`,
 	}
 }
 
+// A file written on Windows ends each line with CRLF. The carriage return
+// belongs to the line ending, not to the directive, so a directive has to read
+// the same either way. Reading it as trailing content silently turned the
+// directive off, since validateDirectives still saw a known name and raised
+// nothing.
+func TestDirectivesWithCRLFLineEndings(t *testing.T) {
+	tests := []struct {
+		name  string
+		sql   string
+		check func(t *testing.T, r *ParseResult)
+	}{
+		{
+			name: "ignore",
+			sql: "CREATE TABLE public.a (id integer);\n" +
+				"-- pista:ignore\r\n" +
+				"CREATE TABLE public.b (id integer);\n",
+			check: func(t *testing.T, r *ParseResult) {
+				t.Helper()
+				assert.True(t, r.Tables.Get("public.b").Ignore)
+			},
+		},
+		{
+			name: "concurrently",
+			sql: "CREATE TABLE public.a (id integer);\n" +
+				"-- pista:concurrently\r\n" +
+				"CREATE INDEX idx ON public.a (id);\n",
+			check: func(t *testing.T, r *ParseResult) {
+				t.Helper()
+				assert.True(t, r.Tables.Get("public.a").Indexes.Get("idx").Concurrently)
+			},
+		},
+		{
+			name: "bulk-alter",
+			sql: "-- pista:bulk-alter\r\n" +
+				"CREATE TABLE public.a (id integer);\n",
+			check: func(t *testing.T, r *ParseResult) {
+				t.Helper()
+				assert.True(t, r.Tables.Get("public.a").BulkAlter)
+			},
+		},
+		{
+			name: "execute",
+			sql: "CREATE TABLE public.a (id integer);\n" +
+				"-- pista:execute\r\n" +
+				"GRANT SELECT ON public.a TO someone;\n",
+			check: func(t *testing.T, r *ParseResult) {
+				t.Helper()
+				require.Len(t, r.ExecuteStmts, 1)
+				assert.Contains(t, r.ExecuteStmts[0].SQL, "GRANT")
+			},
+		},
+		{
+			name: "renamed-from",
+			sql: "CREATE TABLE public.a (id integer);\n" +
+				"-- pista:renamed-from public.old_b\r\n" +
+				"CREATE TABLE public.b (id integer);\n",
+			check: func(t *testing.T, r *ParseResult) {
+				t.Helper()
+				b := r.Tables.Get("public.b")
+				require.NotNil(t, b.RenameFrom)
+				assert.Equal(t, "public.old_b", *b.RenameFrom)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var warnings bytes.Buffer
+			defer SetWarnWriter(&warnings)()
+
+			r, err := parseSQLWithSchema(tt.sql, "public", nil)
+			require.NoError(t, err)
+			tt.check(t, r)
+		})
+	}
+}
+
 func TestFindLeadingCommentEnd(t *testing.T) {
 	tests := []struct {
 		name string

--- a/parser/directive_test.go
+++ b/parser/directive_test.go
@@ -850,14 +850,14 @@ func TestDirectivesAcrossLineEndings(t *testing.T) {
 func TestValidateDirectivesAcrossLineEndings(t *testing.T) {
 	for _, ending := range []struct{ name, text string }{{"lf", ""}, {"crlf", "\r"}} {
 		t.Run(ending.name, func(t *testing.T) {
-			assert.NoError(t, validateDirectives("-- pista:ignore"+ending.text))
-			assert.NoError(t, validateDirectives("-- pista:concurrently"+ending.text))
-			assert.NoError(t, validateDirectives("-- pista:bulk-alter"+ending.text))
+			require.NoError(t, validateDirectives("-- pista:ignore"+ending.text))
+			require.NoError(t, validateDirectives("-- pista:concurrently"+ending.text))
+			require.NoError(t, validateDirectives("-- pista:bulk-alter"+ending.text))
 
-			assert.Error(t, validateDirectives("-- pista:ignore extra"+ending.text))
-			assert.Error(t, validateDirectives("-- pista:concurrently extra"+ending.text))
-			assert.Error(t, validateDirectives("-- pista:bulk-alter extra"+ending.text))
-			assert.Error(t, validateDirectives("-- pista:unknown"+ending.text))
+			require.Error(t, validateDirectives("-- pista:ignore extra"+ending.text))
+			require.Error(t, validateDirectives("-- pista:concurrently extra"+ending.text))
+			require.Error(t, validateDirectives("-- pista:bulk-alter extra"+ending.text))
+			require.Error(t, validateDirectives("-- pista:unknown"+ending.text))
 		})
 	}
 }

--- a/parser/export_test.go
+++ b/parser/export_test.go
@@ -11,6 +11,14 @@ var (
 	AnnotateError      = annotateError
 )
 
+// The type name normalization runs on every column, so it is tested on its
+// own rather than only through the schemas that reach it.
+var (
+	NormalizeTypeName = normalizeTypeName
+	SplitTypeSuffix   = splitTypeSuffix
+	FillNumericScale  = fillNumericScale
+)
+
 // ParseSQLWithSchema parses SQL that came from no file, which is how most
 // parser tests call in. A warning then names no position.
 func ParseSQLWithSchema(sql string, defaultSchema string) (*ParseResult, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -707,13 +707,6 @@ func collationFromClause(cc *pg_query.CollateClause) *string {
 	return &collation
 }
 
-// serialTypes lists the pseudo-types that expand to a column plus a sequence.
-var serialTypes = map[string]bool{
-	"serial":      true,
-	"bigserial":   true,
-	"smallserial": true,
-}
-
 // applyPrimaryKeyNotNull marks the key columns of a primary key NOT NULL.
 // PostgreSQL sets the flag itself whichever way the key arrives, inline with
 // the table or in a later ALTER TABLE, and the catalog reports it, so the
@@ -729,6 +722,13 @@ func applyPrimaryKeyNotNull(table *model.Table, con *model.Constraint) {
 			col.NotNull = true
 		}
 	}
+}
+
+// serialTypes lists the pseudo-types that expand to a column plus a sequence.
+var serialTypes = map[string]bool{
+	"serial":      true,
+	"bigserial":   true,
+	"smallserial": true,
 }
 
 func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -490,6 +490,7 @@ func parseSQLWithSchema(sql string, defaultSchema string, spans []fileSpan) (*Pa
 				if err := setUnique(t.Constraints, con.Name, "constraint", con, fqtn, stmtOffset); err != nil {
 					return nil, err
 				}
+				applyPrimaryKeyNotNull(t, con)
 			}
 
 		case node.GetCreatePolicyStmt() != nil:
@@ -674,14 +675,7 @@ func parseCreateStmt(cs *pg_query.CreateStmt, defaultSchema string) (*model.Tabl
 					if err := setUnique(table.Constraints, constraint.Name, "constraint", constraint, table.FQTN(), con.Location); err != nil {
 						return nil, err
 					}
-					// PK implies NOT NULL on all key columns
-					if constraint.Type.IsPrimaryKeyConstraint() {
-						for _, colName := range constraint.Columns {
-							if col, ok := table.Columns.GetOk(colName); ok {
-								col.NotNull = true
-							}
-						}
-					}
+					applyPrimaryKeyNotNull(table, constraint)
 				}
 			}
 		}
@@ -713,6 +707,46 @@ func collationFromClause(cc *pg_query.CollateClause) *string {
 	return &collation
 }
 
+// serialTypes lists the pseudo-types that expand to a column plus a sequence.
+var serialTypes = map[string]bool{
+	"serial":      true,
+	"bigserial":   true,
+	"smallserial": true,
+}
+
+// isNullDefault reports whether a DEFAULT expression is the null constant,
+// with or without a cast. PostgreSQL drops such a default rather than storing
+// it, so the desired side has to drop it too.
+func isNullDefault(expr *pg_query.Node) bool {
+	for {
+		if c := expr.GetAConst(); c != nil {
+			return c.Isnull
+		}
+		tc := expr.GetTypeCast()
+		if tc == nil || tc.Arg == nil {
+			return false
+		}
+		expr = tc.Arg
+	}
+}
+
+// applyPrimaryKeyNotNull marks the key columns of a primary key NOT NULL.
+// PostgreSQL sets the flag itself whichever way the key arrives, inline with
+// the table or in a later ALTER TABLE, and the catalog reports it, so the
+// desired side has to read both forms the same way. Reading only the inline
+// one planned a DROP NOT NULL that PostgreSQL then refuses with "column is in
+// a primary key".
+func applyPrimaryKeyNotNull(table *model.Table, con *model.Constraint) {
+	if !con.Type.IsPrimaryKeyConstraint() {
+		return
+	}
+	for _, colName := range con.Columns {
+		if col, ok := table.Columns.GetOk(colName); ok {
+			col.NotNull = true
+		}
+	}
+}
+
 func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 	col := &model.Column{
 		Name: cd.Colname,
@@ -724,6 +758,14 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 			return nil, fmt.Errorf("failed to deparse type for column %s: %w", cd.Colname, err)
 		}
 		col.TypeName = typeName
+	}
+
+	// serial expands to a NOT NULL column plus a sequence and a default, so a
+	// declaration that leaves the words off still describes a NOT NULL column.
+	// The catalog reports it that way, so reading it as nullable planned a
+	// DROP NOT NULL right after the table was created.
+	if serialTypes[col.TypeName] {
+		col.NotNull = true
 	}
 
 	col.Collation = collationFromClause(cd.CollClause)
@@ -743,7 +785,10 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 				col.NotNullName = &name
 			}
 		case pg_query.ConstrType_CONSTR_DEFAULT:
-			if con.RawExpr != nil {
+			// DEFAULT NULL is what a column without a default already does, and
+			// PostgreSQL stores no pg_attrdef row for it, so keeping it would
+			// plan SET DEFAULT NULL on every run.
+			if con.RawExpr != nil && !isNullDefault(con.RawExpr) {
 				def, err := deparseExpr(con.RawExpr)
 				if err != nil {
 					return nil, fmt.Errorf("failed to deparse default for column %s: %w", cd.Colname, err)
@@ -2254,9 +2299,52 @@ func normalizeTypeName(name string) string {
 	suffix = strings.ReplaceAll(suffix, ", ", ",")
 
 	if canonical, ok := typeAliases[base]; ok {
-		return canonical + suffix
+		base = canonical
 	}
-	return base + suffix
+
+	mod, array := splitTypeSuffix(suffix)
+	if base == "numeric" {
+		mod = fillNumericScale(mod)
+	}
+	// PostgreSQL keeps neither the dimension count nor a bound: every array
+	// column reads back from format_type as a single "[]". Written any other
+	// way, the two sides would never compare equal.
+	if array != "" {
+		array = "[]"
+	}
+
+	return base + mod + array
+}
+
+// splitTypeSuffix separates a type's modifier from its array marker:
+// "(10,2)[]" becomes "(10,2)" and "[]".
+func splitTypeSuffix(suffix string) (mod, array string) {
+	if strings.HasPrefix(suffix, "(") {
+		if end := strings.Index(suffix, ")"); end != -1 {
+			return suffix[:end+1], suffix[end+1:]
+		}
+		return suffix, ""
+	}
+	return "", suffix
+}
+
+// fillNumericScale writes the scale a numeric modifier leaves out. PostgreSQL
+// takes "numeric(5)" as "numeric(5,0)" and format_type prints both digits, so
+// without this the declaration and the catalog never compare equal.
+func fillNumericScale(mod string) string {
+	if mod == "" || strings.Contains(mod, ",") {
+		return mod
+	}
+	precision := strings.TrimSuffix(strings.TrimPrefix(mod, "("), ")")
+	if precision == "" {
+		return mod
+	}
+	for _, r := range precision {
+		if r < '0' || r > '9' {
+			return mod
+		}
+	}
+	return "(" + precision + ",0)"
 }
 
 func deparseExpr(node *pg_query.Node) (string, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2283,15 +2283,11 @@ func normalizeTypeName(name string) string {
 		base = canonical
 	}
 
+	// The array marker is separated so a modifier on an array type is reached:
+	// numeric(5)[] is stored as numeric(5,0)[].
 	mod, array := splitTypeSuffix(suffix)
 	if base == "numeric" {
 		mod = fillNumericScale(mod)
-	}
-	// PostgreSQL keeps neither the dimension count nor a bound: every array
-	// column reads back from format_type as a single "[]". Written any other
-	// way, the two sides would never compare equal.
-	if array != "" {
-		array = "[]"
 	}
 
 	return base + mod + array

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -714,22 +714,6 @@ var serialTypes = map[string]bool{
 	"smallserial": true,
 }
 
-// isNullDefault reports whether a DEFAULT expression is the null constant,
-// with or without a cast. PostgreSQL drops such a default rather than storing
-// it, so the desired side has to drop it too.
-func isNullDefault(expr *pg_query.Node) bool {
-	for {
-		if c := expr.GetAConst(); c != nil {
-			return c.Isnull
-		}
-		tc := expr.GetTypeCast()
-		if tc == nil || tc.Arg == nil {
-			return false
-		}
-		expr = tc.Arg
-	}
-}
-
 // applyPrimaryKeyNotNull marks the key columns of a primary key NOT NULL.
 // PostgreSQL sets the flag itself whichever way the key arrives, inline with
 // the table or in a later ALTER TABLE, and the catalog reports it, so the
@@ -785,10 +769,7 @@ func parseColumnDef(cd *pg_query.ColumnDef) (*model.Column, error) {
 				col.NotNullName = &name
 			}
 		case pg_query.ConstrType_CONSTR_DEFAULT:
-			// DEFAULT NULL is what a column without a default already does, and
-			// PostgreSQL stores no pg_attrdef row for it, so keeping it would
-			// plan SET DEFAULT NULL on every run.
-			if con.RawExpr != nil && !isNullDefault(con.RawExpr) {
+			if con.RawExpr != nil {
 				def, err := deparseExpr(con.RawExpr)
 				if err != nil {
 					return nil, fmt.Errorf("failed to deparse default for column %s: %w", cd.Colname, err)

--- a/parser/typename_test.go
+++ b/parser/typename_test.go
@@ -1,0 +1,90 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+// The normalization reaches the diff through every column, so an alias or a
+// modifier it renders differently from format_type drifts on every plan. The
+// cases below fix both the shape it changes and the shapes it leaves alone.
+func TestNormalizeTypeName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain type", "integer", "integer"},
+		{"alias", "varchar(255)", "character varying(255)"},
+		{"alias without modifier", "float", "double precision"},
+		{"alias with time zone", "timestamptz", "timestamp with time zone"},
+		{"modifier spacing", "numeric(10, 2)", "numeric(10,2)"},
+
+		// PostgreSQL takes a numeric with only a precision as a scale of zero
+		// and format_type prints both digits.
+		{"numeric precision only", "numeric(5)", "numeric(5,0)"},
+		{"numeric alias precision only", "decimal(7)", "numeric(7,0)"},
+		{"numeric with scale", "numeric(10,2)", "numeric(10,2)"},
+		{"numeric without modifier", "numeric", "numeric"},
+		{"numeric array precision only", "numeric(5)[]", "numeric(5,0)[]"},
+		{"numeric array with scale", "numeric(10,2)[]", "numeric(10,2)[]"},
+
+		// A type of another schema keeps its own modifier, whatever it is
+		// named.
+		{"qualified numeric", "myschema.numeric(5)", "myschema.numeric(5)"},
+
+		// PostgreSQL accepts these and enforces neither, so they are left as
+		// written; see LIMITATIONS.
+		{"array", "text[]", "text[]"},
+		{"multidimensional array", "integer[][]", "integer[][]"},
+		{"bounded array", "integer[3]", "integer[3]"},
+
+		// The modifier is not a plain precision, so there is no scale to fill.
+		{"mixed case modifier", "geometry(Polygon,4326)", "geometry(Polygon,4326)"},
+		{"interval field", "interval(6)", "interval(6)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parser.NormalizeTypeName(tt.in))
+		})
+	}
+}
+
+func TestSplitTypeSuffix(t *testing.T) {
+	tests := []struct {
+		name             string
+		suffix           string
+		wantMod, wantArr string
+	}{
+		{"empty", "", "", ""},
+		{"modifier only", "(10,2)", "(10,2)", ""},
+		{"array only", "[]", "", "[]"},
+		{"modifier and array", "(10,2)[]", "(10,2)", "[]"},
+		{"bounded array", "[3]", "", "[3]"},
+		// Deparse output always closes its parenthesis, so this only guards
+		// against losing the text.
+		{"unterminated modifier", "(10", "(10", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mod, array := parser.SplitTypeSuffix(tt.suffix)
+			assert.Equal(t, tt.wantMod, mod)
+			assert.Equal(t, tt.wantArr, array)
+			assert.Equal(t, tt.suffix, mod+array, "the two halves rejoin to the input")
+		})
+	}
+}
+
+func TestFillNumericScale(t *testing.T) {
+	assert.Equal(t, "(5,0)", parser.FillNumericScale("(5)"))
+	assert.Equal(t, "(10,2)", parser.FillNumericScale("(10,2)"))
+	assert.Empty(t, parser.FillNumericScale(""))
+	assert.Equal(t, "()", parser.FillNumericScale("()"))
+	// Not a plain precision, so it is left alone rather than guessed at.
+	assert.Equal(t, "(Polygon)", parser.FillNumericScale("(Polygon)"))
+	assert.Equal(t, "(5 )", parser.FillNumericScale("(5 )"))
+}

--- a/testdata/apply/composite_attribute_restating_inherited_collation.yml
+++ b/testdata/apply/composite_attribute_restating_inherited_collation.yml
@@ -1,0 +1,29 @@
+# The other half of the shape an earlier pista dump wrote. An attribute takes
+# the softer failure than a domain does: the collation is a type change rather
+# than a refusal, so the statement goes out, applying it leaves the catalog
+# reading unchanged, and the same statement comes back on the next run.
+# Running pista dump again rewrites the file without the clause.
+skip_drift_check: true
+init: |
+  CREATE DOMAIN public.ctext AS text COLLATE "C";
+  CREATE TYPE public.addr AS (
+      zip public.ctext,
+      city text
+  );
+desired: |
+  CREATE DOMAIN public.ctext AS text COLLATE "C";
+  CREATE TYPE public.addr AS (
+      zip ctext COLLATE pg_catalog."C",
+      city text
+  );
+applied_sql: |
+  ALTER TYPE public.addr ALTER ATTRIBUTE zip TYPE ctext COLLATE pg_catalog."C";
+applied: |
+  -- public.ctext
+  CREATE DOMAIN public.ctext AS text COLLATE pg_catalog."C";
+
+  -- public.addr
+  CREATE TYPE public.addr AS (
+      zip ctext,
+      city text
+  );

--- a/testdata/apply/drop_partition_with_inherited_foreign_key.yml
+++ b/testdata/apply/drop_partition_with_inherited_foreign_key.yml
@@ -1,0 +1,49 @@
+# The partition goes with the copy of its parent's foreign key, so dropping it
+# takes one statement. Emitting a DROP CONSTRAINT for the copy first failed
+# with "cannot drop inherited constraint".
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      at date NOT NULL,
+      CONSTRAINT logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users (id)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2024 PARTITION OF public.logs FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      at date NOT NULL,
+      CONSTRAINT logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users (id)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+applied: |
+  -- public.logs
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      at date NOT NULL
+  )
+  PARTITION BY RANGE (at);
+
+  ALTER TABLE public.logs ADD CONSTRAINT logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
+
+  -- public.logs_2025
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/apply/drop_partitioned_table_with_foreign_key.yml
+++ b/testdata/apply/drop_partitioned_table_with_foreign_key.yml
@@ -1,0 +1,31 @@
+# Dropping the whole partitioned table takes the parent's key and the
+# partitions. The parent's key is its own, so it goes out; the partition's copy
+# of it does not, and PostgreSQL would refuse it anyway.
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.logs (
+      uid integer NOT NULL,
+      at date NOT NULL,
+      CONSTRAINT logs_uid_fkey FOREIGN KEY (uid) REFERENCES public.users (id)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2024 PARTITION OF public.logs FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+applied_sql: |
+  ALTER TABLE public.logs DROP CONSTRAINT logs_uid_fkey;
+  DROP TABLE public.logs_2024;
+  DROP TABLE public.logs;
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/plan/domain_restating_inherited_collation.yml
+++ b/testdata/plan/domain_restating_inherited_collation.yml
@@ -1,0 +1,11 @@
+# A file an earlier pista dump wrote restates the collation the domain
+# inherits, since the old reading wrote it on both sides. The catalog reports
+# none for it now, so the file looks like a collation change, which cannot be
+# altered. Running pista dump again rewrites the file without the clause.
+init: |
+  CREATE DOMAIN public.ctext AS text COLLATE "C";
+  CREATE DOMAIN public.ctext2 AS public.ctext;
+desired: |
+  CREATE DOMAIN public.ctext AS text COLLATE "C";
+  CREATE DOMAIN public.ctext2 AS ctext COLLATE pg_catalog."C";
+error: cannot change collation of domain public.ctext2

--- a/testdata/plan/drop_partition_with_inherited_foreign_key.yml
+++ b/testdata/plan/drop_partition_with_inherited_foreign_key.yml
@@ -1,0 +1,33 @@
+# A partition carries a copy of its parent's foreign key, and PostgreSQL
+# refuses to drop that copy on its own: it goes with the partition. Emitting a
+# DROP CONSTRAINT for it failed with "cannot drop inherited constraint", and
+# the same plan came back on every run.
+drop_policy:
+  allow_drop: [all]
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      at date NOT NULL,
+      CONSTRAINT logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users (id)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2024 PARTITION OF public.logs FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.logs (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      at date NOT NULL,
+      CONSTRAINT logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users (id)
+  ) PARTITION BY RANGE (at);
+  CREATE TABLE public.logs_2025 PARTITION OF public.logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+plan: |
+  DROP TABLE public.logs_2024;

--- a/testdata/plan/no_diff_alter_table_add_primary_key.yml
+++ b/testdata/plan/no_diff_alter_table_add_primary_key.yml
@@ -1,0 +1,17 @@
+# A PRIMARY KEY implies NOT NULL on its columns, and PostgreSQL sets the flag
+# whether the key arrives with the table or in a later ALTER. Reading it only
+# from the inline form planned DROP NOT NULL on every run, and applying that
+# fails with "column is in a primary key".
+init: |
+  CREATE TABLE public.users (
+      id integer,
+      name text
+  );
+  ALTER TABLE public.users ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+desired: |
+  CREATE TABLE public.users (
+      id integer,
+      name text
+  );
+  ALTER TABLE public.users ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+plan: ""

--- a/testdata/plan/no_diff_alter_table_add_primary_key.yml
+++ b/testdata/plan/no_diff_alter_table_add_primary_key.yml
@@ -1,17 +1,30 @@
 # A PRIMARY KEY implies NOT NULL on its columns, and PostgreSQL sets the flag
 # whether the key arrives with the table or in a later ALTER. Reading it only
 # from the inline form planned DROP NOT NULL on every run, and applying that
-# fails with "column is in a primary key".
+# fails with "column is in a primary key". Every key column is reached, not
+# just the first.
 init: |
   CREATE TABLE public.users (
       id integer,
       name text
   );
   ALTER TABLE public.users ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+  CREATE TABLE public.memberships (
+      user_id integer,
+      group_id integer,
+      role text
+  );
+  ALTER TABLE public.memberships ADD CONSTRAINT memberships_pkey PRIMARY KEY (user_id, group_id);
 desired: |
   CREATE TABLE public.users (
       id integer,
       name text
   );
   ALTER TABLE public.users ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+  CREATE TABLE public.memberships (
+      user_id integer,
+      group_id integer,
+      role text
+  );
+  ALTER TABLE public.memberships ADD CONSTRAINT memberships_pkey PRIMARY KEY (user_id, group_id);
 plan: ""

--- a/testdata/plan/no_diff_column_type_canonicalization.yml
+++ b/testdata/plan/no_diff_column_type_canonicalization.yml
@@ -1,0 +1,23 @@
+# PostgreSQL canonicalizes each of these as it stores the column: a numeric
+# with only a precision gains a scale of zero, an array forgets its dimensions
+# and bounds, and DEFAULT NULL is no default at all. The desired side has to
+# read them the same way or every plan re-issues the same ALTER.
+init: |
+  CREATE TABLE public.t (
+      a numeric(5),
+      b decimal(7),
+      c integer[][],
+      d integer[3],
+      e text DEFAULT NULL,
+      f numeric(10,2)[]
+  );
+desired: |
+  CREATE TABLE public.t (
+      a numeric(5),
+      b decimal(7),
+      c integer[][],
+      d integer[3],
+      e text DEFAULT NULL,
+      f numeric(10,2)[]
+  );
+plan: ""

--- a/testdata/plan/no_diff_column_type_canonicalization.yml
+++ b/testdata/plan/no_diff_column_type_canonicalization.yml
@@ -1,15 +1,14 @@
 # PostgreSQL canonicalizes each of these as it stores the column: a numeric
-# with only a precision gains a scale of zero, an array forgets its dimensions
-# and bounds, and DEFAULT NULL is no default at all. The desired side has to
-# read them the same way or every plan re-issues the same ALTER.
+# with only a precision gains a scale of zero, and an array forgets its
+# dimensions and bounds. The desired side has to read them the same way or
+# every plan re-issues the same ALTER.
 init: |
   CREATE TABLE public.t (
       a numeric(5),
       b decimal(7),
       c integer[][],
       d integer[3],
-      e text DEFAULT NULL,
-      f numeric(10,2)[]
+      e numeric(10,2)[]
   );
 desired: |
   CREATE TABLE public.t (
@@ -17,7 +16,6 @@ desired: |
       b decimal(7),
       c integer[][],
       d integer[3],
-      e text DEFAULT NULL,
-      f numeric(10,2)[]
+      e numeric(10,2)[]
   );
 plan: ""

--- a/testdata/plan/no_diff_column_type_canonicalization.yml
+++ b/testdata/plan/no_diff_column_type_canonicalization.yml
@@ -1,21 +1,19 @@
-# PostgreSQL canonicalizes each of these as it stores the column: a numeric
-# with only a precision gains a scale of zero, and an array forgets its
-# dimensions and bounds. The desired side has to read them the same way or
-# every plan re-issues the same ALTER.
+# A numeric written with only a precision is stored with a scale of zero, and
+# format_type prints both digits. The desired side has to read it the same way
+# or every plan re-issues the same ALTER. The marker is separated from the
+# modifier so an array of the type is reached as well.
 init: |
   CREATE TABLE public.t (
       a numeric(5),
       b decimal(7),
-      c integer[][],
-      d integer[3],
-      e numeric(10,2)[]
+      c numeric(5)[],
+      d numeric(10,2)
   );
 desired: |
   CREATE TABLE public.t (
       a numeric(5),
       b decimal(7),
-      c integer[][],
-      d integer[3],
-      e numeric(10,2)[]
+      c numeric(5)[],
+      d numeric(10,2)
   );
 plan: ""

--- a/testdata/plan/no_diff_domain_over_collated_domain.yml
+++ b/testdata/plan/no_diff_domain_over_collated_domain.yml
@@ -1,13 +1,17 @@
 # A domain over a collated domain inherits its collation rather than declaring
 # one. Reading the inherited collation as explicit made the desired side, which
 # writes none, look like a collation change, and a domain's collation cannot be
-# altered, so every plan failed instead of merely drifting.
+# altered, so every plan failed instead of merely drifting. A collation the
+# domain or the attribute sets itself, whether over an uncollated type or over
+# a collated one, is still read.
 init: |
   CREATE DOMAIN public.ctext AS text COLLATE "C";
   CREATE DOMAIN public.ctext2 AS public.ctext;
-  CREATE TYPE public.addr AS (zip public.ctext, city text);
+  CREATE DOMAIN public.ctext3 AS public.ctext COLLATE "POSIX";
+  CREATE TYPE public.addr AS (zip public.ctext, city text, note text COLLATE "C");
 desired: |
   CREATE DOMAIN public.ctext AS text COLLATE "C";
   CREATE DOMAIN public.ctext2 AS ctext;
-  CREATE TYPE public.addr AS (zip ctext, city text);
+  CREATE DOMAIN public.ctext3 AS ctext COLLATE "POSIX";
+  CREATE TYPE public.addr AS (zip ctext, city text, note text COLLATE "C");
 plan: ""

--- a/testdata/plan/no_diff_domain_over_collated_domain.yml
+++ b/testdata/plan/no_diff_domain_over_collated_domain.yml
@@ -1,0 +1,13 @@
+# A domain over a collated domain inherits its collation rather than declaring
+# one. Reading the inherited collation as explicit made the desired side, which
+# writes none, look like a collation change, and a domain's collation cannot be
+# altered, so every plan failed instead of merely drifting.
+init: |
+  CREATE DOMAIN public.ctext AS text COLLATE "C";
+  CREATE DOMAIN public.ctext2 AS public.ctext;
+  CREATE TYPE public.addr AS (zip public.ctext, city text);
+desired: |
+  CREATE DOMAIN public.ctext AS text COLLATE "C";
+  CREATE DOMAIN public.ctext2 AS ctext;
+  CREATE TYPE public.addr AS (zip ctext, city text);
+plan: ""

--- a/testdata/plan/no_diff_domain_over_schema_qualified_enum.yml
+++ b/testdata/plan/no_diff_domain_over_schema_qualified_enum.yml
@@ -1,0 +1,10 @@
+# format_type writes a base type that is on the search path unqualified, so a
+# domain written over public.status was compared as "status" against
+# "public.status". A base type cannot be altered, so every plan failed.
+init: |
+  CREATE TYPE public.status AS ENUM ('draft', 'published');
+  CREATE DOMAIN public.status_dom AS public.status;
+desired: |
+  CREATE TYPE public.status AS ENUM ('draft', 'published');
+  CREATE DOMAIN public.status_dom AS public.status;
+plan: ""

--- a/testdata/plan/no_diff_numeric_precision.yml
+++ b/testdata/plan/no_diff_numeric_precision.yml
@@ -1,7 +1,7 @@
 # A numeric written with only a precision is stored with a scale of zero, and
-# format_type prints both digits. The desired side has to read it the same way
-# or every plan re-issues the same ALTER. The marker is separated from the
-# modifier so an array of the type is reached as well.
+# format_type prints both digits, so the two sides have to read it the same way
+# or every plan re-issues the same ALTER. The array marker is separated from
+# the modifier so an array of the type is reached as well.
 init: |
   CREATE TABLE public.t (
       a numeric(5),

--- a/testdata/plan/no_diff_serial_without_not_null.yml
+++ b/testdata/plan/no_diff_serial_without_not_null.yml
@@ -4,11 +4,15 @@
 init: |
   CREATE TABLE public.users (
       id serial,
+      big bigserial,
+      small smallserial,
       name text
   );
 desired: |
   CREATE TABLE public.users (
       id serial,
+      big bigserial,
+      small smallserial,
       name text
   );
 plan: ""

--- a/testdata/plan/no_diff_serial_without_not_null.yml
+++ b/testdata/plan/no_diff_serial_without_not_null.yml
@@ -1,0 +1,14 @@
+# serial expands to a NOT NULL column, so a file that leaves the words off
+# still describes a NOT NULL column. Reading it as nullable planned
+# DROP NOT NULL right after the table was created.
+init: |
+  CREATE TABLE public.users (
+      id serial,
+      name text
+  );
+desired: |
+  CREATE TABLE public.users (
+      id serial,
+      name text
+  );
+plan: ""


### PR DESCRIPTION
Six bugs that each break the `apply` then `plan` round trip. #544 carried the ones with a one-line cause; these need a few lines each. Every case was reproduced against PostgreSQL 16 before the fix.

Four of them reach only a hand-written schema, since `pista dump` writes the form that avoids them. The partition drop and the inherited collation reach a dump too.

The collation change is marked BREAKING: a file an earlier `pista dump` wrote no longer plans until it is dumped again. See below.

## A primary key added by `ALTER TABLE` does not imply `NOT NULL`

PostgreSQL sets the flag whichever way the key arrives, and only the inline form was read that way. A file that adds the key in a later statement plans `ALTER COLUMN id DROP NOT NULL` on every run, and applying it fails with `column "id" is in a primary key`.

The inline path's own code moves into a helper both paths call, so nothing new is inferred: it is the rule that path already had, applied to the other spelling.

`pista dump` writes the key inline with `NOT NULL` on the column, and `pg_dump` writes `NOT NULL` too, so neither output reaches this. `PRIMARY KEY USING INDEX` still does; that form has a larger gap, recorded in LIMITATIONS.

## A `serial` column declared without `NOT NULL` is read as nullable

The type expands to a `NOT NULL` column and the catalog reports one, so the plan right after the table was created proposes `DROP NOT NULL`. Applying it takes the constraint away, and the next plan is clean, so nothing says it happened. A `serial` column that also carries a primary key is reached through the key and was never affected.

Of the 757 serial declarations in the sample schemas, 381 write `NOT NULL`, 54 carry a primary key instead, and 322 write neither.

## A `numeric` written with only a precision drifts

PostgreSQL stores `numeric(5)` as `numeric(5,0)` and `format_type` prints both digits, so the two sides never compare equal and the column is retyped on every plan.

The array marker is separated from the modifier so an array of the type is reached: `numeric(5)[]` is stored as `numeric(5,0)[]`.

An earlier revision also folded `integer[3]` and `integer[][]` to `integer[]`. That is dropped. PostgreSQL accepts those for SQL standard compatibility and enforces neither, so a column declared that way has already lost what it was trying to say, and none of the sample schemas declares one. LIMITATIONS records the drift that leaves.

## Dropping a partition emits a `DROP CONSTRAINT` for an inherited key

A partition carries a copy of its parent's foreign key, and PostgreSQL refuses to drop that copy on its own:

```
ERROR: cannot drop inherited constraint "logs_user_id_fkey" of relation "logs_2024"
```

The copy goes with the partition anyway. `diffForeignKeys` already skipped an inherited key; the drop path does too now. Dropping the whole partitioned table failed the same way, and the parent's own key still goes out there.

This one reaches a dump. Removing one partition from `pista dump` output is enough, since the copy is on the current side rather than in the file.

## A domain's base type is compared as written

`format_type` writes a base type on the search path unqualified, so a domain written over `public.status` compares `status` against `public.status` and reads as a base type change, which cannot be altered:

```
pista: error: failed to diff domains: cannot change base type of domain public.status_dom
```

It goes through `equalTypeName` now, the way a column's type does. Both objects are in the same schema, so this is not the cross-schema case in LIMITATIONS.

## An inherited collation is read as a declared one (BREAKING)

A domain or a composite attribute typed over a collated domain inherits that collation without declaring it, and the catalog stores declared and inherited alike. Reading the inherited one as declared made the desired side, which writes none, look like a collation change. A domain's collation cannot be altered, so the plan stopped, and nothing else in the schema could be planned either.

Both queries compare against the base type's collation now, as `columns.go` already did. Checked against a domain that sets its own collation, one that overrides its base type's, and one that only inherits: the first two are still reported.

`dump` stops writing the inherited clause, which is what `pg_dump` does. The old dump round-tripped only because it wrote the same redundant clause on both sides.

That is what breaks. A file an earlier `pista dump` wrote restates the inherited clause, and the catalog reports none for it now, so the file reads as a collation change:

```sql
CREATE DOMAIN public.ctext2 AS ctext COLLATE pg_catalog."C";
```

A domain fails with `cannot change collation of domain`, which stops the whole plan; a composite attribute drifts on every run instead. Running `pista dump` again rewrites the file, and the new output plans clean. Only a domain or an attribute over a collated type is affected. `plan/domain_restating_inherited_collation.yml` pins the failure.

## A directive on a file with CRLF line endings is silently ignored

The carriage return was taken as trailing content, so `ignore`, `concurrently`, `bulk-alter` and `execute` turned off with no warning: the name is still a known one, so `validateDirectives` raised nothing either. A table marked `-- pista:ignore` was created as if the line were not there.

Git for Windows converts LF to CRLF on checkout by default, and this repository sets no `.gitattributes`, so a schema file committed with LF reaches a Windows working tree as CRLF. pistachio already reads the SQL in such a file correctly; only the directives fell out.

## Tests

Ten fixtures and three unit test groups. Each was checked by reverting its fix:

- `plan/no_diff_alter_table_add_primary_key.yml`, with a composite key so a fix reaching only the first column fails it
- `plan/no_diff_serial_without_not_null.yml`, over all three serial spellings
- `plan/no_diff_numeric_precision.yml`
- `plan/drop_partition_with_inherited_foreign_key.yml`, `apply/drop_partition_with_inherited_foreign_key.yml`, `apply/drop_partitioned_table_with_foreign_key.yml`
- `plan/no_diff_domain_over_schema_qualified_enum.yml`
- `plan/no_diff_domain_over_collated_domain.yml`, covering a domain and an attribute that inherit, one that overrides and one that declares its own, so a predicate reporting too little fails it as well as one reporting too much
- `plan/domain_restating_inherited_collation.yml`, the shape the old dump wrote
- `TestDirectivesAcrossLineEndings`, seven directive forms against four line endings, plus `TestValidateDirectivesAcrossLineEndings` for the argument check; reverting the patterns fails 13 of its cases
- `TestNormalizeTypeName`, `TestSplitTypeSuffix`, `TestFillNumericScale` through `export_test.go`, and `TestDiffTables_dropTableWithInheritedForeignKey` over both drop policies

CI measures coverage per package, so the root package fixtures credit nothing to `parser` and `diff`; the unit tests cover that code where it lives. Every changed line is covered, and project coverage is 96.70%, up from 96.69% on `main`.

`make lint`, `make vet`, `make test`, `make test-scenario` and `make test-fidelity` pass against PostgreSQL 16.

## Also

`LIMITATIONS.md` gains two entries this work turned up: the array dimension drift left by the narrowed type fix, and `PRIMARY KEY USING INDEX`, which does not converge at all and takes the `DROP NOT NULL` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iZFWSeiGCSNGi6zT4R81Q