### PR TITLE
Write a table's columns as a JSON array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.53.0] - 2026-09-12
+
+* **BREAKING**: `parse` and `dump --json` write a table's `columns` as an array rather than an object keyed by name. The order is the column order, which a JSON object does not promise to keep, and the name is already a field of the column. The published JSON Schema at `schema-1.0.json` is updated in place.
+
 ## [1.52.0] - 2026-09-12
 
 * **BREAKING**: The connection options (`-c` / `--conn-string`, `-d` / `--dbname`, `--password`, `-n` / `--schemas`, `-m` / `--schema-map`, `--search-path`) belong to the command that opens a connection, so they are written after it rather than before: `pista dump -n myschema`, not `pista -n myschema dump`. `fmt` reads no database and no longer takes them at all, and `parse` takes `-n` alone, which it uses to qualify unqualified names. `-C` / `--config`, `--pager` and `--version` stay where they were, and the environment variables and the config file are unchanged.

--- a/cmd/command/dump_test.go
+++ b/cmd/command/dump_test.go
@@ -298,9 +298,9 @@ CREATE VIEW public.live AS SELECT id FROM public.users;`)
 	table := result["tables"].(map[string]any)["public.users"].(map[string]any)
 	assert.Equal(t, "users", table["name"])
 
-	columns := table["columns"].(map[string]any)
-	assert.Equal(t, "always", columns["id"].(map[string]any)["identity"])
-	assert.Equal(t, true, columns["email"].(map[string]any)["not_null"])
+	columns := columnsByName(t, table)
+	assert.Equal(t, "always", columns["id"]["identity"])
+	assert.Equal(t, true, columns["email"]["not_null"])
 
 	assert.Contains(t, table["indexes"], "idx_users_email")
 	assert.Contains(t, result["views"], "public.live")
@@ -312,7 +312,7 @@ CREATE VIEW public.live AS SELECT id FROM public.users;`)
 
 	// The catalog fills what a schema file cannot say.
 	assert.NotEqual(t, float64(0), table["oid"], "the catalog reports an OID")
-	assert.Equal(t, "extended", columns["email"].(map[string]any)["type_storage"])
+	assert.Equal(t, "extended", columns["email"]["type_storage"])
 }
 
 // The document dump writes is the one the published schema describes, which is
@@ -514,10 +514,10 @@ ALTER TABLE public.docs ALTER COLUMN body SET STORAGE EXTERNAL;`)
 
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	columns := result["tables"].(map[string]any)["public.docs"].(map[string]any)["columns"].(map[string]any)
+	columns := columnsByName(t, result["tables"].(map[string]any)["public.docs"].(map[string]any))
 
 	// Every column carries one, written or not.
-	assert.Equal(t, "plain", columns["id"].(map[string]any)["storage_type"])
-	assert.Equal(t, "external", columns["body"].(map[string]any)["storage_type"])
-	assert.Equal(t, "extended", columns["note"].(map[string]any)["storage_type"])
+	assert.Equal(t, "plain", columns["id"]["storage_type"])
+	assert.Equal(t, "external", columns["body"]["storage_type"])
+	assert.Equal(t, "extended", columns["note"]["storage_type"])
 }

--- a/cmd/command/helper_test.go
+++ b/cmd/command/helper_test.go
@@ -25,3 +25,18 @@ func firstLine(s string) string {
 	}
 	return s
 }
+
+// columnsByName indexes a table's columns by name. The document writes them as
+// an array, so a test that wants one column looks it up rather than keying
+// into a map.
+func columnsByName(t *testing.T, table map[string]any) map[string]map[string]any {
+	t.Helper()
+
+	columns := map[string]map[string]any{}
+	for _, c := range table["columns"].([]any) {
+		column := c.(map[string]any)
+		columns[column["name"].(string)] = column
+	}
+
+	return columns
+}

--- a/cmd/command/json.go
+++ b/cmd/command/json.go
@@ -5,14 +5,18 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
+
+	"github.com/winebarrel/pistachio/model"
 )
 
 // writeJSON writes v as the JSON document pistachio prints, and the newline a
 // text file ends on. Deterministic sorts the keys of a Go map, without which
 // an enum's value_rename_from would come out in a different order on every
-// run. parse and dump share it so one schema describes what both write.
+// run. model.JSONMarshalers writes what the struct tags do not say by
+// themselves. parse and dump share both so one schema describes what they
+// write.
 func writeJSON(w io.Writer, v any) error {
-	if err := json.MarshalWrite(w, v, jsontext.WithIndent("  "), json.Deterministic(true)); err != nil {
+	if err := json.MarshalWrite(w, v, jsontext.WithIndent("  "), json.Deterministic(true), model.JSONMarshalers); err != nil {
 		return err
 	}
 

--- a/cmd/command/parse_test.go
+++ b/cmd/command/parse_test.go
@@ -37,11 +37,14 @@ func TestParse_Run(t *testing.T) {
 	items, ok := tables["public.items"].(map[string]any)
 	require.True(t, ok, "unqualified names are qualified with the default schema")
 
-	columns := items["columns"].(map[string]any)
-	id := columns["id"].(map[string]any)
+	// Columns are an array, in the order the file declares them.
+	columns := items["columns"].([]any)
+	id := columns[0].(map[string]any)
+	assert.Equal(t, "id", id["name"])
 	assert.Equal(t, "bigint", id["type"])
 	assert.Equal(t, "always", id["identity"])
-	name := columns["name"].(map[string]any)
+	name := columns[1].(map[string]any)
+	assert.Equal(t, "name", name["name"])
 	assert.Equal(t, true, name["not_null"])
 
 	constraints := items["constraints"].(map[string]any)
@@ -84,7 +87,7 @@ func TestParse_Run_WritesEveryField(t *testing.T) {
 		assert.Contains(t, table, key)
 	}
 
-	col := table["columns"].(map[string]any)["note"].(map[string]any)
+	col := table["columns"].([]any)[0].(map[string]any)
 	for _, key := range []string{
 		"name", "rename_from", "type", "serial_sequence", "not_null",
 		"not_null_name", "default", "identity", "identity_sequence",

--- a/docs/guides/parsing.md
+++ b/docs/guides/parsing.md
@@ -34,8 +34,8 @@ create table public.items (
       "partition_bound": null,
       "row_security": false,
       "force_row_security": false,
-      "columns": {
-        "id": {
+      "columns": [
+        {
           "name": "id",
           "rename_from": null,
           "type": "bigint",
@@ -52,7 +52,7 @@ create table public.items (
           "compression": "",
           "comment": null
         }
-      },
+      ],
       "constraints": {},
       "foreign_keys": {},
       "indexes": {},
@@ -75,6 +75,8 @@ create table public.items (
 ## The shape of the output
 
 The top level holds one object per managed type: `tables`, `views`, `enums`, `domains`, `composite_types`, `sequences` and `routines`. Each is keyed by the qualified name, in the order the files declare it. A name written without a schema is qualified with the first schema in `--schemas`, the way `plan` reads it. A routine's key carries its identity argument types, `public.add(bigint, bigint)`, since two routines can share a name.
+
+A table's `columns` is an array rather than an object. The order is the column order, which a JSON object does not promise to keep, and the name an object would key on is in the column's `name` field. Everything else a table holds, `constraints`, `foreign_keys`, `indexes`, `policies` and `triggers`, is an object keyed by name. Their order is the order the files declare them, and the catalog's name order under `dump`, but nothing is lost by reading them in another order.
 
 Statements from `-- pista:execute` follow the objects, in `execute_stmts`.
 

--- a/docs/json/schema-1.0.json
+++ b/docs/json/schema-1.0.json
@@ -1112,10 +1112,10 @@
         "columns": {
           "oneOf": [
             {
-              "additionalProperties": {
+              "items": {
                 "$ref": "#/$defs/Column"
               },
-              "type": "object"
+              "type": "array"
             },
             {
               "type": "null"

--- a/internal/jsonschema/reflect.go
+++ b/internal/jsonschema/reflect.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/invopop/jsonschema"
+	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/parser"
 )
 
@@ -124,6 +125,12 @@ func mapper(t reflect.Type) *jsonschema.Schema {
 			// left to the reflector, which describes it as best it can. Build
 			// catches it: the definition the $ref would have named is missing.
 			return nil
+		}
+
+		// A table's columns are written as an array, in the physical column
+		// order. model.JSONMarshalers is what writes them that way.
+		if deref(valueType) == reflect.TypeFor[model.Column]() {
+			return &jsonschema.Schema{Type: "array", Items: value}
 		}
 
 		return &jsonschema.Schema{Type: "object", AdditionalProperties: value}

--- a/internal/jsonschema/reflect_test.go
+++ b/internal/jsonschema/reflect_test.go
@@ -64,6 +64,30 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+// A table's columns are written as an array, in the physical column order.
+// Everything else an ordered map holds stays an object keyed by name.
+func TestBuild_ColumnsAreAnArray(t *testing.T) {
+	schema, err := jsonschema.Build()
+	require.NoError(t, err)
+
+	table, ok := schema.Definitions["Table"]
+	require.True(t, ok)
+
+	columns, ok := table.Properties.Get("columns")
+	require.True(t, ok)
+	require.Len(t, columns.OneOf, 2, "a pointer property is a choice of the type and null")
+	assert.Equal(t, "array", columns.OneOf[0].Type)
+	require.NotNil(t, columns.OneOf[0].Items)
+	assert.Equal(t, "#/$defs/Column", columns.OneOf[0].Items.Ref)
+
+	indexes, ok := table.Properties.Get("indexes")
+	require.True(t, ok)
+	require.Len(t, indexes.OneOf, 2)
+	assert.Equal(t, "object", indexes.OneOf[0].Type)
+	require.NotNil(t, indexes.OneOf[0].AdditionalProperties)
+	assert.Equal(t, "#/$defs/Index", indexes.OneOf[0].AdditionalProperties.Ref)
+}
+
 // The words a byte enum marshals as are read off the marshaler, so the schema
 // cannot name a value the output never holds, or miss one it does.
 func TestBuild_EnumValues(t *testing.T) {

--- a/internal/jsonschema/validate_test.go
+++ b/internal/jsonschema/validate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	pistaschema "github.com/winebarrel/pistachio/internal/jsonschema"
+	"github.com/winebarrel/pistachio/model"
 	"github.com/winebarrel/pistachio/parser"
 )
 
@@ -38,15 +39,16 @@ func compileSchema(t *testing.T) *jsonschema.Schema {
 }
 
 // parseDocument parses the files and returns the document as an any tree, the
-// way a consumer reads it. The marshaling matches command.Parse: json/v2, so
-// the field presence is what the command writes.
+// way a consumer reads it. The marshaling matches command.Parse: json/v2 with
+// the model's marshalers, so the field presence and the shape are what the
+// command writes.
 func parseDocument(t *testing.T, files ...string) any {
 	t.Helper()
 
 	result, err := parser.ParseSQLFilesWithSchema(files, "public")
 	require.NoError(t, err)
 
-	b, err := json.Marshal(result)
+	b, err := json.Marshal(result, model.JSONMarshalers)
 	require.NoError(t, err)
 
 	var doc any
@@ -159,7 +161,7 @@ func TestSchema_RejectsMalformed(t *testing.T) {
 		return doc.(map[string]any)["tables"].(map[string]any)["public.t"].(map[string]any)
 	}
 	column := func(doc any) map[string]any {
-		return table(doc)["columns"].(map[string]any)["id"].(map[string]any)
+		return table(doc)["columns"].([]any)[0].(map[string]any)
 	}
 
 	for name, break_ := range map[string]func(doc any){
@@ -170,6 +172,7 @@ func TestSchema_RejectsMalformed(t *testing.T) {
 		"a missing field":               func(doc any) { delete(column(doc), "not_null") },
 		"a missing object kind":         func(doc any) { delete(doc.(map[string]any), "views") },
 		"an object where a map belongs": func(doc any) { doc.(map[string]any)["tables"] = []any{} },
+		"a map where an array belongs":  func(doc any) { table(doc)["columns"] = map[string]any{} },
 		"a null where a string belongs": func(doc any) { table(doc)["name"] = nil },
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -189,7 +192,7 @@ func TestSchema_AcceptsNullForAnUnsetPointer(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("create table t (id bigint);\n"), 0o644))
 
 	doc := parseDocument(t, path)
-	column := doc.(map[string]any)["tables"].(map[string]any)["public.t"].(map[string]any)["columns"].(map[string]any)["id"].(map[string]any)
+	column := doc.(map[string]any)["tables"].(map[string]any)["public.t"].(map[string]any)["columns"].([]any)[0].(map[string]any)
 	require.Nil(t, column["default"], "an unset default reaches the reader as null")
 
 	assert.NoError(t, schema.Validate(doc))

--- a/model/json.go
+++ b/model/json.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+
+	"github.com/winebarrel/orderedmap/v2"
+)
+
+// JSONMarshalers holds what the JSON document pistachio writes needs on top of
+// the struct tags. `parse` and `dump` both write through it, and the JSON
+// Schema describes what it produces, so a test that takes a golden through it
+// sees the bytes the commands write.
+var JSONMarshalers = json.WithMarshalers(json.MarshalToFunc(marshalColumns))
+
+// marshalColumns writes a table's columns as a JSON array rather than an
+// object keyed by name. The order is the physical column order, which a JSON
+// object does not promise to keep, and the key an object would carry is
+// already the column's name field.
+func marshalColumns(enc *jsontext.Encoder, columns *orderedmap.Map[string, *Column]) error {
+	if err := enc.WriteToken(jsontext.BeginArray); err != nil {
+		return err
+	}
+
+	for column := range columns.Values() {
+		if err := json.MarshalEncode(enc, column); err != nil {
+			return err
+		}
+	}
+
+	return enc.WriteToken(jsontext.EndArray)
+}

--- a/model/json.go
+++ b/model/json.go
@@ -16,17 +16,8 @@ var JSONMarshalers = json.WithMarshalers(json.MarshalToFunc(marshalColumns))
 // marshalColumns writes a table's columns as a JSON array rather than an
 // object keyed by name. The order is the physical column order, which a JSON
 // object does not promise to keep, and the key an object would carry is
-// already the column's name field.
+// already the column's name field. CollectValues holds the order and answers
+// an empty table with an empty slice, which is written as [] rather than null.
 func marshalColumns(enc *jsontext.Encoder, columns *orderedmap.Map[string, *Column]) error {
-	if err := enc.WriteToken(jsontext.BeginArray); err != nil {
-		return err
-	}
-
-	for column := range columns.Values() {
-		if err := json.MarshalEncode(enc, column); err != nil {
-			return err
-		}
-	}
-
-	return enc.WriteToken(jsontext.EndArray)
+	return json.MarshalEncode(enc, columns.CollectValues())
 }

--- a/model/json_test.go
+++ b/model/json_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/winebarrel/pistachio/model"
 )
 
-// marshalJSON encodes with json/v2, which is what the parse command writes
-// with. v1 escapes <, > and & in a string, so a golden taken through it would
-// not be the bytes the command produces.
+// marshalJSON encodes with json/v2 and the marshalers the parse command
+// writes with. v1 escapes <, > and & in a string, so a golden taken through it
+// would not be the bytes the command produces.
 func marshalJSON(t *testing.T, v any) string {
 	t.Helper()
-	b, err := json.Marshal(v)
+	b, err := json.Marshal(v, model.JSONMarshalers)
 	require.NoError(t, err)
 
 	return string(b)
@@ -220,7 +220,7 @@ func TestTable_MarshalJSON(t *testing.T) {
 		"partition_bound": null,
 		"row_security": false,
 		"force_row_security": false,
-		"columns": {},
+		"columns": [],
 		"constraints": {},
 		"foreign_keys": {},
 		"indexes": {},
@@ -228,6 +228,29 @@ func TestTable_MarshalJSON(t *testing.T) {
 		"triggers": {},
 		"comment": null
 	}`, marshalJSON(t, tbl))
+}
+
+// Columns write as a JSON array, in the order the table holds them. That
+// order is the physical column order, which a JSON object does not promise to
+// keep, and the key an object would carry is already the column's name.
+func TestTable_MarshalJSON_ColumnsAreAnOrderedArray(t *testing.T) {
+	columns := orderedmap.New[string, *model.Column]()
+	columns.Set("z_id", &model.Column{Name: "z_id", TypeName: "bigint"})
+	columns.Set("a_col", &model.Column{Name: "a_col", TypeName: "text"})
+	tbl := &model.Table{Schema: "public", Name: "items", Columns: columns}
+
+	var doc struct {
+		Columns []struct {
+			Name string `json:"name"`
+		} `json:"columns"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(marshalJSON(t, tbl)), &doc))
+
+	names := make([]string, 0, len(doc.Columns))
+	for _, column := range doc.Columns {
+		names = append(names, column.Name)
+	}
+	assert.Equal(t, []string{"z_id", "a_col"}, names)
 }
 
 func TestPolicy_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
`parse` and `dump --json` wrote a table's `columns` as an object keyed by the
column name. The order is the physical column order, which a JSON object does
not promise to keep, and the key is already the column's `name` field, so the
object shape carried nothing the array does not.

```json
"columns": [
  { "name": "z_id", "type": "bigint", ... },
  { "name": "a_col", "type": "text",  ... }
]
```

Only `columns` changes. Everything else an ordered map holds stays an object:
the catalog gives it a name order, and the parser a declaration order, that a
consumer can sort back to from what the document already carries.

## How

The structs are unchanged. `model.JSONMarshalers` holds a json/v2 marshaler for
`*orderedmap.Map[string, *Column]`, the one ordered map that holds columns, and
`writeJSON` passes it, so `parse` and `dump` write the same shape from one
place. None of the 36 call sites that read `Table.Columns` moved.

The JSON Schema reflector answers for the same type with an array, and
`schema-1.0.json` is regenerated. Per the request this breaks 1.0 in place
rather than publishing a 2.0.

## Tests

- `model`: the `Table` golden, and a new case pinning the array and its order.
- `internal/jsonschema`: `columns` reflects as an array of `Column` while
  `indexes` stays an object, and a document with a map where the array belongs
  now fails validation. `parseDocument` marshals with the same marshalers the
  command uses, so schema validation still measures what `parse` writes.
- `cmd/command`: the `parse` and `dump --json` assertions read the array, with
  a `columnsByName` helper for the cases that want one column.

`make vet`, `make lint` and `make test` pass. Coverage holds: `model` 99.8%,
`internal/jsonschema` 92.4% -> 92.5%, `cmd/command` 95.9%.
