### PR TITLE
Update CHANGELOG for version 1.51.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.51.0] - 2026-09-11
+## [1.51.0] - 2026-09-12
 
 * Add `--json` to `dump` (`$PISTA_DUMP_JSON`). It writes JSON in the same shape `pista parse` writes, read from the database rather than from files, so the published JSON Schema describes both.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.51.0] - 2026-09-11
 
 * Add `--json` to `dump` (`$PISTA_DUMP_JSON`). It writes JSON in the same shape `pista parse` writes, read from the database rather than from files, so the published JSON Schema describes both.
 


### PR DESCRIPTION
This pull request updates the changelog to document the release of version 1.51.0 and describes the addition of the `--json` flag to the `dump` command. No other changes are included.