### PR TITLE
Show --explain in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ pista plan --allow-drop all schema.sql # review the diff (with drops)
 pista apply schema.sql                 # apply it
 ```
 
+See what each statement costs before it runs:
+
+```sql
+$ pista plan --explain schema.sql
+-- rewrite, blocks reads and writes: public.orders (~2,000,000 rows, 210 MB, as of 2026-09-09, 3 indexes rebuilt)
+ALTER TABLE public.orders ALTER COLUMN amount SET DATA TYPE numeric(12,2);
+-- scan, blocks writes: public.orders (~2,000,000 rows, 210 MB, as of 2026-09-09), public.customers (~50,000 rows, 6280 kB, as of 2026-07-21)
+ALTER TABLE ONLY public.orders ADD CONSTRAINT orders_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customers (id);
+-- scan, blocks nothing: public.orders (~2,000,000 rows, 210 MB, as of 2026-09-09)
+CREATE INDEX CONCURRENTLY orders_created_at_idx ON public.orders USING btree (created_at);
+```
+
+The rows and bytes are the estimates the last VACUUM or ANALYZE wrote, with the date it wrote them, so the comment costs no read of the table. See [Explaining a plan](https://winebarrel.github.io/pistachio/guides/explaining-plans/).
+
 Or split the schema across multiple files:
 
 ```bash


### PR DESCRIPTION
The README walks through `plan`, `apply`, `dump --split` and `fmt`, but never mentions `--explain`. It is the one flag that says what a statement costs against the database in front of you, and it was visible only to someone who opened the guide.

Adds the guide example right after the plan/apply block, with one line on where the numbers come from and a link to [Explaining a plan](https://winebarrel.github.io/pistachio/guides/explaining-plans/).

The example keeps the guide table names rather than reusing `users`/`posts` from the schema above it: that schema only creates tables, which take no comment, so a different scenario reads more honestly and matches what the linked guide shows.

Documentation only.