### PR TITLE
Leave execute statements out of diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.54.1] - 2026-09-13
+
+* `diff` no longer prints `-- pista:execute` statements. They are not schema state and their check SQL cannot be evaluated without a database; `apply` runs them as usual.
+
 ## [1.54.0] - 2026-09-13
 
 * Add `pista diff`. It compares two schema SQL files and prints the DDL that takes the first to the second, with the same statements and ordering `plan` produces, without reading a database. `--check` exits with code 2 when the diff contains executable changes.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ pista diff old.sql new.sql         # print the DDL that takes old.sql to new.sql
 pista diff --check old.sql new.sql # exit 2 when the two differ
 ```
 
-The output carries the same statements as `plan`, so diffing two revisions of a schema file previews a migration in CI. See [Diffing schema files](https://winebarrel.github.io/pistachio/guides/diffing/).
+The output carries the same schema DDL as `plan`, so diffing two revisions of a schema file previews a migration in CI. See [Diffing schema files](https://winebarrel.github.io/pistachio/guides/diffing/).
 
 Or read the schema as JSON:
 

--- a/diff.go
+++ b/diff.go
@@ -21,7 +21,8 @@ type DiffOptions struct {
 
 // Diff diffs two schema SQL files without a database: the first file stands in
 // for the current state the catalog gives Plan, the second is the desired
-// state. The output is the DDL that takes the first schema to the second.
+// state. The output is the DDL that takes the first schema to the second,
+// and nothing else: -- pista:execute statements are left out.
 func (client *Client) Diff(options *DiffOptions) (*PlanResult, error) {
 	if err := client.validateSchemas(); err != nil {
 		return nil, err
@@ -71,34 +72,14 @@ func (client *Client) Diff(options *DiffOptions) (*PlanResult, error) {
 		return nil, err
 	}
 
-	// A -- pista:execute statement is kept the way plan keeps one whose check
-	// could not be evaluated: there is no database to ask, so the check is
-	// noted and apply decides. Order matches plan: execute-first statements
-	// before the schema changes, plain execute statements after them.
-	appendExecuteStmts := func(stmts []string, first bool) []string {
-		for _, es := range result.ExecuteStmts {
-			if es.First != first {
-				continue
-			}
-			note := ""
-			if es.CheckSQL != "" {
-				note = "check SQL is not evaluated without a database; apply will decide"
-			}
-			stmts = append(stmts, parser.FormatExecuteStmtWithNote(es, note))
-		}
-		return stmts
-	}
-
-	var stmts []string
-	stmts = appendExecuteStmts(stmts, true)
-	stmts = append(stmts, result.Stmts...)
-	stmts = appendExecuteStmts(stmts, false)
-
+	// A -- pista:execute statement is not part of the diff: it is not schema
+	// state, and its check SQL cannot be evaluated without a database. apply
+	// runs execute statements as usual.
 	return &PlanResult{
-		SQL:             strings.Join(stmts, "\n"),
+		SQL:             strings.Join(result.Stmts, "\n"),
 		DisallowedDrops: strings.Join(result.DisallowedDrops, "\n"),
 		Ignored:         strings.Join(result.Ignored, "\n"),
 		Count:           result.Count,
-		HasChanges:      len(stmts) > 0,
+		HasChanges:      len(result.Stmts) > 0,
 	}, nil
 }

--- a/docs/guides/diffing.md
+++ b/docs/guides/diffing.md
@@ -39,7 +39,7 @@ CREATE INDEX idx_users_email ON public.users USING btree (email);
 
 ## The same rules as plan
 
-Both files go through the parser `plan` and `apply` use, and the diff is the one `plan` computes: the same statements, in the same order, under the same drop policy. Diffing a file against `pista dump` output previews a plan for that database without a connection.
+Both files go through the parser `plan` and `apply` use, and the diff is the one `plan` computes: the same schema DDL, in the same order, under the same drop policy. Diffing a file against `pista dump` output previews a plan for that database without a connection.
 
 Drops are suppressed by default and printed as comments; `--allow-drop` opts in. See [Controlling drops](drops.md).
 
@@ -65,13 +65,7 @@ Directives in the first file count as its state. A `-- pista:concurrently` there
 
 ## Execute directives
 
-A [`-- pista:execute`](executing-sql.md) statement in the desired file is kept in the output. Its check SQL cannot be evaluated without a database, so the statement carries a note and `apply` decides:
-
-```sql
--- pista:execute SELECT NOT EXISTS (SELECT 1 FROM users)
--- check SQL is not evaluated without a database; apply will decide
-INSERT INTO users (id) VALUES (1);
-```
+A [`-- pista:execute`](executing-sql.md) statement is not part of the diff. It is not schema state, and its check SQL cannot be evaluated without a database, so `diff` prints the schema DDL alone. `apply` runs execute statements as usual.
 
 
 ## What it is not

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -504,7 +504,7 @@ Compare two schema SQL files and print the DDL that takes the first to the secon
 pista diff old.sql new.sql
 ```
 
-The output follows the same rules as `plan`: the same statements, the same ordering, the same drop policy. Diffing a schema file against `pista dump` output previews what `plan` would print against that database, without a connection.
+The output follows the same rules as `plan`: the same schema DDL, the same ordering, the same drop policy. Diffing a schema file against `pista dump` output previews what `plan` would print against that database, without a connection.
 
 `--check` works as it does for `plan`: exit code 2 when the diff contains executable changes, 0 when not, 1 on error.
 
@@ -513,7 +513,7 @@ pista diff --check old.sql new.sql
 echo $?  # 0: no changes, 2: changes, 1: error
 ```
 
-A `-- pista:execute` statement in the desired file is kept in the output. Its check SQL cannot be evaluated without a database, so the statement carries a note and `apply` decides.
+A `-- pista:execute` statement is not part of the output: it is not schema state, and its check SQL cannot be evaluated without a database. `apply` runs execute statements as usual.
 
 See [Diffing schema files](../guides/diffing.md).
 

--- a/testdata/diff/execute_excluded.yml
+++ b/testdata/diff/execute_excluded.yml
@@ -1,3 +1,6 @@
+# A -- pista:execute statement is not part of the diff: it is not schema
+# state, and its check SQL cannot be evaluated without a database. apply runs
+# it as usual.
 current: |
   CREATE TABLE public.users (
       id integer NOT NULL,
@@ -10,7 +13,4 @@ desired: |
   );
   -- pista:execute SELECT NOT EXISTS (SELECT 1 FROM users)
   INSERT INTO users (id) VALUES (1);
-diff: |
-  -- pista:execute SELECT NOT EXISTS (SELECT 1 FROM users)
-  -- check SQL is not evaluated without a database; apply will decide
-  INSERT INTO users (id) VALUES (1);
+diff: ""

--- a/testdata/diff/execute_first_excluded.yml
+++ b/testdata/diff/execute_first_excluded.yml
@@ -1,3 +1,5 @@
+# An execute-first statement is left out the same way; only the schema DDL is
+# printed.
 current: ""
 desired: |
   -- pista:execute-first
@@ -7,8 +9,6 @@ desired: |
       CONSTRAINT users_pkey PRIMARY KEY (id)
   );
 diff: |
-  -- pista:execute-first
-  CREATE EXTENSION IF NOT EXISTS pg_trgm;
   CREATE TABLE public.users (
       id integer NOT NULL,
       CONSTRAINT users_pkey PRIMARY KEY (id)


### PR DESCRIPTION
`pista diff` printed a `-- pista:execute` statement with a note saying its check SQL could not be evaluated, leaving the decision to `apply`. Printing it at all was inferred from `plan` rather than asked for; `diff` now prints the schema DDL alone, and an execute-only difference is `-- No changes` with exit code 0 under `--check`. `apply` runs execute statements as usual.

- Fixtures replaced with ones pinning the exclusion (`execute_excluded.yml`, `execute_first_excluded.yml`).
- Docs updated, and the "same statements as plan" wording in the guide, `commands.md` and the README tightened to "same schema DDL", which stays exact.
- CHANGELOG entry under 1.54.1.