### PR TITLE
Group the digits of the row estimate in --explain comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Write the row estimate in an `--explain` comment with a comma between every three digits, `~120,000,000 rows` rather than `~120000000 rows`.
+
 ## [1.49.0] - 2026-09-10
 
 * Add `--explain` to `plan` (`$PISTA_EXPLAIN`). It writes a comment before each statement that scans or rewrites a table that already holds data: what the statement does to the rows, what its lock blocks, and the table's row and byte estimate from `pg_class`, with the number of indexes a rewrite builds again and the partitions or `INHERITS` children it recurses into. A foreign key names the referenced table next to the referencing one, and a domain change names every table with a column of the domain. A statement that changes the catalog alone takes no comment, and neither does one on a table the same plan creates. The estimates are what VACUUM and ANALYZE last wrote, the TOAST relation's pages included; a table neither has visited reads as not analyzed. Whether a type change is a relabel or a conversion, and whether a default calls a volatile function, is one catalog read each, made only when the plan holds such a statement, and a plan with no statements makes none.

--- a/docs/guides/explaining-plans.md
+++ b/docs/guides/explaining-plans.md
@@ -4,13 +4,13 @@ A plan says what will run, not what it costs. `--explain` writes a comment befor
 
 ```sql
 $ pista plan --explain schema.sql
--- rewrite, blocks reads and writes: public.orders (~2000000 rows, 210 MB, 3 indexes rebuilt)
+-- rewrite, blocks reads and writes: public.orders (~2,000,000 rows, 210 MB, 3 indexes rebuilt)
 ALTER TABLE public.orders ALTER COLUMN amount SET DATA TYPE numeric(12,2);
--- scan, blocks writes: public.orders (~2000000 rows, 210 MB), public.customers (~50000 rows, 6280 kB)
+-- scan, blocks writes: public.orders (~2,000,000 rows, 210 MB), public.customers (~50,000 rows, 6280 kB)
 ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customers (id);
--- scan, blocks nothing: public.orders (~2000000 rows, 210 MB)
+-- scan, blocks nothing: public.orders (~2,000,000 rows, 210 MB)
 CREATE INDEX CONCURRENTLY orders_created_at_idx ON public.orders USING btree (created_at);
--- scan, blocks writes: public.events (~120000000 rows, 9629 MB, 24 partitions)
+-- scan, blocks writes: public.events (~120,000,000 rows, 9629 MB, 24 partitions)
 CREATE INDEX events_at_idx ON public.events USING btree (at);
 ALTER TABLE public.orders ALTER COLUMN note SET DEFAULT '';
 ```

--- a/explain.go
+++ b/explain.go
@@ -20,7 +20,7 @@ import (
 // read off each statement, whether it scans or rewrites the table and what
 // the lock it takes stops, and the table's size is added from pg_class:
 //
-//	-- rewrite, blocks reads and writes: public.events (~120000000 rows, 9629 MB, 5 indexes rebuilt)
+//	-- rewrite, blocks reads and writes: public.events (~120,000,000 rows, 9629 MB, 5 indexes rebuilt)
 //	ALTER TABLE public.events ALTER COLUMN amount SET DATA TYPE numeric(12,2);
 //
 // A statement that only changes the catalog takes no comment, whatever lock
@@ -813,7 +813,11 @@ func (ex *explainer) renderTarget(tg explainTarget) string {
 
 	var details []string
 	if analyzed {
-		details = append(details, "~"+pluralize(int(rows), "row"), sizePretty(bytes))
+		noun := "rows"
+		if rows == 1 {
+			noun = "row"
+		}
+		details = append(details, "~"+groupDigits(rows)+" "+noun, sizePretty(bytes))
 	} else {
 		details = append(details, "not analyzed")
 	}
@@ -832,6 +836,26 @@ func plural(n int, singular, pluralForm string) string {
 		return fmt.Sprintf("%d %s", n, singular)
 	}
 	return fmt.Sprintf("%d %s", n, pluralForm)
+}
+
+// groupDigits writes a count with a comma between every three digits, so a
+// row estimate in the hundreds of millions reads at a glance. The byte count
+// needs none: sizePretty keeps it under five digits.
+func groupDigits(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	if len(s) <= 3 {
+		return s
+	}
+	var b strings.Builder
+	head := len(s) % 3
+	b.WriteString(s[:head])
+	for i := head; i < len(s); i += 3 {
+		if b.Len() > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(s[i : i+3])
+	}
+	return b.String()
 }
 
 // sizePretty writes a byte count the way pg_size_pretty does: in bytes up to

--- a/explain_test.go
+++ b/explain_test.go
@@ -27,6 +27,25 @@ func TestSizePretty(t *testing.T) {
 	}
 }
 
+func TestGroupDigits(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0"},
+		{3, "3"},
+		{999, "999"},
+		{1000, "1,000"},
+		{12345, "12,345"},
+		{123456, "123,456"},
+		{1234567, "1,234,567"},
+		{120000000, "120,000,000"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, groupDigits(tt.n), "%d", tt.n)
+	}
+}
+
 func TestTypmodOf(t *testing.T) {
 	assert.Nil(t, typmodOf("text"))
 	assert.Equal(t, []int64{50}, typmodOf("character varying(50)"))

--- a/testdata/plan/explain_row_count_grouping.yml
+++ b/testdata/plan/explain_row_count_grouping.yml
@@ -1,0 +1,18 @@
+explain: true
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  INSERT INTO public.users SELECT g, 'n' FROM generate_series(1, 1234) g;
+  ANALYZE public.users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+plan: |
+  -- scan, blocks reads and writes: public.users (~1,234 rows, 48 kB)
+  ALTER TABLE public.users ALTER COLUMN name SET NOT NULL;


### PR DESCRIPTION
A row count in the hundreds of millions is hard to read without a
separator, so the estimate is now written as ~120,000,000 rows. The byte
count is left alone: sizePretty keeps it under five digits.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GGce2W2keke28phJQD37rb