### PR TITLE
Read ADD CONSTRAINT ... USING INDEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Read a constraint added with `UNIQUE USING INDEX` or `PRIMARY KEY USING INDEX`. The form never compared equal to the constraint it created, so every plan re-issued DROP and ADD, and the index it takes over was planned as a DROP, which ran first under `--allow-drop index` and broke the ADD. The index now stays, the file plans clean, and a constraint written without a name takes the index's name, the way PostgreSQL names it.
+
 ## [1.49.2] - 2026-09-10
 
 * Date the size an `--explain` comment prints, `~120,000,000 rows, 9629 MB, as of 2026-09-08`. It is when a VACUUM or an ANALYZE last wrote the estimate, so a plan says how stale the numbers are. A size the server can no longer date is printed without it.

--- a/diff/tables.go
+++ b/diff/tables.go
@@ -166,7 +166,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	// auto-inherit them), so they're still diffed here, mirroring how
 	// indexes and FKs work.
 	if desired.IsPartitionChild() {
-		idxResult, err := diffIndexes(current.Indexes, desired.Indexes, dc)
+		idxResult, err := diffIndexes(current.Indexes, desired.Indexes, usingIndexNames(desired.Constraints), dc)
 		if err != nil {
 			return nil, err
 		}
@@ -234,7 +234,7 @@ func diffTable(current, desired *model.Table, dc DropChecker) (*tableDiffResult,
 	result.Stmts = append(result.Stmts, conStmts...)
 	result.DisallowedDropStmts = append(result.DisallowedDropStmts, conDisallowed...)
 
-	idxResult2, err := diffIndexes(current.Indexes, desired.Indexes, dc)
+	idxResult2, err := diffIndexes(current.Indexes, desired.Indexes, usingIndexNames(desired.Constraints), dc)
 	if err != nil {
 		return nil, err
 	}
@@ -1222,10 +1222,27 @@ func constraintChanges(current, desired *orderedmap.Map[string, *model.Constrain
 			continue
 		}
 		changes[name] = newDefinitionChange(
-			equalConstraintDef(currentCon.Definition, desiredCon.Definition),
+			sameConstraintDef(currentCon, desiredCon),
 			currentCon.Validated, desiredCon.Validated)
 	}
 	return changes
+}
+
+// sameConstraintDef says whether the two sides describe the same constraint.
+// A desired constraint written ADD CONSTRAINT ... USING INDEX carries no
+// column list, only an index name, and the promotion renames that index to
+// the constraint's name, so once the constraint exists there is nothing left
+// to compare the name to: the catalog renders what it created as a plain
+// UNIQUE (col). The form is transitional, like NOT VALID, so an existing
+// constraint of the same name, type and deferral satisfies it; the columns
+// are pinned down when the file is rewritten the way dump writes it.
+func sameConstraintDef(current, desired *model.Constraint) bool {
+	if desired.IndexName != "" {
+		return desired.Type == current.Type &&
+			desired.Deferrable == current.Deferrable &&
+			desired.Deferred == current.Deferred
+	}
+	return equalConstraintDef(current.Definition, desired.Definition)
 }
 
 func diffConstraints(fqtn string, current, desired *orderedmap.Map[string, *model.Constraint], dc DropChecker) (stmts []string, disallowed []string, err error) {
@@ -1321,7 +1338,22 @@ type diffIndexesResult struct {
 	HasConcurrently     bool
 }
 
-func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], dc DropChecker) (*diffIndexesResult, error) {
+// usingIndexNames collects the index names the desired constraints take over
+// via ADD CONSTRAINT ... USING INDEX.
+func usingIndexNames(cons *orderedmap.Map[string, *model.Constraint]) map[string]bool {
+	var names map[string]bool
+	for _, con := range cons.All() {
+		if con.IndexName != "" {
+			if names == nil {
+				names = map[string]bool{}
+			}
+			names[con.IndexName] = true
+		}
+	}
+	return names
+}
+
+func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], consumed map[string]bool, dc DropChecker) (*diffIndexesResult, error) {
 	dc = normalizeDropChecker(dc)
 	result := &diffIndexesResult{}
 
@@ -1340,6 +1372,12 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], dc Drop
 	idxAllowed := dc.IsDropAllowed("index")
 	for name, currentIdx := range current.All() {
 		desiredIdx, ok := desired.GetOk(name)
+		if !ok && consumed[name] {
+			// The index is not going away: a desired USING INDEX constraint
+			// takes it over, so dropping it would pull the index out from
+			// under the ADD CONSTRAINT.
+			continue
+		}
 		if !ok || !sameDef[name] {
 			// Use CONCURRENTLY when the desired index (when it exists and is
 			// being changed) has the per-index directive. For pure drops the
@@ -1368,6 +1406,12 @@ func diffIndexes(current, desired *orderedmap.Map[string, *model.Index], dc Drop
 	// Add new or changed indexes
 	for name, desiredIdx := range desired.All() {
 		currentIdx, ok := current.GetOk(name)
+		if !ok && consumed[name] {
+			// A desired USING INDEX constraint owns this index, and an owned
+			// index is not read as a plain one, so declaring it next to the
+			// constraint is not a missing index.
+			continue
+		}
 		if ok && sameDef[name] {
 			// The index stays, so only a comment that differs is emitted.
 			result.Stmts = append(result.Stmts, indexCommentStmts(currentIdx.Comment, desiredIdx)...)

--- a/diff/tables_test.go
+++ b/diff/tables_test.go
@@ -933,12 +933,63 @@ func TestDiffConstraints_renameAlreadyAppliedAndNotValid(t *testing.T) {
 	assert.Equal(t, "ALTER TABLE public.users ADD CONSTRAINT chk_new CHECK (age > 0) NOT VALID;", stmts[1])
 }
 
+func TestSameConstraintDef_usingIndex(t *testing.T) {
+	current := &model.Constraint{Name: "users_email_key", Type: model.ConstraintType('u'), Definition: "UNIQUE (email)", Validated: true}
+
+	// The promotion renames the index to the constraint's name, so the index
+	// the desired form names never survives to compare against: an existing
+	// constraint of the same name, type and deferral satisfies the form.
+	usingIndex := &model.Constraint{Name: "users_email_key", Type: model.ConstraintType('u'), Definition: "UNIQUE USING INDEX users_email_idx", IndexName: "users_email_idx", Validated: true}
+	assert.True(t, sameConstraintDef(current, usingIndex))
+
+	primaryKey := &model.Constraint{Name: "users_email_key", Type: model.ConstraintType('p'), Definition: "PRIMARY KEY USING INDEX users_email_idx", IndexName: "users_email_idx", Validated: true}
+	assert.False(t, sameConstraintDef(current, primaryKey))
+
+	deferrable := &model.Constraint{Name: "users_email_key", Type: model.ConstraintType('u'), Definition: "UNIQUE USING INDEX users_email_idx DEFERRABLE", IndexName: "users_email_idx", Deferrable: true, Validated: true}
+	assert.False(t, sameConstraintDef(current, deferrable))
+}
+
+func TestUsingIndexNames(t *testing.T) {
+	cons := orderedmap.New[string, *model.Constraint]()
+	cons.Set("users_pkey", &model.Constraint{Name: "users_pkey", Type: model.ConstraintType('p'), Definition: "PRIMARY KEY (id)"})
+	assert.Nil(t, usingIndexNames(cons))
+
+	cons.Set("users_email_key", &model.Constraint{Name: "users_email_key", Type: model.ConstraintType('u'), Definition: "UNIQUE USING INDEX users_email_key", IndexName: "users_email_key"})
+	assert.Equal(t, map[string]bool{"users_email_key": true}, usingIndexNames(cons))
+}
+
+func TestDiffIndexes_dropConsumedByUsingIndex(t *testing.T) {
+	// The index a desired USING INDEX constraint takes over is not dropped,
+	// even when the index-drop policy would allow it.
+	current := orderedmap.New[string, *model.Index]()
+	current.Set("users_email_key", &model.Index{Schema: "public", Name: "users_email_key", Definition: "CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)"})
+	desired := orderedmap.New[string, *model.Index]()
+
+	idxResult, err := diffIndexes(current, desired, map[string]bool{"users_email_key": true}, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, idxResult.Stmts)
+	assert.Empty(t, idxResult.DisallowedDropStmts)
+}
+
+func TestDiffIndexes_addConsumedByUsingIndex(t *testing.T) {
+	// The index a desired USING INDEX constraint owns is not read back as a
+	// plain index, so its declaration next to the constraint is not a
+	// missing index.
+	current := orderedmap.New[string, *model.Index]()
+	desired := orderedmap.New[string, *model.Index]()
+	desired.Set("users_email_idx", &model.Index{Schema: "public", Name: "users_email_idx", Definition: "CREATE UNIQUE INDEX users_email_idx ON public.users USING btree (email)"})
+
+	idxResult, err := diffIndexes(current, desired, map[string]bool{"users_email_idx": true}, allowAllDrops{})
+	require.NoError(t, err)
+	assert.Empty(t, idxResult.Stmts)
+}
+
 func TestDiffIndexes_add(t *testing.T) {
 	current := orderedmap.New[string, *model.Index]()
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE INDEX idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -948,7 +999,7 @@ func TestDiffIndexes_drop(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
 }
@@ -958,7 +1009,7 @@ func TestDiffIndexes_drop_denied(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired, denyAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.Stmts)
 	assert.Equal(t, []string{"-- skipped: DROP INDEX public.idx_name;"}, idxResult.DisallowedDropStmts)
@@ -972,7 +1023,7 @@ func TestDiffIndexes_change_denied_alwaysExecutes(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	idxResult, err := diffIndexes(current, desired, denyAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, denyAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.DisallowedDropStmts)
 	assert.Len(t, idxResult.Stmts, 2)
@@ -985,7 +1036,7 @@ func TestDiffIndexes_change(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)"})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "DROP INDEX public.idx_name;", idxResult.Stmts[0])
@@ -1001,7 +1052,7 @@ func TestDiffIndexes_comment(t *testing.T) {
 		desired := orderedmap.New[string, *model.Index]()
 		desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def, Comment: new("Lookup by name")})
 
-		idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+		idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 		require.NoError(t, err)
 		assert.Equal(t, []string{"COMMENT ON INDEX public.idx_name IS 'Lookup by name';"}, idxResult.Stmts)
 	})
@@ -1012,7 +1063,7 @@ func TestDiffIndexes_comment(t *testing.T) {
 		desired := orderedmap.New[string, *model.Index]()
 		desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def})
 
-		idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+		idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 		require.NoError(t, err)
 		assert.Equal(t, []string{"COMMENT ON INDEX public.idx_name IS NULL;"}, idxResult.Stmts)
 	})
@@ -1023,7 +1074,7 @@ func TestDiffIndexes_comment(t *testing.T) {
 		desired := orderedmap.New[string, *model.Index]()
 		desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: def, Comment: new("Lookup by name")})
 
-		idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+		idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 		require.NoError(t, err)
 		assert.Empty(t, idxResult.Stmts)
 	})
@@ -1040,7 +1091,7 @@ func TestDiffIndexes_comment(t *testing.T) {
 			Comment:    new("Lookup by name"),
 		})
 
-		idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+		idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 		require.NoError(t, err)
 		assert.Equal(t, []string{
 			"DROP INDEX public.idx_name;",
@@ -1055,7 +1106,7 @@ func TestDiffIndexes_add_uniqueConcurrently_perDirective(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE UNIQUE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE UNIQUE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -1065,7 +1116,7 @@ func TestDiffIndexes_add_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);"}, idxResult.Stmts)
 }
@@ -1077,7 +1128,7 @@ func TestDiffIndexes_drop_pureDrop_neverConcurrently(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)"})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX public.idx_name;"}, idxResult.Stmts)
 }
@@ -1090,7 +1141,7 @@ func TestDiffIndexes_drop_pureDrop_currentConcurrentlyForced(t *testing.T) {
 	current.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 	desired := orderedmap.New[string, *model.Index]()
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"DROP INDEX CONCURRENTLY public.idx_name;"}, idxResult.Stmts)
 	assert.True(t, idxResult.HasConcurrently)
@@ -1102,7 +1153,7 @@ func TestDiffIndexes_change_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING hash (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "DROP INDEX CONCURRENTLY public.idx_name;", idxResult.Stmts[0])
@@ -1115,7 +1166,7 @@ func TestDiffIndexes_mixedConcurrently(t *testing.T) {
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 	desired.Set("idx_email", &model.Index{Schema: "public", Name: "idx_email", Definition: "CREATE INDEX idx_email ON public.users USING btree (email)"})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 2)
 	assert.Equal(t, "CREATE INDEX CONCURRENTLY idx_name ON public.users USING btree (name);", idxResult.Stmts[0])
@@ -1130,7 +1181,7 @@ func TestDiffIndexes_rename_perIndexConcurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	// Rename should NOT use CONCURRENTLY even with per-index directive
 	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
@@ -1142,7 +1193,7 @@ func TestDiffIndexes_partialIndex_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_active", &model.Index{Schema: "public", Name: "idx_active", Definition: "CREATE INDEX idx_active ON public.users USING btree (name) WHERE (active = true)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 1)
 	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
@@ -1155,7 +1206,7 @@ func TestDiffIndexes_expressionIndex_concurrently(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_lower", &model.Index{Schema: "public", Name: "idx_lower", Definition: "CREATE INDEX idx_lower ON public.users USING btree (lower(name))", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Len(t, idxResult.Stmts, 1)
 	assert.Contains(t, idxResult.Stmts[0], "CREATE INDEX CONCURRENTLY")
@@ -1168,7 +1219,7 @@ func TestDiffIndexes_hasConcurrently_directive(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx_name", &model.Index{Schema: "public", Name: "idx_name", Definition: "CREATE INDEX idx_name ON public.users USING btree (name)", Concurrently: true})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.True(t, idxResult.HasConcurrently)
 }
@@ -3075,7 +3126,7 @@ func TestDiffIndexes_rename_selfRename_skipped(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("idx", &model.Index{Schema: "public", Name: "idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.Stmts)
 }
@@ -3279,7 +3330,7 @@ func TestDiffIndexes_rename(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ALTER INDEX public.old_idx RENAME TO new_idx;"}, idxResult.Stmts)
 }
@@ -3317,7 +3368,7 @@ func TestDiffIndexes_rename_alreadyApplied(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	idxResult, err := diffIndexes(current, desired, allowAllDrops{})
+	idxResult, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.NoError(t, err)
 	assert.Empty(t, idxResult.Stmts)
 }
@@ -3329,7 +3380,7 @@ func TestDiffIndexes_rename_sourceNotFound(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	_, err := diffIndexes(current, desired, allowAllDrops{})
+	_, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rename source index")
 }
@@ -3415,7 +3466,7 @@ func TestDiffIndexes_rename_destinationExists_error(t *testing.T) {
 	desired := orderedmap.New[string, *model.Index]()
 	desired.Set("new_idx", &model.Index{Schema: "public", Name: "new_idx", RenameFrom: &oldName, Table: "users", Definition: "CREATE INDEX new_idx ON public.users USING btree (name)"})
 
-	_, err := diffIndexes(current, desired, allowAllDrops{})
+	_, err := diffIndexes(current, desired, nil, allowAllDrops{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination already exists")
 }

--- a/explain.go
+++ b/explain.go
@@ -404,7 +404,7 @@ func (ex *explainer) classifyAlterTableCmd(key string, t *model.Table, recurse b
 			return self(touchScan, blockAll)
 		case pg_query.ConstrType_CONSTR_PRIMARY, pg_query.ConstrType_CONSTR_UNIQUE, pg_query.ConstrType_CONSTR_EXCLUSION:
 			// USING INDEX takes an index that already exists rather than
-			// building one. pistachio does not emit it today.
+			// building one, so nothing is scanned.
 			if con.GetIndexname() != "" {
 				return explainEffect{}
 			}

--- a/model/constraint.go
+++ b/model/constraint.go
@@ -45,6 +45,13 @@ type Constraint struct {
 	// statement on the parent reaches it, so the diff leaves it alone. Only
 	// the catalog sets it: a desired schema declares what it writes.
 	Inherited bool
+	// IndexName is the index a desired constraint written
+	// ADD CONSTRAINT ... USING INDEX takes over. Only the parser sets it:
+	// the promotion renames the index to the constraint's name, so the
+	// catalog has no such name to report. The diff keeps that index out of
+	// the index drops and adds, and takes an existing constraint of the same
+	// name, type and deferral as satisfying the declaration.
+	IndexName string
 }
 
 func (con *Constraint) String() string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1220,11 +1220,17 @@ func extractColumnConstraints(cd *pg_query.ColumnDef, table *model.Table, schema
 
 func parseTableConstraint(con *pg_query.Constraint, tableName string) (*model.Constraint, error) {
 	if con.Conname == "" {
-		cols := constraintKeyCols(con)
-		if con.Contype == pg_query.ConstrType_CONSTR_CHECK {
-			cols = checkExprCols(con.RawExpr)
+		if con.Indexname != "" {
+			// ADD UNIQUE USING INDEX without CONSTRAINT: PostgreSQL names
+			// the constraint after the index.
+			con.Conname = con.Indexname
+		} else {
+			cols := constraintKeyCols(con)
+			if con.Contype == pg_query.ConstrType_CONSTR_CHECK {
+				cols = checkExprCols(con.RawExpr)
+			}
+			con.Conname = autoNameConstraint(tableName, cols, con.Contype)
 		}
-		con.Conname = autoNameConstraint(tableName, cols, con.Contype)
 	}
 
 	var conType model.ConstraintType
@@ -1261,6 +1267,7 @@ func parseTableConstraint(con *pg_query.Constraint, tableName string) (*model.Co
 		Deferrable: con.Deferrable,
 		Deferred:   con.Initdeferred,
 		Validated:  !con.SkipValidation,
+		IndexName:  con.Indexname,
 	}, nil
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1382,6 +1382,33 @@ ALTER TABLE public.items ADD CONSTRAINT items_code_unique UNIQUE (code);`
 	assert.True(t, ok)
 }
 
+func TestParseSQL_AlterTableUsingIndex(t *testing.T) {
+	sql := `CREATE TABLE public.items (
+    id integer NOT NULL,
+    code text NOT NULL
+);
+ALTER TABLE ONLY public.items ADD CONSTRAINT items_code_key UNIQUE USING INDEX items_code_key;
+ALTER TABLE ONLY public.items ADD PRIMARY KEY USING INDEX items_pkey;`
+
+	result, err := parseSQLWithPublicSchema(sql)
+	require.NoError(t, err)
+
+	tbl := result.Tables.Get("public.items")
+	require.NotNil(t, tbl)
+
+	con, ok := tbl.Constraints.GetOk("items_code_key")
+	require.True(t, ok)
+	assert.True(t, con.Type.IsUniqueConstraint())
+	assert.Equal(t, "items_code_key", con.IndexName)
+
+	// Written without CONSTRAINT, the constraint takes the index's name, the
+	// way PostgreSQL names it.
+	pk, ok := tbl.Constraints.GetOk("items_pkey")
+	require.True(t, ok)
+	assert.True(t, pk.Type.IsPrimaryKeyConstraint())
+	assert.Equal(t, "items_pkey", pk.IndexName)
+}
+
 func TestParseSQL_AlterTableUnknownTable(t *testing.T) {
 	// ALTER TABLE referencing a table not in parsed result is silently skipped
 	sql := `ALTER TABLE public.nonexistent ADD CONSTRAINT fk FOREIGN KEY (id) REFERENCES public.other(id);`

--- a/testdata/apply/add_primary_key_using_index.yml
+++ b/testdata/apply/add_primary_key_using_index.yml
@@ -1,0 +1,24 @@
+# The recipe from the ALTER TABLE reference: build a unique index under a
+# scratch name, then promote it to the primary key, which renames the index.
+# The re-plan must find no drift while the desired schema still declares the
+# scratch index and the USING INDEX form.
+init: |
+  CREATE TABLE public.distributors (
+      dist_id integer NOT NULL,
+      name text
+  );
+  CREATE UNIQUE INDEX dist_id_temp_idx ON public.distributors USING btree (dist_id);
+desired: |
+  CREATE TABLE public.distributors (
+      dist_id integer NOT NULL,
+      name text
+  );
+  CREATE UNIQUE INDEX dist_id_temp_idx ON public.distributors USING btree (dist_id);
+  ALTER TABLE ONLY public.distributors ADD CONSTRAINT distributors_pkey PRIMARY KEY USING INDEX dist_id_temp_idx;
+applied: |
+  -- public.distributors
+  CREATE TABLE public.distributors (
+      dist_id integer NOT NULL,
+      name text,
+      CONSTRAINT distributors_pkey PRIMARY KEY (dist_id)
+  );

--- a/testdata/apply/add_unique_constraint_using_index.yml
+++ b/testdata/apply/add_unique_constraint_using_index.yml
@@ -1,0 +1,22 @@
+# Promoting a unique index to a unique constraint with USING INDEX. The
+# re-plan after the apply must find no drift while the desired schema still
+# spells the constraint in the USING INDEX form.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE USING INDEX users_email_key;
+applied: |
+  -- public.users
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL,
+      CONSTRAINT users_email_key UNIQUE (email)
+  );

--- a/testdata/plan/add_primary_key_using_index.yml
+++ b/testdata/plan/add_primary_key_using_index.yml
@@ -1,0 +1,15 @@
+# PRIMARY KEY USING INDEX takes the same path as UNIQUE USING INDEX.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  CREATE UNIQUE INDEX users_pkey ON public.users USING btree (id);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  ALTER TABLE ONLY public.users ADD CONSTRAINT users_pkey PRIMARY KEY USING INDEX users_pkey;
+plan: |
+  ALTER TABLE public.users ADD CONSTRAINT users_pkey PRIMARY KEY USING INDEX users_pkey;

--- a/testdata/plan/add_unique_constraint_using_index.yml
+++ b/testdata/plan/add_unique_constraint_using_index.yml
@@ -1,0 +1,17 @@
+# ADD CONSTRAINT ... UNIQUE USING INDEX promotes an existing unique index to
+# a constraint. The index the constraint consumes must not be dropped, even
+# though the desired schema no longer declares it.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE USING INDEX users_email_key;
+plan: |
+  ALTER TABLE public.users ADD CONSTRAINT users_email_key UNIQUE USING INDEX users_email_key;

--- a/testdata/plan/unique_constraint_using_index_no_drift.yml
+++ b/testdata/plan/unique_constraint_using_index_no_drift.yml
@@ -1,0 +1,17 @@
+# A desired schema still written in the USING INDEX form must compare equal
+# to the unique constraint it created, so the file plans clean until it is
+# rewritten in the form dump writes.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email);
+  ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE USING INDEX users_email_key;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE USING INDEX users_email_key;
+plan: ""

--- a/testdata/plan/unique_using_index_unnamed_no_drift.yml
+++ b/testdata/plan/unique_using_index_unnamed_no_drift.yml
@@ -1,0 +1,16 @@
+# ADD UNIQUE USING INDEX without CONSTRAINT names the constraint after the
+# index, the way PostgreSQL does.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email);
+  ALTER TABLE ONLY public.users ADD UNIQUE USING INDEX users_email_key;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  ALTER TABLE ONLY public.users ADD UNIQUE USING INDEX users_email_key;
+plan: ""

--- a/testdata/plan/unique_using_index_with_index_declared_no_drift.yml
+++ b/testdata/plan/unique_using_index_with_index_declared_no_drift.yml
@@ -1,0 +1,19 @@
+# The ALTER TABLE reference builds the index under a scratch name and lets
+# the promotion rename it to the constraint's name. A file that keeps the
+# CREATE UNIQUE INDEX line next to the USING INDEX constraint plans clean:
+# the index the constraint took over is neither missing nor left to drop.
+init: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  CREATE UNIQUE INDEX users_email_idx ON public.users USING btree (email);
+  ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE USING INDEX users_email_idx;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text NOT NULL
+  );
+  CREATE UNIQUE INDEX users_email_idx ON public.users USING btree (email);
+  ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE USING INDEX users_email_idx;
+plan: ""


### PR DESCRIPTION
## Problem

`ALTER TABLE ... ADD CONSTRAINT ... UNIQUE USING INDEX` (and the `PRIMARY KEY` form) is the recipe the ALTER TABLE reference gives for adding a constraint without a long lock: build the index with `CREATE UNIQUE INDEX CONCURRENTLY`, then promote it. A desired schema written this way broke in three places:

1. The form never compared equal to the constraint it created. The catalog renders that constraint as `UNIQUE (col)`, so every plan re-issued `DROP CONSTRAINT` and `ADD CONSTRAINT`.
2. The index the constraint takes over was planned as a `DROP INDEX`. Under `--allow-drop index` the drop ran before the `ADD CONSTRAINT`, which then failed with `index "..." does not exist`.
3. `ADD UNIQUE USING INDEX` without a constraint name was auto-named the usual way instead of taking the index's name, which is how PostgreSQL names it.

## Fix

The promotion renames the index to the constraint's name, so once the constraint exists there is nothing left to compare the written index name against. The form is treated as transitional, like `NOT VALID`: an existing constraint of the same name, type and deferral satisfies it, and the file plans clean until it is rewritten the way `dump` writes it. The index a desired `USING INDEX` constraint names is kept out of the index drops and adds, so the recipe works both with and without the `CREATE UNIQUE INDEX` line left in the file. An unnamed form takes the index's name.

`--explain` already classified the statement as catalog-only; only its stale comment changed.

## Testing

- Plan fixtures: promotion, the `PRIMARY KEY` form, the unnamed form, no drift after apply with and without the index declaration left in place.
- Apply fixtures re-plan and require no drift; one reproduces the `dist_id_temp_idx` -> `distributors_pkey` example from the ALTER TABLE reference, including the rename.
- Package-local tests for the parser, and for the diff's equality and index bookkeeping.
- Coverage is at the same level as main (diff 97.7%, parser 94.5%, catalog 93.5%).

Not covered on purpose: applying the transitional file to an empty database fails in PostgreSQL with `index does not exist`. Constraint statements are emitted before index statements, so even a file that keeps the `CREATE UNIQUE INDEX` line cannot provision from scratch; the form is transitional and assumes the index is already there.
