### PR TITLE
Cover the sequence collection in the diff package

### DIFF
--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -238,6 +238,27 @@ func TestDiffTables_noChange(t *testing.T) {
 	assert.Empty(t, result.Stmts)
 }
 
+// The sequence statement lands after every column statement, so a --bulk-alter
+// run of ALTER TABLE on one table stays in a single statement.
+func TestDiffColumns_serialWideningOrder(t *testing.T) {
+	seq := "public.t_id_seq"
+	current := orderedmap.New[string, *model.Column]()
+	current.Set("id", &model.Column{Name: "id", TypeName: "serial", NotNull: true, SerialSequence: &seq})
+	current.Set("a", &model.Column{Name: "a", TypeName: "smallint"})
+
+	desired := orderedmap.New[string, *model.Column]()
+	desired.Set("id", &model.Column{Name: "id", TypeName: "bigserial", NotNull: true})
+	desired.Set("a", &model.Column{Name: "a", TypeName: "integer"})
+
+	stmts, _, _, err := diffColumns("public.t", current, desired, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"ALTER TABLE public.t ALTER COLUMN id SET DATA TYPE bigint;",
+		"ALTER TABLE public.t ALTER COLUMN a SET DATA TYPE integer;",
+		"ALTER SEQUENCE public.t_id_seq AS bigint;",
+	}, stmts)
+}
+
 func TestDiffColumns_generatedToggle(t *testing.T) {
 	// One side STORED GENERATED, the other not, must error; PostgreSQL
 	// has no in-place toggle for GENERATED.


### PR DESCRIPTION
Follow-up commit left on the branch after #544 merged. Test only, no production change.

## What it adds

A `diffColumns` case that widens a serial column alongside a plain one and asserts the order the `--bulk-alter` merge depends on, with the sequence statement last in the raw list.

## Why

CI measures coverage per package: the workflow runs `go test -coverprofile` with no `-coverpkg`, so the root package fixtures do not count toward `diff/tables.go`. Under the diff package's own tests, line 357 of `diff/tables.go`, the `seqStmts` append inside `diffColumns`, is the only uncovered line in that function. This case reaches it, taking `diffColumns` from 97.7% to 100% and the diff package from 97.6% to 97.7%.

## Caveat worth weighing before merging

The behavior itself is already covered end to end by `testdata/apply/bulk_alter_serial_widening.yml`, which widens a serial column next to two others under `--bulk-alter` and asserts the merged `ALTER TABLE` a user actually sees. Any regression this case catches, that fixture catches too.

The case also pins an intermediate order: `diffColumns` returns the sequence statement last, and a later sort moves it to the front, so the asserted order is the reverse of what the plan prints. That is a real internal invariant the sort depends on, but it reads against the fixture comment that says `ALTER SEQUENCE` sorts first.

The project coverage gate is 88% against 96.69% today, so the one line does not move the gate.

## Verification

Applied onto current `main` and ran `go test -run TestDiffColumns_serialWideningOrder ./diff/`, which passes. The branch merges into `main` without conflict. No CHANGELOG entry, since nothing user-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGce2W2keke28phJQD37rb

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGce2W2keke28phJQD37rb)_