### PR TITLE
Ask before loading Google Analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,19 @@ hooks:
   - hooks.py
 
 extra:
+  # Google Analytics sets first-party cookies, which are not strictly necessary
+  # to serve the documentation, so the banner asks before the tag is loaded.
+  # Material holds the tag back until the visitor accepts.
+  consent:
+    title: Cookies
+    description: >-
+      This site uses Google Analytics to see which pages get read, so the
+      documentation can be improved where it is needed. Nothing is loaded
+      until you accept, and rejecting costs you nothing.
+    actions:
+      - accept
+      - reject
+      - manage
   analytics:
     provider: google
     property: G-L2YHGE2CEF


### PR DESCRIPTION
The documentation site loads Google Analytics, which sets first-party cookies
that are not needed to serve the pages. Add Material's consent banner and let
it hold the tag back until the visitor accepts.

The banner offers accept, reject and manage, so a visitor can change the
answer later. Material records the choice in its own `__md_consent` cookie,
which is functionally necessary and needs no consent itself.