### PR TITLE
Drop the header comment from diff output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.54.2] - 2026-09-13
+
+* `diff` no longer prints the `-- Diff for schema ...` header. There is no connection to name and the object counts of a file say little, so the output is the DDL alone.
+
 ## [1.54.1] - 2026-09-13
 
 * `diff` no longer prints `-- pista:execute` statements. They are not schema state and their check SQL cannot be evaluated without a database; `apply` runs them as usual.

--- a/cmd/command/diff.go
+++ b/cmd/command/diff.go
@@ -31,8 +31,9 @@ func (cmd *Diff) Run(w io.Writer) error {
 		return err
 	}
 
-	fmt.Fprintf(w, "-- Diff for %s (%s)\n", result.Count.SchemaLabel(), result.Count.Summary()) //nolint:errcheck
-
+	// No header comment: unlike plan there is no connection to name, and the
+	// object counts of a file say little, so the output is the DDL alone.
+	//
 	// Order matches plan: executable SQL first so it can be piped/copied as a
 	// runnable script; skipped DROPs follow as informational comments. In the
 	// no-SQL case, skipped DROPs come before "-- No changes" so the summary

--- a/cmd/command/diff_test.go
+++ b/cmd/command/diff_test.go
@@ -33,8 +33,8 @@ create table users (
 	require.NoError(t, cmd.Run(&buf))
 
 	out := buf.String()
-	assert.Equal(t, "-- Diff for schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)", firstLine(out))
-	assert.Contains(t, out, "ALTER TABLE public.users ADD COLUMN email text;")
+	// No header comment: the output starts with the DDL itself.
+	assert.Equal(t, "ALTER TABLE public.users ADD COLUMN email text;", firstLine(out))
 }
 
 func TestDiff_Run_NoChanges(t *testing.T) {
@@ -49,7 +49,7 @@ func TestDiff_Run_NoChanges(t *testing.T) {
 		Desired: desired,
 	}
 	require.NoError(t, cmd.Run(&buf))
-	assert.Contains(t, buf.String(), "-- No changes")
+	assert.Equal(t, "-- No changes\n", buf.String())
 }
 
 // --check reports changes as ErrDiffChanges, which main maps to exit code 2.

--- a/docs/guides/diffing.md
+++ b/docs/guides/diffing.md
@@ -31,7 +31,6 @@ CREATE INDEX idx_users_email ON users (email);
 
 ```sql
 $ pista diff old.sql new.sql
--- Diff for schema public (1 table, 0 views, 0 enums, 0 domains, 0 composite types, 0 sequences)
 ALTER TABLE public.users ADD COLUMN email text;
 CREATE INDEX idx_users_email ON public.users USING btree (email);
 ```


### PR DESCRIPTION
`pista diff` printed a `-- Diff for schema public (...)` header the way `plan` does. Unlike `plan` there is no connection to name, and the object counts of a file say little, so the output is now the DDL alone (`-- No changes` when the two files match).

The library still returns `PlanResult.Count`; only the command output changes. Docs example and CHANGELOG updated.