### PR TITLE
Replace Google Analytics with GoatCounter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - docs/**
+      - overrides/**
       - mkdocs.yml
       - hooks.py
       - requirements-docs.txt
@@ -17,6 +18,7 @@ on:
   pull_request:
     paths:
       - docs/**
+      - overrides/**
       - mkdocs.yml
       - hooks.py
       - requirements-docs.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  # Holds partials/integrations/analytics/custom.html, the analytics snippet.
+  custom_dir: overrides
   favicon: assets/favicon.ico
   # The header draws the logo at 24px next to site_name, so this is the nut
   # mark on its own. The full logo carries the wordmark, which would be
@@ -40,22 +42,8 @@ hooks:
   - hooks.py
 
 extra:
-  # Google Analytics sets first-party cookies, which are not strictly necessary
-  # to serve the documentation, so the banner asks before the tag is loaded.
-  # Material holds the tag back until the visitor accepts.
-  consent:
-    title: Cookies
-    description: >-
-      This site uses Google Analytics to see which pages get read, so the
-      documentation can be improved where it is needed. Nothing is loaded
-      until you accept, and rejecting costs you nothing.
-    actions:
-      - accept
-      - reject
-      - manage
   analytics:
-    provider: google
-    property: G-L2YHGE2CEF
+    provider: custom
 
 extra_css:
   - stylesheets/extra.css

--- a/overrides/partials/integrations/analytics/custom.html
+++ b/overrides/partials/integrations/analytics/custom.html
@@ -1,0 +1,7 @@
+<!--
+  GoatCounter. It sets no cookie and stores no IP address, so the site needs
+  no consent banner for it. Material includes this partial in place of its
+  built-in providers because extra.analytics.provider is custom.
+-->
+<script data-goatcounter="https://winebarrel.goatcounter.com/count"
+        async src="https://gc.zgo.at/count.js"></script>


### PR DESCRIPTION
GoatCounter sets no cookie and stores no IP address, so it needs no consent
banner. Switch the documentation site to it and drop both the Google
Analytics property and the banner #548 added for it.

Material has no built-in provider for GoatCounter, so the snippet lives in an
override of `partials/integrations/analytics/custom.html`, with
`theme.custom_dir` pointing at `overrides/` and `extra.analytics.provider` set
to `custom`. The docs workflow watches `overrides/**` as well, so a later edit
to the snippet alone still triggers a build.