### PR TITLE
Add pista diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Add `pista diff`. It compares two schema SQL files and prints the DDL that takes the first to the second, with the same statements and ordering `plan` produces, without reading a database. `--check` exits with code 2 when the diff contains executable changes.
+
 ## [1.53.0] - 2026-09-12
 
 * **BREAKING**: `parse` and `dump --json` write a table's `columns` as an array rather than an object keyed by name. The order is the column order, which a JSON object does not promise to keep, and the name is already a field of the column. The published JSON Schema at `schema-1.0.json` is updated in place.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ pista fmt ./schema/*.sql           # rewrite them in place
 pista fmt --check ./schema/*.sql   # exit 2 when a file is not formatted
 ```
 
+Or diff two schema files without a database:
+
+```bash
+pista diff old.sql new.sql         # print the DDL that takes old.sql to new.sql
+pista diff --check old.sql new.sql # exit 2 when the two differ
+```
+
 Or read the schema as JSON:
 
 ```bash

--- a/cmd/command/diff.go
+++ b/cmd/command/diff.go
@@ -1,0 +1,63 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/winebarrel/pistachio"
+)
+
+// ErrDiffChanges is returned by Diff.Run when --check is set and the diff
+// contains executable DDL. main maps it to exit code 2. Suppressed drops
+// alone do not trigger it.
+var ErrDiffChanges = errors.New("diff contains changes")
+
+type Diff struct {
+	// Schemas is the one connection option diff reads. No database is opened,
+	// but the parser qualifies an unqualified name with the first entry, and
+	// only objects in these schemas are compared, the same way plan reads the
+	// catalog.
+	Schemas []string `short:"n" env:"PISTA_SCHEMAS" default:"public" help:"Schemas to compare. Unqualified names are qualified with the first."`
+	pistachio.DiffOptions
+	Check bool `env:"PISTA_CHECK" help:"Exit with code 2 when the diff contains executable changes."`
+}
+
+func (cmd *Diff) Run(w io.Writer) error {
+	client := pistachio.NewClient(&pistachio.Options{Schemas: cmd.Schemas})
+
+	result, err := client.Diff(&cmd.DiffOptions)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "-- Diff for %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
+
+	// Order matches plan: executable SQL first so it can be piped/copied as a
+	// runnable script; skipped DROPs follow as informational comments. In the
+	// no-SQL case, skipped DROPs come before "-- No changes" so the summary
+	// line reads naturally at the end.
+	if !result.HasChanges {
+		if result.Ignored != "" {
+			fmt.Fprintln(w, result.Ignored) //nolint:errcheck
+		}
+		if result.DisallowedDrops != "" {
+			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
+		}
+		fmt.Fprintln(w, "-- No changes") //nolint:errcheck
+	} else {
+		fmt.Fprintln(w, result.SQL) //nolint:errcheck
+		if result.Ignored != "" {
+			fmt.Fprintln(w, result.Ignored) //nolint:errcheck
+		}
+		if result.DisallowedDrops != "" {
+			fmt.Fprintln(w, result.DisallowedDrops) //nolint:errcheck
+		}
+	}
+
+	if cmd.Check && result.HasChanges {
+		return ErrDiffChanges
+	}
+
+	return nil
+}

--- a/cmd/command/diff_test.go
+++ b/cmd/command/diff_test.go
@@ -1,0 +1,145 @@
+package command_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/pistachio/cmd/command"
+)
+
+func TestDiff_Run(t *testing.T) {
+	current := writeSQLFile(t, "current.sql", `
+create table users (
+    id integer not null,
+    constraint users_pkey primary key (id)
+);
+`)
+	desired := writeSQLFile(t, "desired.sql", `
+create table users (
+    id integer not null,
+    email text,
+    constraint users_pkey primary key (id)
+);
+`)
+
+	var buf bytes.Buffer
+	cmd := &command.Diff{
+		Schemas: []string{"public"},
+		Current: current,
+		Desired: desired,
+	}
+	require.NoError(t, cmd.Run(&buf))
+
+	out := buf.String()
+	assert.Equal(t, "-- Diff for schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)", firstLine(out))
+	assert.Contains(t, out, "ALTER TABLE public.users ADD COLUMN email text;")
+}
+
+func TestDiff_Run_NoChanges(t *testing.T) {
+	sql := "create table users (id integer not null, constraint users_pkey primary key (id));"
+	current := writeSQLFile(t, "current.sql", sql)
+	desired := writeSQLFile(t, "desired.sql", sql)
+
+	var buf bytes.Buffer
+	cmd := &command.Diff{
+		Schemas: []string{"public"},
+		Current: current,
+		Desired: desired,
+	}
+	require.NoError(t, cmd.Run(&buf))
+	assert.Contains(t, buf.String(), "-- No changes")
+}
+
+// --check reports changes as ErrDiffChanges, which main maps to exit code 2.
+// The diff has still been written.
+func TestDiff_Run_Check(t *testing.T) {
+	current := writeSQLFile(t, "current.sql", "")
+	desired := writeSQLFile(t, "desired.sql", "create table users (id integer);")
+
+	var buf bytes.Buffer
+	cmd := &command.Diff{
+		Schemas: []string{"public"},
+		Current: current,
+		Desired: desired,
+		Check:   true,
+	}
+	err := cmd.Run(&buf)
+	require.ErrorIs(t, err, command.ErrDiffChanges)
+	assert.Contains(t, buf.String(), "CREATE TABLE public.users")
+}
+
+func TestDiff_Run_CheckNoChanges(t *testing.T) {
+	sql := "create table users (id integer);"
+	current := writeSQLFile(t, "current.sql", sql)
+	desired := writeSQLFile(t, "desired.sql", sql)
+
+	var buf bytes.Buffer
+	cmd := &command.Diff{
+		Schemas: []string{"public"},
+		Current: current,
+		Desired: desired,
+		Check:   true,
+	}
+	require.NoError(t, cmd.Run(&buf))
+	assert.Contains(t, buf.String(), "-- No changes")
+}
+
+// A drop the policy does not allow is a comment, not an executable change, so
+// it does not trip --check; it still has to be written in the no-SQL case.
+func TestDiff_Run_DisallowedDropIsNotAChange(t *testing.T) {
+	current := writeSQLFile(t, "current.sql", "create table users (id integer);")
+	desired := writeSQLFile(t, "desired.sql", "")
+
+	var buf bytes.Buffer
+	cmd := &command.Diff{
+		Schemas: []string{"public"},
+		Current: current,
+		Desired: desired,
+		Check:   true,
+	}
+	require.NoError(t, cmd.Run(&buf))
+	assert.Contains(t, buf.String(), "-- skipped: DROP TABLE public.users;")
+	assert.Contains(t, buf.String(), "-- No changes")
+}
+
+// With changes present, ignored objects and skipped drops still follow the
+// SQL as comments.
+func TestDiff_Run_ChangesWithIgnoredAndSkippedDrop(t *testing.T) {
+	current := writeSQLFile(t, "current.sql", `
+create table users (id integer);
+create table legacy (id integer);
+create table gone (id integer);
+`)
+	desired := writeSQLFile(t, "desired.sql", `
+create table users (id integer, email text);
+-- pista:ignore
+create table legacy (id integer);
+`)
+
+	var buf bytes.Buffer
+	cmd := &command.Diff{
+		Schemas: []string{"public"},
+		Current: current,
+		Desired: desired,
+	}
+	require.NoError(t, cmd.Run(&buf))
+	out := buf.String()
+	assert.Contains(t, out, "ALTER TABLE public.users ADD COLUMN email text;")
+	assert.Contains(t, out, "-- ignored: public.legacy")
+	assert.Contains(t, out, "-- skipped: DROP TABLE public.gone;")
+}
+
+func TestDiff_Run_ParseError(t *testing.T) {
+	current := writeSQLFile(t, "current.sql", "CREATE TABLE (;")
+	desired := writeSQLFile(t, "desired.sql", "")
+
+	var buf bytes.Buffer
+	cmd := &command.Diff{
+		Schemas: []string{"public"},
+		Current: current,
+		Desired: desired,
+	}
+	require.Error(t, cmd.Run(&buf))
+}

--- a/cmd/pista/main.go
+++ b/cmd/pista/main.go
@@ -23,6 +23,7 @@ type cli struct {
 
 	Apply command.Apply `cmd:"" help:"Apply schema changes to the database."`
 	Plan  command.Plan  `cmd:"" help:"Print the schema diff SQL without applying it."`
+	Diff  command.Diff  `cmd:"" help:"Print the DDL that takes one schema SQL file to another. No database is read."`
 	Dump  command.Dump  `cmd:"" help:"Dump the current database schema as SQL."`
 	Fmt   command.Fmt   `cmd:"" help:"Format schema SQL files in place."`
 	Parse command.Parse `cmd:"" help:"Parse schema SQL files and print the result as JSON."`
@@ -65,9 +66,9 @@ func run(args []string, stdout, stderr io.Writer, exit func(int)) {
 
 	err = kctx.Run()
 	closePager()
-	// plan --check and fmt --check report a difference as exit code 2 instead
-	// of a fatal error. The output has already been written.
-	if errors.Is(err, command.ErrPlanDiff) || errors.Is(err, command.ErrFormatDiff) {
+	// plan --check, diff --check and fmt --check report a difference as exit
+	// code 2 instead of a fatal error. The output has already been written.
+	if errors.Is(err, command.ErrPlanDiff) || errors.Is(err, command.ErrDiffChanges) || errors.Is(err, command.ErrFormatDiff) {
 		kctx.Exit(2)
 		return
 	}

--- a/diff.go
+++ b/diff.go
@@ -1,0 +1,104 @@
+package pistachio
+
+import (
+	"strings"
+
+	"github.com/winebarrel/orderedmap/v2"
+	"github.com/winebarrel/pistachio/model"
+	"github.com/winebarrel/pistachio/parser"
+)
+
+type DiffOptions struct {
+	FilterOptions
+	DropPolicy
+	Current                  string `arg:"" help:"Path to the current schema SQL file."`
+	Desired                  string `arg:"" help:"Path to the desired schema SQL file."`
+	DisableIndexConcurrently bool   `xor:"index-concurrently" env:"PISTA_DISABLE_INDEX_CONCURRENTLY" help:"Ignore CONCURRENTLY opt-ins (directive and inline) and emit plain CREATE/DROP INDEX."`
+	ForceIndexConcurrently   bool   `xor:"index-concurrently" env:"PISTA_FORCE_INDEX_CONCURRENTLY" help:"Force CONCURRENTLY on every CREATE/DROP INDEX, including pure drops."`
+	BulkAlter                bool   `env:"PISTA_BULK_ALTER" help:"Combine consecutive ALTER TABLE actions on the same table into a single statement. FK changes, RENAME, VALIDATE CONSTRAINT, RLS toggles, and skipped DROPs stay separate."`
+	AssumeValidated          bool   `env:"PISTA_ASSUME_VALIDATED" help:"Treat every table constraint, domain constraint, and foreign key as validated: ignore NOT VALID and never emit VALIDATE CONSTRAINT."`
+}
+
+// Diff diffs two schema SQL files without a database: the first file stands in
+// for the current state the catalog gives Plan, the second is the desired
+// state. The output is the DDL that takes the first schema to the second.
+func (client *Client) Diff(options *DiffOptions) (*PlanResult, error) {
+	if err := client.validateSchemas(); err != nil {
+		return nil, err
+	}
+
+	// Not wrapped: the parser's message already names the file.
+	current, err := parser.ParseSQLFilesWithSchema([]string{options.Current}, client.Schemas[0])
+	if err != nil {
+		return nil, err
+	}
+	desired, err := parser.ParseSQLFilesWithSchema([]string{options.Desired}, client.Schemas[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// The current file plays the catalog's role, and the catalog reads only
+	// the target schemas, so an object outside them is out of scope rather
+	// than a drop. No schema map applies: its names are already current-side.
+	filterDesiredBySchemas(current, client.Schemas, nil)
+
+	// Routines mirror the catalog side: read only when --manage-routine asked
+	// for it. Owned sequences are excluded the way the desired side excludes
+	// them, so a sequence tied to a column stays unmanaged on both sides.
+	currentRoutines := orderedmap.New[string, *model.Routine]()
+	if options.ManageRoutine {
+		currentRoutines = current.Routines
+	}
+
+	result, err := client.diffObjects(&currentObjects{
+		Tables:         current.Tables,
+		Views:          current.Views,
+		Enums:          current.Enums,
+		Domains:        current.Domains,
+		CompositeTypes: current.CompositeTypes,
+		Sequences:      standaloneSequences(current.Sequences),
+		Routines:       currentRoutines,
+	}, &diffAllOptions{
+		FilterOptions:            options.FilterOptions,
+		DropPolicy:               options.DropPolicy,
+		Desired:                  &desiredInput{schema: desired},
+		DisableIndexConcurrently: options.DisableIndexConcurrently,
+		ForceIndexConcurrently:   options.ForceIndexConcurrently,
+		BulkAlter:                options.BulkAlter,
+		AssumeValidated:          options.AssumeValidated,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// A -- pista:execute statement is kept the way plan keeps one whose check
+	// could not be evaluated: there is no database to ask, so the check is
+	// noted and apply decides. Order matches plan: execute-first statements
+	// before the schema changes, plain execute statements after them.
+	appendExecuteStmts := func(stmts []string, first bool) []string {
+		for _, es := range result.ExecuteStmts {
+			if es.First != first {
+				continue
+			}
+			note := ""
+			if es.CheckSQL != "" {
+				note = "check SQL is not evaluated without a database; apply will decide"
+			}
+			stmts = append(stmts, parser.FormatExecuteStmtWithNote(es, note))
+		}
+		return stmts
+	}
+
+	var stmts []string
+	stmts = appendExecuteStmts(stmts, true)
+	stmts = append(stmts, result.Stmts...)
+	stmts = appendExecuteStmts(stmts, false)
+
+	return &PlanResult{
+		SQL:             strings.Join(stmts, "\n"),
+		DisallowedDrops: strings.Join(result.DisallowedDrops, "\n"),
+		Ignored:         strings.Join(result.Ignored, "\n"),
+		Count:           result.Count,
+		HasChanges:      len(stmts) > 0,
+	}, nil
+}

--- a/diff_all.go
+++ b/diff_all.go
@@ -225,6 +225,11 @@ func (client *Client) diffObjects(current *currentObjects, options *diffAllOptio
 
 	switch {
 	case options.DisableIndexConcurrently:
+		// The current side is cleared too. The catalog never sets the flag,
+		// so this is a no-op for plan and apply, but Diff parses the current
+		// side from a file, where a -- pista:concurrently would otherwise
+		// reach a pure drop.
+		clearConcurrentlyDirectives(filteredTables, filteredViews)
 		clearConcurrentlyDirectives(desiredTables, desiredViews)
 	case options.ForceIndexConcurrently:
 		forceConcurrentlyDirectives(filteredTables, filteredViews, desiredTables, desiredViews)
@@ -346,7 +351,7 @@ func removeIgnored[V any](desired, current *orderedmap.Map[string, V], ignored f
 }
 
 // clearConcurrentlyDirectives wipes the per-index Concurrently flag on every
-// table and materialized view index in the desired schema, used to implement
+// table and materialized view index in the given maps, used to implement
 // --disable-index-concurrently.
 func clearConcurrentlyDirectives(
 	tables *orderedmap.Map[string, *model.Table],

--- a/diff_all.go
+++ b/diff_all.go
@@ -86,6 +86,19 @@ type diffAllResult struct {
 	DesiredDomains *orderedmap.Map[string, *model.Domain]
 }
 
+// currentObjects holds the current side of a diff: one map per object kind.
+// diffAll reads it from the system catalogs; Diff fills it from a parsed
+// schema file.
+type currentObjects struct {
+	Tables         *orderedmap.Map[string, *model.Table]
+	Views          *orderedmap.Map[string, *model.View]
+	Enums          *orderedmap.Map[string, *model.Enum]
+	Domains        *orderedmap.Map[string, *model.Domain]
+	CompositeTypes *orderedmap.Map[string, *model.CompositeType]
+	Sequences      *orderedmap.Map[string, *model.Sequence]
+	Routines       *orderedmap.Map[string, *model.Routine]
+}
+
 // diffAll performs the common catalog fetch, parse, diff, and statement
 // ordering logic shared by Plan and Apply.
 func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diffAllOptions) (*diffAllResult, error) {
@@ -94,45 +107,62 @@ func (client *Client) diffAll(ctx context.Context, conn *pgx.Conn, options *diff
 		return nil, fmt.Errorf("failed to create catalog: %w", err)
 	}
 
-	currentTables, err := cat.Tables(ctx)
+	current := &currentObjects{}
+
+	current.Tables, err = cat.Tables(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch tables: %w", err)
 	}
 
-	currentViews, err := cat.Views(ctx)
+	current.Views, err = cat.Views(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch views: %w", err)
 	}
 
-	currentEnums, err := cat.Enums(ctx)
+	current.Enums, err = cat.Enums(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch enums: %w", err)
 	}
 
-	currentDomains, err := cat.Domains(ctx)
+	current.Domains, err = cat.Domains(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch domains: %w", err)
 	}
 
-	currentCompositeTypes, err := cat.CompositeTypes(ctx)
+	current.CompositeTypes, err = cat.CompositeTypes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch composite types: %w", err)
 	}
 
-	currentSequences, err := cat.Sequences(ctx)
+	current.Sequences, err = cat.Sequences(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch sequences: %w", err)
 	}
 
 	// pg_proc is read only when --manage-routine asked for it. Skipping the
 	// query keeps the extra round trip off every other run.
-	currentRoutines := orderedmap.New[string, *model.Routine]()
+	current.Routines = orderedmap.New[string, *model.Routine]()
 	if options.ManageRoutine {
-		currentRoutines, err = cat.Routines(ctx)
+		current.Routines, err = cat.Routines(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch routines: %w", err)
 		}
 	}
+
+	return client.diffObjects(current, options)
+}
+
+// diffObjects diffs the desired schema against an already-loaded current side
+// and orders the statements. diffAll hands it the catalog's view of the
+// database; Diff hands it a parsed schema file.
+func (client *Client) diffObjects(current *currentObjects, options *diffAllOptions) (*diffAllResult, error) {
+	currentTables := current.Tables
+	currentViews := current.Views
+	currentEnums := current.Enums
+	currentDomains := current.Domains
+	currentCompositeTypes := current.CompositeTypes
+	currentSequences := current.Sequences
+	currentRoutines := current.Routines
 
 	desired := options.Desired.schema
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,0 +1,152 @@
+package pistachio
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type diffTestCase struct {
+	Current                  string          `yaml:"current"`
+	Desired                  string          `yaml:"desired"`
+	Diff                     string          `yaml:"diff"`
+	Error                    string          `yaml:"error"`
+	Count                    *expectedCount  `yaml:"count,omitempty"`
+	DropPolicy               *planDropPolicy `yaml:"drop_policy,omitempty"`
+	DisallowedDrops          string          `yaml:"disallowed_drops,omitempty"`
+	Ignored                  string          `yaml:"ignored,omitempty"`
+	DisableIndexConcurrently bool            `yaml:"disable_index_concurrently,omitempty"`
+	ForceIndexConcurrently   bool            `yaml:"force_index_concurrently,omitempty"`
+	BulkAlter                bool            `yaml:"bulk_alter,omitempty"`
+	AssumeValidated          bool            `yaml:"assume_validated,omitempty"`
+	Include                  []string        `yaml:"include,omitempty"`
+	Exclude                  []string        `yaml:"exclude,omitempty"`
+	Enable                   []string        `yaml:"enable,omitempty"`
+	Disable                  []string        `yaml:"disable,omitempty"`
+	ManageRoutine            bool            `yaml:"manage_routine,omitempty"`
+	ManageStorageParam       bool            `yaml:"manage_storage_param,omitempty"`
+	SkipPartitionChild       bool            `yaml:"skip_partition_child,omitempty"`
+}
+
+// TestDiff runs the fixture suite. Diff reads no database, so unlike the plan
+// and apply suites it needs no server; both sides come from SQL files.
+func TestDiff(t *testing.T) {
+	files, err := filepath.Glob("testdata/diff/*.yml")
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	for _, file := range files {
+		name := strings.TrimSuffix(filepath.Base(file), ".yml")
+
+		t.Run(name, func(t *testing.T) {
+			tc := loadYAML[diffTestCase](t, file)
+
+			tmpDir := t.TempDir()
+			currentFile := filepath.Join(tmpDir, "current.sql")
+			require.NoError(t, os.WriteFile(currentFile, []byte(tc.Current), 0o644))
+			desiredFile := filepath.Join(tmpDir, "desired.sql")
+			require.NoError(t, os.WriteFile(desiredFile, []byte(tc.Desired), 0o644))
+
+			client := NewClient(&Options{Schemas: []string{"public"}})
+
+			dropPolicy := DropPolicy{AllowDrop: []string{"all"}}
+			if tc.DropPolicy != nil {
+				dropPolicy = DropPolicy{AllowDrop: tc.DropPolicy.AllowDrop}
+			}
+			got, err := client.Diff(&DiffOptions{
+				DropPolicy:               dropPolicy,
+				Include:                  tc.Include,
+				Exclude:                  tc.Exclude,
+				Enable:                   tc.Enable,
+				Disable:                  tc.Disable,
+				ManageRoutine:            tc.ManageRoutine,
+				ManageStorageParam:       tc.ManageStorageParam,
+				SkipPartitionChild:       tc.SkipPartitionChild,
+				Current:                  currentFile,
+				Desired:                  desiredFile,
+				DisableIndexConcurrently: tc.DisableIndexConcurrently,
+				ForceIndexConcurrently:   tc.ForceIndexConcurrently,
+				BulkAlter:                tc.BulkAlter,
+				AssumeValidated:          tc.AssumeValidated,
+			})
+			if tc.Error != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.Error)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, strings.TrimSpace(tc.Diff), strings.TrimSpace(got.SQL))
+			assert.Equal(t, strings.TrimSpace(tc.DisallowedDrops), strings.TrimSpace(got.DisallowedDrops))
+			assert.Equal(t, strings.TrimSpace(tc.Ignored), strings.TrimSpace(got.Ignored))
+			assert.Equal(t, got.SQL != "", got.HasChanges, "HasChanges must match presence of executable SQL")
+			assertExpectedCount(t, tc.Count, got.Count)
+		})
+	}
+}
+
+func TestDiff_MissingCurrentFile(t *testing.T) {
+	desiredFile := filepath.Join(t.TempDir(), "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	client := NewClient(&Options{Schemas: []string{"public"}})
+	_, err := client.Diff(&DiffOptions{Current: "/nonexistent/current.sql", Desired: desiredFile})
+	require.Error(t, err)
+}
+
+func TestDiff_MissingDesiredFile(t *testing.T) {
+	currentFile := filepath.Join(t.TempDir(), "current.sql")
+	require.NoError(t, os.WriteFile(currentFile, []byte("CREATE TABLE t (id int);"), 0o644))
+
+	client := NewClient(&Options{Schemas: []string{"public"}})
+	_, err := client.Diff(&DiffOptions{Current: currentFile, Desired: "/nonexistent/desired.sql"})
+	require.Error(t, err)
+}
+
+func TestDiff_EmptySchemas(t *testing.T) {
+	client := NewClient(&Options{Schemas: []string{}})
+	_, err := client.Diff(&DiffOptions{Current: "current.sql", Desired: "desired.sql"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one schema must be specified")
+}
+
+// An unqualified name is qualified with the first schema, the same way plan
+// and apply read their input, so the two sides meet on one key.
+func TestDiff_DefaultSchemaQualification(t *testing.T) {
+	tmpDir := t.TempDir()
+	currentFile := filepath.Join(tmpDir, "current.sql")
+	require.NoError(t, os.WriteFile(currentFile, []byte("CREATE TABLE users (id int);"), 0o644))
+	desiredFile := filepath.Join(tmpDir, "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE public.users (id int);"), 0o644))
+
+	client := NewClient(&Options{Schemas: []string{"public"}})
+	got, err := client.Diff(&DiffOptions{Current: currentFile, Desired: desiredFile})
+	require.NoError(t, err)
+	assert.False(t, got.HasChanges)
+	assert.Empty(t, got.SQL)
+}
+
+// An object outside the target schemas is out of scope on both sides: a
+// current-side one is not dropped and a desired-side one is not created,
+// matching what plan does when the catalog reads only the target schemas.
+func TestDiff_FiltersBothSidesBySchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	currentFile := filepath.Join(tmpDir, "current.sql")
+	require.NoError(t, os.WriteFile(currentFile, []byte("CREATE TABLE other.legacy (id int);"), 0o644))
+	desiredFile := filepath.Join(tmpDir, "desired.sql")
+	require.NoError(t, os.WriteFile(desiredFile, []byte("CREATE TABLE other.upcoming (id int);"), 0o644))
+
+	client := NewClient(&Options{Schemas: []string{"public"}})
+	got, err := client.Diff(&DiffOptions{
+		AllowDrop: []string{"all"},
+		Current:   currentFile,
+		Desired:   desiredFile,
+	})
+	require.NoError(t, err)
+	assert.False(t, got.HasChanges)
+	assert.Empty(t, got.SQL)
+	assert.Empty(t, got.DisallowedDrops)
+}

--- a/docs/guides/diffing.md
+++ b/docs/guides/diffing.md
@@ -60,6 +60,8 @@ pista diff --check /tmp/main-schema.sql schema.sql
 
 The first file plays the catalog's role. Only objects in the target schemas (`-n` / `--schemas`) are compared; an object outside them is out of scope on both sides, not a drop. Functions and procedures are read only under `--manage-routine`, and a sequence a column owns is unmanaged, as in the catalog.
 
+Directives in the first file count as its state. A `-- pista:concurrently` there makes a dropped index `DROP INDEX CONCURRENTLY`, which a plan against a database cannot know; `--disable-index-concurrently` clears it on both sides.
+
 
 ## Execute directives
 

--- a/docs/guides/diffing.md
+++ b/docs/guides/diffing.md
@@ -1,0 +1,77 @@
+# Diffing schema files
+
+`pista diff` compares two schema SQL files and prints the DDL that takes the first to the second. No database is read: the first file stands in for the current state `plan` reads from the catalog, the second is the desired state.
+
+```bash
+pista diff old.sql new.sql
+```
+
+
+## An example
+
+`old.sql`:
+
+```sql
+CREATE TABLE users (
+    id integer NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+```
+
+`new.sql`:
+
+```sql
+CREATE TABLE users (
+    id integer NOT NULL,
+    email text,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_users_email ON users (email);
+```
+
+```console
+$ pista diff old.sql new.sql
+-- Diff for schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)
+ALTER TABLE public.users ADD COLUMN email text;
+CREATE INDEX idx_users_email ON public.users USING btree (email);
+```
+
+
+## The same rules as plan
+
+Both files go through the parser `plan` and `apply` use, and the diff is the one `plan` computes: the same statements, in the same order, under the same drop policy. Diffing a file against `pista dump` output previews a plan for that database without a connection.
+
+Drops are suppressed by default and printed as comments; `--allow-drop` opts in. See [Controlling drops](drops.md).
+
+The filter options, `--bulk-alter`, `--assume-validated` and the index CONCURRENTLY flags work as they do for `plan`. Directives too: a `-- pista:renamed-from` in the second file resolves against the first file's names.
+
+
+## Checking two revisions in CI
+
+`--check` exits with code 2 when the diff contains executable changes, 0 when not, and 1 on error. Suppressed drops alone exit 0, as with `plan --check`.
+
+```bash
+git show main:schema.sql > /tmp/main-schema.sql
+pista diff --check /tmp/main-schema.sql schema.sql
+```
+
+
+## What the first file means
+
+The first file plays the catalog's role. Only objects in the target schemas (`-n` / `--schemas`) are compared; an object outside them is out of scope on both sides, not a drop. Functions and procedures are read only under `--manage-routine`, and a sequence a column owns is unmanaged, as in the catalog.
+
+
+## Execute directives
+
+A [`-- pista:execute`](executing-sql.md) statement in the desired file is kept in the output. Its check SQL cannot be evaluated without a database, so the statement carries a note and `apply` decides:
+
+```sql
+-- pista:execute SELECT NOT EXISTS (SELECT 1 FROM users)
+-- check SQL is not evaluated without a database; apply will decide
+INSERT INTO users (id) VALUES (1);
+```
+
+
+## What it is not
+
+`diff` compares two files, not a database. The drift check is `pista plan --check`; `diff` answers what changed between two versions of the schema.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -17,6 +17,10 @@ Commands:
   plan <files> ... [flags]
     Print the schema diff SQL without applying it.
 
+  diff <current> <desired> [flags]
+    Print the DDL that takes one schema SQL file to another. No database is
+    read.
+
   dump [flags]
     Dump the current database schema as SQL.
 
@@ -133,6 +137,79 @@ Flags:
                                 and the table's row and byte estimate from
                                 pg_class ($PISTA_EXPLAIN).
       --check                   Exit with code 2 when the plan contains
+                                executable changes ($PISTA_CHECK).
+```
+
+</details>
+
+<details>
+<summary><code>pista diff --help</code></summary>
+
+```
+Usage: pista diff <current> <desired> [flags]
+
+Print the DDL that takes one schema SQL file to another. No database is read.
+
+Arguments:
+  <current>    Path to the current schema SQL file.
+  <desired>    Path to the desired schema SQL file.
+
+Flags:
+  -h, --help                    Show context-sensitive help.
+  -C, --config=FILE             Load options from a YAML file ($PISTA_CONFIG).
+      --version
+      --[no-]pager              Force paging via $PISTA_PAGER even when stdout
+                                is not a TTY. PISTA_PAGER must be set.
+
+  -n, --schemas=public,...      Schemas to compare. Unqualified names are
+                                qualified with the first ($PISTA_SCHEMAS).
+  -I, --include=INCLUDE,...     Include only
+                                tables/views/enums/domains/composite
+                                types/sequences/routines matching the pattern
+                                (wildcard: *, ?; /re/ for a regular expression)
+                                ($PISTA_INCLUDE).
+  -E, --exclude=EXCLUDE,...     Exclude tables/views/enums/domains/composite
+                                types/sequences/routines matching the pattern
+                                (wildcard: *, ?; /re/ for a regular expression)
+                                ($PISTA_EXCLUDE).
+      --enable=ENABLE,...       Enable only specified object types (can be
+                                repeated) ($PISTA_ENABLE).
+      --disable=DISABLE,...     Disable specified object types (can be repeated)
+                                ($PISTA_DISABLE).
+      --manage-routine          Manage functions and procedures. Off by default;
+                                --allow-drop routine still gates dropping them
+                                ($PISTA_MANAGE_ROUTINE).
+      --manage-storage-param    Manage the storage parameters of a table and
+                                a materialized view, the WITH (...) clause.
+                                Off by default; without it the clause is
+                                ignored on both sides and dump does not
+                                write it. A plain view's security_barrier
+                                and security_invoker are managed either way
+                                ($PISTA_MANAGE_STORAGE_PARAM).
+      --skip-partition-child    Manage a partitioned table without its
+                                partitions. For a schema whose partitions
+                                another tool creates. An INHERITS child is
+                                unaffected ($PISTA_SKIP_PARTITION_CHILD).
+      --allow-drop=ALLOW-DROP,...
+                                Allow dropping these object types (repeatable;
+                                'all' allows everything) ($PISTA_ALLOW_DROP).
+      --disable-index-concurrently
+                                Ignore CONCURRENTLY opt-ins (directive and
+                                inline) and emit plain CREATE/DROP INDEX
+                                ($PISTA_DISABLE_INDEX_CONCURRENTLY).
+      --force-index-concurrently
+                                Force CONCURRENTLY on every
+                                CREATE/DROP INDEX, including pure drops
+                                ($PISTA_FORCE_INDEX_CONCURRENTLY).
+      --bulk-alter              Combine consecutive ALTER TABLE actions on the
+                                same table into a single statement. FK changes,
+                                RENAME, VALIDATE CONSTRAINT, RLS toggles, and
+                                skipped DROPs stay separate ($PISTA_BULK_ALTER).
+      --assume-validated        Treat every table constraint, domain constraint,
+                                and foreign key as validated: ignore NOT
+                                VALID and never emit VALIDATE CONSTRAINT
+                                ($PISTA_ASSUME_VALIDATED).
+      --check                   Exit with code 2 when the diff contains
                                 executable changes ($PISTA_CHECK).
 ```
 
@@ -417,6 +494,28 @@ The catalog reports an object reachable through `search_path` without its schema
 
 !!! note
     `apply` sets `search_path` to the target schemas plus `public` so unqualified type and object references resolve. `plan` output does not include that `SET search_path`, so piping `pista plan -n <schema>` into `psql` for a non-public schema may fail on an unqualified reference. Qualify the reference or run `pista apply`.
+
+
+## diff
+
+Compare two schema SQL files and print the DDL that takes the first to the second. No database is read: the first file stands in for the current state `plan` reads from the catalog, the second is the desired state.
+
+```bash
+pista diff old.sql new.sql
+```
+
+The output follows the same rules as `plan`: the same statements, the same ordering, the same drop policy. Diffing a schema file against `pista dump` output previews what `plan` would print against that database, without a connection.
+
+`--check` works as it does for `plan`: exit code 2 when the diff contains executable changes, 0 when not, 1 on error.
+
+```bash
+pista diff --check old.sql new.sql
+echo $?  # 0: no changes, 2: changes, 1: error
+```
+
+A `-- pista:execute` statement in the desired file is kept in the output. Its check SQL cannot be evaluated without a database, so the statement carries a note and `apply` decides.
+
+See [Diffing schema files](../guides/diffing.md).
 
 
 ## apply

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - guides/exclusive-apply.md
       - guides/executing-sql.md
       - guides/splitting.md
+      - guides/diffing.md
       - guides/formatting.md
       - guides/parsing.md
   - Reference:

--- a/testdata/diff/add_column.yml
+++ b/testdata/diff/add_column.yml
@@ -1,0 +1,17 @@
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: |
+  ALTER TABLE public.users ADD COLUMN email text;
+count:
+  tables: 1

--- a/testdata/diff/allow_drop_none.yml
+++ b/testdata/diff/allow_drop_none.yml
@@ -1,0 +1,12 @@
+drop_policy:
+  allow_drop: []
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: ""
+diff: ""
+disallowed_drops: |
+  -- skipped: DROP TABLE public.users;

--- a/testdata/diff/alter_sequence.yml
+++ b/testdata/diff/alter_sequence.yml
@@ -1,0 +1,8 @@
+current: |
+  CREATE SEQUENCE public.order_seq MINVALUE 1 START WITH 1;
+desired: |
+  CREATE SEQUENCE public.order_seq MINVALUE 5 START WITH 10;
+diff: |
+  ALTER SEQUENCE public.order_seq MINVALUE 5 START WITH 10;
+count:
+  sequences: 1

--- a/testdata/diff/assume_validated_fk.yml
+++ b/testdata/diff/assume_validated_fk.yml
@@ -1,0 +1,24 @@
+assume_validated: true
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.orders (
+      id integer NOT NULL,
+      user_id integer NOT NULL,
+      CONSTRAINT orders_pkey PRIMARY KEY (id),
+      CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID
+  );
+diff: |
+  ALTER TABLE ONLY public.orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES public.users (id);

--- a/testdata/diff/bulk_alter.yml
+++ b/testdata/diff/bulk_alter.yml
@@ -1,0 +1,17 @@
+bulk_alter: true
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      age integer,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: |
+  ALTER TABLE public.users
+    ADD COLUMN email text,
+    ADD COLUMN age integer;

--- a/testdata/diff/create_table.yml
+++ b/testdata/diff/create_table.yml
@@ -1,0 +1,15 @@
+current: ""
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+count:
+  tables: 0

--- a/testdata/diff/disable_index_concurrently.yml
+++ b/testdata/diff/disable_index_concurrently.yml
@@ -1,0 +1,17 @@
+disable_index_concurrently: true
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:concurrently
+  CREATE INDEX idx_users_name ON public.users (name);
+diff: |
+  CREATE INDEX idx_users_name ON public.users USING btree (name);

--- a/testdata/diff/disable_index_concurrently_drop.yml
+++ b/testdata/diff/disable_index_concurrently_drop.yml
@@ -1,0 +1,20 @@
+# --disable-index-concurrently reaches the current side too: a
+# -- pista:concurrently in the current file would otherwise turn this pure
+# drop into DROP INDEX CONCURRENTLY.
+disable_index_concurrently: true
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:concurrently
+  CREATE INDEX idx_users_name ON public.users (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: |
+  DROP INDEX public.idx_users_name;

--- a/testdata/diff/drop_table.yml
+++ b/testdata/diff/drop_table.yml
@@ -1,0 +1,9 @@
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: ""
+diff: |
+  DROP TABLE public.users;

--- a/testdata/diff/exclude_pattern.yml
+++ b/testdata/diff/exclude_pattern.yml
@@ -1,0 +1,20 @@
+exclude:
+  - legacy*
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.legacy_logs (
+      id integer NOT NULL
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      email text,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: |
+  ALTER TABLE public.users ADD COLUMN email text;
+count:
+  tables: 1

--- a/testdata/diff/execute_with_check.yml
+++ b/testdata/diff/execute_with_check.yml
@@ -1,0 +1,16 @@
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:execute SELECT NOT EXISTS (SELECT 1 FROM users)
+  INSERT INTO users (id) VALUES (1);
+diff: |
+  -- pista:execute SELECT NOT EXISTS (SELECT 1 FROM users)
+  -- check SQL is not evaluated without a database; apply will decide
+  INSERT INTO users (id) VALUES (1);

--- a/testdata/diff/execute_without_check.yml
+++ b/testdata/diff/execute_without_check.yml
@@ -1,0 +1,15 @@
+current: ""
+desired: |
+  -- pista:execute-first
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: |
+  -- pista:execute-first
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );

--- a/testdata/diff/force_index_concurrently_drop.yml
+++ b/testdata/diff/force_index_concurrently_drop.yml
@@ -1,0 +1,18 @@
+# --force-index-concurrently reaches a pure drop: the index exists only in the
+# current file, which carries no directive, so the flag has to set it there.
+force_index_concurrently: true
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: |
+  DROP INDEX CONCURRENTLY public.idx_users_name;

--- a/testdata/diff/ignore_table.yml
+++ b/testdata/diff/ignore_table.yml
@@ -1,0 +1,20 @@
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE TABLE public.legacy (
+      id integer NOT NULL
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:ignore
+  CREATE TABLE public.legacy (
+      id integer NOT NULL
+  );
+diff: ""
+ignored: |
+  -- ignored: public.legacy

--- a/testdata/diff/index_concurrently_directive.yml
+++ b/testdata/diff/index_concurrently_directive.yml
@@ -1,0 +1,16 @@
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  -- pista:concurrently
+  CREATE INDEX idx_users_name ON public.users (name);
+diff: |
+  CREATE INDEX CONCURRENTLY idx_users_name ON public.users USING btree (name);

--- a/testdata/diff/no_changes.yml
+++ b/testdata/diff/no_changes.yml
@@ -1,0 +1,20 @@
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+  CREATE TYPE public.status AS ENUM ('active', 'archived');
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE INDEX idx_users_name ON public.users (name);
+  CREATE TYPE public.status AS ENUM ('active', 'archived');
+diff: ""
+count:
+  tables: 1
+  enums: 1

--- a/testdata/diff/rename_column.yml
+++ b/testdata/diff/rename_column.yml
@@ -1,0 +1,15 @@
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      -- pista:renamed-from name
+      display_name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: |
+  ALTER TABLE public.users RENAME COLUMN name TO display_name;

--- a/testdata/diff/replace_view.yml
+++ b/testdata/diff/replace_view.yml
@@ -1,0 +1,20 @@
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.user_names AS SELECT name FROM users;
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      name text NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+  CREATE VIEW public.user_names AS SELECT id, name FROM users;
+diff: |
+  DROP VIEW public.user_names;
+  CREATE OR REPLACE VIEW public.user_names AS
+  SELECT id, name FROM users;
+count:
+  views: 1

--- a/testdata/diff/routine_managed.yml
+++ b/testdata/diff/routine_managed.yml
@@ -1,0 +1,17 @@
+manage_routine: true
+current: |
+  CREATE FUNCTION public.add(a integer, b integer) RETURNS integer
+      LANGUAGE sql IMMUTABLE STRICT
+      AS $$ SELECT a + b $$;
+desired: |
+  CREATE FUNCTION public.add(a integer, b integer) RETURNS integer
+      LANGUAGE sql IMMUTABLE STRICT
+      AS $$ SELECT b + a $$;
+diff: |
+  CREATE OR REPLACE FUNCTION public.add(a integer, b integer)
+      RETURNS integer
+      LANGUAGE sql
+      IMMUTABLE STRICT
+      AS $$ SELECT b + a $$;
+count:
+  routines: 1

--- a/testdata/diff/routine_unmanaged.yml
+++ b/testdata/diff/routine_unmanaged.yml
@@ -1,0 +1,11 @@
+# Routines are opt-in. Without --manage-routine a function in the current file
+# is not dropped and one in the desired file is not created.
+current: |
+  CREATE FUNCTION public.add(a integer, b integer) RETURNS integer
+      LANGUAGE sql
+      AS $$ SELECT a + b $$;
+desired: |
+  CREATE FUNCTION public.sub(a integer, b integer) RETURNS integer
+      LANGUAGE sql
+      AS $$ SELECT a - b $$;
+diff: ""

--- a/testdata/diff/sequence_owned_current_side.yml
+++ b/testdata/diff/sequence_owned_current_side.yml
@@ -1,0 +1,14 @@
+# A CREATE SEQUENCE ... OWNED BY in the current file is unmanaged, the way the
+# catalog leaves out serial/identity-owned sequences, so no DROP is planned.
+current: |
+  CREATE TABLE public.t (
+      id integer NOT NULL
+  );
+  CREATE SEQUENCE public.s OWNED BY public.t.id;
+desired: |
+  CREATE TABLE public.t (
+      id integer NOT NULL
+  );
+diff: ""
+count:
+  sequences: 0

--- a/testdata/diff/storage_param_unmanaged.yml
+++ b/testdata/diff/storage_param_unmanaged.yml
@@ -1,0 +1,13 @@
+# Storage parameters are opt-in. Without --manage-storage-param the WITH
+# clause is cleared on both sides, so it produces no SET and no RESET.
+current: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  ) WITH (fillfactor = 70);
+desired: |
+  CREATE TABLE public.users (
+      id integer NOT NULL,
+      CONSTRAINT users_pkey PRIMARY KEY (id)
+  );
+diff: ""


### PR DESCRIPTION
Adds `pista diff <current> <desired>`: compares two schema SQL files and prints the DDL that takes the first to the second, without reading a database.

The first file plays the catalog's role, so the output carries the same statements, order and drop policy as `plan`. `pista plan` against an empty database and `pista diff` from an empty file produce identical output (verified against the pagila sample schema, which also self-diffs clean).

- The diff pipeline in `diff_all.go` is split off the catalog fetch (`diffObjects`); `plan` and `apply` behavior is unchanged.
- Routines are read only under `--manage-routine` and a column-owned sequence stays unmanaged, mirroring the catalog side.
- A `-- pista:execute` check SQL cannot be evaluated without a database, so the statement is kept with a note and `apply` decides.
- `--check` exits with code 2 when the diff contains executable changes, like `plan --check`.
- Tests: `testdata/diff/` fixture suite (21 cases, needs no server) plus Go tests for the error paths and the command output. Package coverage: root 97.7% -> 97.8%, cmd/command unchanged.
- Docs: `docs/guides/diffing.md`, the `diff` section and help block in `docs/reference/commands.md`, README and CHANGELOG.